### PR TITLE
Wire validate_bucket_list_structure into catchup apply_buckets

### DIFF
--- a/crates/bucket/src/bucket.rs
+++ b/crates/bucket/src/bucket.rs
@@ -922,14 +922,13 @@ impl Bucket {
                 if let Some(v) = protocol_version.get() {
                     return Ok(*v);
                 }
-                // Slow path (first call): scan for the leading metaentry.
-                // Stop at the first non-metaentry — by construction the
-                // metaentry is at the head of the entry list.
-                let computed = entries.iter().find_map(|e| match e {
-                    BucketEntry::Metaentry(m) => Some(Some(m.ledger_version)),
+                // Slow path (first call): inspect only the leading entry —
+                // by construction the metaentry is at index 0 if present, so
+                // we never need to scan past the head.
+                let value = match entries.first() {
+                    Some(BucketEntry::Metaentry(m)) => Some(m.ledger_version),
                     _ => None,
-                });
-                let value = computed.unwrap_or(None);
+                };
                 // Best-effort populate; if a concurrent caller already set it,
                 // the value is identical (deterministic from `entries`).
                 let _ = protocol_version.set(value);

--- a/crates/bucket/src/bucket.rs
+++ b/crates/bucket/src/bucket.rs
@@ -32,7 +32,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use stellar_xdr::curr::{LedgerEntry, LedgerKey, Limits, ReadXdr, WriteXdr};
 
@@ -58,6 +58,14 @@ enum BucketStorage {
         entries: Arc<Vec<BucketEntry>>,
         /// Map from ledger key to entry index for O(1) lookups.
         key_index: Arc<HashMap<LedgerKey, usize>>,
+        /// Cached protocol version computed once from the leading metaentry.
+        ///
+        /// Mirrors the cache on `DiskBucket` for the disk-backed variant so
+        /// `Bucket::protocol_version()` is O(1) after first access regardless
+        /// of storage mode. `Some(Some(v))` = metaentry with `ledger_version=v`,
+        /// `Some(None)` = no metaentry / empty bucket. The `Arc` lets clones
+        /// share a single computation.
+        protocol_version: Arc<OnceLock<Option<u32>>>,
     },
     /// Entries stored on disk with a compact index for on-demand loading.
     DiskBacked {
@@ -153,6 +161,7 @@ impl Bucket {
             storage: BucketStorage::InMemory {
                 entries: Arc::new(Vec::new()),
                 key_index: Arc::new(HashMap::new()),
+                protocol_version: Arc::new(OnceLock::new()),
             },
             // Empty bucket with shared state at offset 0 - matches stellar-core where mEntries is empty vector
             level_zero_state: LevelZeroState::SharedWithStorage { metadata_count: 0 },
@@ -262,6 +271,7 @@ impl Bucket {
             storage: BucketStorage::InMemory {
                 entries: Arc::new(entries),
                 key_index: Arc::new(key_index),
+                protocol_version: Arc::new(OnceLock::new()),
             },
             level_zero_state: LevelZeroState::None,
         })
@@ -296,7 +306,11 @@ impl Bucket {
         }
         Ok(Self {
             hash,
-            storage: BucketStorage::InMemory { entries, key_index },
+            storage: BucketStorage::InMemory {
+                entries,
+                key_index,
+                protocol_version: Arc::new(OnceLock::new()),
+            },
             level_zero_state: LevelZeroState::SharedWithStorage { metadata_count },
         })
     }
@@ -333,6 +347,7 @@ impl Bucket {
             storage: BucketStorage::InMemory {
                 entries: Arc::new(entries),
                 key_index: Arc::new(HashMap::new()), // No index needed for merge input
+                protocol_version: Arc::new(OnceLock::new()),
             },
             // Use shared state - no cloning needed
             level_zero_state: LevelZeroState::SharedWithStorage { metadata_count },
@@ -490,6 +505,7 @@ impl Bucket {
             storage: BucketStorage::InMemory {
                 entries: Arc::new(entries),
                 key_index: Arc::new(key_index),
+                protocol_version: Arc::new(OnceLock::new()),
             },
             level_zero_state: LevelZeroState::None,
         })
@@ -729,7 +745,9 @@ impl Bucket {
     /// Estimate heap bytes used by this bucket (index + cache, excluding mmap).
     pub fn estimate_heap_bytes(&self) -> usize {
         match &self.storage {
-            BucketStorage::InMemory { entries, key_index } => {
+            BucketStorage::InMemory {
+                entries, key_index, ..
+            } => {
                 // entries Vec: BucketEntry structs on heap
                 let entries_cap = entries.capacity() * std::mem::size_of::<BucketEntry>();
                 // key_index: HashMap<LedgerKey, usize>
@@ -827,7 +845,9 @@ impl Bucket {
     /// loads the entry from disk.
     pub fn get(&self, key: &LedgerKey) -> Result<Option<BucketEntry>> {
         match &self.storage {
-            BucketStorage::InMemory { entries, key_index } => {
+            BucketStorage::InMemory {
+                entries, key_index, ..
+            } => {
                 if let Some(&idx) = key_index.get(key) {
                     Ok(entries.get(idx).cloned())
                 } else {
@@ -848,7 +868,9 @@ impl Bucket {
         key_bytes: &[u8],
     ) -> Result<Option<BucketEntry>> {
         match &self.storage {
-            BucketStorage::InMemory { entries, key_index } => {
+            BucketStorage::InMemory {
+                entries, key_index, ..
+            } => {
                 if let Some(&idx) = key_index.get(key) {
                     Ok(entries.get(idx).cloned())
                 } else {
@@ -875,18 +897,45 @@ impl Bucket {
 
     /// Get the protocol version from bucket metadata, if present.
     ///
-    /// Returns `Ok(None)` for empty buckets (no entries, no metadata).
+    /// Returns `Ok(None)` for empty buckets (no entries, no metadata) and for
+    /// buckets that have entries but no leading metaentry (legacy data — real
+    /// protocol 24+ buckets always carry one).
     /// Returns `Err` on I/O or deserialization errors from disk-backed buckets.
+    ///
+    /// **Performance:** O(1) after first call. The disk-backed variant reads
+    /// from a cache populated at load time (no file I/O); the in-memory
+    /// variant computes the value once from the leading entry and memoizes
+    /// it on a per-bucket `OnceLock`.
     pub fn protocol_version(&self) -> Result<Option<u32>> {
-        let iter = self.iter()?;
-        for entry_result in iter {
-            match entry_result {
-                Ok(BucketEntry::Metaentry(meta)) => return Ok(Some(meta.ledger_version)),
-                Ok(_) => {}
-                Err(e) => return Err(e),
+        // Empty/sentinel buckets carry no metaentry — short-circuit.
+        if self.is_empty() {
+            return Ok(None);
+        }
+        match &self.storage {
+            BucketStorage::DiskBacked { disk_bucket } => Ok(disk_bucket.protocol_version()),
+            BucketStorage::InMemory {
+                entries,
+                protocol_version,
+                ..
+            } => {
+                // Fast path: cached.
+                if let Some(v) = protocol_version.get() {
+                    return Ok(*v);
+                }
+                // Slow path (first call): scan for the leading metaentry.
+                // Stop at the first non-metaentry — by construction the
+                // metaentry is at the head of the entry list.
+                let computed = entries.iter().find_map(|e| match e {
+                    BucketEntry::Metaentry(m) => Some(Some(m.ledger_version)),
+                    _ => None,
+                });
+                let value = computed.unwrap_or(None);
+                // Best-effort populate; if a concurrent caller already set it,
+                // the value is identical (deterministic from `entries`).
+                let _ = protocol_version.set(value);
+                Ok(value)
             }
         }
-        Ok(None)
     }
 
     /// Convert bucket contents to uncompressed XDR bytes.
@@ -1021,6 +1070,7 @@ impl Bucket {
             storage: BucketStorage::InMemory {
                 entries: Arc::new(entries),
                 key_index: Arc::new(key_index),
+                protocol_version: Arc::new(OnceLock::new()),
             },
             // Use shared state - no cloning needed!
             level_zero_state: LevelZeroState::SharedWithStorage { metadata_count },
@@ -1918,5 +1968,44 @@ mod tests {
 
         let result = Bucket::from_parts(Hash256::ZERO, entries, key_index, 0);
         assert!(result.is_ok(), "from_parts should accept sorted entries");
+    }
+
+    #[test]
+    fn test_bucket_protocol_version_empty_bucket_returns_none() {
+        // Bucket::empty() — zero hash, no entries.
+        let empty = Bucket::empty();
+        assert_eq!(empty.protocol_version().unwrap(), None);
+
+        // Sentinel empty_hash bucket — non-zero hash, empty entries.
+        let sentinel = Bucket::for_sentinel_hash(Hash256::empty_hash()).unwrap();
+        assert_eq!(sentinel.protocol_version().unwrap(), None);
+    }
+
+    #[test]
+    fn test_bucket_protocol_version_in_memory_path() {
+        use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt};
+
+        let entries = vec![
+            BucketEntry::Metaentry(BucketMetadata {
+                ledger_version: 24,
+                ext: BucketMetadataExt::V0,
+            }),
+            BucketEntry::Liveentry(make_account_entry([1u8; 32], 100)),
+        ];
+        let bucket = Bucket::from_entries(entries).unwrap();
+
+        // First call computes; second call hits the cached OnceLock.
+        assert_eq!(bucket.protocol_version().unwrap(), Some(24));
+        assert_eq!(bucket.protocol_version().unwrap(), Some(24));
+    }
+
+    #[test]
+    fn test_bucket_protocol_version_in_memory_no_metaentry_returns_none() {
+        let entries = vec![
+            BucketEntry::Liveentry(make_account_entry([1u8; 32], 100)),
+            BucketEntry::Liveentry(make_account_entry([2u8; 32], 200)),
+        ];
+        let bucket = Bucket::from_entries(entries).unwrap();
+        assert_eq!(bucket.protocol_version().unwrap(), None);
     }
 }

--- a/crates/bucket/src/disk_bucket.rs
+++ b/crates/bucket/src/disk_bucket.rs
@@ -40,7 +40,9 @@ use std::sync::{Arc, OnceLock};
 use memmap2::Mmap;
 
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{LedgerEntryType, LedgerKey, Limits, ReadXdr};
+use stellar_xdr::curr::{
+    BucketEntry as XdrBucketEntry, LedgerEntryType, LedgerKey, Limits, ReadXdr,
+};
 
 use henyey_common::{BucketListDbConfig, Hash256};
 
@@ -107,6 +109,16 @@ pub struct DiskBucket {
     /// Initialized lazily via `maybe_initialize_cache()`.
     /// Only caches ACCOUNT entries (matching stellar-core).
     cache: OnceLock<Arc<RandomEvictionCache>>,
+    /// Cached protocol version read from the leading metaentry.
+    ///
+    /// `Some(Some(v))` — bucket has a metaentry with `ledger_version = v`.
+    /// `Some(None)`     — bucket has no metaentry (legacy / empty bucket).
+    /// Not yet set      — cache has not been populated (no constructor exposes
+    ///                     this state in normal use; see `protocol_version()`).
+    ///
+    /// Populated cheaply at construction by every public constructor so calls
+    /// to `protocol_version()` are O(1) with no fallback file read.
+    protocol_version: OnceLock<Option<u32>>,
 }
 
 impl Clone for DiskBucket {
@@ -119,6 +131,7 @@ impl Clone for DiskBucket {
             index: self.index.clone(),
             mmap: self.mmap.clone(),
             cache: self.cache.clone(),
+            protocol_version: self.protocol_version.clone(),
         }
     }
 }
@@ -138,6 +151,14 @@ struct StreamingXdrEntryIterator {
     validator: crate::entry::StreamingSortedValidator,
     /// Number of records read (including those that failed to parse).
     record_count: usize,
+    /// Captured `ledger_version` from the bucket's leading metaentry, if any.
+    ///
+    /// We capture this here because `key().is_some()` filters metaentries out
+    /// of the yielded records below — but we need the value for the
+    /// disk-bucket-level `protocol_version` cache. Set on the *first*
+    /// metaentry encountered (matching stellar-core's `getBucketVersion`,
+    /// which reads the leading metaentry).
+    protocol_version: Option<u32>,
     failed: bool,
 }
 
@@ -153,6 +174,7 @@ impl StreamingXdrEntryIterator {
             },
             validator: crate::entry::StreamingSortedValidator::new(),
             record_count: 0,
+            protocol_version: None,
             failed: false,
         })
     }
@@ -161,14 +183,22 @@ impl StreamingXdrEntryIterator {
         self.records.position()
     }
 
-    /// Finalize the iterator, returning (record_count, hash).
-    /// Hash is only available if the iterator was created with `compute_hash=true`.
-    fn finalize(self) -> (usize, Option<Hash256>) {
+    /// Finalize the iterator, returning `(record_count, hash, protocol_version)`.
+    ///
+    /// - `hash` is only available if the iterator was created with `compute_hash=true`.
+    /// - `protocol_version` is `Some(v)` if a metaentry was observed during the
+    ///   stream (carrying `ledger_version = v`), otherwise `None`.
+    ///
+    /// **Note:** the return type was extended from
+    /// `(usize, Option<Hash256>)` to `(usize, Option<Hash256>, Option<u32>)`
+    /// when `protocol_version` capture was added — update any external
+    /// destructuring sites accordingly.
+    fn finalize(self) -> (usize, Option<Hash256>, Option<u32>) {
         let hash = self.hasher.map(|h| {
             let hash_bytes: [u8; 32] = h.finalize().into();
             Hash256::from_bytes(hash_bytes)
         });
-        (self.record_count, hash)
+        (self.record_count, hash, self.protocol_version)
     }
 }
 
@@ -213,6 +243,17 @@ impl Iterator for StreamingXdrEntryIterator {
             if let Err(e) = self.validator.validate(&xdr_entry) {
                 self.failed = true;
                 return Some(Err(e));
+            }
+
+            // Capture the leading metaentry's ledger_version for the disk bucket
+            // protocol-version cache. The metaentry is filtered out below
+            // (it has no key), but its `ledger_version` is what stellar-core's
+            // `getBucketVersion` returns. We only record the *first* metaentry
+            // because real bucket files have at most one metaentry at the head.
+            if let XdrBucketEntry::Metaentry(ref meta) = xdr_entry {
+                if self.protocol_version.is_none() {
+                    self.protocol_version = Some(meta.ledger_version);
+                }
             }
 
             if xdr_entry.key().is_some() {
@@ -312,7 +353,7 @@ impl DiskBucket {
                 ),
             )));
         }
-        let (entry_count, hash) = iter.finalize();
+        let (entry_count, hash, protocol_version) = iter.finalize();
         let hash = hash.expect("hasher was enabled");
 
         tracing::debug!(
@@ -330,6 +371,11 @@ impl DiskBucket {
         mmap.set(Self::create_mmap(path)?)
             .expect("just initialized");
 
+        let protocol_version_cache = OnceLock::new();
+        protocol_version_cache
+            .set(protocol_version)
+            .expect("just initialized");
+
         Ok(Self {
             hash,
             file_path: path.to_path_buf(),
@@ -338,6 +384,7 @@ impl DiskBucket {
             index: Box::new(live_index),
             mmap,
             cache: OnceLock::new(),
+            protocol_version: protocol_version_cache,
         })
     }
 
@@ -383,8 +430,19 @@ impl DiskBucket {
             });
         }
 
+        // Eagerly populate the protocol_version cache by reading the file's
+        // leading XDR record (one disk seek per bucket on startup). This keeps
+        // the post-construction contract uniform with `from_file_streaming_*`:
+        // `protocol_version()` is always O(1) with no fallback file read.
+        let protocol_version = Self::read_leading_protocol_version(path)?;
+
         let mmap = OnceLock::new();
         mmap.set(Self::create_mmap(path)?)
+            .expect("just initialized");
+
+        let protocol_version_cache = OnceLock::new();
+        protocol_version_cache
+            .set(protocol_version)
             .expect("just initialized");
 
         Ok(Self {
@@ -395,6 +453,36 @@ impl DiskBucket {
             index: Box::new(prebuilt_index),
             mmap,
             cache: OnceLock::new(),
+            protocol_version: protocol_version_cache,
+        })
+    }
+
+    /// Read just the leading XDR record of a bucket file and return the
+    /// metaentry's `ledger_version` if the leading record is a `Metaentry`.
+    /// Returns `Ok(None)` if the file is empty or the leading record is not a
+    /// metaentry (the latter matches stellar-core's `getBucketVersion` which
+    /// returns 0 for buckets without a leading metaentry — protocol 24+
+    /// always emits one for non-empty merges, so this is the legacy/empty
+    /// path).
+    fn read_leading_protocol_version(path: &Path) -> Result<Option<u32>> {
+        let file_len = std::fs::metadata(path)?.len();
+        if file_len == 0 {
+            return Ok(None);
+        }
+        let file = File::open(path)?;
+        let mut records = crate::record::RecordMarkedReader::new(BufReader::new(file), file_len);
+        let Some(record) = records.next_record()? else {
+            return Ok(None);
+        };
+        let xdr_entry = XdrBucketEntry::from_xdr(record.body, Limits::none()).map_err(|e| {
+            BucketError::Serialization(format!(
+                "Failed to parse leading bucket entry at offset {}: {}",
+                record.offset, e
+            ))
+        })?;
+        Ok(match xdr_entry {
+            XdrBucketEntry::Metaentry(m) => Some(m.ledger_version),
+            _ => None,
         })
     }
 
@@ -446,6 +534,25 @@ impl DiskBucket {
     /// Get the path to the bucket file.
     pub fn file_path(&self) -> &Path {
         &self.file_path
+    }
+
+    /// Get the protocol version recorded in this bucket's leading metaentry.
+    ///
+    /// Returns `Ok(Some(v))` if the bucket has a metaentry with
+    /// `ledger_version = v`, or `Ok(None)` if the bucket has no leading
+    /// metaentry (matches stellar-core's `getBucketVersion` returning 0 for
+    /// metaentry-less buckets — callers typically map `None` to 0).
+    ///
+    /// This is O(1) and never reads from disk: the value is captured at
+    /// construction time by every public constructor (`from_file_streaming*`
+    /// captures it during the streaming load; `from_prebuilt` reads just the
+    /// leading record once).
+    pub fn protocol_version(&self) -> Option<u32> {
+        // Every public constructor sets this OnceLock before returning, so the
+        // unwrap below cannot fail in normal use. Use `*get_or_init(... None)`
+        // as a defensive default rather than panicking, in case a future
+        // internal constructor forgets to populate it.
+        *self.protocol_version.get_or_init(|| None)
     }
 
     /// Returns a reference to the live bucket index.
@@ -1049,6 +1156,7 @@ mod tests {
             )),
             mmap: OnceLock::new(),
             cache: OnceLock::new(),
+            protocol_version: OnceLock::new(),
         };
         let key = LedgerKey::Account(LedgerKeyAccount {
             account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([9u8; 32]))),
@@ -1337,5 +1445,78 @@ mod tests {
             "streaming loader should accept sorted entries"
         );
         assert_eq!(result.unwrap().len(), 2);
+    }
+
+    fn make_metaentry_bytes(ledger_version: u32) -> Vec<u8> {
+        use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt, WriteXdr};
+
+        let entry = stellar_xdr::curr::BucketEntry::Metaentry(BucketMetadata {
+            ledger_version,
+            ext: BucketMetadataExt::V0,
+        });
+        let entry_bytes = entry.to_xdr(Limits::none()).unwrap();
+        let record_mark = (entry_bytes.len() as u32) | crate::XDR_RECORD_MARK;
+        let mut out = Vec::new();
+        out.extend_from_slice(&record_mark.to_be_bytes());
+        out.extend_from_slice(&entry_bytes);
+        out
+    }
+
+    fn make_bucket_bytes_with_metadata(ledger_version: u32) -> Vec<u8> {
+        let mut bytes = make_metaentry_bytes(ledger_version);
+        bytes.extend(make_test_bucket_bytes());
+        bytes
+    }
+
+    #[test]
+    fn test_disk_bucket_caches_protocol_version_on_streaming_load() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("with_meta.bucket");
+
+        let bytes = make_bucket_bytes_with_metadata(24);
+        let bucket = DiskBucket::from_xdr_bytes(&bytes, &path).unwrap();
+
+        // Cached value matches metaentry's ledger_version.
+        assert_eq!(bucket.protocol_version(), Some(24));
+
+        // Delete the underlying file — protocol_version() must still return
+        // the cached value (proves no fallback file read).
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(bucket.protocol_version(), Some(24));
+    }
+
+    #[test]
+    fn test_disk_bucket_caches_protocol_version_on_prebuilt() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("prebuilt.bucket");
+
+        let bytes = make_bucket_bytes_with_metadata(25);
+        let original = DiskBucket::from_xdr_bytes(&bytes, &path).unwrap();
+
+        // Reconstruct via from_prebuilt using the original's index and metadata.
+        let prebuilt_index = (*original.index).clone();
+        let entry_count = original.entry_count;
+        let hash = original.hash();
+        // Drop the original bucket so the prebuilt path opens the file fresh.
+        drop(original);
+
+        let prebuilt = DiskBucket::from_prebuilt(&path, hash, entry_count, prebuilt_index).unwrap();
+        assert_eq!(
+            prebuilt.protocol_version(),
+            Some(25),
+            "from_prebuilt should eagerly populate the cache via a leading-record read"
+        );
+    }
+
+    #[test]
+    fn test_disk_bucket_protocol_version_no_metaentry_returns_none() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("no_meta.bucket");
+
+        // make_test_bucket_bytes produces a single liveentry with no metaentry.
+        let bytes = make_test_bucket_bytes();
+        let bucket = DiskBucket::from_xdr_bytes(&bytes, &path).unwrap();
+
+        assert_eq!(bucket.protocol_version(), None);
     }
 }

--- a/crates/history/src/archive_state.rs
+++ b/crates/history/src/archive_state.rs
@@ -390,6 +390,17 @@ const FIRST_PROTOCOL_SHADOWS_REMOVED: u32 = 12;
 /// Empty buckets have version 0 and are skipped until the first non-empty bucket
 /// is seen (bottom-up). After a non-empty bucket, all higher-level buckets
 /// must satisfy the version constraint.
+///
+/// # Equivalence note
+///
+/// Stellar-core's `validateBucketListHelper` flips its `nonEmptySeen` flag from
+/// `!bucket->isEmpty()`, while this implementation flips it from `version > 0`.
+/// For protocol 24+ (the only protocol range henyey supports — see
+/// `crates/henyey/Cargo.toml` and the project README) every non-empty bucket
+/// carries a leading metaentry with `ledger_version >= 11`, so the two
+/// formulations are equivalent. Older protocols (pre-11) could in principle
+/// produce a non-empty bucket without a metaentry (`version == 0`), but those
+/// are out of scope for this codebase.
 pub fn validate_bucket_list_structure(
     levels: &[BucketLevelVersionInfo],
     expected_level_count: usize,

--- a/crates/history/src/catchup/buckets.rs
+++ b/crates/history/src/catchup/buckets.rs
@@ -1,8 +1,12 @@
 //! Bucket application logic for catchup: restoring bucket lists from HAS.
 
+use crate::archive_state::{
+    validate_bucket_list_structure, BucketLevelVersionInfo, HASBucketLevel,
+};
 use crate::{archive_state::HistoryArchiveState, HistoryError, Result};
 use henyey_bucket::{
-    canonical_bucket_filename, Bucket, BucketList, HotArchiveBucketList, PendingMergeState,
+    canonical_bucket_filename, Bucket, BucketLevel, BucketList, HotArchiveBucketLevel,
+    HotArchiveBucketList, PendingMergeState,
 };
 use henyey_common::fs_utils::atomic_write_bytes;
 use henyey_common::Hash256;
@@ -51,6 +55,96 @@ pub(super) fn verified_hot_archive_bucket_loader(
     bucket_manager: std::sync::Arc<henyey_bucket::BucketManager>,
 ) -> impl FnMut(&Hash256) -> henyey_bucket::Result<henyey_bucket::HotArchiveBucket> {
     move |hash: &Hash256| bucket_manager.load_hot_archive_bucket_for_merge(hash)
+}
+
+/// Build per-level version info for a restored live `BucketList`, suitable
+/// for passing to [`validate_bucket_list_structure`].
+///
+/// The `levels` and `has_levels` slices are zipped — any length mismatch is
+/// surfaced by the validator's own size check, not by an indexing panic, so
+/// passing mismatched lengths still yields the validator's structured error.
+///
+/// Each bucket's protocol version is taken from the cached
+/// `Bucket::protocol_version()` (O(1) after load); empty / metaentry-less
+/// buckets map to version 0, matching stellar-core's
+/// `bucket->isEmpty() ? 0 : bucket->getBucketVersion()` branch.
+pub(super) fn build_live_level_version_infos(
+    levels: &[BucketLevel],
+    has_levels: &[HASBucketLevel],
+) -> Result<Vec<BucketLevelVersionInfo>> {
+    let mut out = Vec::with_capacity(levels.len().max(has_levels.len()));
+    for (level, has_level) in levels.iter().zip(has_levels.iter()) {
+        let curr_version = level
+            .curr
+            .protocol_version()
+            .map_err(|e| {
+                HistoryError::CatchupFailed(format!(
+                    "failed to read curr bucket protocol version: {}",
+                    e
+                ))
+            })?
+            .unwrap_or(0);
+        let snap_version = level
+            .snap
+            .protocol_version()
+            .map_err(|e| {
+                HistoryError::CatchupFailed(format!(
+                    "failed to read snap bucket protocol version: {}",
+                    e
+                ))
+            })?
+            .unwrap_or(0);
+        out.push(BucketLevelVersionInfo {
+            snap_version,
+            curr_version,
+            next: has_level.next.clone(),
+        });
+    }
+    Ok(out)
+}
+
+/// Build per-level version info for a restored hot-archive bucket list,
+/// suitable for passing to [`validate_bucket_list_structure`].
+///
+/// Same contract as [`build_live_level_version_infos`] but for hot-archive
+/// levels — `HotArchiveBucket::get_protocol_version()` returns `Ok(0)` for
+/// empty buckets directly, so no `unwrap_or(0)` is needed.
+pub(super) fn build_hot_archive_level_version_infos(
+    levels: &[HotArchiveBucketLevel],
+    has_levels: &[HASBucketLevel],
+) -> Result<Vec<BucketLevelVersionInfo>> {
+    let mut out = Vec::with_capacity(levels.len().max(has_levels.len()));
+    for (level, has_level) in levels.iter().zip(has_levels.iter()) {
+        let curr_version = level.curr().get_protocol_version().map_err(|e| {
+            HistoryError::CatchupFailed(format!(
+                "failed to read hot-archive curr bucket protocol version: {}",
+                e
+            ))
+        })?;
+        let snap_version = level.snap_bucket().get_protocol_version().map_err(|e| {
+            HistoryError::CatchupFailed(format!(
+                "failed to read hot-archive snap bucket protocol version: {}",
+                e
+            ))
+        })?;
+        out.push(BucketLevelVersionInfo {
+            snap_version,
+            curr_version,
+            next: has_level.next.clone(),
+        });
+    }
+    Ok(out)
+}
+
+/// Translate a `validate_bucket_list_structure` error into the catchup error
+/// class so the catchup orchestrator's existing handling kicks in unchanged.
+fn map_validation_error(scope: &str, e: HistoryError) -> HistoryError {
+    match e {
+        HistoryError::VerificationFailed(msg) => {
+            HistoryError::CatchupFailed(format!("invalid {} bucket list structure: {}", scope, msg))
+        }
+        other => other,
+    }
 }
 
 impl CatchupManager {
@@ -348,6 +442,19 @@ impl CatchupManager {
                 })?;
         bucket_list.set_bucket_dir(bucket_dir.to_path_buf());
 
+        // Validate live bucket-list structure post-restore.
+        //
+        // This mirrors stellar-core's `containsValidBuckets` invocation in
+        // `CatchupWork.cpp:217` between `DownloadBucketsWork` and
+        // `ApplyBucketsWork`. Henyey runs the check inside `apply_buckets`
+        // (the structurally analogous post-restore point), still before any
+        // DB mutation so the observable effect is identical: a malformed HAS
+        // aborts catchup with the same error class.
+        let live_infos =
+            build_live_level_version_infos(bucket_list.levels(), &has.current_buckets)?;
+        validate_bucket_list_structure(&live_infos, BucketList::NUM_LEVELS)
+            .map_err(|e| map_validation_error("live", e))?;
+
         // Log the restored bucket list hash
         info!("Live bucket list restored hash: {}", bucket_list.hash());
         info!(
@@ -555,6 +662,15 @@ impl CatchupManager {
                 );
             }
 
+            // Validate hot-archive bucket-list structure post-restore.
+            // Mirrors stellar-core's second `validateBucketListHelper` call
+            // inside `containsValidBuckets` for the hot-archive list.
+            let hot_has_levels = has.hot_archive_levels();
+            let hot_infos =
+                build_hot_archive_level_version_infos(hot_bucket_list.levels(), hot_has_levels)?;
+            validate_bucket_list_structure(&hot_infos, HotArchiveBucketList::NUM_LEVELS)
+                .map_err(|e| map_validation_error("hot archive", e))?;
+
             hot_bucket_list
         } else {
             HotArchiveBucketList::new()
@@ -575,6 +691,34 @@ impl CatchupManager {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::archive_state::HASBucketNext;
+    use henyey_bucket::{BucketEntry, HOT_ARCHIVE_BUCKET_LIST_LEVELS};
+    use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt};
+
+    fn meta_entry(version: u32) -> BucketEntry {
+        BucketEntry::Metaentry(BucketMetadata {
+            ledger_version: version,
+            ext: BucketMetadataExt::V0,
+        })
+    }
+
+    fn bucket_with_version(version: u32) -> Bucket {
+        Bucket::from_entries(vec![meta_entry(version)]).expect("metaentry-only bucket valid")
+    }
+
+    fn empty_has_level() -> HASBucketLevel {
+        HASBucketLevel {
+            curr: Hash256::ZERO.to_hex(),
+            snap: Hash256::ZERO.to_hex(),
+            next: HASBucketNext::default(),
+        }
+    }
+
+    fn cleared_levels(n: usize) -> Vec<HASBucketLevel> {
+        (0..n).map(|_| empty_has_level()).collect()
+    }
+
     /// Stage E: pin the metric literals emitted from this module so a typo
     /// can't silently detach this crate from the central catalog.
     #[test]
@@ -618,6 +762,156 @@ mod tests {
                 search_from = idx + metric.len();
             }
             assert!(found_any, "metric {metric} not found in catchup/buckets.rs",);
+        }
+    }
+
+    #[test]
+    fn test_build_level_version_infos_pairs_buckets_and_has_levels() {
+        let mut bucket_list = BucketList::new();
+        // Level 0: curr=v24, snap=empty(0); higher levels: empty.
+        let level0 = bucket_list.level_mut(0).unwrap();
+        level0.set_curr(bucket_with_version(24));
+        // snap stays empty.
+
+        let mut has_levels = cleared_levels(BucketList::NUM_LEVELS);
+        // Default `next` (state=CLEAR) is fine for level 0.
+        has_levels[0].next = HASBucketNext::default();
+
+        let infos = build_live_level_version_infos(bucket_list.levels(), &has_levels).unwrap();
+        assert_eq!(infos.len(), BucketList::NUM_LEVELS);
+        assert_eq!(infos[0].curr_version, 24);
+        assert_eq!(infos[0].snap_version, 0);
+        for level_info in infos.iter().skip(1) {
+            assert_eq!(level_info.curr_version, 0);
+            assert_eq!(level_info.snap_version, 0);
+        }
+    }
+
+    #[test]
+    fn test_build_live_then_validator_accepts_well_formed_list() {
+        // All-empty bucket list: every level has version 0; the validator
+        // skips the next-field check via `non_empty_seen=false` until j==0,
+        // where the only check is `next.is_clear()` — satisfied by the
+        // default `HASBucketNext`.
+        let bucket_list = BucketList::new();
+        let has_levels = cleared_levels(BucketList::NUM_LEVELS);
+        let infos = build_live_level_version_infos(bucket_list.levels(), &has_levels).unwrap();
+        validate_bucket_list_structure(&infos, BucketList::NUM_LEVELS)
+            .expect("well-formed (all-empty) list must validate");
+    }
+
+    #[test]
+    fn test_build_live_then_validator_rejects_non_monotonic_versions() {
+        // Walking from deepest to level 0, snap then curr must be
+        // non-decreasing. Put the LOWER version at a deeper level than
+        // a HIGHER version → triggers the monotonicity error.
+        //
+        // Place v24 at the deepest curr and v20 at the next-deeper snap. Use
+        // version 24 at the prev-snap (level deep-1 snap) so the validator's
+        // `prev_snap_version >= FIRST_PROTOCOL_SHADOWS_REMOVED` branch
+        // accepts the cleared `next` field; the failure must come from the
+        // version monotonicity check, not the next-field check.
+        let mut bucket_list = BucketList::new();
+        let deep = BucketList::NUM_LEVELS - 1;
+        bucket_list
+            .level_mut(deep)
+            .unwrap()
+            .set_curr(bucket_with_version(24));
+        bucket_list
+            .level_mut(deep - 1)
+            .unwrap()
+            .set_snap(bucket_with_version(20));
+
+        let has_levels = cleared_levels(BucketList::NUM_LEVELS);
+        let infos = build_live_level_version_infos(bucket_list.levels(), &has_levels).unwrap();
+        let err = validate_bucket_list_structure(&infos, BucketList::NUM_LEVELS)
+            .expect_err("non-monotonic versions must be rejected");
+        match err {
+            HistoryError::VerificationFailed(msg) => {
+                assert!(
+                    msg.contains("incompatible bucket versions"),
+                    "unexpected error: {msg}"
+                );
+            }
+            other => panic!("expected VerificationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_live_then_validator_rejects_level0_next_not_clear() {
+        // All-empty list (so prev-level next-field checks are skipped via
+        // `non_empty_seen=false`) but with a non-clear `next` at level 0 →
+        // the level-0 next-clear check fires unconditionally.
+        let bucket_list = BucketList::new();
+        let mut has_levels = cleared_levels(BucketList::NUM_LEVELS);
+        has_levels[0].next = HASBucketNext {
+            state: 1, // FB_HASH_OUTPUT
+            output: Some(Hash256::ZERO.to_hex()),
+            ..HASBucketNext::default()
+        };
+
+        let infos = build_live_level_version_infos(bucket_list.levels(), &has_levels).unwrap();
+        let err = validate_bucket_list_structure(&infos, BucketList::NUM_LEVELS)
+            .expect_err("non-clear next at level 0 must be rejected");
+        match err {
+            HistoryError::VerificationFailed(msg) => {
+                assert!(
+                    msg.contains("next must be clear at level 0"),
+                    "unexpected error: {msg}"
+                );
+            }
+            other => panic!("expected VerificationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_hot_archive_then_validator_rejects_level0_next_not_clear() {
+        // All-empty hot archive list — level 0 next-clear check fires
+        // unconditionally regardless of versions (matches validator semantics).
+        let hot_list = HotArchiveBucketList::new();
+
+        let mut has_levels = cleared_levels(HOT_ARCHIVE_BUCKET_LIST_LEVELS);
+        has_levels[0].next = HASBucketNext {
+            state: 1,
+            output: Some(Hash256::ZERO.to_hex()),
+            ..HASBucketNext::default()
+        };
+
+        let infos = build_hot_archive_level_version_infos(hot_list.levels(), &has_levels).unwrap();
+        // Sanity: helper produced one info per level, all version 0.
+        assert_eq!(infos.len(), HotArchiveBucketList::NUM_LEVELS);
+        assert!(infos
+            .iter()
+            .all(|i| i.curr_version == 0 && i.snap_version == 0));
+
+        let err = validate_bucket_list_structure(&infos, HotArchiveBucketList::NUM_LEVELS)
+            .expect_err("non-clear next at level 0 must be rejected for hot archive");
+        match err {
+            HistoryError::VerificationFailed(msg) => {
+                assert!(
+                    msg.contains("next must be clear at level 0"),
+                    "unexpected error: {msg}"
+                );
+            }
+            other => panic!("expected VerificationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_validation_error_translates_to_catchup_failed() {
+        let v = HistoryError::VerificationFailed("boom".to_string());
+        match map_validation_error("live", v) {
+            HistoryError::CatchupFailed(msg) => {
+                assert!(msg.contains("invalid live bucket list structure"));
+                assert!(msg.contains("boom"));
+            }
+            other => panic!("expected CatchupFailed, got {other:?}"),
+        }
+        // Non-VerificationFailed errors pass through unchanged.
+        let other = HistoryError::CatchupFailed("untouched".to_string());
+        match map_validation_error("hot archive", other) {
+            HistoryError::CatchupFailed(msg) => assert_eq!(msg, "untouched"),
+            other => panic!("unexpected error variant: {other:?}"),
         }
     }
 }

--- a/crates/history/src/catchup/buckets.rs
+++ b/crates/history/src/catchup/buckets.rs
@@ -60,9 +60,14 @@ pub(super) fn verified_hot_archive_bucket_loader(
 /// Build per-level version info for a restored live `BucketList`, suitable
 /// for passing to [`validate_bucket_list_structure`].
 ///
-/// The `levels` and `has_levels` slices are zipped — any length mismatch is
-/// surfaced by the validator's own size check, not by an indexing panic, so
-/// passing mismatched lengths still yields the validator's structured error.
+/// The `levels` and `has_levels` slices are zipped: any length mismatch is
+/// surfaced by the validator's own size check rather than by an indexing
+/// panic, so passing mismatched lengths still yields the validator's
+/// structured error — **provided** callers pass the *expected*
+/// `BucketList::NUM_LEVELS` (not `infos.len()`) to
+/// `validate_bucket_list_structure`. Passing `infos.len()` would silently
+/// short-circuit the size check; the call sites in this module pass the
+/// constant directly to make that intent explicit.
 ///
 /// Each bucket's protocol version is taken from the cached
 /// `Bucket::protocol_version()` (O(1) after load); empty / metaentry-less
@@ -106,9 +111,10 @@ pub(super) fn build_live_level_version_infos(
 /// Build per-level version info for a restored hot-archive bucket list,
 /// suitable for passing to [`validate_bucket_list_structure`].
 ///
-/// Same contract as [`build_live_level_version_infos`] but for hot-archive
-/// levels — `HotArchiveBucket::get_protocol_version()` returns `Ok(0)` for
-/// empty buckets directly, so no `unwrap_or(0)` is needed.
+/// Same contract as [`build_live_level_version_infos`] (including the
+/// caller-must-pass-`NUM_LEVELS` requirement for the validator's size check)
+/// but for hot-archive levels — `HotArchiveBucket::get_protocol_version()`
+/// returns `Ok(0)` for empty buckets directly, so no `unwrap_or(0)` is needed.
 pub(super) fn build_hot_archive_level_version_infos(
     levels: &[HotArchiveBucketLevel],
     has_levels: &[HASBucketLevel],


### PR DESCRIPTION
Closes #2683

## Summary

Wires the existing `validate_bucket_list_structure` checker into the catchup
`apply_buckets` flow. Per-bucket protocol versions are cached on both
`DiskBucket` and `BucketStorage::InMemory`, and `Bucket::protocol_version()`
becomes O(1) after construction.

## Implementation notes

- **DiskBucket cache**: New `OnceLock<Option<u32>>` field, populated by the
  streaming loader from the leading `Metaentry::ledger_version` and by the
  prebuilt path via a single XDR record read (`read_leading_protocol_version`).
- **InMemory cache**: New `Arc<OnceLock<Option<u32>>>` shared across clones;
  `Bucket::protocol_version()` short-circuits `is_empty()`, delegates to
  the disk cache, or scans entries once and memoizes for in-memory.
- **Validation wiring**: After `BucketList::restore_from_has`, build
  per-level `BucketLevelVersionInfo` and call
  `validate_bucket_list_structure`; same for the hot-archive list, gated on
  `has.has_hot_archive_buckets()`. `VerificationFailed` is remapped to
  `CatchupFailed("invalid {scope} bucket list structure: ...")`.
- Doc comment added to `validate_bucket_list_structure` documenting the
  `version > 0 ↔ non-empty` equivalence vs stellar-core's `!isEmpty()`
  formulation (safe for protocol 24+).

## Deviations from plan

- The plan called for a single helper to build `BucketLevelVersionInfo`s.
  I split it into two parallel free functions
  (`build_live_level_version_infos` / `build_hot_archive_level_version_infos`)
  because live and hot-archive use different level types
  (`BucketLevel` vs `HotArchiveBucketLevel`) without a shared trait. This is
  simpler than introducing a generic over an ad-hoc trait.
- No PARITY_STATUS row maps directly to this validation; nothing to flip.

## Test plan

- [x] `cargo test -p henyey-bucket --lib` — all green (includes 6 new tests
      for the protocol-version cache on disk and in-memory paths).
- [x] `cargo test -p henyey-history --lib` — all green (includes 6 new tests
      for the helpers and validator wiring).
- [x] `cargo test --all` — all green.
- [x] `cargo fmt --all -- --check`.
- [x] `cargo clippy --all -- -D warnings` — clean.
