### PR TITLE
Drop redundant hash compute for synthetic virtual_entry in knit-to-LCL apply path

### DIFF
--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -185,14 +185,12 @@ impl CatchupManager {
         }
         if let Some(first) = apply_data.first() {
             let header = first.header().clone();
-            let entry_hash = henyey_ledger::compute_header_hash(&header).map_err(|e| {
-                HistoryError::CatchupFailed(format!(
-                    "Failed to compute header hash for ledger {}: {}",
-                    header.ledger_seq, e
-                ))
-            })?;
+            // `knit_to_lcl_decision` only reads `header.previous_ledger_hash` on
+            // the case-4 (Apply) branch exercised here, so the entry hash is
+            // unused. Use a zero placeholder rather than recomputing the header
+            // hash for a synthetic entry that we discard immediately.
             let virtual_entry = LedgerHeaderHistoryEntry {
-                hash: entry_hash.into(),
+                hash: stellar_xdr::curr::Hash([0; 32]),
                 header,
                 ext: Default::default(),
             };

--- a/crates/history/src/verify.rs
+++ b/crates/history/src/verify.rs
@@ -2204,7 +2204,7 @@ mod tests {
         // doesn't match hash(lower[126]).
         upper[0].previous_ledger_hash = stellar_xdr::curr::Hash([0xDD; 32]);
 
-        let mut headers: Vec<_> = lower.into_iter().chain(upper.into_iter()).collect();
+        let mut headers: Vec<_> = lower.into_iter().chain(upper).collect();
         // Re-compute internal chain for upper group: header 129's prev must
         // match hash of (tampered) header 128, etc. Use make_chain's approach.
         for i in 128..headers.len() {


### PR DESCRIPTION
Closes #2736

## Summary

The synthetic `virtual_entry` built in `verify_knit_to_lcl` is only used to drive `knit_to_lcl_decision` through its case-4 (Apply) branch, which reads `header.previous_ledger_hash` but never the entry's own `hash` field. Computing the header hash here was wasted work (and a fallible call requiring error mapping). Replace it with a zero-hash placeholder and drop the `compute_header_hash` call along with its error branch.

## Plan reference

Triage report on the issue (trivial short-circuit / no separate plan comment): [Triage report](https://github.com/stellar-experimental/henyey/issues/2736#issuecomment-).

Origin: review comment https://github.com/stellar-experimental/henyey/pull/2732#discussion_r3251387618

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-history --all-targets -- -D warnings`
- [x] `cargo test -p henyey-history` (all targets) — green

## Deviations from plan

- Fixed one trivial pre-existing `clippy::useless_conversion` lint in `crates/history/src/verify.rs` (line 2207) that was blocking `cargo clippy -D warnings` on the touched crate. One-line change (`upper.into_iter()` → `upper`); functionally a no-op.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)