### PR TITLE
Consolidate upload module with RemoteArchive async abstraction

### DIFF
--- a/crates/app/src/app/publish.rs
+++ b/crates/app/src/app/publish.rs
@@ -107,6 +107,13 @@ impl App {
             "Publishing checkpoint to history archive (background)"
         );
 
+        // Capture the runtime handle so the blocking task can drive the
+        // async upload path via `Handle::block_on`. `spawn_blocking` runs on
+        // the runtime's blocking pool, where `Handle::current()` is valid,
+        // but threading the handle explicitly makes the dependency visible
+        // and works from non-async test entry points too.
+        let rt = tokio::runtime::Handle::current();
+
         // Spawn the publish as a background task to avoid blocking the
         // event loop. Publishing involves gzip compression of XDR files
         // and shell command execution (cp/mkdir), which can take 30-50
@@ -128,7 +135,7 @@ impl App {
             // the process (release builds use `panic = "abort"`) and are not
             // counted here.
             let publish_started = std::time::Instant::now();
-            match app.publish_single_checkpoint(checkpoint, &command_archives) {
+            match app.publish_single_checkpoint(checkpoint, &command_archives, &rt) {
                 Ok(()) => {
                     let elapsed = publish_started.elapsed();
                     crate::metrics::HISTORY_PUBLISH_SUCCESS_TOTAL.increment(1);
@@ -173,6 +180,7 @@ impl App {
         &self,
         checkpoint: u32,
         archives: &[&crate::config::HistoryArchiveEntry],
+        rt: &tokio::runtime::Handle,
     ) -> anyhow::Result<()> {
         #[cfg(test)]
         if self.publish_panic_inject.swap(false, Ordering::SeqCst) {
@@ -342,8 +350,17 @@ impl App {
         // skip bucket files already present. Falls back to full upload on error.
         let base_plan = henyey_history::upload::UploadPlan::from_staging_dir(&publish_dir)?;
         for archive in archives {
-            let put_cmd = archive.put.as_ref().unwrap();
-            let mkdir_cmd = archive.mkdir.as_deref();
+            // Build a `RemoteArchive` per command-based archive. `put` is
+            // guaranteed `Some` here by the caller's filter
+            // (`a.put_enabled && a.put.is_some()`); `get_cmd` is `None`
+            // because publish is write-only.
+            let remote_archive =
+                henyey_history::RemoteArchive::new(henyey_history::RemoteArchiveConfig {
+                    name: archive.name.clone(),
+                    put_cmd: archive.put.clone(),
+                    mkdir_cmd: archive.mkdir.clone(),
+                    get_cmd: None,
+                });
 
             let plan = match henyey_history::archive::fetch_root_has_blocking(&archive.url) {
                 Ok(remote_has) => {
@@ -375,7 +392,11 @@ impl App {
                 }
             };
 
-            plan.execute(put_cmd, mkdir_cmd)?;
+            // Drive the async upload path from this blocking task via the
+            // captured runtime handle. `Handle::block_on` is the documented
+            // correct pattern from a `spawn_blocking` worker (no nested
+            // runtime is created).
+            rt.block_on(plan.execute(&remote_archive))?;
         }
 
         // Clean up staging directory (TempDir drops silently on error paths;

--- a/crates/henyey/src/publish_history.rs
+++ b/crates/henyey/src/publish_history.rs
@@ -318,7 +318,14 @@ pub(crate) async fn cmd_publish_history(config: AppConfig, force: bool) -> anyho
             write_scp_history_file(publish_dir, checkpoint, &scp_entries)?;
             let plan = henyey_history::upload::UploadPlan::from_staging_dir(publish_dir)?;
             for archive in &command_targets {
-                plan.execute(&archive.put, archive.mkdir.as_deref())?;
+                let remote_archive =
+                    henyey_history::RemoteArchive::new(henyey_history::RemoteArchiveConfig {
+                        name: archive.name.clone(),
+                        put_cmd: Some(archive.put.clone()),
+                        mkdir_cmd: archive.mkdir.clone(),
+                        get_cmd: None,
+                    });
+                plan.execute(&remote_archive).await?;
                 println!("OK (command: {})", archive.name);
                 published_any = true;
             }

--- a/crates/history/src/remote_archive.rs
+++ b/crates/history/src/remote_archive.rs
@@ -105,6 +105,15 @@ impl RemoteArchive {
         self.config.is_readable()
     }
 
+    /// Check if this archive has a mkdir command configured.
+    ///
+    /// Callers that want to skip mkdir entirely when no command is set
+    /// (rather than receiving `HistoryError::RemoteNotConfigured` from
+    /// [`Self::mkdir`]) should gate on this accessor.
+    pub fn has_mkdir(&self) -> bool {
+        self.config.mkdir_cmd.is_some()
+    }
+
     /// Format a command template by replacing placeholders.
     ///
     /// Placeholders are `{0}`, `{1}`, etc.

--- a/crates/history/src/upload.rs
+++ b/crates/history/src/upload.rs
@@ -34,7 +34,8 @@
 //! that references files not yet present on the archive.
 
 use crate::archive_state::HistoryArchiveState;
-use crate::{paths, HistoryError, Result};
+use crate::remote_archive::RemoteArchive;
+use crate::{paths, Result};
 use henyey_common::Hash256;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -230,39 +231,40 @@ impl UploadPlan {
         &self.entries
     }
 
-    /// Execute the upload plan via shell commands.
+    /// Execute the upload plan against a [`RemoteArchive`].
     ///
-    /// For each entry, creates the remote parent directory (if `mkdir_cmd` is
-    /// provided) and uploads the file using `put_cmd`.
-    ///
-    /// Command templates use positional placeholders:
-    /// - `put_cmd`: `{0}` = local path, `{1}` = remote path
-    /// - `mkdir_cmd`: `{0}` = remote directory
+    /// For each entry, creates the remote parent directory (if the archive
+    /// has a mkdir command configured) and uploads the file using the
+    /// archive's put command. Parent directories created during this plan
+    /// are deduplicated via an internal `HashSet`.
     ///
     /// If any upload fails, execution stops immediately. Because entries are
     /// sorted with `RootHas` last, a failure in any earlier file guarantees
     /// the root HAS is never uploaded.
-    pub fn execute(&self, put_cmd: &str, mkdir_cmd: Option<&str>) -> Result<()> {
-        use std::collections::HashSet;
-        let mut created_dirs = HashSet::new();
+    ///
+    /// Note: [`RemoteArchive::put_file`] returns [`HistoryError::NotFound`]
+    /// (not [`HistoryError::RemoteCommandFailed`]) if a staged local file is
+    /// missing. In production this is unreachable because staging directories
+    /// always contain the files referenced by the plan.
+    pub async fn execute(&self, archive: &RemoteArchive) -> Result<()> {
+        let mut created_dirs: HashSet<String> = HashSet::new();
+        let mkdir_enabled = archive.has_mkdir();
 
         for entry in &self.entries {
-            // Create remote parent directory if needed.
-            if let Some(mkdir) = mkdir_cmd {
+            // Create remote parent directory if needed (and configured).
+            if mkdir_enabled {
                 if let Some(parent) = Path::new(&entry.remote_path).parent() {
                     let parent_str = path_to_unix_string(parent);
                     if !parent_str.is_empty() && created_dirs.insert(parent_str.clone()) {
-                        let cmd = mkdir.replace("{0}", &parent_str);
-                        run_shell_command(&cmd)?;
+                        archive.mkdir(&parent_str).await?;
                     }
                 }
             }
 
             // Upload the file.
-            let cmd = put_cmd
-                .replace("{0}", entry.local_path.to_string_lossy().as_ref())
-                .replace("{1}", &entry.remote_path);
-            run_shell_command(&cmd)?;
+            archive
+                .put_file(&entry.local_path, &entry.remote_path)
+                .await?;
         }
 
         Ok(())
@@ -297,26 +299,22 @@ pub fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-/// Execute a shell command and return an error if it fails.
-fn run_shell_command(cmd: &str) -> Result<()> {
-    use std::process::Command;
-
-    let output = Command::new("sh").arg("-c").arg(cmd).output()?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(HistoryError::RemoteCommandFailed {
-            command: cmd.to_string(),
-            exit_code: output.status.code(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::remote_archive::RemoteArchiveConfig;
+    use crate::HistoryError;
     use std::fs;
+
+    /// Build a `RemoteArchive` from raw shell command templates for tests.
+    fn test_archive(put_cmd: Option<&str>, mkdir_cmd: Option<&str>) -> RemoteArchive {
+        RemoteArchive::new(RemoteArchiveConfig {
+            name: "test".to_string(),
+            put_cmd: put_cmd.map(str::to_string),
+            mkdir_cmd: mkdir_cmd.map(str::to_string),
+            get_cmd: None,
+        })
+    }
 
     // Full 64-hex hashes for bucket test files.
     const BUCKET_HASH_A: &str = "aabbccdd00000000000000000000000000000000000000000000000000000000";
@@ -591,8 +589,8 @@ mod tests {
         HistoryArchiveState::new_for_testing(63, levels)
     }
 
-    #[test]
-    fn execute_uploads_in_correct_order() {
+    #[tokio::test]
+    async fn execute_uploads_in_correct_order() {
         let dir = tempfile::tempdir().unwrap();
         create_staging_dir(dir.path());
         let log_file = dir.path().join("upload-order.log");
@@ -600,7 +598,8 @@ mod tests {
         let plan = UploadPlan::from_staging_dir(dir.path()).unwrap();
 
         let put_cmd = format!("echo {{1}} >> {}", log_file.display());
-        plan.execute(&put_cmd, None).unwrap();
+        let archive = test_archive(Some(&put_cmd), None);
+        plan.execute(&archive).await.unwrap();
 
         let log = fs::read_to_string(&log_file).unwrap();
         let uploaded: Vec<&str> = log.lines().collect();
@@ -632,8 +631,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn execute_failure_prevents_root_has_upload() {
+    #[tokio::test]
+    async fn execute_failure_prevents_root_has_upload() {
         let dir = tempfile::tempdir().unwrap();
         create_staging_dir(dir.path());
         let log_file = dir.path().join("upload-order.log");
@@ -653,7 +652,8 @@ mod tests {
             log_file.display()
         );
 
-        let result = plan.execute(&put_cmd, None);
+        let archive = test_archive(Some(&put_cmd), None);
+        let result = plan.execute(&archive).await;
         assert!(result.is_err(), "upload should fail");
 
         if log_file.exists() {
@@ -665,8 +665,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn execute_creates_directories_before_upload() {
+    #[tokio::test]
+    async fn execute_creates_directories_before_upload() {
         let dir = tempfile::tempdir().unwrap();
         create_staging_dir(dir.path());
         let log_file = dir.path().join("cmd-order.log");
@@ -676,7 +676,8 @@ mod tests {
         let put_cmd = format!("echo PUT {{1}} >> {}", log_file.display());
         let mkdir_cmd = format!("echo MKDIR {{0}} >> {}", log_file.display());
 
-        plan.execute(&put_cmd, Some(&mkdir_cmd)).unwrap();
+        let archive = test_archive(Some(&put_cmd), Some(&mkdir_cmd));
+        plan.execute(&archive).await.unwrap();
 
         let log = fs::read_to_string(&log_file).unwrap();
         let lines: Vec<&str> = log.lines().collect();
@@ -699,5 +700,73 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[tokio::test]
+    async fn execute_propagates_remote_archive_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        create_staging_dir(dir.path());
+        let plan = UploadPlan::from_staging_dir(dir.path()).unwrap();
+
+        // put_cmd always fails with exit 7. The local files exist (so the
+        // pre-check in `put_file` passes) and the shell command propagates
+        // its exit code through `HistoryError::RemoteCommandFailed`.
+        let archive = test_archive(Some("exit 7"), None);
+        let err = plan.execute(&archive).await.expect_err("should fail");
+        match err {
+            HistoryError::RemoteCommandFailed { exit_code, .. } => {
+                assert_eq!(exit_code, Some(7));
+            }
+            other => panic!("expected RemoteCommandFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_skips_mkdir_when_unconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        create_staging_dir(dir.path());
+        let log_file = dir.path().join("upload.log");
+        let plan = UploadPlan::from_staging_dir(dir.path()).unwrap();
+        let expected_uploads = plan.entries().len();
+
+        // No mkdir command — every entry must still upload without error.
+        let put_cmd = format!("echo {{1}} >> {}", log_file.display());
+        let archive = test_archive(Some(&put_cmd), None);
+        plan.execute(&archive).await.unwrap();
+
+        let log = fs::read_to_string(&log_file).unwrap();
+        let lines: Vec<&str> = log.lines().collect();
+        assert_eq!(
+            lines.len(),
+            expected_uploads,
+            "all entries must be uploaded even when mkdir is unconfigured"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_reports_missing_local_file() {
+        let dir = tempfile::tempdir().unwrap();
+        create_staging_dir(dir.path());
+        let log_file = dir.path().join("upload.log");
+        let plan = UploadPlan::from_staging_dir(dir.path()).unwrap();
+
+        // Delete the first entry's local file. RemoteArchive::put_file's
+        // pre-check fires before the shell command runs, returning
+        // `HistoryError::NotFound`. No subsequent entry should be uploaded.
+        let victim = plan.entries().first().expect("plan is non-empty");
+        fs::remove_file(&victim.local_path).unwrap();
+
+        let put_cmd = format!("echo {{1}} >> {}", log_file.display());
+        let archive = test_archive(Some(&put_cmd), None);
+        let err = plan.execute(&archive).await.expect_err("should fail");
+        assert!(
+            matches!(err, HistoryError::NotFound(_)),
+            "expected HistoryError::NotFound, got {err:?}"
+        );
+
+        assert!(
+            !log_file.exists(),
+            "no entry should be uploaded after the pre-check failure"
+        );
     }
 }


### PR DESCRIPTION
Closes #2728

## Summary

Migrate `UploadPlan::execute` to async and accept a `&RemoteArchive` instead of raw `put_cmd`/`mkdir_cmd` shell-command templates. Port both publish callers (`crates/app/src/app/publish.rs` and `crates/henyey/src/publish_history.rs`) and delete the redundant sync `run_shell_command` helper in `upload.rs`. This consolidates the two parallel command-execution stacks introduced alongside #2679: `RemoteArchive` now owns all shell exec / format / error mapping, while `UploadPlan` retains ordering, mkdir deduplication, and stop-on-first-failure semantics.

A new `RemoteArchive::has_mkdir()` accessor preserves the "mkdir optional" semantics from the old `Option<&str>` signature (rather than letting `mkdir` return `RemoteNotConfigured`). The async/sync bridge in `app/publish.rs` captures `Handle::current()` in the async caller and threads it into `publish_single_checkpoint`, which calls `rt.block_on(plan.execute(&remote_archive))` from `spawn_blocking` — the documented, panic-free pattern.

Shell commands invoked, error variants surfaced on the production path, and ordering invariants (data → CheckpointHas → RootHas) are all unchanged. The one documented strictness increase: `RemoteArchive::put_file` pre-checks that the local file exists, returning `HistoryError::NotFound` instead of letting the shell fail with `RemoteCommandFailed`. Unreachable in production because staging dirs always contain the referenced files; documented in a comment on `execute`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2728#issuecomment-4463608422)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo test -p henyey-history --lib` — 480 passed
- [x] `cargo test -p henyey-history --tests` — all green (including 3 converted + 3 new `execute_*` tests)
- [x] `cargo test -p henyey-app --tests` — 921 + integration tests passed (exercises the new `spawn_blocking → Handle::block_on(plan.execute)` bridge end-to-end via `maybe_publish_history`)
- [x] `cargo test -p henyey --tests` — green (exercises the async CLI path in `cmd_publish_history`)

## Deviations from plan

None.
