### PR TITLE
Reorder make_test_catchup_manager tuple to drop manager before TempDir

### DIFF
--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -817,11 +817,16 @@ mod tests {
     //     `apply_data[0]` for the case-4 (Apply) check.
     // ---------------------------------------------------------------
 
-    /// Returns the manager together with the `TempDir` guard backing its
-    /// `BucketManager`. The caller must keep the `TempDir` alive for the
-    /// duration of the test so the bucket directory is deleted on drop
-    /// rather than leaked under the system temp location.
-    fn make_test_catchup_manager() -> (CatchupManager, tempfile::TempDir) {
+    /// Returns the `TempDir` guard backing the `BucketManager` together
+    /// with the manager. The `TempDir` is returned **first** so callers
+    /// destructure as `let (_tmp_dir, manager) = ...`: Rust drops local
+    /// bindings in reverse declaration order, so binding `manager`
+    /// second guarantees it (and any file handles its `BucketManager`
+    /// holds) is dropped before the `TempDir` removes the directory.
+    /// The caller must keep `_tmp_dir` alive for the duration of the
+    /// test so the bucket directory is deleted on drop rather than
+    /// leaked under the system temp location.
+    fn make_test_catchup_manager() -> (tempfile::TempDir, CatchupManager) {
         use henyey_bucket::BucketManager;
         use henyey_db::Database;
 
@@ -831,8 +836,8 @@ mod tests {
             BucketManager::new(tmp_dir.path().to_path_buf()).expect("bucket manager");
         let archive = crate::HistoryArchive::new("https://example.com").expect("archive");
         (
-            CatchupManager::new(vec![archive], bucket_manager, db),
             tmp_dir,
+            CatchupManager::new(vec![archive], bucket_manager, db),
         )
     }
 
@@ -862,7 +867,7 @@ mod tests {
     fn test_verify_knit_to_lcl_happy_path_mixed() {
         // LCL = 100, lcl_hash = H100, previous_ledger_hash = H99.
         let lcl = make_test_lcl(100, h(0x10), h(0x09));
-        let (manager, _tmp_dir) = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
 
         // Three knit entries spanning cases 1/2/3 — each must classify
         // as Skip inside the loop, exercising 3 iterations of the body.
@@ -896,7 +901,7 @@ mod tests {
     fn test_verify_knit_to_lcl_tampered_knit_entry_returns_fatal() {
         // LCL = 100, lcl_hash = H100, previous_ledger_hash = H99.
         let lcl = make_test_lcl(100, h(0x10), h(0x09));
-        let (manager, _tmp_dir) = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
         // apply_data is irrelevant — the loop must error out before
         // we reach the `.first()` branch.
         let apply_data = vec![make_apply_ledger_data(101, h(0x10))];
@@ -938,7 +943,7 @@ mod tests {
     #[test]
     fn test_verify_knit_to_lcl_empty_apply_data_noop() {
         let lcl = make_test_lcl(100, h(0x10), h(0x09));
-        let (manager, _tmp_dir) = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
 
         // No knit entries, no apply data: pure no-op, must Ok.
         manager


### PR DESCRIPTION
Closes #2751

## Summary

Swap the return tuple of `make_test_catchup_manager` in `crates/history/src/catchup/replay.rs` from `(CatchupManager, TempDir)` to `(TempDir, CatchupManager)`, and update the three destructuring call sites to `let (_tmp_dir, manager) = ...`. Rust drops local bindings in reverse declaration order, so binding `manager` second guarantees it (and any open file handles its `BucketManager` may hold) is dropped before the `TempDir` removes the bucket directory. Latent correctness fix; no behavioral change to production code.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2751#issuecomment-converged)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-history --tests -- -D warnings` — clean
- [x] `cargo test -p henyey-history --tests` — all tests pass (including the three callers: `test_verify_knit_to_lcl_happy_path_mixed`, the tampered-knit-entry test, and the third caller at the previous line ~941)

## Deviations from plan

None.