### PR TITLE
Fix DashMap shard-reentrancy deadlock in tx_set_tracker test

### DIFF
--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -70,6 +70,15 @@ impl TxSetTracker {
     /// Register a pending tx-set request. Returns true if new.
     /// Returns false if already pending, already cached, or the pending map
     /// has reached its best-effort capacity cap (`MAX_PENDING_TXSET_REQUESTS`).
+    ///
+    /// # Reentrancy
+    ///
+    /// Callers (including tests) MUST NOT hold any guard into `self.pending`
+    /// (e.g. a `dashmap::mapref::one::Ref`/`RefMut` from `pending.get` or
+    /// `pending.get_mut`) when calling this. `request` acquires a write lock
+    /// on the destination shard via `pending.entry(...)` and read locks on
+    /// every shard via `pending.len()`; same-thread reentry will deadlock
+    /// whenever the held guard's shard collides with one of those.
     pub fn request(&self, hash: Hash256, slot: u64) -> bool {
         if self.cache.contains_key(&hash) {
             return false;
@@ -978,9 +987,14 @@ mod tests {
         // The first hash we inserted should still be incrementable.
         let first_hash = Hash256::from_bytes([0u8; 32]);
         assert!(!tracker.request(first_hash, 100));
-        let entry = tracker.pending.get(&first_hash).unwrap();
+        // Snapshot the field by value and let the `Ref` drop at the end of
+        // this statement BEFORE re-entering `tracker.request(...)` below.
+        // Holding the shard read-guard across `request()` would deadlock
+        // whenever `new_hash` collides with `first_hash` on a DashMap shard,
+        // because `request()` needs a write lock on the destination shard.
+        let request_count = tracker.pending.get(&first_hash).unwrap().request_count;
         assert_eq!(
-            entry.request_count, 2,
+            request_count, 2,
             "existing entry should increment even at cap"
         );
 


### PR DESCRIPTION
Closes #2744

## Summary

`herder::tx_set_tracker::tests::test_request_at_cap_still_increments_existing` was hanging intermittently in CI. Root cause: the test bound a `dashmap::Ref` from `tracker.pending.get(&first_hash)` and held it across a subsequent `tracker.request(new_hash, 100)` call. `request()` acquires a write lock on the destination shard via `pending.entry(...)`; whenever `new_hash` happens to map to the same DashMap shard as `first_hash`, same-thread read→write reentry deadlocks. DashMap's shard count is `4 * num_cpus.next_power_of_two()`, so the collision (and the hang) is CPU-count dependent — explaining "hangs only on some CI runners".

Fix: snapshot `request_count` by value so the `Ref` is dropped before re-entering `request()`. Also added a short `# Reentrancy` doc-comment on `pub fn request` so the precondition is explicit at the call site future contributors will read.

Test-only restructuring; production behavior is unchanged. The `pending` field is private and no production code path holds a `pending` shard guard across a `request()` call.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2744#issuecomment-4464950353)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-herder --lib tx_set_tracker::` — 32 passed
- [x] `cargo test -p henyey-herder --lib tx_set_tracker::tests::test_request_at_cap_still_increments_existing` — re-ran 5x, each <1s, all pass
- [x] `cargo test --all` — workspace green

## Deviations from plan

None.