### PR TITLE
Test custom bucket directory publishing

### DIFF
--- a/crates/app/src/app/publish.rs
+++ b/crates/app/src/app/publish.rs
@@ -114,7 +114,7 @@ impl App {
         checkpoint: u32,
         archives: &[&crate::config::HistoryArchiveEntry],
     ) -> anyhow::Result<()> {
-        use henyey_bucket::{BucketList, BucketManager};
+        use henyey_bucket::BucketList;
         use henyey_history::paths::root_has_path;
         use henyey_history::publish::{PublishConfig, PublishManager};
 
@@ -163,10 +163,7 @@ impl App {
             .load_bucket_list(checkpoint)?
             .ok_or_else(|| anyhow::anyhow!("Missing bucket list snapshot {}", checkpoint))?;
 
-        let bucket_manager = BucketManager::with_cache_size(
-            self.config.buckets.directory.clone(),
-            self.config.buckets.cache_size,
-        )?;
+        let bucket_manager = self.bucket_manager.clone();
 
         let mut bucket_list = BucketList::new();
         bucket_list.set_bucket_dir(bucket_manager.bucket_dir().to_path_buf());
@@ -452,5 +449,333 @@ fn run_shell_command(cmd: &str) -> anyhow::Result<()> {
         Ok(())
     } else {
         anyhow::bail!("command failed (exit {}): {}", status, cmd);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use henyey_bucket::{BucketList, HotArchiveBucketList};
+    use henyey_common::Hash256;
+    use henyey_db::queries::{
+        BucketListQueries, HistoryQueries, LedgerQueries, PublishQueueQueries, StateQueries,
+    };
+    use henyey_db::schema::state_keys;
+    use henyey_history::publish::build_history_archive_state;
+    use henyey_ledger::TransactionSetVariant;
+    use stellar_xdr::curr::{
+        Hash, LedgerHeader, LedgerHeaderExt, Limits, StellarValue, StellarValueExt,
+        TransactionHistoryEntry, TransactionHistoryEntryExt, TransactionHistoryResultEntry,
+        TransactionHistoryResultEntryExt, TransactionResultSet, TransactionSet, VecM, WriteXdr,
+    };
+
+    const CHECKPOINT: u32 = 63;
+    const TOTAL_COINS: i64 = 100_000_000_000_000_000;
+
+    fn combined_bucket_hash(live: Hash256, hot: Hash256) -> Hash256 {
+        let mut bytes = Vec::with_capacity(64);
+        bytes.extend_from_slice(live.as_bytes());
+        bytes.extend_from_slice(hot.as_bytes());
+        Hash256::hash(&bytes)
+    }
+
+    fn empty_tx_history(seq: u32, previous_ledger_hash: Hash256) -> TransactionHistoryEntry {
+        TransactionHistoryEntry {
+            ledger_seq: seq,
+            tx_set: TransactionSet {
+                previous_ledger_hash: Hash(previous_ledger_hash.0),
+                txs: VecM::default(),
+            },
+            ext: TransactionHistoryEntryExt::V0,
+        }
+    }
+
+    fn empty_tx_result(seq: u32) -> TransactionHistoryResultEntry {
+        TransactionHistoryResultEntry {
+            ledger_seq: seq,
+            tx_result_set: TransactionResultSet {
+                results: VecM::default(),
+            },
+            ext: TransactionHistoryResultEntryExt::V0,
+        }
+    }
+
+    fn make_header(
+        seq: u32,
+        previous_ledger_hash: Hash256,
+        tx_set_hash: Hash256,
+        tx_result_hash: Hash256,
+        bucket_list_hash: Hash256,
+    ) -> LedgerHeader {
+        LedgerHeader {
+            ledger_version: 24,
+            previous_ledger_hash: Hash(previous_ledger_hash.0),
+            scp_value: StellarValue {
+                tx_set_hash: Hash(tx_set_hash.0),
+                close_time: stellar_xdr::curr::TimePoint(seq as u64),
+                upgrades: VecM::default(),
+                ext: StellarValueExt::Basic,
+            },
+            tx_set_result_hash: Hash(tx_result_hash.0),
+            bucket_list_hash: Hash(bucket_list_hash.0),
+            ledger_seq: seq,
+            total_coins: TOTAL_COINS,
+            fee_pool: 0,
+            inflation_seq: 0,
+            id_pool: seq as u64,
+            base_fee: 100,
+            base_reserve: 5_000_000,
+            max_tx_set_size: 100,
+            skip_list: [Hash([0; 32]), Hash([0; 32]), Hash([0; 32]), Hash([0; 32])],
+            ext: LedgerHeaderExt::V0,
+        }
+    }
+
+    fn bucket_levels(bucket_list: &BucketList) -> Vec<(Hash256, Hash256)> {
+        bucket_list
+            .levels()
+            .iter()
+            .map(|level| (level.curr.hash(), level.snap.hash()))
+            .collect()
+    }
+
+    fn canonical_bucket_file_count(path: &std::path::Path) -> usize {
+        files_matching(path, |path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".bucket.xdr"))
+        })
+    }
+
+    fn archive_bucket_file_count(path: &std::path::Path) -> usize {
+        files_matching(path, |path| {
+            path.to_string_lossy().contains("/bucket/")
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("bucket-") && name.ends_with(".xdr.gz"))
+        })
+    }
+
+    fn files_matching(
+        path: &std::path::Path,
+        predicate: impl Fn(&std::path::Path) -> bool,
+    ) -> usize {
+        fn visit(path: &std::path::Path, predicate: &dyn Fn(&std::path::Path) -> bool) -> usize {
+            if !path.exists() {
+                return 0;
+            }
+            if path.is_file() {
+                return usize::from(predicate(path));
+            }
+            std::fs::read_dir(path)
+                .unwrap()
+                .map(|entry| visit(&entry.unwrap().path(), predicate))
+                .sum()
+        }
+
+        visit(path, &predicate)
+    }
+
+    async fn wait_for_publish_queue_to_drain(app: &App) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let queue = app
+                .db_blocking("check-publish-queue", |db| {
+                    db.load_publish_queue(None).map_err(Into::into)
+                })
+                .await
+                .unwrap();
+            if queue.is_empty() {
+                return;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "publish queue did not drain; queue={queue:?}, publish_in_progress={}",
+                    app.publish_in_progress.load(Ordering::SeqCst)
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn custom_bucket_directory_survives_genesis_publish_and_restore() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_dir = dir.path().join("db");
+        let db_path = db_dir.join("henyey.sqlite");
+        let custom_bucket_dir = dir.path().join("custom-buckets");
+        let derived_bucket_dir = db_dir.join("buckets");
+        let archive_dir = dir.path().join("archive");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        std::fs::create_dir_all(&custom_bucket_dir).unwrap();
+        std::fs::create_dir_all(&archive_dir).unwrap();
+
+        let mut config = crate::config::ConfigBuilder::new()
+            .database_path(&db_path)
+            .bucket_directory(&custom_bucket_dir)
+            .validator(true)
+            .node_seed("SAFTEV5U6QDFE2DRMSD7HBE76XG7SQZJD6VIUTHIXTJGO77RUQYVURLA")
+            .build();
+        config.history.archives = vec![crate::config::HistoryArchiveEntry {
+            name: "local-test".to_string(),
+            url: format!("file://{}", archive_dir.display()),
+            get_enabled: false,
+            put_enabled: true,
+            put: Some(format!(
+                "mkdir -p {}/$(dirname {{1}}) && cp {{0}} {}/{{1}}",
+                archive_dir.display(),
+                archive_dir.display()
+            )),
+            mkdir: Some(format!("mkdir -p {}/{{0}}", archive_dir.display())),
+        }];
+
+        {
+            let app = Arc::new(App::new(config.clone()).await.unwrap());
+            app.set_self_arc().await;
+            assert_eq!(app.bucket_manager.bucket_dir(), custom_bucket_dir.as_path());
+
+            let passphrase = app.config.network.passphrase.clone();
+            let genesis_entries = App::build_genesis_entries(&passphrase, 0, TOTAL_COINS);
+            let live_probe_header = make_header(
+                1,
+                Hash256::ZERO,
+                Hash256::ZERO,
+                Hash256::ZERO,
+                Hash256::ZERO,
+            );
+            let mut probe_bucket_list = BucketList::new();
+            probe_bucket_list.set_bucket_dir(custom_bucket_dir.clone());
+            probe_bucket_list
+                .add_batch(
+                    1,
+                    0,
+                    stellar_xdr::curr::BucketListType::Live,
+                    genesis_entries.clone(),
+                    vec![],
+                    vec![],
+                )
+                .unwrap();
+            let live_hash = probe_bucket_list.hash();
+            let hot_archive = HotArchiveBucketList::new();
+            let combined_hash = combined_bucket_hash(live_hash, hot_archive.hash());
+
+            let live_header = LedgerHeader {
+                bucket_list_hash: Hash(live_hash.0),
+                ..live_probe_header
+            };
+            let mut bucket_list =
+                App::create_genesis_bucket_list(&custom_bucket_dir, genesis_entries, &live_header)
+                    .unwrap();
+            bucket_list.set_ledger_seq(CHECKPOINT);
+            let has = build_history_archive_state(
+                CHECKPOINT,
+                &bucket_list,
+                Some(&hot_archive),
+                Some(passphrase.clone()),
+            )
+            .unwrap();
+            let has_json = has.to_json().unwrap();
+
+            let empty_result = empty_tx_result(1);
+            let empty_result_hash = Hash256::hash(
+                &empty_result
+                    .tx_result_set
+                    .to_xdr(Limits::none())
+                    .expect("empty result xdr"),
+            );
+
+            let mut headers_and_history = Vec::new();
+            let mut previous_header_hash = Hash256::ZERO;
+            let mut checkpoint_header = None;
+            let mut checkpoint_header_hash = Hash256::ZERO;
+            for seq in 1..=CHECKPOINT {
+                let tx_entry = empty_tx_history(seq, previous_header_hash);
+                let tx_hash = if seq == 1 {
+                    Hash256::ZERO
+                } else {
+                    henyey_history::verify::compute_tx_set_hash(&TransactionSetVariant::Classic(
+                        tx_entry.tx_set.clone(),
+                    ))
+                    .unwrap()
+                };
+                let result_entry = empty_tx_result(seq);
+                let result_hash = if seq == 1 {
+                    Hash256::ZERO
+                } else {
+                    empty_result_hash
+                };
+                let header = make_header(
+                    seq,
+                    previous_header_hash,
+                    tx_hash,
+                    result_hash,
+                    combined_hash,
+                );
+                let header_xdr = header.to_xdr(Limits::none()).unwrap();
+                previous_header_hash = henyey_ledger::compute_header_hash(&header).unwrap();
+                if seq == CHECKPOINT {
+                    checkpoint_header_hash = previous_header_hash;
+                    checkpoint_header = Some(header.clone());
+                }
+                headers_and_history.push((header, header_xdr, tx_entry, result_entry));
+            }
+
+            app.db_blocking("seed-custom-bucket-checkpoint", {
+                let bucket_levels = bucket_levels(&bucket_list);
+                let has_json = has_json.clone();
+                let headers_and_history = headers_and_history.clone();
+                move |db| {
+                    db.with_connection(|conn| {
+                        for (header, header_xdr, tx_entry, result_entry) in &headers_and_history {
+                            conn.store_ledger_header(header, header_xdr)?;
+                            conn.store_tx_history_entry(header.ledger_seq, tx_entry)?;
+                            conn.store_tx_result_entry(header.ledger_seq, result_entry)?;
+                        }
+                        conn.set_last_closed_ledger(CHECKPOINT)?;
+                        conn.store_bucket_list(CHECKPOINT, &bucket_levels)?;
+                        conn.set_state(state_keys::HISTORY_ARCHIVE_STATE, &has_json)?;
+                        conn.enqueue_publish(CHECKPOINT, &has_json)?;
+                        Ok::<_, henyey_db::DbError>(())
+                    })
+                    .map_err(Into::into)
+                }
+            })
+            .await
+            .unwrap();
+
+            app.ledger_manager
+                .initialize(
+                    bucket_list,
+                    hot_archive,
+                    checkpoint_header.expect("checkpoint header"),
+                    checkpoint_header_hash,
+                )
+                .unwrap();
+
+            assert!(canonical_bucket_file_count(&custom_bucket_dir) > 0);
+            assert_eq!(canonical_bucket_file_count(&derived_bucket_dir), 0);
+
+            app.maybe_publish_history().await;
+            wait_for_publish_queue_to_drain(&app).await;
+
+            assert!(archive_bucket_file_count(&archive_dir) > 0);
+            assert_eq!(canonical_bucket_file_count(&derived_bucket_dir), 0);
+        }
+
+        let second_app = App::new(config).await.unwrap();
+        assert_eq!(
+            second_app.load_last_known_ledger().await.unwrap(),
+            RestoreResult::Restored
+        );
+        assert_eq!(
+            second_app.bucket_manager.bucket_dir(),
+            custom_bucket_dir.as_path()
+        );
+        assert_eq!(canonical_bucket_file_count(&derived_bucket_dir), 0);
     }
 }

--- a/crates/app/src/app/publish.rs
+++ b/crates/app/src/app/publish.rs
@@ -603,6 +603,41 @@ mod tests {
         }
     }
 
+    #[test]
+    fn app_runtime_does_not_reconstruct_bucket_manager_from_config() {
+        let app_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/app");
+        let constructor = ["BucketManager::", "with_cache_size"].concat();
+        let config_bucket_dir = ["config.buckets", ".directory"].concat();
+        let mut offenders = Vec::new();
+        let mut stack = vec![app_dir];
+
+        while let Some(path) = stack.pop() {
+            for entry in std::fs::read_dir(&path).unwrap() {
+                let path = entry.unwrap().path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                    continue;
+                }
+
+                let source = std::fs::read_to_string(&path).unwrap();
+                if path.file_name().and_then(|name| name.to_str()) == Some("mod.rs") {
+                    continue;
+                }
+                if source.contains(&constructor) && source.contains(&config_bucket_dir) {
+                    offenders.push(path);
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "app runtime must use App::bucket_manager after construction; offenders: {offenders:?}"
+        );
+    }
+
     #[tokio::test]
     async fn custom_bucket_directory_survives_genesis_publish_and_restore() {
         let dir = tempfile::tempdir().expect("temp dir");

--- a/crates/app/src/app/publish.rs
+++ b/crates/app/src/app/publish.rs
@@ -606,7 +606,10 @@ mod tests {
     #[test]
     fn app_runtime_does_not_reconstruct_bucket_manager_from_config() {
         let app_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/app");
-        let constructor = ["BucketManager::", "with_cache_size"].concat();
+        let constructors = [
+            ["BucketManager::", "with_cache_size"].concat(),
+            ["BucketManager::", "new"].concat(),
+        ];
         let config_bucket_dir = ["config.buckets", ".directory"].concat();
         let mut offenders = Vec::new();
         let mut stack = vec![app_dir];
@@ -623,11 +626,18 @@ mod tests {
                 }
 
                 let source = std::fs::read_to_string(&path).unwrap();
-                if path.file_name().and_then(|name| name.to_str()) == Some("mod.rs") {
+                if path.file_name().and_then(|name| name.to_str()) == Some("mod.rs")
+                    && source.matches(&constructors[0]).count() == 1
+                    && !source.contains(&constructors[1])
+                {
                     continue;
                 }
-                if source.contains(&constructor) && source.contains(&config_bucket_dir) {
-                    offenders.push(path);
+                if constructors
+                    .iter()
+                    .any(|constructor| source.contains(constructor))
+                    && source.contains(&config_bucket_dir)
+                {
+                    offenders.push(path.clone());
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Use the app-owned bucket manager when publishing checkpoints instead of reconstructing bucket storage from config.
- Add an internal app regression test covering custom bucket directory use across genesis bucket persistence, history publishing, and restart restore.

## Test plan
- `CARGO_TARGET_DIR=$HOME/data/pdr-1979/cargo-target rustup run 1.88.0 cargo test -p henyey-app custom_bucket_directory -- --nocapture`
- `CARGO_TARGET_DIR=$HOME/data/pdr-1979/cargo-target rustup run 1.88.0 cargo check --all`
- `CARGO_TARGET_DIR=$HOME/data/pdr-1979/cargo-target rustup run 1.88.0 cargo test --all`
- `CARGO_TARGET_DIR=$HOME/data/pdr-1979/cargo-target rustup run 1.88.0 cargo clippy --all`
- `CARGO_TARGET_DIR=$HOME/data/pdr-1979/cargo-target rustup run 1.88.0 cargo fmt --all -- --check`

Closes #1979
