### PR TITLE
Stage F.1: Overlay byte/async/lifecycle metrics for full dashboard (10334)

### DIFF
--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -433,6 +433,34 @@ metric_catalog! {
         OVERLAY_TIMEOUT_STRAGGLER_TOTAL = "stellar_overlay_timeout_straggler_total"
             => "Total peers dropped due to straggler timeout";
 
+        // Stage F.1: Overlay byte / async I/O counters (issue #2236).
+        OVERLAY_BYTE_READ_TOTAL = "stellar_overlay_byte_read_total"
+            => "Total bytes read from peers (XDR-encoded AuthenticatedMessage size, excluding 4-byte length header)";
+        OVERLAY_BYTE_WRITE_TOTAL = "stellar_overlay_byte_write_total"
+            => "Total bytes written to peers (XDR-encoded AuthenticatedMessage size, excluding 4-byte length header)";
+        OVERLAY_ASYNC_READ_TOTAL = "stellar_overlay_async_read_total"
+            => "Total successful recv I/O operations";
+        OVERLAY_ASYNC_WRITE_TOTAL = "stellar_overlay_async_write_total"
+            => "Total successful send I/O operations";
+
+        // Stage F.1: Overlay connection lifecycle counters (issue #2236).
+        OVERLAY_INBOUND_ATTEMPT_TOTAL = "stellar_overlay_inbound_attempt_total"
+            => "Total inbound connection accepts (TCP listener.accept() Ok)";
+        OVERLAY_INBOUND_ESTABLISH_TOTAL = "stellar_overlay_inbound_establish_total"
+            => "Total inbound peers fully established (registered after handshake)";
+        OVERLAY_INBOUND_DROP_TOTAL = "stellar_overlay_inbound_drop_total"
+            => "Total inbound peer disconnections (run_peer_loop returned)";
+        OVERLAY_INBOUND_REJECT_TOTAL = "stellar_overlay_inbound_reject_total"
+            => "Total inbound connections rejected before establishment";
+        OVERLAY_OUTBOUND_ATTEMPT_TOTAL = "stellar_overlay_outbound_attempt_total"
+            => "Total outbound connection attempts (dial initiated)";
+        OVERLAY_OUTBOUND_ESTABLISH_TOTAL = "stellar_overlay_outbound_establish_total"
+            => "Total outbound peers fully established (registered after handshake)";
+        OVERLAY_OUTBOUND_DROP_TOTAL = "stellar_overlay_outbound_drop_total"
+            => "Total outbound peer disconnections (run_peer_loop returned)";
+        OVERLAY_OUTBOUND_REJECT_TOTAL = "stellar_overlay_outbound_reject_total"
+            => "Total outbound connections rejected before establishment";
+
         // Herder pending envelope counters (Phase 2).
         HERDER_PENDING_ADDED_TOTAL = "stellar_herder_pending_added_total"
             => "Envelopes added to the pending pool";
@@ -707,6 +735,22 @@ pub(crate) async fn refresh_gauges(state: &ServerState) {
         counter!(OVERLAY_ERROR_WRITE_TOTAL).absolute(ov.errors_write);
         counter!(OVERLAY_TIMEOUT_IDLE_TOTAL).absolute(ov.timeouts_idle);
         counter!(OVERLAY_TIMEOUT_STRAGGLER_TOTAL).absolute(ov.timeouts_straggler);
+
+        // Stage F.1: byte / async I/O counters (issue #2236).
+        counter!(OVERLAY_BYTE_READ_TOTAL).absolute(ov.bytes_read);
+        counter!(OVERLAY_BYTE_WRITE_TOTAL).absolute(ov.bytes_written);
+        counter!(OVERLAY_ASYNC_READ_TOTAL).absolute(ov.async_read);
+        counter!(OVERLAY_ASYNC_WRITE_TOTAL).absolute(ov.async_write);
+
+        // Stage F.1: connection lifecycle counters (issue #2236).
+        counter!(OVERLAY_INBOUND_ATTEMPT_TOTAL).absolute(ov.inbound_attempt);
+        counter!(OVERLAY_INBOUND_ESTABLISH_TOTAL).absolute(ov.inbound_establish);
+        counter!(OVERLAY_INBOUND_DROP_TOTAL).absolute(ov.inbound_drop);
+        counter!(OVERLAY_INBOUND_REJECT_TOTAL).absolute(ov.inbound_reject);
+        counter!(OVERLAY_OUTBOUND_ATTEMPT_TOTAL).absolute(ov.outbound_attempt);
+        counter!(OVERLAY_OUTBOUND_ESTABLISH_TOTAL).absolute(ov.outbound_establish);
+        counter!(OVERLAY_OUTBOUND_DROP_TOTAL).absolute(ov.outbound_drop);
+        counter!(OVERLAY_OUTBOUND_REJECT_TOTAL).absolute(ov.outbound_reject);
     }
 
     // Ledger close stats (Phase 2).
@@ -1201,10 +1245,11 @@ mod tests {
         register_label_series();
         let output = handle.render();
 
+        // Note: stellar_overlay_byte_read_total and stellar_overlay_byte_write_total
+        // were re-added in Stage F.1 (issue #2236) with proper instrumentation in the
+        // peer send/recv paths. They are no longer absent.
         let removed = [
             "stellar_overlay_message_drop_total",
-            "stellar_overlay_byte_read_total",
-            "stellar_overlay_byte_write_total",
             "stellar_overlay_pending_peers",
             "stellar_overlay_authenticated_peers",
             "stellar_overlay_flood_demanded_total",
@@ -1254,6 +1299,65 @@ mod tests {
             .chain(ALL_HISTOGRAM_NAMES.iter());
         for name in all_names {
             assert!(seen.insert(name), "duplicate metric name: {}", name);
+        }
+    }
+
+    #[test]
+    fn test_stage_f1_overlay_byte_async_counters_in_catalog() {
+        // Stage F.1 (issue #2236): byte / async I/O counters and connection
+        // lifecycle counters must all be in the pre-registered counter catalog
+        // so they appear at 0 on the very first scrape.
+        let counter_names: HashSet<&str> = ALL_COUNTER_NAMES.iter().copied().collect();
+        for expected in &[
+            "stellar_overlay_byte_read_total",
+            "stellar_overlay_byte_write_total",
+            "stellar_overlay_async_read_total",
+            "stellar_overlay_async_write_total",
+            "stellar_overlay_inbound_attempt_total",
+            "stellar_overlay_inbound_establish_total",
+            "stellar_overlay_inbound_drop_total",
+            "stellar_overlay_inbound_reject_total",
+            "stellar_overlay_outbound_attempt_total",
+            "stellar_overlay_outbound_establish_total",
+            "stellar_overlay_outbound_drop_total",
+            "stellar_overlay_outbound_reject_total",
+        ] {
+            assert!(
+                counter_names.contains(expected),
+                "Stage F.1 counter {} missing from catalog",
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_stage_f1_overlay_counters_preregistered_at_zero() {
+        // Stage F.1 counters must be visible on the very first scrape with a
+        // 0 value so dashboard panels render even before any peer traffic.
+        let handle = ensure_test_recorder();
+        describe_metrics();
+        register_label_series();
+        let output = handle.render();
+
+        for name in &[
+            "stellar_overlay_byte_read_total",
+            "stellar_overlay_byte_write_total",
+            "stellar_overlay_async_read_total",
+            "stellar_overlay_async_write_total",
+            "stellar_overlay_inbound_attempt_total",
+            "stellar_overlay_inbound_establish_total",
+            "stellar_overlay_inbound_drop_total",
+            "stellar_overlay_inbound_reject_total",
+            "stellar_overlay_outbound_attempt_total",
+            "stellar_overlay_outbound_establish_total",
+            "stellar_overlay_outbound_drop_total",
+            "stellar_overlay_outbound_reject_total",
+        ] {
+            assert!(
+                output.contains(&format!("{} 0", name)),
+                "Stage F.1 counter {} should be pre-registered at 0",
+                name
+            );
         }
     }
 

--- a/crates/overlay/src/connection.rs
+++ b/crates/overlay/src/connection.rs
@@ -26,7 +26,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use stellar_xdr::curr::AuthenticatedMessage;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::timeout;
 use tokio_util::codec::Framed;
@@ -178,11 +178,15 @@ impl Connection {
 
     /// Sends an authenticated message to the peer.
     ///
+    /// On success, returns the on-the-wire frame size in bytes (the XDR-encoded
+    /// message body length, NOT including the 4-byte length prefix). Callers
+    /// use this to update wire-byte metrics without re-encoding the message.
+    ///
     /// # Errors
     ///
     /// Returns `PeerDisconnected` if the connection is already closed,
     /// or a codec error if encoding fails.
-    pub async fn send(&mut self, message: AuthenticatedMessage) -> Result<()> {
+    pub async fn send(&mut self, message: AuthenticatedMessage) -> Result<u64> {
         if self.closed {
             return Err(OverlayError::PeerDisconnected(
                 "connection closed".to_string(),
@@ -191,18 +195,26 @@ impl Connection {
 
         trace!("Sending message to {}", self.remote_addr);
 
+        // Encode once here so we can return the wire size to the caller
+        // without forcing a second XDR pass downstream. The Encoder pipeline
+        // would otherwise re-encode internally and discard the length.
+        let encoded = MessageCodec::encode_message(&message)?;
+        // `encoded` is `[len_prefix(4) | xdr_body]`; the wire body size is
+        // `encoded.len() - 4`.
+        let wire_size = (encoded.len() - 4) as u64;
+
         // Add timeout to prevent blocking indefinitely on TCP backpressure
         const SEND_TIMEOUT_SECS: u64 = 10;
         match timeout(
             Duration::from_secs(SEND_TIMEOUT_SECS),
-            self.framed.send(message),
+            self.framed.get_mut().write_all(&encoded),
         )
         .await
         {
-            Ok(Ok(())) => Ok(()),
+            Ok(Ok(())) => Ok(wire_size),
             Ok(Err(e)) => {
                 self.closed = true;
-                Err(e)
+                Err(OverlayError::Io(e))
             }
             Err(_) => {
                 self.closed = true;

--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -416,26 +416,27 @@ impl OverlayManager {
         shared: SharedPeerState,
         connection_factory: Arc<dyn ConnectionFactory>,
     ) {
-        // Count this dial as an outbound attempt: a TCP connect is about to
-        // happen. Caller-side skips (e.g., `add_peer` returning early because
-        // the pool is full before dialing) are NOT counted as attempts —
-        // those are tracked via the pool's pending count, not lifecycle.
-        shared.metrics.outbound_attempt.inc();
-
-        // Reserve address slot to prevent duplicate outbound dials.
+        // Reserve address slot to prevent duplicate outbound dials. If the
+        // address is already in flight, no actual dial happens, so this is a
+        // no-op skip — neither `outbound_attempt` nor `outbound_reject` fire
+        // (those track real on-the-wire lifecycle events).
         let addr_key = format!("{}:{}", addr.host, addr.port);
         if !shared
             .pending_connections
             .try_reserve_address(addr_key.clone())
         {
             debug!(
-                "Rejected discovered peer {} — connection already in flight",
+                "Skipped discovered peer {} — connection already in flight",
                 addr
             );
-            shared.metrics.outbound_reject.inc();
             pool.release_pending();
             return;
         }
+
+        // Reservation succeeded — a TCP connect is about to happen. Count
+        // the dial as an outbound attempt now (after reservation, before
+        // the actual dial).
+        shared.metrics.outbound_attempt.inc();
 
         let connection = match connection_factory
             .connect(&addr, timeouts.connect_secs)
@@ -669,23 +670,25 @@ pub(super) async fn connect_to_explicit_peer(
     shared: SharedPeerState,
     connection_factory: Arc<dyn ConnectionFactory>,
 ) -> Result<PeerId> {
-    // Count this dial as an outbound attempt: a TCP connect is about to happen.
+    // Reserve address slot to prevent duplicate outbound dials. If the
+    // address is already in flight, no actual dial happens — this is a
+    // no-op skip (neither `outbound_attempt` nor `outbound_reject` fire).
     // See `connect_to_discovered_peer` for the matching contract.
-    shared.metrics.outbound_attempt.inc();
-
-    // Reserve address slot to prevent duplicate outbound dials.
     let addr_key = format!("{}:{}", addr.host, addr.port);
     if !shared
         .pending_connections
         .try_reserve_address(addr_key.clone())
     {
-        shared.metrics.outbound_reject.inc();
         pool.release_pending();
         return Err(OverlayError::Internal(format!(
             "connection to {} already in flight",
             addr
         )));
     }
+
+    // Reservation succeeded — a TCP connect is about to happen. Count the
+    // dial as an outbound attempt.
+    shared.metrics.outbound_attempt.inc();
 
     let connection = match connection_factory
         .connect(addr, timeouts.connect_secs)

--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -235,12 +235,14 @@ impl OverlayManager {
         let peer_id = peer.id().clone();
         if shared.banned_peers.read().contains(&peer_id) {
             warn!("Rejected banned peer {}", peer_id);
+            shared.metrics.inbound_reject.inc();
             peer.close().await;
             pool.release_pending();
             return;
         }
         if shared.peers.contains_key(&peer_id) {
             debug!("Rejected duplicate inbound peer {}", peer_id);
+            shared.metrics.inbound_reject.inc();
             peer.close().await;
             shared.pending_connections.release_peer_id(&peer_id);
             pool.release_pending();
@@ -267,6 +269,7 @@ impl OverlayManager {
                 "Inbound authenticated peer {} rejected because {}",
                 peer_id, reason
             );
+            shared.metrics.inbound_reject.inc();
             Self::reject_authenticated_load(&mut peer, &shared).await;
             shared.pending_connections.release_peer_id(&peer_id);
             pool.release_pending();
@@ -287,6 +290,7 @@ impl OverlayManager {
                 Ok(result) => result,
                 Err(_) => {
                     debug!("Rejected duplicate inbound peer {} (race)", peer_id);
+                    shared.metrics.inbound_reject.inc();
                     peer.close().await;
                     shared.pending_connections.release_peer_id(&peer_id);
                     pool.release_authenticated();
@@ -296,6 +300,7 @@ impl OverlayManager {
 
         // Successfully registered — release the pending reservation.
         shared.pending_connections.release_peer_id(&peer_id);
+        shared.metrics.inbound_establish.inc();
 
         Self::run_peer_loop(
             peer_id.clone(),
@@ -306,6 +311,7 @@ impl OverlayManager {
         )
         .await;
 
+        shared.metrics.inbound_drop.inc();
         shared.cleanup_peer(&peer_id);
         pool.release_authenticated();
     }
@@ -331,6 +337,10 @@ impl OverlayManager {
                     result = listener.accept() => {
                         match result {
                             Ok(connection) => {
+                                // Count every TCP-accepted inbound connection. Even
+                                // connections we immediately reject (pool full, handshake
+                                // failure) are real "attempts" from a wire perspective.
+                                shared.metrics.inbound_attempt.inc();
                                 let peer_ip = connection.remote_addr().ip();
                                 // Reserve a pending slot. We allow the handshake to proceed
                                 // even when authenticated slots are full — the actual
@@ -340,6 +350,7 @@ impl OverlayManager {
                                 // handshake and sends PEERS before rejecting with ERR_LOAD.
                                 if !pool.try_reserve_with_ip(Some(peer_ip)) {
                                     warn!("Inbound peer limit reached, rejecting connection from {}", peer_ip);
+                                    shared.metrics.inbound_reject.inc();
                                     continue;
                                 }
 
@@ -355,12 +366,13 @@ impl OverlayManager {
                                     let initial_byte_grant = shared.flow_control_bytes_config.bytes_total(
                                         shared.max_tx_size_bytes.load(Ordering::Relaxed),
                                     );
-                                    match Peer::accept(connection, local_node, auth_timeout, Arc::clone(&shared.banned_peers), pending_peer_ids, initial_byte_grant).await {
+                                    match Peer::accept(connection, local_node, auth_timeout, Arc::clone(&shared.banned_peers), pending_peer_ids, initial_byte_grant, Arc::clone(&shared.metrics)).await {
                                         Ok(peer) => {
                                             Self::handle_accepted_inbound_peer(peer, shared, pool, initial_byte_grant).await;
                                         }
                                         Err(e) => {
                                             debug!("Failed to accept peer: {}", e);
+                                            shared.metrics.inbound_reject.inc();
                                             shared.send_peer_event(PeerEvent::Failed(
                                                 PeerAddress::from(remote_addr),
                                                 PeerType::Inbound,
@@ -404,6 +416,12 @@ impl OverlayManager {
         shared: SharedPeerState,
         connection_factory: Arc<dyn ConnectionFactory>,
     ) {
+        // Count this dial as an outbound attempt: a TCP connect is about to
+        // happen. Caller-side skips (e.g., `add_peer` returning early because
+        // the pool is full before dialing) are NOT counted as attempts —
+        // those are tracked via the pool's pending count, not lifecycle.
+        shared.metrics.outbound_attempt.inc();
+
         // Reserve address slot to prevent duplicate outbound dials.
         let addr_key = format!("{}:{}", addr.host, addr.port);
         if !shared
@@ -414,6 +432,7 @@ impl OverlayManager {
                 "Rejected discovered peer {} — connection already in flight",
                 addr
             );
+            shared.metrics.outbound_reject.inc();
             pool.release_pending();
             return;
         }
@@ -425,6 +444,7 @@ impl OverlayManager {
             Ok(c) => c,
             Err(e) => {
                 debug!("Failed to connect to discovered peer {}: {}", addr, e);
+                shared.metrics.outbound_reject.inc();
                 shared
                     .send_peer_event(PeerEvent::Failed(addr.clone(), PeerType::Outbound))
                     .await;
@@ -448,12 +468,14 @@ impl OverlayManager {
             timeouts.auth_secs,
             pending_peer_ids,
             initial_byte_grant,
+            Arc::clone(&shared.metrics),
         )
         .await
         {
             Ok(p) => p,
             Err(e) => {
                 debug!("Failed to connect to discovered peer {}: {}", addr, e);
+                shared.metrics.outbound_reject.inc();
                 shared
                     .send_peer_event(PeerEvent::Failed(addr.clone(), PeerType::Outbound))
                     .await;
@@ -470,6 +492,7 @@ impl OverlayManager {
         // Reject banned peers (mirrors connect_outbound_inner).
         if shared.banned_peers.read().contains(&peer_id) {
             debug!("Rejected banned discovered peer {} at {}", peer_id, addr);
+            shared.metrics.outbound_reject.inc();
             peer.close().await;
             shared.pending_connections.release_peer_id(&peer_id);
             pool.release_pending();
@@ -479,6 +502,7 @@ impl OverlayManager {
         // Reject peers we're already connected to (mirrors connect_outbound_inner).
         if shared.peers.contains_key(&peer_id) {
             debug!("Rejected duplicate discovered peer {} at {}", peer_id, addr);
+            shared.metrics.outbound_reject.inc();
             peer.close().await;
             shared.pending_connections.release_peer_id(&peer_id);
             pool.release_pending();
@@ -496,6 +520,7 @@ impl OverlayManager {
                 "Outbound discovered peer {} rejected because {}",
                 peer_id, reason
             );
+            shared.metrics.outbound_reject.inc();
             Self::reject_authenticated_load(&mut peer, &shared).await;
             shared.pending_connections.release_peer_id(&peer_id);
             pool.release_pending();
@@ -508,6 +533,7 @@ impl OverlayManager {
                 Ok(result) => result,
                 Err(_) => {
                     debug!("Rejected duplicate discovered peer {} (race)", peer_id);
+                    shared.metrics.outbound_reject.inc();
                     peer.close().await;
                     shared.pending_connections.release_peer_id(&peer_id);
                     pool.release_authenticated();
@@ -516,6 +542,7 @@ impl OverlayManager {
             };
 
         shared.pending_connections.release_peer_id(&peer_id);
+        shared.metrics.outbound_establish.inc();
         shared
             .send_peer_event(PeerEvent::Connected(addr.clone(), PeerType::Outbound))
             .await;
@@ -531,6 +558,7 @@ impl OverlayManager {
         )
         .await;
 
+        shared.metrics.outbound_drop.inc();
         shared.cleanup_peer(&peer_id);
         pool.release_authenticated();
     }
@@ -641,12 +669,17 @@ pub(super) async fn connect_to_explicit_peer(
     shared: SharedPeerState,
     connection_factory: Arc<dyn ConnectionFactory>,
 ) -> Result<PeerId> {
+    // Count this dial as an outbound attempt: a TCP connect is about to happen.
+    // See `connect_to_discovered_peer` for the matching contract.
+    shared.metrics.outbound_attempt.inc();
+
     // Reserve address slot to prevent duplicate outbound dials.
     let addr_key = format!("{}:{}", addr.host, addr.port);
     if !shared
         .pending_connections
         .try_reserve_address(addr_key.clone())
     {
+        shared.metrics.outbound_reject.inc();
         pool.release_pending();
         return Err(OverlayError::Internal(format!(
             "connection to {} already in flight",
@@ -660,6 +693,7 @@ pub(super) async fn connect_to_explicit_peer(
     {
         Ok(connection) => connection,
         Err(e) => {
+            shared.metrics.outbound_reject.inc();
             shared.pending_connections.release_address(&addr_key);
             pool.release_pending();
             shared
@@ -683,11 +717,13 @@ pub(super) async fn connect_to_explicit_peer(
         timeouts.auth_secs,
         pending_peer_ids,
         initial_byte_grant,
+        Arc::clone(&shared.metrics),
     )
     .await
     {
         Ok(peer) => peer,
         Err(e) => {
+            shared.metrics.outbound_reject.inc();
             shared.pending_connections.release_address(&addr_key);
             pool.release_pending();
             shared
@@ -702,12 +738,14 @@ pub(super) async fn connect_to_explicit_peer(
     shared.pending_connections.release_address(&addr_key);
 
     if shared.banned_peers.read().contains(&peer_id) {
+        shared.metrics.outbound_reject.inc();
         peer.close().await;
         pool.release_pending();
         return Err(OverlayError::PeerBanned(peer_id.to_string()));
     }
 
     if shared.peers.contains_key(&peer_id) {
+        shared.metrics.outbound_reject.inc();
         peer.close().await;
         shared.pending_connections.release_peer_id(&peer_id);
         pool.release_pending();
@@ -722,6 +760,7 @@ pub(super) async fn connect_to_explicit_peer(
             "all available slots are taken"
         };
         info!("Outbound peer {} rejected because {}", peer_id, reason);
+        shared.metrics.outbound_reject.inc();
         OverlayManager::reject_authenticated_load(&mut peer, &shared).await;
         shared.pending_connections.release_peer_id(&peer_id);
         pool.release_pending();
@@ -741,6 +780,7 @@ pub(super) async fn connect_to_explicit_peer(
         Ok(result) => result,
         Err(e) => {
             debug!("Rejected duplicate peer {} (race)", peer_id);
+            shared.metrics.outbound_reject.inc();
             peer.close().await;
             shared.pending_connections.release_peer_id(&peer_id);
             pool.release_authenticated();
@@ -749,6 +789,7 @@ pub(super) async fn connect_to_explicit_peer(
     };
 
     shared.pending_connections.release_peer_id(&peer_id);
+    shared.metrics.outbound_establish.inc();
     shared
         .send_peer_event(PeerEvent::Connected(addr.clone(), PeerType::Outbound))
         .await;
@@ -771,6 +812,7 @@ pub(super) async fn connect_to_explicit_peer(
             shared_clone.clone(),
         )
         .await;
+        shared_clone.metrics.outbound_drop.inc();
         shared_clone.cleanup_peer(&peer_id_clone);
         pool_clone.release_authenticated();
     });
@@ -922,6 +964,22 @@ mod tests {
             "pending address reservation not cleared"
         );
 
+        // Stage F.1: outbound_attempt was counted at function entry, and
+        // outbound_reject was counted on the handshake failure. No establish
+        // or drop because the peer never registered.
+        assert_eq!(
+            shared.metrics.outbound_attempt.get(),
+            1,
+            "outbound_attempt should fire once per connect_to_explicit_peer call"
+        );
+        assert_eq!(
+            shared.metrics.outbound_reject.get(),
+            1,
+            "outbound_reject should fire on handshake timeout"
+        );
+        assert_eq!(shared.metrics.outbound_establish.get(), 0);
+        assert_eq!(shared.metrics.outbound_drop.get(), 0);
+
         // Verify PeerEvent::Failed was emitted.
         let event = peer_event_rx
             .try_recv()
@@ -988,6 +1046,13 @@ mod tests {
             "pending address reservation not cleared"
         );
 
+        // Stage F.1: TCP connect failure path also goes through
+        // outbound_attempt + outbound_reject.
+        assert_eq!(shared.metrics.outbound_attempt.get(), 1);
+        assert_eq!(shared.metrics.outbound_reject.get(), 1);
+        assert_eq!(shared.metrics.outbound_establish.get(), 0);
+        assert_eq!(shared.metrics.outbound_drop.get(), 0);
+
         let event = peer_event_rx
             .try_recv()
             .expect("expected PeerEvent::Failed");
@@ -1049,6 +1114,13 @@ mod tests {
             "pending address reservation not cleared"
         );
 
+        // Stage F.1: discovered-peer path also bumps outbound_attempt +
+        // outbound_reject on handshake failure.
+        assert_eq!(shared.metrics.outbound_attempt.get(), 1);
+        assert_eq!(shared.metrics.outbound_reject.get(), 1);
+        assert_eq!(shared.metrics.outbound_establish.get(), 0);
+        assert_eq!(shared.metrics.outbound_drop.get(), 0);
+
         // Verify PeerEvent::Failed was emitted.
         let event = peer_event_rx
             .try_recv()
@@ -1057,5 +1129,113 @@ mod tests {
             matches!(event, PeerEvent::Failed(_, PeerType::Outbound)),
             "expected Failed(_, Outbound), got: {event:?}"
         );
+    }
+
+    /// Verify that a successful end-to-end connection between two managers
+    /// produces matching `outbound_establish` (initiator) and
+    /// `inbound_establish` (acceptor) increments, plus matching `*_drop`
+    /// counts after teardown.
+    ///
+    /// This is the success-path counterpart to the timeout/reject tests above.
+    #[tokio::test]
+    async fn test_connection_lifecycle_counters_on_handshake_success() {
+        use crate::loopback::LoopbackConnectionFactory;
+        use crate::OverlayConfig;
+
+        let factory = Arc::new(LoopbackConnectionFactory::default());
+
+        // Two managers wired up via the loopback connection factory.
+        let mut config_a = OverlayConfig::testnet();
+        config_a.listen_port = 11625;
+        config_a.listen_enabled = true;
+        config_a.known_peers.clear();
+        config_a.connect_timeout_secs = 1;
+
+        let mut config_b = OverlayConfig::testnet();
+        config_b.listen_port = 11626;
+        config_b.listen_enabled = true;
+        config_b.known_peers.clear();
+        config_b.connect_timeout_secs = 1;
+
+        let local_a = LocalNode::new_testnet(SecretKey::generate());
+        let local_b = LocalNode::new_testnet(SecretKey::generate());
+
+        let mut manager_a = super::super::OverlayManager::new_with_connection_factory(
+            config_a,
+            local_a,
+            Arc::clone(&factory) as Arc<dyn ConnectionFactory>,
+        )
+        .unwrap();
+        let mut manager_b = super::super::OverlayManager::new_with_connection_factory(
+            config_b,
+            local_b,
+            factory as Arc<dyn ConnectionFactory>,
+        )
+        .unwrap();
+
+        manager_a.start().await.expect("start a");
+        manager_b.start().await.expect("start b");
+
+        let metrics_a = Arc::clone(&manager_a.shared_state().metrics);
+        let metrics_b = Arc::clone(&manager_b.shared_state().metrics);
+
+        // A dials B.
+        let addr_b = PeerAddress::new("127.0.0.1", 11626);
+        manager_a.connect(&addr_b).await.expect("connect");
+
+        // Wait for the handshake on both sides. The loopback duplex completes
+        // both within ~50ms; poll up to ~2s.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if metrics_a.outbound_establish.get() >= 1 && metrics_b.inbound_establish.get() >= 1 {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "lifecycle counters did not reach establish: \
+                     A: outbound_attempt={}, outbound_establish={}, outbound_reject={}; \
+                     B: inbound_attempt={}, inbound_establish={}, inbound_reject={}",
+                    metrics_a.outbound_attempt.get(),
+                    metrics_a.outbound_establish.get(),
+                    metrics_a.outbound_reject.get(),
+                    metrics_b.inbound_attempt.get(),
+                    metrics_b.inbound_establish.get(),
+                    metrics_b.inbound_reject.get(),
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Initiator side: exactly one outbound attempt + one establish, no reject.
+        assert_eq!(metrics_a.outbound_attempt.get(), 1, "outbound_attempt");
+        assert_eq!(metrics_a.outbound_establish.get(), 1, "outbound_establish");
+        assert_eq!(metrics_a.outbound_reject.get(), 0, "outbound_reject");
+
+        // Acceptor side: exactly one inbound attempt + one establish, no reject.
+        assert_eq!(metrics_b.inbound_attempt.get(), 1, "inbound_attempt");
+        assert_eq!(metrics_b.inbound_establish.get(), 1, "inbound_establish");
+        assert_eq!(metrics_b.inbound_reject.get(), 0, "inbound_reject");
+
+        // Tear down and verify drop counters match establish counters.
+        manager_a.shutdown().await.expect("shutdown a");
+        manager_b.shutdown().await.expect("shutdown b");
+
+        let drop_deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if metrics_a.outbound_drop.get() >= 1 && metrics_b.inbound_drop.get() >= 1 {
+                break;
+            }
+            if std::time::Instant::now() > drop_deadline {
+                panic!(
+                    "drop counters did not reach 1: \
+                     outbound_drop={}, inbound_drop={}",
+                    metrics_a.outbound_drop.get(),
+                    metrics_b.inbound_drop.get()
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(metrics_a.outbound_drop.get(), 1);
+        assert_eq!(metrics_b.inbound_drop.get(), 1);
     }
 }

--- a/crates/overlay/src/metrics.rs
+++ b/crates/overlay/src/metrics.rs
@@ -251,10 +251,47 @@ pub struct OverlayMetrics {
     pub messages_broadcast: Counter,
 
     // ===== Byte Metrics =====
-    /// Bytes read from peers.
+    /// Bytes read from peers (wire-level: `AuthenticatedMessage` XDR body, excluding the
+    /// 4-byte length header). Matches stellar-core `mByteRead`.
     pub bytes_read: Counter,
-    /// Bytes written to peers.
+    /// Bytes written to peers (wire-level: `AuthenticatedMessage` XDR body, excluding
+    /// the 4-byte length header). Matches stellar-core `mByteWrite`.
     pub bytes_written: Counter,
+
+    // ===== Async I/O Metrics =====
+    /// Successful recv I/O operations (each `Connection::recv*` returning a frame).
+    /// Matches stellar-core `mAsyncRead`.
+    pub async_read: Counter,
+    /// Successful send I/O operations (each `Connection::send` returning Ok).
+    /// Matches stellar-core `mAsyncWrite`.
+    pub async_write: Counter,
+
+    // ===== Connection Lifecycle Metrics =====
+    /// Inbound connection accepts: `listener.accept()` returning `Ok`.
+    /// Counts every TCP-accepted inbound connection, including those later rejected.
+    pub inbound_attempt: Counter,
+    /// Inbound connections that completed handshake and were fully registered as peers.
+    /// Incremented exactly once per inbound peer that reaches `register_peer` Ok.
+    pub inbound_establish: Counter,
+    /// Inbound peer disconnections: incremented after `run_peer_loop` returns for an
+    /// inbound peer (mirrors `inbound_establish`).
+    pub inbound_drop: Counter,
+    /// Inbound connections rejected at any point after accept but before establish
+    /// (handshake failure, banned, duplicate, slots full, register race).
+    pub inbound_reject: Counter,
+    /// Outbound connection attempts: a dial was initiated (entry to
+    /// `connect_to_discovered_peer` / `connect_to_explicit_peer`). Does NOT include
+    /// caller-side skips (e.g., `add_peer` returning early because the pool is full
+    /// before dialing) — those are not "attempts" in the wire sense.
+    pub outbound_attempt: Counter,
+    /// Outbound connections that completed handshake and were fully registered.
+    pub outbound_establish: Counter,
+    /// Outbound peer disconnections: incremented after `run_peer_loop` returns for an
+    /// outbound peer (mirrors `outbound_establish`).
+    pub outbound_drop: Counter,
+    /// Outbound connections rejected at any point after attempt but before establish
+    /// (TCP connect fail, handshake fail, banned, duplicate, slots full, register race).
+    pub outbound_reject: Counter,
 
     // ===== Error Metrics =====
     /// Read errors encountered.
@@ -426,6 +463,20 @@ impl OverlayMetrics {
             bytes_read: self.bytes_read.get(),
             bytes_written: self.bytes_written.get(),
 
+            // Async I/O metrics
+            async_read: self.async_read.get(),
+            async_write: self.async_write.get(),
+
+            // Connection lifecycle metrics
+            inbound_attempt: self.inbound_attempt.get(),
+            inbound_establish: self.inbound_establish.get(),
+            inbound_drop: self.inbound_drop.get(),
+            inbound_reject: self.inbound_reject.get(),
+            outbound_attempt: self.outbound_attempt.get(),
+            outbound_establish: self.outbound_establish.get(),
+            outbound_drop: self.outbound_drop.get(),
+            outbound_reject: self.outbound_reject.get(),
+
             // Error metrics
             errors_read: self.errors_read.get(),
             errors_write: self.errors_write.get(),
@@ -492,6 +543,16 @@ impl OverlayMetrics {
             &self.messages_broadcast,
             &self.bytes_read,
             &self.bytes_written,
+            &self.async_read,
+            &self.async_write,
+            &self.inbound_attempt,
+            &self.inbound_establish,
+            &self.inbound_drop,
+            &self.inbound_reject,
+            &self.outbound_attempt,
+            &self.outbound_establish,
+            &self.outbound_drop,
+            &self.outbound_reject,
             &self.errors_read,
             &self.errors_write,
             &self.timeouts_idle,
@@ -577,6 +638,20 @@ pub struct OverlayMetricsSnapshot {
     // Byte metrics
     pub bytes_read: u64,
     pub bytes_written: u64,
+
+    // Async I/O metrics
+    pub async_read: u64,
+    pub async_write: u64,
+
+    // Connection lifecycle metrics
+    pub inbound_attempt: u64,
+    pub inbound_establish: u64,
+    pub inbound_drop: u64,
+    pub inbound_reject: u64,
+    pub outbound_attempt: u64,
+    pub outbound_establish: u64,
+    pub outbound_drop: u64,
+    pub outbound_reject: u64,
 
     // Error metrics
     pub errors_read: u64,

--- a/crates/overlay/src/metrics.rs
+++ b/crates/overlay/src/metrics.rs
@@ -279,10 +279,12 @@ pub struct OverlayMetrics {
     /// Inbound connections rejected at any point after accept but before establish
     /// (handshake failure, banned, duplicate, slots full, register race).
     pub inbound_reject: Counter,
-    /// Outbound connection attempts: a dial was initiated (entry to
-    /// `connect_to_discovered_peer` / `connect_to_explicit_peer`). Does NOT include
-    /// caller-side skips (e.g., `add_peer` returning early because the pool is full
-    /// before dialing) — those are not "attempts" in the wire sense.
+    /// Outbound connection attempts: a dial was actually initiated (after the
+    /// address reservation succeeded inside `connect_to_discovered_peer` /
+    /// `connect_to_explicit_peer`). Does NOT include caller-side skips (e.g.,
+    /// `add_peer` returning early because the pool is full before dialing) or
+    /// in-flight-duplicate skips (where the address is already reserved by
+    /// another in-progress dial) — those are not "attempts" in the wire sense.
     pub outbound_attempt: Counter,
     /// Outbound connections that completed handshake and were fully registered.
     pub outbound_establish: Counter,

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -982,44 +982,39 @@ mod tests {
         assert_eq!(m.outbound_reject.get(), 0);
     }
 
-    /// Drive a `send_raw` (HELLO-style unauthenticated) message from peer A to
-    /// peer B and assert that:
-    ///   - A's `bytes_written` and `async_write` increment by the wire size /
-    ///     1
-    ///   - B's `bytes_read` and `async_read` increment by the same wire size
-    ///     / 1
+    /// Drive a `Peer::send_hello` -> `Peer::recv_hello` round-trip and assert
+    /// that BOTH sides update their counters via the real instrumented paths
+    /// (no manual counter bumps). A regression in either `send_raw`'s or
+    /// `recv_hello`'s instrumentation would cause this test to fail.
     ///
-    /// This is the "happy-path" unit test for the new instrumentation.
+    /// Asserts:
+    ///   - A's `bytes_written` / `async_write` increment by wire size / 1
+    ///   - B's `bytes_read` / `async_read` increment by the same wire size / 1
     #[tokio::test]
     async fn test_peer_send_recv_metrics_increment() {
-        // Use `recv()` (authenticated) on peer B requires authenticated MAC
-        // keys, which we don't have without a full handshake. So we drive
-        // `send_raw` (unauthenticated) on A and `recv_hello` on B (which uses
-        // `connection.recv_timeout()` + `auth.unwrap_message`, where unwrap of
-        // an unauthenticated frame works without MAC).
+        // We drive `send_hello` (unauthenticated send_raw) on A and
+        // `recv_hello` on B (instrumented receive). We can't use the
+        // post-auth `send`/`recv` here because the test peers don't have
+        // derived MAC keys without a full handshake — `recv_hello` only
+        // requires unwrap of an unauthenticated frame.
         let metrics_a = Arc::new(OverlayMetrics::new());
         let metrics_b = Arc::new(OverlayMetrics::new());
         let (mut peer_a, mut peer_b) =
             make_authenticated_peer_pair(Arc::clone(&metrics_a), Arc::clone(&metrics_b));
 
-        // Send a HELLO via `send_hello` (which calls send_raw). This is the
-        // simplest unauthenticated path through the instrumented code.
+        // Send a HELLO via the real `send_hello` (which calls send_raw) and
+        // receive it on B via the real `recv_hello`. Both paths run their
+        // metric instrumentation; a regression in either would break this
+        // assertion.
         peer_a.send_hello().await.expect("send_hello");
+        // `recv_hello` will fail at `process_hello` (network mismatch /
+        // self-cert checks) for our synthetic peer pair, but the
+        // instrumentation runs BEFORE process_hello — so we accept either
+        // outcome here and only assert on the counter side-effects below.
+        let _ = peer_b.recv_hello(5).await;
 
-        // On the receive side, the *connection* delivers the frame. We drive
-        // the lower-level path directly to avoid `recv_hello`'s unwrap, which
-        // also calls `process_hello` and may fail on duplicate/etc. checks.
-        let frame = peer_b
-            .connection
-            .recv()
-            .await
-            .expect("recv ok")
-            .expect("frame present");
-        // Manually mirror what recv_hello would do for the metrics part:
-        peer_b.metrics.bytes_read.add(frame.raw_len as u64);
-        peer_b.metrics.async_read.inc();
-
-        // Sender side: bytes_written / async_write incremented exactly once.
+        // Sender side: bytes_written / async_write incremented exactly once
+        // by the real `send_raw` instrumentation.
         assert_eq!(metrics_a.async_write.get(), 1);
         assert!(
             metrics_a.bytes_written.get() > 0,
@@ -1027,49 +1022,57 @@ mod tests {
             metrics_a.bytes_written.get()
         );
 
-        // Receiver side: counts the same wire bytes.
-        assert_eq!(metrics_b.async_read.get(), 1);
+        // Receiver side: counts the same wire bytes via the real
+        // `recv_hello` instrumentation.
+        assert_eq!(
+            metrics_b.async_read.get(),
+            1,
+            "recv_hello must bump async_read exactly once"
+        );
         assert_eq!(
             metrics_b.bytes_read.get(),
             metrics_a.bytes_written.get(),
-            "wire-level byte counts must match between sender and receiver"
+            "wire-level byte counts must match between sender and receiver \
+             (both sides must use real instrumentation)"
         );
     }
 
     /// Verify that a failed send does NOT increment success-only counters.
-    /// We simulate this by closing the peer's connection before sending.
+    ///
+    /// We force a deterministic failure by closing peer_a's own connection
+    /// BEFORE attempting the send: `Connection::send` has an early return
+    /// path that yields `PeerDisconnected` when `self.closed` is true, so
+    /// the send is guaranteed to fail without depending on duplex-buffer
+    /// timing.
     #[tokio::test]
     async fn test_peer_failed_send_does_not_increment_counters() {
         let metrics_a = Arc::new(OverlayMetrics::new());
         let metrics_b = Arc::new(OverlayMetrics::new());
-        let (mut peer_a, mut peer_b) =
+        let (mut peer_a, _peer_b) =
             make_authenticated_peer_pair(Arc::clone(&metrics_a), Arc::clone(&metrics_b));
 
-        // Drop the receiver half of the duplex by closing peer_b's connection.
-        // The next send on peer_a will get a write error (broken pipe).
-        peer_b.connection.close().await;
-        drop(peer_b);
+        // Close peer_a's connection. `Connection::send` will return
+        // `PeerDisconnected` immediately on the next call (deterministic).
+        peer_a.connection.close().await;
 
-        // Drain pending bytes on the receive side before triggering an error.
-        // tokio::io::duplex returns Err on send only after the buffer fills or
-        // the peer half is dropped — give it a chance.
-        let _ = tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let result = peer_a.send_hello().await;
+        assert!(
+            result.is_err(),
+            "send_hello must fail deterministically when local connection is closed, got: {:?}",
+            result
+        );
 
-        // Attempt a send. It may succeed (bytes go into the duplex buffer) or
-        // fail. We only assert that on failure, the success counters stay at 0.
-        match peer_a.send_hello().await {
-            Ok(()) => {
-                // If the buffer absorbed the write, that's still a successful
-                // I/O op; counters reflect it.
-                assert_eq!(metrics_a.async_write.get(), 1);
-                assert!(metrics_a.bytes_written.get() > 0);
-            }
-            Err(_) => {
-                // Failed send: success-only counters must remain zero.
-                assert_eq!(metrics_a.async_write.get(), 0);
-                assert_eq!(metrics_a.bytes_written.get(), 0);
-            }
-        }
+        // Success-only counters must remain at zero on the failure path.
+        assert_eq!(
+            metrics_a.async_write.get(),
+            0,
+            "async_write must not increment on failed send"
+        );
+        assert_eq!(
+            metrics_a.bytes_written.get(),
+            0,
+            "bytes_written must not increment on failed send"
+        );
     }
 
     /// Verify reset() includes the new Stage F.1 fields.

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -26,9 +26,11 @@ use crate::{
     codec::helpers,
     connection::{Connection, ConnectionDirection},
     flow_control::{msg_body_size, FlowControlConfig, INITIAL_PEER_FLOOD_READING_CAPACITY_BYTES},
+    metrics::OverlayMetrics,
     LocalNode, OverlayError, PeerAddress, PeerId, Result,
 };
 use dashmap::DashMap;
+use henyey_common::xdr_encoded_len;
 use parking_lot::RwLock;
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -203,6 +205,10 @@ pub struct Peer {
     auth: AuthContext,
     /// Statistics.
     stats: Arc<PeerStats>,
+    /// Shared overlay-wide metrics. The same `Arc` is held by `SharedPeerState`,
+    /// so per-peer increments aggregate into the overlay totals exposed via
+    /// `/metrics`.
+    metrics: Arc<OverlayMetrics>,
 }
 
 impl Peer {
@@ -216,6 +222,7 @@ impl Peer {
         addr: &PeerAddress,
         local_node: LocalNode,
         timeouts: crate::OutboundTimeouts,
+        metrics: Arc<OverlayMetrics>,
     ) -> Result<Self> {
         debug!("Connecting to peer: {}", addr);
 
@@ -240,6 +247,7 @@ impl Peer {
             connection,
             auth,
             stats: Arc::new(PeerStats::default()),
+            metrics,
         };
 
         // Perform handshake
@@ -265,6 +273,7 @@ impl Peer {
         auth_timeout_secs: u64,
         pending_peer_ids: Option<Arc<DashMap<PeerId, Instant>>>,
         initial_byte_grant: u32,
+        metrics: Arc<OverlayMetrics>,
     ) -> Result<Self> {
         let auth = AuthContext::new(local_node, true);
 
@@ -283,6 +292,7 @@ impl Peer {
             connection,
             auth,
             stats: Arc::new(PeerStats::default()),
+            metrics,
         };
 
         peer.handshake(
@@ -306,6 +316,7 @@ impl Peer {
         banned_peers: Arc<RwLock<HashSet<PeerId>>>,
         pending_peer_ids: Arc<DashMap<PeerId, Instant>>,
         initial_byte_grant: u32,
+        metrics: Arc<OverlayMetrics>,
     ) -> Result<Self> {
         debug!("Accepting peer from: {}", connection.remote_addr());
 
@@ -327,6 +338,7 @@ impl Peer {
             connection,
             auth,
             stats: Arc::new(PeerStats::default()),
+            metrics,
         };
 
         // Perform handshake (with ban + pending-dedup checks after HELLO for inbound)
@@ -505,6 +517,8 @@ impl Peer {
             .await?
             .ok_or_else(|| OverlayError::PeerDisconnected("no Hello received".to_string()))?;
         debug!("Received frame with {} bytes", frame.raw_len);
+        self.metrics.bytes_read.add(frame.raw_len as u64);
+        self.metrics.async_read.inc();
 
         let message = self.auth.unwrap_message(frame.message)?;
 
@@ -540,6 +554,8 @@ impl Peer {
             .recv_timeout(timeout_secs)
             .await?
             .ok_or_else(|| OverlayError::PeerDisconnected("no Auth received".to_string()))?;
+        self.metrics.bytes_read.add(frame.raw_len as u64);
+        self.metrics.async_read.inc();
 
         let message = self.auth.unwrap_message(frame.message)?;
 
@@ -631,21 +647,33 @@ impl Peer {
 
     /// Send a raw message (before authentication, e.g., Hello).
     async fn send_raw(&mut self, message: StellarMessage) -> Result<()> {
-        let size = msg_body_size(&message);
+        let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_unauthenticated(message);
+        let wire_size = xdr_encoded_len(&auth_msg) as u64;
         self.connection.send(auth_msg).await?;
+        // Success-only instrumentation: connection errors go to errors_write at
+        // the caller (peer_loop), not bytes_written/async_write.
+        self.metrics.bytes_written.add(wire_size);
+        self.metrics.async_write.inc();
         self.stats.messages_sent.fetch_add(1, Ordering::Relaxed);
-        self.stats.bytes_sent.fetch_add(size, Ordering::Relaxed);
+        self.stats
+            .bytes_sent
+            .fetch_add(body_size, Ordering::Relaxed);
         Ok(())
     }
 
     /// Send an Auth message (with MAC but sequence 0).
     async fn send_auth(&mut self, message: StellarMessage) -> Result<()> {
-        let size = msg_body_size(&message);
+        let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_auth_message(message)?;
+        let wire_size = xdr_encoded_len(&auth_msg) as u64;
         self.connection.send(auth_msg).await?;
+        self.metrics.bytes_written.add(wire_size);
+        self.metrics.async_write.inc();
         self.stats.messages_sent.fetch_add(1, Ordering::Relaxed);
-        self.stats.bytes_sent.fetch_add(size, Ordering::Relaxed);
+        self.stats
+            .bytes_sent
+            .fetch_add(body_size, Ordering::Relaxed);
         Ok(())
     }
 
@@ -660,11 +688,16 @@ impl Peer {
         let msg_type = helpers::message_type_name(&message);
         trace!("SEND {} to {}", msg_type, self.info.peer_id);
 
-        let size = msg_body_size(&message);
+        let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_message(message)?;
+        let wire_size = xdr_encoded_len(&auth_msg) as u64;
         self.connection.send(auth_msg).await?;
+        self.metrics.bytes_written.add(wire_size);
+        self.metrics.async_write.inc();
         self.stats.messages_sent.fetch_add(1, Ordering::Relaxed);
-        self.stats.bytes_sent.fetch_add(size, Ordering::Relaxed);
+        self.stats
+            .bytes_sent
+            .fetch_add(body_size, Ordering::Relaxed);
 
         Ok(())
     }
@@ -683,6 +716,11 @@ impl Peer {
             }
         };
 
+        // Success-only instrumentation: a frame was successfully decoded from
+        // the wire. Decode failures surface as `Err` from `connection.recv()`
+        // and are counted as `errors_read` by the peer loop.
+        self.metrics.bytes_read.add(frame.raw_len as u64);
+        self.metrics.async_read.inc();
         self.stats.messages_received.fetch_add(1, Ordering::Relaxed);
         self.stats
             .bytes_received
@@ -709,6 +747,8 @@ impl Peer {
             }
         };
 
+        self.metrics.bytes_read.add(frame.raw_len as u64);
+        self.metrics.async_read.inc();
         self.stats.messages_received.fetch_add(1, Ordering::Relaxed);
         self.stats
             .bytes_received
@@ -856,5 +896,247 @@ mod tests {
         let snapshot = stats.snapshot();
         assert_eq!(snapshot.messages_sent, 10);
         assert_eq!(snapshot.messages_received, 5);
+    }
+
+    /// Construct a `Peer` directly without going through a real handshake,
+    /// pre-set to `Authenticated` so `send()` and `recv()` will run their
+    /// instrumented bodies. Used by the byte/async-counter tests below.
+    fn make_authenticated_peer_pair(
+        metrics_a: Arc<OverlayMetrics>,
+        metrics_b: Arc<OverlayMetrics>,
+    ) -> (Peer, Peer) {
+        use crate::auth::AuthContext;
+        use crate::connection::Connection;
+        use henyey_crypto::SecretKey;
+
+        let (client, server) = tokio::io::duplex(1024 * 1024);
+        let addr_a: SocketAddr = "127.0.0.1:11625".parse().unwrap();
+        let addr_b: SocketAddr = "127.0.0.1:11626".parse().unwrap();
+        let conn_a = Connection::from_io(client, addr_a, ConnectionDirection::Outbound).unwrap();
+        let conn_b = Connection::from_io(server, addr_b, ConnectionDirection::Inbound).unwrap();
+
+        let local_a = LocalNode::new_testnet(SecretKey::generate());
+        let local_b = LocalNode::new_testnet(SecretKey::generate());
+        // Cross-wire the peers' AuthContexts so `wrap_unauthenticated` /
+        // `unwrap_message` agree on the unauthenticated framing. Authenticated
+        // frames are not exchanged here because `state == Authenticated` does
+        // not actually mean the MAC keys are derived — for that we'd need a
+        // full handshake. The tests in this module that call `peer.send()`
+        // therefore restrict themselves to the *unauthenticated* path
+        // (i.e., directly drive `Connection::send` via `Peer::send_raw`).
+        let auth_a = AuthContext::new(local_a, true);
+        let auth_b = AuthContext::new(local_b, false);
+
+        let peer_a = Peer {
+            info: PeerInfo {
+                peer_id: PeerId::from_bytes([0u8; 32]),
+                address: addr_b,
+                direction: ConnectionDirection::Outbound,
+                version_string: String::new(),
+                overlay_version: 0,
+                ledger_version: 0,
+                connected_at: Instant::now(),
+                original_address: None,
+            },
+            state: PeerState::Authenticated,
+            connection: conn_a,
+            auth: auth_a,
+            stats: Arc::new(PeerStats::default()),
+            metrics: metrics_a,
+        };
+        let peer_b = Peer {
+            info: PeerInfo {
+                peer_id: PeerId::from_bytes([0u8; 32]),
+                address: addr_a,
+                direction: ConnectionDirection::Inbound,
+                version_string: String::new(),
+                overlay_version: 0,
+                ledger_version: 0,
+                connected_at: Instant::now(),
+                original_address: None,
+            },
+            state: PeerState::Authenticated,
+            connection: conn_b,
+            auth: auth_b,
+            stats: Arc::new(PeerStats::default()),
+            metrics: metrics_b,
+        };
+        (peer_a, peer_b)
+    }
+
+    /// Verify that the byte and async I/O counters are zero on a fresh peer
+    /// — sanity check that adding the new fields didn't accidentally
+    /// initialize them with non-zero values.
+    #[test]
+    fn test_metrics_default_zero() {
+        let m = OverlayMetrics::new();
+        assert_eq!(m.bytes_read.get(), 0);
+        assert_eq!(m.bytes_written.get(), 0);
+        assert_eq!(m.async_read.get(), 0);
+        assert_eq!(m.async_write.get(), 0);
+        assert_eq!(m.inbound_attempt.get(), 0);
+        assert_eq!(m.inbound_establish.get(), 0);
+        assert_eq!(m.inbound_drop.get(), 0);
+        assert_eq!(m.inbound_reject.get(), 0);
+        assert_eq!(m.outbound_attempt.get(), 0);
+        assert_eq!(m.outbound_establish.get(), 0);
+        assert_eq!(m.outbound_drop.get(), 0);
+        assert_eq!(m.outbound_reject.get(), 0);
+    }
+
+    /// Drive a `send_raw` (HELLO-style unauthenticated) message from peer A to
+    /// peer B and assert that:
+    ///   - A's `bytes_written` and `async_write` increment by the wire size /
+    ///     1
+    ///   - B's `bytes_read` and `async_read` increment by the same wire size
+    ///     / 1
+    ///
+    /// This is the "happy-path" unit test for the new instrumentation.
+    #[tokio::test]
+    async fn test_peer_send_recv_metrics_increment() {
+        // Use `recv()` (authenticated) on peer B requires authenticated MAC
+        // keys, which we don't have without a full handshake. So we drive
+        // `send_raw` (unauthenticated) on A and `recv_hello` on B (which uses
+        // `connection.recv_timeout()` + `auth.unwrap_message`, where unwrap of
+        // an unauthenticated frame works without MAC).
+        let metrics_a = Arc::new(OverlayMetrics::new());
+        let metrics_b = Arc::new(OverlayMetrics::new());
+        let (mut peer_a, mut peer_b) =
+            make_authenticated_peer_pair(Arc::clone(&metrics_a), Arc::clone(&metrics_b));
+
+        // Send a HELLO via `send_hello` (which calls send_raw). This is the
+        // simplest unauthenticated path through the instrumented code.
+        peer_a.send_hello().await.expect("send_hello");
+
+        // On the receive side, the *connection* delivers the frame. We drive
+        // the lower-level path directly to avoid `recv_hello`'s unwrap, which
+        // also calls `process_hello` and may fail on duplicate/etc. checks.
+        let frame = peer_b
+            .connection
+            .recv()
+            .await
+            .expect("recv ok")
+            .expect("frame present");
+        // Manually mirror what recv_hello would do for the metrics part:
+        peer_b.metrics.bytes_read.add(frame.raw_len as u64);
+        peer_b.metrics.async_read.inc();
+
+        // Sender side: bytes_written / async_write incremented exactly once.
+        assert_eq!(metrics_a.async_write.get(), 1);
+        assert!(
+            metrics_a.bytes_written.get() > 0,
+            "expected bytes_written > 0, got {}",
+            metrics_a.bytes_written.get()
+        );
+
+        // Receiver side: counts the same wire bytes.
+        assert_eq!(metrics_b.async_read.get(), 1);
+        assert_eq!(
+            metrics_b.bytes_read.get(),
+            metrics_a.bytes_written.get(),
+            "wire-level byte counts must match between sender and receiver"
+        );
+    }
+
+    /// Verify that a failed send does NOT increment success-only counters.
+    /// We simulate this by closing the peer's connection before sending.
+    #[tokio::test]
+    async fn test_peer_failed_send_does_not_increment_counters() {
+        let metrics_a = Arc::new(OverlayMetrics::new());
+        let metrics_b = Arc::new(OverlayMetrics::new());
+        let (mut peer_a, mut peer_b) =
+            make_authenticated_peer_pair(Arc::clone(&metrics_a), Arc::clone(&metrics_b));
+
+        // Drop the receiver half of the duplex by closing peer_b's connection.
+        // The next send on peer_a will get a write error (broken pipe).
+        peer_b.connection.close().await;
+        drop(peer_b);
+
+        // Drain pending bytes on the receive side before triggering an error.
+        // tokio::io::duplex returns Err on send only after the buffer fills or
+        // the peer half is dropped — give it a chance.
+        let _ = tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Attempt a send. It may succeed (bytes go into the duplex buffer) or
+        // fail. We only assert that on failure, the success counters stay at 0.
+        match peer_a.send_hello().await {
+            Ok(()) => {
+                // If the buffer absorbed the write, that's still a successful
+                // I/O op; counters reflect it.
+                assert_eq!(metrics_a.async_write.get(), 1);
+                assert!(metrics_a.bytes_written.get() > 0);
+            }
+            Err(_) => {
+                // Failed send: success-only counters must remain zero.
+                assert_eq!(metrics_a.async_write.get(), 0);
+                assert_eq!(metrics_a.bytes_written.get(), 0);
+            }
+        }
+    }
+
+    /// Verify reset() includes the new Stage F.1 fields.
+    #[test]
+    fn test_metrics_reset_clears_stage_f1_fields() {
+        let m = OverlayMetrics::new();
+        m.bytes_read.add(100);
+        m.bytes_written.add(200);
+        m.async_read.inc();
+        m.async_write.inc();
+        m.inbound_attempt.inc();
+        m.inbound_establish.inc();
+        m.inbound_drop.inc();
+        m.inbound_reject.inc();
+        m.outbound_attempt.inc();
+        m.outbound_establish.inc();
+        m.outbound_drop.inc();
+        m.outbound_reject.inc();
+
+        m.reset();
+
+        assert_eq!(m.bytes_read.get(), 0);
+        assert_eq!(m.bytes_written.get(), 0);
+        assert_eq!(m.async_read.get(), 0);
+        assert_eq!(m.async_write.get(), 0);
+        assert_eq!(m.inbound_attempt.get(), 0);
+        assert_eq!(m.inbound_establish.get(), 0);
+        assert_eq!(m.inbound_drop.get(), 0);
+        assert_eq!(m.inbound_reject.get(), 0);
+        assert_eq!(m.outbound_attempt.get(), 0);
+        assert_eq!(m.outbound_establish.get(), 0);
+        assert_eq!(m.outbound_drop.get(), 0);
+        assert_eq!(m.outbound_reject.get(), 0);
+    }
+
+    /// Verify the snapshot includes all new Stage F.1 fields.
+    #[test]
+    fn test_metrics_snapshot_includes_stage_f1_fields() {
+        let m = OverlayMetrics::new();
+        m.bytes_read.add(123);
+        m.bytes_written.add(456);
+        m.async_read.add(7);
+        m.async_write.add(8);
+        m.inbound_attempt.add(11);
+        m.inbound_establish.add(12);
+        m.inbound_drop.add(13);
+        m.inbound_reject.add(14);
+        m.outbound_attempt.add(21);
+        m.outbound_establish.add(22);
+        m.outbound_drop.add(23);
+        m.outbound_reject.add(24);
+
+        let snap = m.snapshot();
+
+        assert_eq!(snap.bytes_read, 123);
+        assert_eq!(snap.bytes_written, 456);
+        assert_eq!(snap.async_read, 7);
+        assert_eq!(snap.async_write, 8);
+        assert_eq!(snap.inbound_attempt, 11);
+        assert_eq!(snap.inbound_establish, 12);
+        assert_eq!(snap.inbound_drop, 13);
+        assert_eq!(snap.inbound_reject, 14);
+        assert_eq!(snap.outbound_attempt, 21);
+        assert_eq!(snap.outbound_establish, 22);
+        assert_eq!(snap.outbound_drop, 23);
+        assert_eq!(snap.outbound_reject, 24);
     }
 }

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -30,7 +30,6 @@ use crate::{
     LocalNode, OverlayError, PeerAddress, PeerId, Result,
 };
 use dashmap::DashMap;
-use henyey_common::xdr_encoded_len;
 use parking_lot::RwLock;
 use std::collections::HashSet;
 use std::net::SocketAddr;
@@ -649,8 +648,9 @@ impl Peer {
     async fn send_raw(&mut self, message: StellarMessage) -> Result<()> {
         let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_unauthenticated(message);
-        let wire_size = xdr_encoded_len(&auth_msg) as u64;
-        self.connection.send(auth_msg).await?;
+        // `Connection::send` returns the on-the-wire frame size, so we don't
+        // need to re-encode the message here just to measure it.
+        let wire_size = self.connection.send(auth_msg).await?;
         // Success-only instrumentation: connection errors go to errors_write at
         // the caller (peer_loop), not bytes_written/async_write.
         self.metrics.bytes_written.add(wire_size);
@@ -666,8 +666,7 @@ impl Peer {
     async fn send_auth(&mut self, message: StellarMessage) -> Result<()> {
         let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_auth_message(message)?;
-        let wire_size = xdr_encoded_len(&auth_msg) as u64;
-        self.connection.send(auth_msg).await?;
+        let wire_size = self.connection.send(auth_msg).await?;
         self.metrics.bytes_written.add(wire_size);
         self.metrics.async_write.inc();
         self.stats.messages_sent.fetch_add(1, Ordering::Relaxed);
@@ -690,8 +689,7 @@ impl Peer {
 
         let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_message(message)?;
-        let wire_size = xdr_encoded_len(&auth_msg) as u64;
-        self.connection.send(auth_msg).await?;
+        let wire_size = self.connection.send(auth_msg).await?;
         self.metrics.bytes_written.add(wire_size);
         self.metrics.async_write.inc();
         self.stats.messages_sent.fetch_add(1, Ordering::Relaxed);

--- a/docs/henyey-monitoring-full.json
+++ b/docs/henyey-monitoring-full.json
@@ -687,11 +687,16 @@
     },
     {
       "id": 51,
-      "type": "text",
-      "title": "Byte Read/Write Rate — Coming in Stage F",
-      "description": "Panels 77-80 of 10334. Byte counters.",
+      "type": "timeseries",
+      "title": "Byte Read/Write Rate",
+      "description": "Wire-level bytes per second read from / written to peers (XDR-encoded AuthenticatedMessage size). Panels 77-78 of 10334.",
       "gridPos": {"h": 6, "w": 6, "x": 0, "y": 95},
-      "options": {"mode": "markdown", "content": "**Coming in Stage F** — `stellar_overlay_byte_{read,write}_total` and async I/O counters."}
+      "datasource": {"type": "prometheus", "uid": "000000001"},
+      "targets": [
+        {"expr": "rate(stellar_overlay_byte_read_total{instance=~\"$instance\"}[5m])", "legendFormat": "read"},
+        {"expr": "rate(stellar_overlay_byte_write_total{instance=~\"$instance\"}[5m])", "legendFormat": "write"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "Bps"}}
     },
     {
       "id": 52,
@@ -772,10 +777,72 @@
     {
       "id": 59,
       "type": "text",
-      "title": "Fetch/Flood/Item Fetcher/Send Counters — Coming in Stage F",
-      "description": "Panels 88-99 of 10334.",
+      "title": "Fetch/Flood/Item Fetcher/Send Counters — Coming in Stage F.2/F.3",
+      "description": "Panels 88-94 and 97-99 of 10334.",
       "gridPos": {"h": 6, "w": 12, "x": 0, "y": 107},
-      "options": {"mode": "markdown", "content": "**Coming in Stage F** — Overlay counters:\n- `stellar_overlay_fetch_{duplicate,unique}_recv_total`\n- `stellar_overlay_flood_{broadcast,duplicate_recv,unique_recv}_total`\n- `stellar_overlay_item_fetcher_next_peer_total`\n- `stellar_overlay_memory_flood_known`\n- `stellar_overlay_send_total{type=...}` (14 message types)\n- `stellar_overlay_{inbound,outbound}_{attempt,drop,establish,reject}_total`"}
+      "options": {"mode": "markdown", "content": "**Coming in Stage F.2/F.3** — Remaining overlay counters:\n- `stellar_overlay_fetch_{duplicate,unique}_recv_total`\n- `stellar_overlay_flood_{broadcast,duplicate_recv,unique_recv}_total`\n- `stellar_overlay_item_fetcher_next_peer_total`\n- `stellar_overlay_memory_flood_known`\n- `stellar_overlay_send_total{type=...}` (per-message-type counter)\n\n**Shipped in Stage F.1**: byte rate, async I/O rate, and connection lifecycle (rows below)."}
+    },
+    {
+      "id": 113,
+      "type": "timeseries",
+      "title": "Async I/O Rate (Reads/Writes per second)",
+      "description": "Successful per-frame send/recv I/O operations. Mirrors stellar-core mAsyncRead/mAsyncWrite. Panels 79-80 of 10334.",
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 113},
+      "datasource": {"type": "prometheus", "uid": "000000001"},
+      "targets": [
+        {"expr": "rate(stellar_overlay_async_read_total{instance=~\"$instance\"}[5m])", "legendFormat": "async_read"},
+        {"expr": "rate(stellar_overlay_async_write_total{instance=~\"$instance\"}[5m])", "legendFormat": "async_write"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "id": 114,
+      "type": "timeseries",
+      "title": "Inbound Connection Lifecycle Rate",
+      "description": "Inbound connection events per second: TCP accepts, full establishments, drops, and rejections. Panels 97-98 of 10334.",
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 113},
+      "datasource": {"type": "prometheus", "uid": "000000001"},
+      "targets": [
+        {"expr": "rate(stellar_overlay_inbound_attempt_total{instance=~\"$instance\"}[5m])", "legendFormat": "attempt"},
+        {"expr": "rate(stellar_overlay_inbound_establish_total{instance=~\"$instance\"}[5m])", "legendFormat": "establish"},
+        {"expr": "rate(stellar_overlay_inbound_drop_total{instance=~\"$instance\"}[5m])", "legendFormat": "drop"},
+        {"expr": "rate(stellar_overlay_inbound_reject_total{instance=~\"$instance\"}[5m])", "legendFormat": "reject"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "id": 115,
+      "type": "timeseries",
+      "title": "Outbound Connection Lifecycle Rate",
+      "description": "Outbound connection events per second: dial attempts, full establishments, drops, and rejections. Panels 97-98 of 10334.",
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 119},
+      "datasource": {"type": "prometheus", "uid": "000000001"},
+      "targets": [
+        {"expr": "rate(stellar_overlay_outbound_attempt_total{instance=~\"$instance\"}[5m])", "legendFormat": "attempt"},
+        {"expr": "rate(stellar_overlay_outbound_establish_total{instance=~\"$instance\"}[5m])", "legendFormat": "establish"},
+        {"expr": "rate(stellar_overlay_outbound_drop_total{instance=~\"$instance\"}[5m])", "legendFormat": "drop"},
+        {"expr": "rate(stellar_overlay_outbound_reject_total{instance=~\"$instance\"}[5m])", "legendFormat": "reject"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "id": 116,
+      "type": "stat",
+      "title": "Connection Lifecycle Totals (cumulative)",
+      "description": "Cumulative attempt/establish/drop/reject counts since process start. Useful for spotting churn or runaway-rejection patterns.",
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 119},
+      "datasource": {"type": "prometheus", "uid": "000000001"},
+      "targets": [
+        {"expr": "stellar_overlay_inbound_attempt_total{instance=~\"$instance\"}", "legendFormat": "in attempt"},
+        {"expr": "stellar_overlay_inbound_establish_total{instance=~\"$instance\"}", "legendFormat": "in establish"},
+        {"expr": "stellar_overlay_inbound_reject_total{instance=~\"$instance\"}", "legendFormat": "in reject"},
+        {"expr": "stellar_overlay_inbound_drop_total{instance=~\"$instance\"}", "legendFormat": "in drop"},
+        {"expr": "stellar_overlay_outbound_attempt_total{instance=~\"$instance\"}", "legendFormat": "out attempt"},
+        {"expr": "stellar_overlay_outbound_establish_total{instance=~\"$instance\"}", "legendFormat": "out establish"},
+        {"expr": "stellar_overlay_outbound_reject_total{instance=~\"$instance\"}", "legendFormat": "out reject"},
+        {"expr": "stellar_overlay_outbound_drop_total{instance=~\"$instance\"}", "legendFormat": "out drop"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "short"}}
     },
     {
       "id": 60,

--- a/docs/henyey-monitoring-full.json
+++ b/docs/henyey-monitoring-full.json
@@ -783,7 +783,7 @@
       "options": {"mode": "markdown", "content": "**Coming in Stage F.2/F.3** — Remaining overlay counters:\n- `stellar_overlay_fetch_{duplicate,unique}_recv_total`\n- `stellar_overlay_flood_{broadcast,duplicate_recv,unique_recv}_total`\n- `stellar_overlay_item_fetcher_next_peer_total`\n- `stellar_overlay_memory_flood_known`\n- `stellar_overlay_send_total{type=...}` (per-message-type counter)\n\n**Shipped in Stage F.1**: byte rate, async I/O rate, and connection lifecycle (rows below)."}
     },
     {
-      "id": 113,
+      "id": 273,
       "type": "timeseries",
       "title": "Async I/O Rate (Reads/Writes per second)",
       "description": "Successful per-frame send/recv I/O operations. Mirrors stellar-core mAsyncRead/mAsyncWrite. Panels 79-80 of 10334.",
@@ -796,7 +796,7 @@
       "fieldConfig": {"defaults": {"unit": "ops"}}
     },
     {
-      "id": 114,
+      "id": 274,
       "type": "timeseries",
       "title": "Inbound Connection Lifecycle Rate",
       "description": "Inbound connection events per second: TCP accepts, full establishments, drops, and rejections. Panels 97-98 of 10334.",
@@ -811,7 +811,7 @@
       "fieldConfig": {"defaults": {"unit": "ops"}}
     },
     {
-      "id": 115,
+      "id": 275,
       "type": "timeseries",
       "title": "Outbound Connection Lifecycle Rate",
       "description": "Outbound connection events per second: dial attempts, full establishments, drops, and rejections. Panels 97-98 of 10334.",
@@ -826,7 +826,7 @@
       "fieldConfig": {"defaults": {"unit": "ops"}}
     },
     {
-      "id": 116,
+      "id": 276,
       "type": "stat",
       "title": "Connection Lifecycle Totals (cumulative)",
       "description": "Cumulative attempt/establish/drop/reject counts since process start. Useful for spotting churn or runaway-rejection patterns.",
@@ -868,7 +868,7 @@
       "type": "row",
       "title": "Overlay Operation Duration",
       "collapsed": true,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 113},
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 125},
       "id": 113,
       "panels": [
         {

--- a/docs/metrics-mapping.md
+++ b/docs/metrics-mapping.md
@@ -72,6 +72,18 @@ Metrics with the `stellar_` prefix that directly mirror stellar-core Medida coun
 | `OVERLAY_OUTBOUND_AUTHENTICATED` | `stellar_overlay_outbound_authenticated` | gauge | Authenticated outbound peer count |
 | `OVERLAY_INBOUND_PENDING` | `stellar_overlay_inbound_pending` | gauge | Pending inbound connections |
 | `OVERLAY_OUTBOUND_PENDING` | `stellar_overlay_outbound_pending` | gauge | Pending outbound connections |
+| `OVERLAY_BYTE_READ_TOTAL` | `stellar_overlay_byte_read_total` | counter | `OverlayManagerImpl::mByteRead` — wire-level bytes read from peers (XDR-encoded `AuthenticatedMessage` size, excludes 4-byte length header). |
+| `OVERLAY_BYTE_WRITE_TOTAL` | `stellar_overlay_byte_write_total` | counter | `OverlayManagerImpl::mByteWrite` — wire-level bytes written to peers (same encoding as read side). |
+| `OVERLAY_ASYNC_READ_TOTAL` | `stellar_overlay_async_read_total` | counter | `OverlayManagerImpl::mAsyncRead` — successful per-frame recv I/O operations. |
+| `OVERLAY_ASYNC_WRITE_TOTAL` | `stellar_overlay_async_write_total` | counter | `OverlayManagerImpl::mAsyncWrite` — successful per-frame send I/O operations. |
+| `OVERLAY_INBOUND_ATTEMPT_TOTAL` | `stellar_overlay_inbound_attempt_total` | counter | Henyey-specific — TCP `listener.accept()` Ok events. |
+| `OVERLAY_INBOUND_ESTABLISH_TOTAL` | `stellar_overlay_inbound_establish_total` | counter | Henyey-specific — inbound peers fully registered after handshake. |
+| `OVERLAY_INBOUND_DROP_TOTAL` | `stellar_overlay_inbound_drop_total` | counter | Henyey-specific — inbound peer disconnections (`run_peer_loop` returned). |
+| `OVERLAY_INBOUND_REJECT_TOTAL` | `stellar_overlay_inbound_reject_total` | counter | Henyey-specific — inbound connections rejected before establishment (handshake fail, banned, duplicate, slots full). |
+| `OVERLAY_OUTBOUND_ATTEMPT_TOTAL` | `stellar_overlay_outbound_attempt_total` | counter | Henyey-specific — outbound dial initiated. |
+| `OVERLAY_OUTBOUND_ESTABLISH_TOTAL` | `stellar_overlay_outbound_establish_total` | counter | Henyey-specific — outbound peers fully registered after handshake. |
+| `OVERLAY_OUTBOUND_DROP_TOTAL` | `stellar_overlay_outbound_drop_total` | counter | Henyey-specific — outbound peer disconnections. |
+| `OVERLAY_OUTBOUND_REJECT_TOTAL` | `stellar_overlay_outbound_reject_total` | counter | Henyey-specific — outbound connections rejected before establishment (TCP fail, handshake fail, banned, duplicate, slots full). |
 | `BUCKET_MERGE_COMPLETED_TOTAL` | `stellar_bucket_merge_completed_total` | counter | `BucketManager::mMergesCompleted` |
 | `BUCKET_MERGE_TIME_US_TOTAL` | `stellar_bucket_merge_time_us_total` | counter | Cumulative merge time μs |
 | `BUCKET_MERGE_NEW_LIVE_TOTAL` | `stellar_bucket_merge_new_live_total` | counter | Live entries produced by merges |


### PR DESCRIPTION
## Summary

First sub-PR for Stage F (issue #2236, parent #2231). This ships the F.1 split — the foundational byte/async-I/O counters (re-added with real producers, replacing the stub entries removed earlier) plus the connection lifecycle counters. F.2 (flood/fetch/item-fetcher) and F.3 (per-message-type send counter) will ship as follow-up issues.

### What ships

- **Byte counters** (re-added with producers in `Peer`):
  - `stellar_overlay_byte_read_total` / `_write_total` — wire-level XDR bytes (AuthenticatedMessage size, excludes 4-byte length header).
- **Async I/O counters** (mirrors stellar-core mAsyncRead / mAsyncWrite):
  - `stellar_overlay_async_read_total` / `_write_total` — per-frame successful I/O ops.
- **Connection lifecycle counters** (Henyey-specific operational observability, 8 new counters):
  - `stellar_overlay_{inbound,outbound}_{attempt,establish,drop,reject}_total`
  - Lifecycle: every TCP accept / dial → `attempt`. Handshake-then-register success → `establish`. `run_peer_loop` returns → `drop`. Any rejection between attempt and establish → `reject` (covers 14+ rejection paths).
- **Dashboard** (`docs/henyey-monitoring-full.json`):
  - Replaces the first \"Coming in Stage F\" placeholder (id 51) with a real Byte Read/Write Rate timeseries.
  - Adds 4 new panels (ids 273-276): Async I/O Rate, Inbound/Outbound Lifecycle Rates, Cumulative Lifecycle Totals.
  - Narrows the second placeholder (id 59) to F.2/F.3 scope only.
- **`docs/metrics-mapping.md`** — added all 12 new metrics with stellar-core / Henyey-specific notes.
- **`crates/app/src/metrics.rs`**:
  - Registers and pre-registers all 12 counters.
  - Wires the new snapshot fields in `refresh_gauges`.
  - Drops `byte_read_total` / `byte_write_total` from `test_removed_overlay_metrics_absent` (they're now produced).

### Plumbing

- `Arc<OverlayMetrics>` is threaded through `Peer::accept`, `Peer::connect_with_connection`, and `Peer::connect` from `SharedPeerState::metrics`. Stored as a field on `Peer` so per-peer increments aggregate into the overlay totals.
- Send-path instrumentation in `Peer::{send_raw, send_auth, send}` is success-only (after `connection.send().await?` succeeds). Failures route to the existing `errors_write` at the peer-loop layer.
- Recv-path instrumentation in `Peer::{recv, recv_timeout, recv_hello, recv_auth}` uses `frame.raw_len` (consistent with the existing `bytes_received` accounting on `PeerStats`).

### Test plan

- [x] `cargo test -p henyey-overlay --tests` — 313 unit + 8 item_fetcher + 2 SCP integration tests pass, including the new tests.
- [x] `cargo test -p henyey-app --tests` — 755 unit + 1 doc test pass, including the new Stage F.1 catalog tests.
- [x] `cargo build --workspace` clean.
- [x] `cargo fmt -- --check` clean on touched crates.
- [x] `cargo clippy -p henyey-overlay -p henyey-app --lib` clean. (One pre-existing test-only `match_single_binding` lint in `manager/mod.rs:2761` is on origin/main, not in this PR.)

#### New tests added
- `peer.rs::test_metrics_default_zero` — sanity that all new fields default to 0.
- `peer.rs::test_peer_send_recv_metrics_increment` — happy path: send_hello bumps async_write + bytes_written on sender, async_read + bytes_read on receiver, with matching wire sizes.
- `peer.rs::test_peer_failed_send_does_not_increment_counters` — verifies success-only semantics on a closed connection.
- `peer.rs::test_metrics_reset_clears_stage_f1_fields` — `reset()` clears all new fields.
- `peer.rs::test_metrics_snapshot_includes_stage_f1_fields` — snapshot includes all new fields.
- `manager/connection.rs::test_connection_lifecycle_counters_on_handshake_success` — full two-manager loopback handshake; asserts attempt/establish/drop on both initiator and acceptor.
- `manager/connection.rs::test_stalled_*_uses_*_timeout` (existing tests extended) — assert outbound_attempt + outbound_reject on handshake/connect-fail paths.
- `app/src/metrics.rs::test_stage_f1_overlay_byte_async_counters_in_catalog` — all 12 new counters present in `ALL_COUNTER_NAMES`.
- `app/src/metrics.rs::test_stage_f1_overlay_counters_preregistered_at_zero` — all 12 visible at 0 on first scrape.

### Refs
- Parent: #2231
- Issue: #2236 (this PR ships the F.1 split; F.2 and F.3 will be filed as follow-up issues)
- Sibling stages B/C/D/E: #2232, #2233, #2234, #2235

🤖 Generated with [Claude Code](https://claude.com/claude-code)