### PR TITLE
Suppress sync-recovery in MANUAL_CLOSE+RUN_STANDALONE mode

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -2879,7 +2879,25 @@ impl App {
     /// This spawns a background task that monitors for consensus stuck conditions
     /// and triggers recovery actions when needed. The task is supervised: if it
     /// panics, shutdown is triggered immediately.
+    ///
+    /// In standalone mode (`manual_close && run_standalone`) the manager is not
+    /// started — there is no peer to fall behind, so the consensus-stuck and
+    /// out-of-sync recovery timers would only generate noise. This mirrors the
+    /// stellar-core gates in `HerderImpl::triggerNextLedger` (HerderImpl.cpp:582-588,
+    /// `startOutOfSyncTimer`) and `HerderImpl::trackingHeartBeat`
+    /// (HerderImpl.cpp:2502-2510). The henyey gate intentionally widens the
+    /// `trackingHeartBeat` predicate from `MANUAL_CLOSE` to
+    /// `MANUAL_CLOSE && RUN_STANDALONE` so that simulation tests
+    /// (`manual_close=true, run_standalone=false`) still get sync-recovery —
+    /// see `HerderConfig::suppress_scp` for the same convention.
     pub fn start_sync_recovery(self: &Arc<Self>) {
+        if self.config.node.manual_close && self.config.testing.run_standalone {
+            tracing::info!(
+                "Sync recovery suppressed (standalone mode: MANUAL_CLOSE && RUN_STANDALONE) \
+                 — parity: HerderImpl.cpp:582-588 / 2502-2510"
+            );
+            return;
+        }
         let (handle, manager) = SyncRecoveryManager::new(Arc::clone(self));
         *self.sync_recovery_handle.write() = Some(handle);
         let shutdown_tx = self.shutdown_tx.clone();
@@ -4065,6 +4083,137 @@ mod tests {
 
         // Should not panic when handle is None
         app.sync_recovery_heartbeat();
+    }
+
+    /// Regression test for #2688 — in standalone mode
+    /// (`manual_close && run_standalone`) `start_sync_recovery()` must skip
+    /// spawning the `SyncRecoveryManager`, mirroring stellar-core's
+    /// `HerderImpl.cpp:582-588` (`startOutOfSyncTimer`) and
+    /// `HerderImpl.cpp:2502-2510` (`trackingHeartBeat`) gates.
+    #[tokio::test]
+    async fn test_start_sync_recovery_suppressed_in_standalone_mode() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let mut config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        config.node.manual_close = true;
+        config.testing.run_standalone = true;
+
+        let app = Arc::new(App::new(config).await.unwrap());
+
+        app.start_sync_recovery();
+
+        assert!(
+            app.sync_recovery_handle.read().is_none(),
+            "standalone mode must not create a sync_recovery_handle"
+        );
+        assert!(
+            app.sync_recovery_task.read().is_none(),
+            "standalone mode must not spawn a sync_recovery_task"
+        );
+    }
+
+    /// Regression test for #2688 — henyey intentionally widens stellar-core's
+    /// `trackingHeartBeat` predicate from `MANUAL_CLOSE` to
+    /// `MANUAL_CLOSE && RUN_STANDALONE`, matching the convention used by
+    /// `HerderConfig::suppress_scp`. Simulation tests run with
+    /// `manual_close=true, run_standalone=false` and must keep sync-recovery.
+    #[tokio::test]
+    async fn test_start_sync_recovery_active_when_only_manual_close() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let mut config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        config.node.manual_close = true;
+        config.testing.run_standalone = false;
+
+        let app = Arc::new(App::new(config).await.unwrap());
+
+        app.start_sync_recovery();
+
+        assert!(
+            app.sync_recovery_handle.read().is_some(),
+            "manual_close alone must not suppress sync recovery"
+        );
+        assert!(app.sync_recovery_task.read().is_some());
+
+        // Cleanup: shut down the manager so the spawned task drains.
+        let handle = app.sync_recovery_handle.read().clone();
+        if let Some(handle) = handle {
+            handle.shutdown().await;
+        }
+        let task = app.sync_recovery_task.write().take();
+        if let Some(task) = task {
+            let _ = task.await;
+        }
+    }
+
+    /// Regression test for #2688 — normal (non-standalone, non-manual-close)
+    /// mode must start the sync recovery manager.
+    #[tokio::test]
+    async fn test_start_sync_recovery_active_in_normal_mode() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        // Defaults: manual_close=false, run_standalone=false.
+
+        let app = Arc::new(App::new(config).await.unwrap());
+
+        app.start_sync_recovery();
+
+        assert!(app.sync_recovery_handle.read().is_some());
+        assert!(app.sync_recovery_task.read().is_some());
+
+        let handle = app.sync_recovery_handle.read().clone();
+        if let Some(handle) = handle {
+            handle.shutdown().await;
+        }
+        let task = app.sync_recovery_task.write().take();
+        if let Some(task) = task {
+            let _ = task.await;
+        }
+    }
+
+    /// Regression test for #2688 — when the sync recovery manager is suppressed,
+    /// the public callbacks (`sync_recovery_heartbeat`, `start_sync_recovery_tracking`,
+    /// `set_applying_ledger`) must remain safe no-ops on the channel side. Note:
+    /// `set_applying_ledger` still flips the `is_applying_ledger` AtomicBool,
+    /// which is independent of recovery scheduling and is read by code paths in
+    /// `consensus.rs` and `ledger_close.rs`.
+    #[tokio::test]
+    async fn test_sync_recovery_heartbeat_noop_when_suppressed() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let mut config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        config.node.manual_close = true;
+        config.testing.run_standalone = true;
+
+        let app = Arc::new(App::new(config).await.unwrap());
+        app.start_sync_recovery();
+        assert!(app.sync_recovery_handle.read().is_none());
+
+        // Heartbeat / start-tracking are pure no-ops: no panic, handle stays None.
+        app.sync_recovery_heartbeat();
+        app.start_sync_recovery_tracking();
+        assert!(app.sync_recovery_handle.read().is_none());
+        assert!(app.sync_recovery_task.read().is_none());
+
+        // set_applying_ledger flips the AtomicBool unconditionally (independent
+        // of recovery scheduling) but the channel-send half is a no-op because
+        // the handle is None.
+        assert!(!app.is_applying_ledger.load(Ordering::Relaxed));
+        app.set_applying_ledger(true);
+        assert!(app.is_applying_ledger.load(Ordering::Relaxed));
+        assert!(app.sync_recovery_handle.read().is_none());
+        assert!(app.sync_recovery_task.read().is_none());
+        app.set_applying_ledger(false);
+        assert!(!app.is_applying_ledger.load(Ordering::Relaxed));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #2688

## Summary

Mirror stellar-core's `HerderImpl` gates (HerderImpl.cpp:582-588 in `triggerNextLedger`/`startOutOfSyncTimer`, and HerderImpl.cpp:2502-2510 in `trackingHeartBeat`) by skipping `SyncRecoveryManager` startup when both `manual_close` and `run_standalone` are set. Both stellar-core gates collapse into a single sensible henyey gate at `App::start_sync_recovery()` — with no handle present, the existing `if let Some(handle)` guards in `sync_recovery_heartbeat`, `start_sync_recovery_tracking`, and the channel-send half of `set_applying_ledger` make every downstream call a no-op. Existing call sites in `ledger_close.rs`, `lifecycle.rs`, and `close.rs` are unchanged.

The henyey gate intentionally widens stellar-core's `trackingHeartBeat` predicate from `MANUAL_CLOSE` to `MANUAL_CLOSE && RUN_STANDALONE`, matching the convention already documented for `HerderConfig::suppress_scp` (`herder.rs:354-406`, `:1544-1548`). This preserves sync-recovery for henyey simulation tests (`manual_close=true, run_standalone=false`) which need it to drive multi-node consensus, while suppressing it only in production standalone mode.

Note: `set_applying_ledger`'s `is_applying_ledger` AtomicBool flip is independent of recovery scheduling and continues to run unconditionally — that flag is read by code paths in `consensus.rs` and `ledger_close.rs` and must remain accurate even in standalone mode.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2688#issuecomment-4465230273)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-app --all-targets -- -D warnings` — no new warnings introduced (pre-existing baseline issues unchanged)
- [x] `cargo test -p henyey-app --lib` — 938 passed, 0 failed
- [x] New unit tests cover all four scenarios:
  - `test_start_sync_recovery_suppressed_in_standalone_mode`
  - `test_start_sync_recovery_active_when_only_manual_close` (simulation pattern)
  - `test_start_sync_recovery_active_in_normal_mode`
  - `test_sync_recovery_heartbeat_noop_when_suppressed` (also verifies `is_applying_ledger` AtomicBool still flips independently)

## Deviations from plan

None.

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-cli)