### PR TITLE
Make tx_set_tracker reentrancy regression test shard-deterministic

### DIFF
--- a/crates/herder/Cargo.toml
+++ b/crates/herder/Cargo.toml
@@ -57,3 +57,8 @@ henyey-crypto.workspace = true
 henyey-ledger = { workspace = true, features = ["test-utils"] }
 henyey-scp = { workspace = true, features = ["test-helpers"] }
 sha2.workspace = true
+# `raw-api` exposes `DashMap::determine_map`, used by the
+# `test_request_at_cap_still_increments_existing` regression test to make the
+# shard collision between `first_hash` and `new_hash` deterministic across all
+# runners regardless of `num_cpus()`. Purely additive feature.
+dashmap = { workspace = true, features = ["raw-api"] }

--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -998,8 +998,62 @@ mod tests {
             "existing entry should increment even at cap"
         );
 
+        // REGRESSION GUARD for PR #2747 / issues #2744, #2750.
+        //
+        // The pre-fix code held a `dashmap::mapref::one::Ref` into `pending`
+        // across the call to `tracker.request(new_hash, ...)`. `request()`
+        // takes a write lock on the destination shard via `pending.entry(...)`.
+        // When `new_hash` and `first_hash` land on the same DashMap shard,
+        // the still-live read guard from `pending.get(&first_hash)` causes
+        // `parking_lot`'s shard `RwLock::write()` call to deadlock the same
+        // thread.
+        //
+        // DashMap's shard count is `4 * num_cpus().next_power_of_two()`, so
+        // whether two arbitrary hashes share a shard depends on the runner.
+        // To make this regression test fail _deterministically_ on every
+        // runner if the snapshot pattern above is ever reverted, we pick
+        // `new_hash` to be provably on the same shard as `first_hash` using
+        // `DashMap::determine_map` (gated behind dashmap's `raw-api`
+        // dev-feature in `crates/herder/Cargo.toml`).
+        //
+        // Inlining `tracker.pending.get(&first_hash).unwrap().request_count`
+        // into the `assert_eq!` above (or re-binding it to a `let entry =
+        // tracker.pending.get(...)` that outlives the next `tracker.request`
+        // call) resurrects the deadlock.
+        let target_shard = tracker.pending.determine_map(&first_hash);
+        let new_hash = {
+            let mut found = None;
+            for i in 0u32..1_000_000 {
+                let mut bytes = [0xFFu8; 32];
+                bytes[0..4].copy_from_slice(&i.to_le_bytes());
+                let candidate = Hash256::from_bytes(bytes);
+                if candidate == first_hash {
+                    continue;
+                }
+                if tracker.pending.contains_key(&candidate) {
+                    continue;
+                }
+                if tracker.pending.determine_map(&candidate) == target_shard {
+                    found = Some(candidate);
+                    break;
+                }
+            }
+            found.expect(
+                "must find a hash on the same DashMap shard as first_hash within 1M tries; \
+                 shard count is 4 * num_cpus().next_power_of_two() so this should converge in O(shards)",
+            )
+        };
+        // Load-bearing invariant: if this ever fires, the regression guard
+        // below has lost its teeth and the test silently stops catching the
+        // bug it was written for.
+        assert_eq!(
+            tracker.pending.determine_map(&first_hash),
+            tracker.pending.determine_map(&new_hash),
+            "test invariant: first_hash and new_hash must collide on a DashMap shard \
+             so a Ref-held-across-request() regression deadlocks deterministically"
+        );
+
         // A brand new hash should be rejected.
-        let new_hash = Hash256::from_bytes([0xFF; 32]);
         assert!(!tracker.request(new_hash, 100));
         assert!(
             tracker.pending.get(&new_hash).is_none(),


### PR DESCRIPTION
Closes #2750

## Summary

Strengthen `test_request_at_cap_still_increments_existing` so the chosen `first_hash`/`new_hash` constants are *provably* on the same DashMap shard via `DashMap::determine_map` (gated behind dashmap's `raw-api` dev-feature). Previously the collision relied on `num_cpus()` at runtime, so the regression guard for PR #2747 silently lost its teeth on some runners. Also adds a load-bearing `assert_eq!(determine_map(first), determine_map(new))` invariant and expands the inline `REGRESSION GUARD` doc comment.

Test-only change. No production behavior changes.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2750#issuecomment-4465489565)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-herder` — 1107 unit + integration tests pass
- [x] **Manual revert-and-verify (per plan §Test plan):** locally reverted the snapshot to the Ref-held form (held `let entry = tracker.pending.get(&first_hash).unwrap();` across `tracker.request(new_hash, 100)` and used `entry.request_count` afterwards). Test deadlocked deterministically and was killed by a 30s `timeout` (exit 143). Restored the snapshot pattern; final committed code uses the snapshot, so this confirms the strengthened test catches the bug PR #2747 fixed.

## Deviations from plan

None.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
