### PR TITLE
Narrow henyey-db public API: replace pub use rusqlite with type aliases

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -31,7 +31,7 @@ fn record_phase_histogram(
 /// whether to enqueue the checkpoint for publishing, so the read, the
 /// enqueue suppression, and the marker clear are all atomic.
 fn consume_skip_marker_if_matches(
-    conn: &henyey_db::rusqlite::Connection,
+    conn: &henyey_db::Connection,
     checkpoint_seq: u32,
 ) -> Result<bool, henyey_db::DbError> {
     use henyey_db::queries::StateQueries;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -41,7 +41,7 @@
 //! # Query Traits
 //!
 //! Query functionality is organized into domain-specific traits that extend
-//! [`rusqlite::Connection`]. The [`Database`] type provides convenience methods
+//! [`Connection`]. The [`Database`] type provides convenience methods
 //! that wrap these traits for common operations.
 //!
 //! For advanced use cases, you can obtain a connection and use the traits directly:
@@ -70,10 +70,36 @@ pub use error::DbError;
 
 pub use pool::Database;
 pub use queries::*;
-/// Re-export of `rusqlite` so downstream crates can name `rusqlite::Connection`
-/// without taking a direct dependency on the crate.
-pub use rusqlite;
 pub use scp_persistence::SqliteScpPersistence;
+
+/// SQLite connection type used by [`Database`]'s closure-based APIs
+/// (e.g. [`Database::with_connection`]).
+///
+/// This is a narrow alias for [`rusqlite::Connection`] rather than a broad
+/// `pub use rusqlite;` re-export: only the two types that appear in
+/// `henyey-db`'s public signatures (`Connection` and [`Transaction`]) are
+/// re-exposed, so callers in higher-level crates can name them without taking
+/// a direct `rusqlite` dependency. Every other `rusqlite` item (the `params!`
+/// macro, `rusqlite::Error` variants, `OptionalExtension`, etc.) is an
+/// implementation detail of `henyey-db` and is not reachable through it.
+///
+/// This keeps the named SemVer surface of `henyey-db` scoped to these two
+/// types — a `rusqlite` major-version bump that touches any other item is no
+/// longer automatically a breaking change to `henyey-db`'s API contract.
+///
+/// This is a deliberate two-step migration: the alias still resolves
+/// structurally to `rusqlite::Connection` (so its method signatures still
+/// propagate). A future follow-up to issue #2748 may promote this into a
+/// fully opaque newtype wrapper once the cost of migrating the internal
+/// `impl XQueries for rusqlite::Connection` blocks is justified.
+pub type Connection = rusqlite::Connection;
+
+/// SQLite transaction type used by [`Database`]'s closure-based APIs
+/// (e.g. [`Database::transaction`]).
+///
+/// See [`Connection`] for the rationale behind exposing this as a narrow
+/// `pub type` alias rather than a broad `pub use rusqlite;` re-export.
+pub type Transaction<'conn> = rusqlite::Transaction<'conn>;
 
 /// Result type for database operations.
 pub type Result<T> = std::result::Result<T, DbError>;


### PR DESCRIPTION
Closes #2748

## Summary


The sole external caller of the old `henyey_db::rusqlite::*` path (`consume_skip_marker_if_matches` in `app/ledger_close.rs`) is migrated to the new `henyey_db::Connection` alias. All other call sites use closure-argument type inference and need no source change.

The new aliases still resolve structurally to `rusqlite` types, so this is deliberately a two-step migration — a future follow-up to #2748 may promote them into fully opaque newtype wrappers once the cost of migrating the internal `impl XQueries for rusqlite::Connection` blocks is justified. Doc comments link this issue so the next reader understands the staging.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2748#issuecomment-4465417574)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-db --tests` (105 passed)
- [x] `cargo test --doc -p henyey-db` (5 passed, 2 ignored)
- [x] `cargo test -p henyey-app --tests` (all passed, including the two `consume_skip_marker_if_matches` tests)
- [x] `cargo test --all` (7045 passed, 0 failed)
- [x] `grep -rn 'henyey_db::rusqlite' crates/` returns zero matches after the change

## Deviations from plan

None.

🤖 Generated with GitHub Copilot CLI