### PR TITLE
Reframe checkpoint-boundary comment in catchup replay test

### DIFF
--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -749,9 +749,20 @@ mod tests {
 
     #[test]
     fn test_knit_lcl_at_checkpoint_boundary() {
-        // When LCL is the LAST ledger of its checkpoint (seq == 63, 127, ...),
-        // LCL-1 lives in the same checkpoint, so it IS available in the
-        // current download. Case 2 fires normally.
+        // This test exercises the pure decision function only — it has no
+        // checkpoint awareness, so any LCL seq is a valid input. LCL=127
+        // is chosen here for convenience; we are NOT asserting anything
+        // about which checkpoint file LCL-1 actually lives in.
+        //
+        // Separate note about the surrounding download path (not exercised
+        // here): with checkpoint frequency 64, LCL-1 is only visible in the
+        // LCL+1 download when LCL and LCL-1 share the LCL+1 checkpoint
+        // file. That holds for e.g. LCL=100 ([64..127], LCL+1=101 still in
+        // the same checkpoint), but NOT for LCL=127 — there LCL=127 is the
+        // last ledger of checkpoint K=127 ([64..127]) and LCL+1=128 starts
+        // a new checkpoint K=191 ([128..191]), so neither LCL nor LCL-1
+        // appear in the LCL+1 download file. The decision function still
+        // returns Skip for the case 2 input regardless.
         let lcl = make_test_lcl(127, h(0x10), h(0x09));
         let entry_at_lcl_minus_1 = make_test_entry(126, h(0x09), h(0x08));
         assert_eq!(


### PR DESCRIPTION
Closes #2735

## Summary

Rewrites a misleading comment in `test_knit_lcl_at_checkpoint_boundary` (`crates/history/src/catchup/replay.rs`). The old comment claimed that when LCL is the last ledger of its checkpoint (e.g. seq 127), LCL-1 lives in the same checkpoint download. That is incorrect — with checkpoint frequency 64, LCL=127 ends checkpoint K=127 ([64..127]) and LCL+1=128 starts a new checkpoint K=191 ([128..191]), so neither LCL nor LCL-1 appears in the LCL+1 download file.

The test still passes because `knit_to_lcl_decision` is a pure decision function with no checkpoint awareness. The new comment makes that explicit and adds a separate note about the actual download-path constraint (e.g. LCL=100 is a case where LCL-1 *does* share the LCL+1 checkpoint).

Comment-only change. No behavior, no parity, no test logic changes.

## Plan reference

Trivial short-circuit via [Triage Report](https://github.com/stellar-experimental/henyey/issues/2735#issuecomment-4464479052) — no separate `/plan` was needed.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-history --lib catchup::replay::tests` — 19/19 pass, including `test_knit_lcl_at_checkpoint_boundary`

## Deviations from plan

None.

🤖 Generated with GitHub Copilot CLI