### PR TITLE
Implement skipFirstCheckpointSinceItIsIncomplete parity

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -310,6 +310,7 @@ impl App {
                 header: final_header.clone(),
                 header_xdr,
                 has_json,
+                publish_enabled: self.is_validator && self.config.history.publish_enabled(),
             });
 
             tracing::info!(

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -35,19 +35,33 @@ fn consume_skip_marker_if_matches(
     checkpoint_seq: u32,
 ) -> Result<bool, henyey_db::DbError> {
     use henyey_db::queries::StateQueries;
-    let skip_target: Option<u32> = conn
-        .get_state(henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT)?
-        .and_then(|s| s.parse::<u32>().ok());
+    let raw = conn.get_state(henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT)?;
+    let skip_target: Option<u32> = match raw.as_deref() {
+        None => None,
+        Some(s) => Some(s.parse::<u32>().map_err(|e| {
+            henyey_db::DbError::Integrity(format!(
+                "PUBLISH_SKIP_FIRST_CHECKPOINT marker value {:?} is not a valid u32: {}",
+                s, e
+            ))
+        })?),
+    };
 
-    // If a marker survives past its target checkpoint, a prior close
-    // failed to clear it — surface that loudly in debug builds.
-    debug_assert!(
-        skip_target.map_or(true, |t| t >= checkpoint_seq),
-        "PUBLISH_SKIP_FIRST_CHECKPOINT marker ({:?}) is older than the current \
-         checkpoint ledger ({}); a prior close should have cleared it",
-        skip_target,
-        checkpoint_seq
-    );
+    // If a marker survives past its target checkpoint, a prior close failed
+    // to clear it. Warn and actively delete so the orphan can't sit in the
+    // `state` table forever (the seq monotone means it would otherwise
+    // never match again).
+    if let Some(t) = skip_target {
+        if t < checkpoint_seq {
+            tracing::warn!(
+                marker = t,
+                ledger_seq = checkpoint_seq,
+                "PUBLISH_SKIP_FIRST_CHECKPOINT marker is older than the closing \
+                 checkpoint; clearing orphaned marker"
+            );
+            conn.delete_state(henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT)?;
+            return Ok(false);
+        }
+    }
 
     if skip_target == Some(checkpoint_seq) {
         tracing::info!(
@@ -3676,6 +3690,39 @@ mod publish_skip_marker_tests {
             .unwrap()
     }
 
+    /// Orphan marker (older than the closing checkpoint) must be actively
+    /// cleared so it cannot sit in the `state` table forever — checkpoint
+    /// seqs only grow past it. The consumer also reports no skip.
+    #[test]
+    fn clears_orphan_marker_older_than_closing_checkpoint() {
+        let db = Database::open_in_memory().unwrap();
+        set_marker(&db, 63);
+        assert!(!run_consumer(&db, 127));
+        assert!(get_marker(&db).is_none());
+    }
+
+    /// Corrupt (non-numeric) marker must surface as an `Integrity` error
+    /// rather than be silently treated as "no marker", per the
+    /// "never fail silently" project rule.
+    #[test]
+    fn errors_on_corrupt_marker_value() {
+        let db = Database::open_in_memory().unwrap();
+        db.with_connection(|c| {
+            c.set_state(state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT, "not-a-number")
+        })
+        .unwrap();
+        let res = db.transaction(|conn| Ok(consume_skip_marker_if_matches(conn, 127)?));
+        match res {
+            Err(henyey_db::DbError::Integrity(msg)) => {
+                assert!(
+                    msg.contains("PUBLISH_SKIP_FIRST_CHECKPOINT"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected DbError::Integrity, got {other:?}"),
+        }
+    }
+
     /// Marker=127, closing seq=127 → consumer reports skip and clears the
     /// marker in the same transaction.
     #[test]
@@ -3741,13 +3788,12 @@ mod publish_skip_marker_tests {
     }
 
     /// After a catchup ending at LCL=80, a marker is set for ckpt=127.
-    /// A close at an earlier checkpoint (63 — impossible in practice but
-    /// the consumer must not consume the marker) preserves the marker; a
-    /// close at exactly 127 consumes it; a close at the next checkpoint
-    /// (191) finds no marker and reports no skip.
+    /// A close at exactly 127 consumes the marker; a close at the next
+    /// checkpoint (191) finds no marker and reports no skip.
     ///
     /// Guards against the marker accidentally outliving its single
-    /// intended skip.
+    /// intended skip. The "earlier-checkpoint-than-marker" direction is
+    /// covered by `preserves_marker_for_future_checkpoint`.
     #[test]
     fn marker_targets_only_the_first_checkpoint_after_catchup() {
         let db = Database::open_in_memory().unwrap();
@@ -3760,11 +3806,6 @@ mod publish_skip_marker_tests {
             publish_enabled: true,
         };
         data.write_to_db(&db).unwrap();
-
-        // Close at an earlier checkpoint must not consume the marker.
-        // (Use a fresh DB shape for this branch — debug_assert fires if
-        // the marker is older than the closing seq, so we test the
-        // future-marker direction here instead.)
 
         // Close at the marked checkpoint consumes it.
         assert!(run_consumer(&db, 127));

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -13,6 +13,55 @@ fn record_phase_histogram(
     }
 }
 
+/// Read-and-conditionally-clear the post-catchup publish-skip marker.
+///
+/// Returns `true` if the marker is set to exactly `checkpoint_seq`; in that
+/// case the marker is also deleted so the skip fires at most once. Returns
+/// `false` for any other state (absent marker, marker pointing at a future
+/// checkpoint).
+///
+/// stellar-core parity reference: `mSkipFirstCheckpointSinceItIsIncomplete`
+/// in `HistoryManagerImpl`. In stellar-core the flag is an in-memory bool
+/// re-derived on startup from "no dirty checkpoint files on disk"; here it
+/// is persisted in the `state` table by [`super::persist::CatchupPersistData`]
+/// so the skip survives a crash between catchup completion and the first
+/// post-catchup checkpoint close.
+///
+/// The caller must invoke this inside the same DB transaction that decides
+/// whether to enqueue the checkpoint for publishing, so the read, the
+/// enqueue suppression, and the marker clear are all atomic.
+fn consume_skip_marker_if_matches(
+    conn: &henyey_db::rusqlite::Connection,
+    checkpoint_seq: u32,
+) -> Result<bool, henyey_db::DbError> {
+    use henyey_db::queries::StateQueries;
+    let skip_target: Option<u32> = conn
+        .get_state(henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT)?
+        .and_then(|s| s.parse::<u32>().ok());
+
+    // If a marker survives past its target checkpoint, a prior close
+    // failed to clear it — surface that loudly in debug builds.
+    debug_assert!(
+        skip_target.map_or(true, |t| t >= checkpoint_seq),
+        "PUBLISH_SKIP_FIRST_CHECKPOINT marker ({:?}) is older than the current \
+         checkpoint ledger ({}); a prior close should have cleared it",
+        skip_target,
+        checkpoint_seq
+    );
+
+    if skip_target == Some(checkpoint_seq) {
+        tracing::info!(
+            ledger_seq = checkpoint_seq,
+            "Skipping publish-queue enqueue for first checkpoint after catchup \
+             (stellar-core skipFirstCheckpointSinceItIsIncomplete parity)"
+        );
+        conn.delete_state(henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
 /// Raw inputs for a ledger-close persist job, captured on the event loop.
 ///
 /// Phase A of #1733: the event loop captures only cheap clones (no XDR/JSON
@@ -83,7 +132,15 @@ impl LedgerPersistInputs {
                     conn.store_bucket_list(self.header.ledger_seq, levels)?;
                 }
                 if self.publish_enabled {
-                    conn.enqueue_publish(self.header.ledger_seq, &has_json)?;
+                    // stellar-core parity: skipFirstCheckpointSinceItIsIncomplete.
+                    // If a post-catchup marker targets exactly this checkpoint
+                    // seq, suppress the enqueue and consume the marker. The
+                    // read-and-clear happens inside the same DB transaction
+                    // as the enqueue decision so a crash here cannot leave
+                    // the marker partially consumed.
+                    if !consume_skip_marker_if_matches(conn, self.header.ledger_seq)? {
+                        conn.enqueue_publish(self.header.ledger_seq, &has_json)?;
+                    }
                 }
             }
             for index in 0..self.tx_count {
@@ -3581,5 +3638,176 @@ mod refresh_stale_buffer_tests {
             result.is_none(),
             "Should reject refresh when tx_set_hash doesn't match"
         );
+    }
+}
+
+// =============================================================================
+// #2681 — skipFirstCheckpointSinceItIsIncomplete parity (publish-skip marker).
+//
+// Tests the in-transaction marker consumer used by
+// `LedgerPersistInputs::serialize_and_write_to_db` plus its integration with
+// `super::persist::CatchupPersistData::write_to_db`. The marker decision is
+// made strictly inside `consume_skip_marker_if_matches`; the outer
+// `is_checkpoint_ledger` and `publish_enabled` guards are statically
+// auditable, so they don't need separate integration tests beyond the
+// non-checkpoint case that verifies marker preservation.
+// =============================================================================
+#[cfg(test)]
+mod publish_skip_marker_tests {
+    use super::*;
+    use henyey_db::queries::StateQueries;
+    use henyey_db::schema::state_keys;
+    use henyey_db::Database;
+
+    fn get_marker(db: &Database) -> Option<String> {
+        db.with_connection(|c| c.get_state(state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT))
+            .unwrap()
+    }
+
+    fn set_marker(db: &Database, seq: u32) {
+        db.with_connection(|c| {
+            c.set_state(state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT, &seq.to_string())
+        })
+        .unwrap();
+    }
+
+    fn run_consumer(db: &Database, closing_seq: u32) -> bool {
+        db.transaction(|conn| Ok(consume_skip_marker_if_matches(conn, closing_seq)?))
+            .unwrap()
+    }
+
+    /// Marker=127, closing seq=127 → consumer reports skip and clears the
+    /// marker in the same transaction.
+    #[test]
+    fn skips_enqueue_when_marker_matches() {
+        let db = Database::open_in_memory().unwrap();
+        set_marker(&db, 127);
+        assert!(run_consumer(&db, 127));
+        assert!(get_marker(&db).is_none());
+    }
+
+    /// Marker absent, closing seq=63 → consumer reports no skip; nothing to
+    /// clear.
+    #[test]
+    fn does_not_skip_when_no_marker_set() {
+        let db = Database::open_in_memory().unwrap();
+        assert!(!run_consumer(&db, 63));
+        assert!(get_marker(&db).is_none());
+    }
+
+    /// Marker for a future checkpoint (191) must survive a close at an
+    /// earlier checkpoint (127). Guards against the marker being consumed
+    /// by the wrong checkpoint.
+    #[test]
+    fn preserves_marker_for_future_checkpoint() {
+        let db = Database::open_in_memory().unwrap();
+        set_marker(&db, 191);
+        assert!(!run_consumer(&db, 127));
+        assert_eq!(get_marker(&db).as_deref(), Some("191"));
+    }
+
+    /// Marker survives a process restart (drop + reopen the underlying DB
+    /// file) since it is persisted in the `state` table. This is the key
+    /// architectural difference from stellar-core's in-memory flag: stellar-core
+    /// re-derives the flag from on-disk dirty files, henyey persists it.
+    #[test]
+    fn marker_survives_simulated_restart() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.db");
+
+        // Run #1: catchup ends mid-checkpoint, marker is written.
+        {
+            let db = Database::open(&path).unwrap();
+            let (header, header_xdr) = persist_test_header(80);
+            let data = super::super::persist::CatchupPersistData {
+                header,
+                header_xdr,
+                has_json: "{}".to_string(),
+                publish_enabled: true,
+            };
+            data.write_to_db(&db).unwrap();
+            assert_eq!(get_marker(&db).as_deref(), Some("127"));
+        }
+
+        // Run #2: reopen the DB; marker must still be there, and the
+        // checkpoint close at seq=127 must consume it.
+        {
+            let db = Database::open(&path).unwrap();
+            assert_eq!(get_marker(&db).as_deref(), Some("127"));
+            assert!(run_consumer(&db, 127));
+            assert!(get_marker(&db).is_none());
+        }
+    }
+
+    /// After a catchup ending at LCL=80, a marker is set for ckpt=127.
+    /// A close at an earlier checkpoint (63 — impossible in practice but
+    /// the consumer must not consume the marker) preserves the marker; a
+    /// close at exactly 127 consumes it; a close at the next checkpoint
+    /// (191) finds no marker and reports no skip.
+    ///
+    /// Guards against the marker accidentally outliving its single
+    /// intended skip.
+    #[test]
+    fn marker_targets_only_the_first_checkpoint_after_catchup() {
+        let db = Database::open_in_memory().unwrap();
+
+        let (header, header_xdr) = persist_test_header(80);
+        let data = super::super::persist::CatchupPersistData {
+            header,
+            header_xdr,
+            has_json: "{}".to_string(),
+            publish_enabled: true,
+        };
+        data.write_to_db(&db).unwrap();
+
+        // Close at an earlier checkpoint must not consume the marker.
+        // (Use a fresh DB shape for this branch — debug_assert fires if
+        // the marker is older than the closing seq, so we test the
+        // future-marker direction here instead.)
+
+        // Close at the marked checkpoint consumes it.
+        assert!(run_consumer(&db, 127));
+        assert!(get_marker(&db).is_none());
+
+        // A subsequent close at the next checkpoint must not see any
+        // marker and must report no skip.
+        assert!(!run_consumer(&db, 191));
+    }
+
+    /// Convenience: minimal LedgerHeader fixture for the persist path.
+    /// Mirrors `persist::tests::make_header` but is private to this module.
+    fn persist_test_header(seq: u32) -> (stellar_xdr::curr::LedgerHeader, Vec<u8>) {
+        use stellar_xdr::curr::{
+            Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderExtensionV1,
+            LedgerHeaderExtensionV1Ext, Limits, StellarValue, StellarValueExt, WriteXdr,
+        };
+        let header = LedgerHeader {
+            ledger_version: 24,
+            previous_ledger_hash: Hash([0; 32]),
+            scp_value: StellarValue {
+                tx_set_hash: Hash([0; 32]),
+                close_time: stellar_xdr::curr::TimePoint(0),
+                upgrades: vec![].try_into().unwrap(),
+                ext: StellarValueExt::Basic,
+            },
+            tx_set_result_hash: Hash([0; 32]),
+            bucket_list_hash: Hash([0; 32]),
+            ledger_seq: seq,
+            total_coins: 0,
+            fee_pool: 0,
+            inflation_seq: 0,
+            id_pool: 0,
+            base_fee: 100,
+            base_reserve: 5_000_000,
+            max_tx_set_size: 1000,
+            skip_list: [Hash([0; 32]), Hash([0; 32]), Hash([0; 32]), Hash([0; 32])],
+            ext: LedgerHeaderExt::V1(LedgerHeaderExtensionV1 {
+                flags: 0,
+                ext: LedgerHeaderExtensionV1Ext::V0,
+            }),
+        };
+        let xdr = header.to_xdr(Limits::none()).unwrap();
+        (header, xdr)
     }
 }

--- a/crates/app/src/app/persist.rs
+++ b/crates/app/src/app/persist.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use henyey_bucket::HotArchiveBucket;
 use henyey_db::Database;
+use henyey_history::{checkpoint_ledger, is_checkpoint_ledger, GENESIS_LEDGER_SEQ};
 use henyey_ledger::LedgerManager;
 
 use super::types::PendingPersist;
@@ -35,6 +36,14 @@ pub(super) struct CatchupPersistData {
     pub header: stellar_xdr::curr::LedgerHeader,
     pub header_xdr: Vec<u8>,
     pub has_json: String,
+    /// Whether checkpoint publishing is enabled for this run. Drives the
+    /// `skipFirstCheckpointSinceItIsIncomplete` parity logic: when true
+    /// and the catchup terminus is mid-checkpoint, a marker is persisted
+    /// so the first post-catchup checkpoint close skips its
+    /// `enqueue_publish` (it would otherwise publish an incomplete
+    /// checkpoint, since ledgers prior to the catchup LCL are absent
+    /// from the local DB).
+    pub publish_enabled: bool,
 }
 
 impl CatchupPersistData {
@@ -52,6 +61,23 @@ impl CatchupPersistData {
             // atomically with the state update so a crash before this
             // transaction leaves the sentinel set for startup detection.
             conn.delete_state(henyey_db::schema::state_keys::CATCHUP_PERSIST_PENDING)?;
+
+            // stellar-core parity: `skipFirstCheckpointSinceItIsIncomplete`.
+            // If publish is enabled and the catchup terminus is mid-checkpoint,
+            // record the target checkpoint seq so the next ledger close at
+            // that checkpoint suppresses its publish-queue enqueue. The
+            // set-or-delete pattern guarantees we never leak a stale marker
+            // from a prior run: every code path through `write_to_db` either
+            // sets the key to a fresh value or deletes it outright.
+            let lcl = self.header.ledger_seq;
+            if self.publish_enabled && lcl > GENESIS_LEDGER_SEQ && !is_checkpoint_ledger(lcl) {
+                conn.set_state(
+                    henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT,
+                    &checkpoint_ledger(lcl).to_string(),
+                )?;
+            } else {
+                conn.delete_state(henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT)?;
+            }
             Ok(())
         })
     }
@@ -451,6 +477,7 @@ mod tests {
             header,
             header_xdr,
             has_json: "{\"version\":1}".to_string(),
+            publish_enabled: false,
         };
 
         persist.write_to_db(&db).unwrap();
@@ -523,6 +550,7 @@ mod tests {
             header,
             header_xdr,
             has_json: "{}".to_string(),
+            publish_enabled: false,
         };
         let ready = CatchupPersistReady::new(data, db, lm);
         assert_eq!(ready.ledger_seq(), 99);
@@ -566,6 +594,7 @@ mod tests {
             header,
             header_xdr,
             has_json: "{}".to_string(),
+            publish_enabled: false,
         };
         let ready = CatchupPersistReady::new(data, db, lm);
         let result_ok = Ok(crate::app::types::CatchupResult {
@@ -893,6 +922,7 @@ mod tests {
             header,
             header_xdr,
             has_json: "{\"version\":1}".to_string(),
+            publish_enabled: false,
         };
         data.write_to_db(&db).unwrap();
 
@@ -925,5 +955,137 @@ mod tests {
             val.is_some(),
             "sentinel must persist when write_to_db is never called"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // #2681: skipFirstCheckpointSinceItIsIncomplete parity tests
+    //
+    // The marker key (`PUBLISH_SKIP_FIRST_CHECKPOINT`) records the target
+    // checkpoint seq whose enqueue must be suppressed because the catchup
+    // terminus is mid-checkpoint. These tests pin down the set-or-delete
+    // contract in `CatchupPersistData::write_to_db` for the full grid of
+    // (publish_enabled, LCL-position) inputs, including stale-marker
+    // cleanup. The companion enqueue-time skip tests live in
+    // `app::ledger_close::tests`.
+    // ---------------------------------------------------------------------
+
+    fn skip_marker(db: &Database) -> Option<String> {
+        db.with_connection(|c| {
+            c.get_state(henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT)
+        })
+        .unwrap()
+    }
+
+    fn set_skip_marker(db: &Database, value: &str) {
+        db.with_connection(|c| {
+            c.set_state(
+                henyey_db::schema::state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT,
+                value,
+            )
+        })
+        .unwrap();
+    }
+
+    /// LCL=80 is mid-checkpoint (the checkpoint covers 64..=127), and
+    /// publish is enabled → marker must point at 127.
+    #[test]
+    fn catchup_persist_mid_checkpoint_sets_skip_marker() {
+        let db = Database::open_in_memory().unwrap();
+        let (header, header_xdr) = make_header(80);
+        let data = CatchupPersistData {
+            header,
+            header_xdr,
+            has_json: "{}".to_string(),
+            publish_enabled: true,
+        };
+        data.write_to_db(&db).unwrap();
+        assert_eq!(skip_marker(&db).as_deref(), Some("127"));
+    }
+
+    /// LCL=127 is a checkpoint boundary (the checkpoint just completed
+    /// at this LCL) → no skip is required and any stale marker must be
+    /// cleared.
+    #[test]
+    fn catchup_persist_at_checkpoint_boundary_does_not_set_skip_marker() {
+        let db = Database::open_in_memory().unwrap();
+        let (header, header_xdr) = make_header(127);
+        let data = CatchupPersistData {
+            header,
+            header_xdr,
+            has_json: "{}".to_string(),
+            publish_enabled: true,
+        };
+        data.write_to_db(&db).unwrap();
+        assert!(skip_marker(&db).is_none());
+    }
+
+    /// Publish disabled → marker must never be set, regardless of LCL.
+    #[test]
+    fn catchup_persist_with_publish_disabled_does_not_set_skip_marker() {
+        let db = Database::open_in_memory().unwrap();
+        let (header, header_xdr) = make_header(80);
+        let data = CatchupPersistData {
+            header,
+            header_xdr,
+            has_json: "{}".to_string(),
+            publish_enabled: false,
+        };
+        data.write_to_db(&db).unwrap();
+        assert!(skip_marker(&db).is_none());
+    }
+
+    /// A marker left over from a previous catchup must be cleared when a
+    /// new catchup ends at a checkpoint boundary — the set-or-delete
+    /// pattern guarantees this.
+    #[test]
+    fn catchup_persist_clears_stale_skip_marker_when_lcl_complete() {
+        let db = Database::open_in_memory().unwrap();
+        set_skip_marker(&db, "127");
+
+        let (header, header_xdr) = make_header(127);
+        let data = CatchupPersistData {
+            header,
+            header_xdr,
+            has_json: "{}".to_string(),
+            publish_enabled: true,
+        };
+        data.write_to_db(&db).unwrap();
+        assert!(skip_marker(&db).is_none());
+    }
+
+    /// A stale marker must also be cleared when publish is disabled,
+    /// even if the LCL is mid-checkpoint (the "publish was on then went
+    /// off across runs" path).
+    #[test]
+    fn catchup_persist_clears_stale_skip_marker_when_publish_disabled() {
+        let db = Database::open_in_memory().unwrap();
+        set_skip_marker(&db, "127");
+
+        let (header, header_xdr) = make_header(80);
+        let data = CatchupPersistData {
+            header,
+            header_xdr,
+            has_json: "{}".to_string(),
+            publish_enabled: false,
+        };
+        data.write_to_db(&db).unwrap();
+        assert!(skip_marker(&db).is_none());
+    }
+
+    /// LCL=GENESIS_LEDGER_SEQ (1) → marker must not be set. Mirrors
+    /// stellar-core's flag init (false) and ensures we never skip
+    /// publishing checkpoint 63 on a fresh node.
+    #[test]
+    fn catchup_persist_at_genesis_does_not_set_marker() {
+        let db = Database::open_in_memory().unwrap();
+        let (header, header_xdr) = make_header(GENESIS_LEDGER_SEQ);
+        let data = CatchupPersistData {
+            header,
+            header_xdr,
+            has_json: "{}".to_string(),
+            publish_enabled: true,
+        };
+        data.write_to_db(&db).unwrap();
+        assert!(skip_marker(&db).is_none());
     }
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -70,6 +70,9 @@ pub use error::DbError;
 
 pub use pool::Database;
 pub use queries::*;
+/// Re-export of `rusqlite` so downstream crates can name `rusqlite::Connection`
+/// without taking a direct dependency on the crate.
+pub use rusqlite;
 pub use scp_persistence::SqliteScpPersistence;
 
 /// Result type for database operations.

--- a/crates/db/src/schema.rs
+++ b/crates/db/src/schema.rs
@@ -197,4 +197,17 @@ pub mod state_keys {
     /// Presence at startup indicates the previous catchup completed
     /// in-memory but crashed before the deferred persist ran (AUDIT-226).
     pub const CATCHUP_PERSIST_PENDING: &str = "catchuppersistpending";
+
+    /// Target checkpoint sequence whose publish-queue enqueue must be
+    /// skipped because the node finished catchup mid-checkpoint, so the
+    /// first checkpoint after catchup is incomplete (stellar-core parity
+    /// for `skipFirstCheckpointSinceItIsIncomplete`).
+    ///
+    /// Stored as the decimal checkpoint ledger seq. Set transactionally
+    /// by [`CatchupPersistData::write_to_db`] when LCL > genesis and LCL
+    /// is not a checkpoint boundary; consumed and cleared atomically by
+    /// the ledger-close persist transaction when the marked checkpoint
+    /// closes. Always set-or-deleted by the catchup persist path so a
+    /// prior-run marker can never leak into a new catchup terminus.
+    pub const PUBLISH_SKIP_FIRST_CHECKPOINT: &str = "publishskipfirstcheckpoint";
 }

--- a/crates/db/src/schema.rs
+++ b/crates/db/src/schema.rs
@@ -204,10 +204,10 @@ pub mod state_keys {
     /// for `skipFirstCheckpointSinceItIsIncomplete`).
     ///
     /// Stored as the decimal checkpoint ledger seq. Set transactionally
-    /// by [`CatchupPersistData::write_to_db`] when LCL > genesis and LCL
-    /// is not a checkpoint boundary; consumed and cleared atomically by
-    /// the ledger-close persist transaction when the marked checkpoint
-    /// closes. Always set-or-deleted by the catchup persist path so a
-    /// prior-run marker can never leak into a new catchup terminus.
+    /// by `CatchupPersistData::write_to_db` (in `henyey-app`) when LCL >
+    /// genesis and LCL is not a checkpoint boundary; consumed and cleared
+    /// atomically by the ledger-close persist transaction when the marked
+    /// checkpoint closes. Always set-or-deleted by the catchup persist path
+    /// so a prior-run marker can never leak into a new catchup terminus.
     pub const PUBLISH_SKIP_FIRST_CHECKPOINT: &str = "publishskipfirstcheckpoint";
 }

--- a/crates/history/PARITY_STATUS.md
+++ b/crates/history/PARITY_STATUS.md
@@ -128,7 +128,30 @@ Corresponds to: `CheckpointBuilder.h`
 | `cleanup(lcl)` | `cleanup()` | Full |
 | `checkpointComplete(checkpoint)` | `checkpoint_complete()` | Full |
 | `ensureOpen(ledgerSeq)` | `ensure_open()` | Full |
-| `skipIncompleteFirstCheckpointSinceRestart()` | -- | None |
+| `skipIncompleteFirstCheckpointSinceRestart()` | publish-queue enqueue guard in `LedgerPersistInputs::serialize_and_write_to_db` (post-catchup branch only) | Partial |
+
+> **Architectural note (#2681).** stellar-core hosts the
+> `skipFirstCheckpointSinceItIsIncomplete` flag inside `CheckpointBuilder`
+> because it writes `.dirty` per-ledger files and re-derives the flag at
+> startup from "no dirty files on disk". Henyey doesn't have a per-ledger
+> append path — checkpoint files are reconstructed from SQLite at publish
+> time — so the parity equivalent is implemented one level up, at the
+> publish-queue enqueue site. `CatchupPersistData::write_to_db` records
+> the target checkpoint sequence in the `publishskipfirstcheckpoint`
+> state key when catchup ends mid-checkpoint with publish enabled, and
+> the next `LedgerPersistInputs::serialize_and_write_to_db` for that
+> checkpoint suppresses its `enqueue_publish` and clears the marker — all
+> inside one DB transaction.
+>
+> stellar-core's trigger is "no dirty files at startup", which covers two
+> paths: (a) post-catchup, and (b) publish-disabled-then-re-enabled. Henyey
+> currently implements only (a). Path (b) is not a supported henyey
+> production configuration today (publish-disable on a validator has no
+> precedent and no observable archive divergence as long as it stays
+> disabled), so the gap is intentional. If/when path (b) becomes a
+> supported configuration, the follow-up should derive the marker at
+> startup from on-disk state (e.g., checkpoint files present but no
+> queued publish for the corresponding ledger).
 
 ### publish_queue.rs / publish.rs (`publish_queue.rs`, `publish.rs`)
 

--- a/crates/history/README.md
+++ b/crates/history/README.md
@@ -149,7 +149,7 @@ println!("ledger {} closed at {}", header.ledger_seq, header.scp_value.close_tim
 - Ledger-header history entries are verified by recomputing `SHA256(XDR(header))` before their advertised hashes are trusted, matching stellar-core's catchup chain verification.
 - Protocol 23+ replay maintains both the live bucket list and the hot-archive bucket list, and verification uses `SHA256(live_hash || hot_archive_hash)`.
 - `HistoryArchiveState::differing_bucket_hashes()` mirrors stellar-core's inhibited bottom-up bucket diff algorithm so catchup can avoid re-downloading buckets already implied by local state.
-- `CheckpointBuilder` uses `.dirty` files plus durable rename so partially written checkpoints never become visible as final archive outputs.
+- `CheckpointBuilder` uses `.dirty` files plus durable rename so partially written checkpoints never become visible as final archive outputs. Unlike stellar-core, henyey's `CheckpointBuilder` only handles startup crash-recovery cleanup — there is no per-ledger append path (checkpoint files are reconstructed from SQLite at publish time). The parity equivalent of stellar-core's `skipFirstCheckpointSinceItIsIncomplete` is therefore enforced one level up, at the publish-queue enqueue site in `henyey-app`'s `LedgerPersistInputs::serialize_and_write_to_db` (see `PARITY_STATUS.md`).
 - Publish-queue backpressure mirrors stellar-core's hysteresis thresholds with `PUBLISH_QUEUE_MAX_SIZE` and `PUBLISH_QUEUE_UNBLOCK_APPLICATION`.
 
 ## stellar-core Mapping


### PR DESCRIPTION
Closes #2681

## Summary

Adds stellar-core parity for `skipFirstCheckpointSinceItIsIncomplete`: when a node finishes catchup mid-checkpoint, the first post-catchup checkpoint is incomplete (ledgers prior to the catchup LCL are not in the local DB) and must not be published. henyey doesn't have a per-ledger append path like stellar-core's `CheckpointBuilder`, so the parity equivalent is enforced at the publish-queue enqueue site in `LedgerPersistInputs::serialize_and_write_to_db`.

The mechanism: a new `publishskipfirstcheckpoint` state-table key holds the target checkpoint sequence. `CatchupPersistData::write_to_db` sets it atomically with the LCL write (set-or-delete every call, so stale markers can't leak); the next checkpoint close reads-and-clears it inside its own transaction, suppressing the `enqueue_publish` for that one checkpoint.

Persisting the marker (rather than holding an in-memory flag) makes the skip survive a crash between catchup completion and the next checkpoint close — stellar-core achieves equivalent durability by re-deriving its flag from on-disk dirty-file state at startup.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2681#issuecomment-4464622777)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all` — all green; new tests cover:
  - 6 `catchup_persist_*` cases in `crates/app/src/app/persist.rs` (mid-checkpoint sets marker, boundary clears, publish-disabled clears, stale clears for both completion and publish-disable, genesis no-set).
  - 5 `publish_skip_marker_*` cases in `crates/app/src/app/ledger_close.rs` (skip on match, no-skip when absent, preserve future-checkpoint marker, restart survival across DB reopen, multi-checkpoint single-shot).

## Deviations from plan

- `catchup_impl.rs` populates `publish_enabled: self.is_validator && self.config.history.publish_enabled()` (plan said just `publish_enabled()`). Using the validator-gated form matches the convention already in `ledger_close.rs` (lines 385, 545, etc.) and `mod.rs` (lines 2478, 2956), and prevents a non-validator with publish enabled in config from setting a marker that the closing path's gate would never let it clear.
- Extracted the in-transaction marker check + clear into a private helper `consume_skip_marker_if_matches` in `ledger_close.rs`, so the contract is directly unit-testable. The call site in `serialize_and_write_to_db` is now a one-liner inside the existing `is_checkpoint_ledger` + `publish_enabled` guards. The plan's `debug_assert!` (marker ≥ closing seq) lives in the helper.
- Re-exported `rusqlite` from `henyey-db` so the new helper in `henyey-app` can name `rusqlite::Connection` without adding a direct rusqlite dep.

🤖 Generated with GitHub Copilot