### PR TITLE
Fix TempDir::keep() leak in catchup download.rs and persist.rs test helpers

### DIFF
--- a/crates/history/src/catchup/download.rs
+++ b/crates/history/src/catchup/download.rs
@@ -604,17 +604,30 @@ mod tests {
     use henyey_bucket::BucketManager;
     use henyey_db::{queries::StateQueries, Database};
 
-    fn make_test_catchup_manager() -> CatchupManager {
+    /// Returns the `TempDir` guard backing the `BucketManager` together
+    /// with the manager. The `TempDir` is returned **first** so callers
+    /// destructure as `let (_tmp_dir, manager) = ...`: Rust drops local
+    /// bindings in reverse declaration order, so binding `manager`
+    /// second guarantees it (and any file handles its `BucketManager`
+    /// holds) is dropped before the `TempDir` removes the directory.
+    /// The caller must keep `_tmp_dir` alive for the duration of the
+    /// test so the bucket directory is deleted on drop rather than
+    /// leaked under the system temp location.
+    fn make_test_catchup_manager() -> (tempfile::TempDir, CatchupManager) {
         let db = Database::open_in_memory().expect("in-memory db");
         let tmp_dir = tempfile::tempdir().expect("temp dir");
-        let bucket_manager = BucketManager::new(tmp_dir.keep()).expect("bucket manager");
+        let bucket_manager =
+            BucketManager::new(tmp_dir.path().to_path_buf()).expect("bucket manager");
         let archive = crate::HistoryArchive::new("https://example.com").expect("archive");
-        super::super::CatchupManager::new(vec![archive], bucket_manager, db)
+        (
+            tmp_dir,
+            super::super::CatchupManager::new(vec![archive], bucket_manager, db),
+        )
     }
 
     #[test]
     fn test_load_local_has_absent() {
-        let mgr = make_test_catchup_manager();
+        let (_tmp_dir, mgr) = make_test_catchup_manager();
         let result = mgr.load_local_has();
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
         assert!(result.unwrap().is_none(), "expected None for fresh DB");
@@ -622,7 +635,7 @@ mod tests {
 
     #[test]
     fn test_load_local_has_valid() {
-        let mgr = make_test_catchup_manager();
+        let (_tmp_dir, mgr) = make_test_catchup_manager();
         // Structurally valid v1 HAS with BUCKET_LIST_LEVELS zero-hash levels.
         let zero = "0".repeat(64);
         let zero_level = format!(
@@ -652,7 +665,7 @@ mod tests {
 
     #[test]
     fn test_load_local_has_corrupt_json() {
-        let mgr = make_test_catchup_manager();
+        let (_tmp_dir, mgr) = make_test_catchup_manager();
         mgr.db
             .with_connection(|conn| {
                 conn.set_state(

--- a/crates/history/src/catchup/persist.rs
+++ b/crates/history/src/catchup/persist.rs
@@ -222,12 +222,25 @@ mod tests {
         NetworkId::from_passphrase("Test SDF Network ; September 2015")
     }
 
-    fn make_test_catchup_manager() -> CatchupManager {
+    /// Returns the `TempDir` guard backing the `BucketManager` together
+    /// with the manager. The `TempDir` is returned **first** so callers
+    /// destructure as `let (_tmp_dir, manager) = ...`: Rust drops local
+    /// bindings in reverse declaration order, so binding `manager`
+    /// second guarantees it (and any file handles its `BucketManager`
+    /// holds) is dropped before the `TempDir` removes the directory.
+    /// The caller must keep `_tmp_dir` alive for the duration of the
+    /// test so the bucket directory is deleted on drop rather than
+    /// leaked under the system temp location.
+    fn make_test_catchup_manager() -> (tempfile::TempDir, CatchupManager) {
         let db = Database::open_in_memory().expect("in-memory db");
         let tmp_dir = tempfile::tempdir().expect("temp dir");
-        let bucket_manager = BucketManager::new(tmp_dir.keep()).expect("bucket manager");
+        let bucket_manager =
+            BucketManager::new(tmp_dir.path().to_path_buf()).expect("bucket manager");
         let archive = crate::HistoryArchive::new("https://example.com").expect("archive");
-        CatchupManager::new(vec![archive], bucket_manager, db)
+        (
+            tmp_dir,
+            CatchupManager::new(vec![archive], bucket_manager, db),
+        )
     }
 
     fn make_test_envelope() -> TransactionEnvelope {
@@ -511,7 +524,7 @@ mod tests {
 
     #[test]
     fn test_persist_ledger_history_happy_path() {
-        let manager = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
         let network_id = test_network_id();
 
         let envelope = make_test_envelope();
@@ -554,7 +567,7 @@ mod tests {
 
     #[test]
     fn test_persist_ledger_history_empty_ledger() {
-        let manager = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
         let network_id = test_network_id();
 
         let data = LedgerData::new(
@@ -575,7 +588,7 @@ mod tests {
 
     #[test]
     fn test_persist_ledger_history_with_absent_entries() {
-        let manager = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
         let network_id = test_network_id();
 
         let header = make_header(300);
@@ -612,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_persist_ledger_history_batch_rollback() {
-        let manager = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
         let network_id = test_network_id();
 
         let envelope = make_test_envelope();
@@ -656,7 +669,7 @@ mod tests {
 
     #[test]
     fn test_persist_and_load_ledger_header_round_trip() {
-        let manager = make_test_catchup_manager();
+        let (_tmp_dir, manager) = make_test_catchup_manager();
         let network_id = test_network_id();
 
         let header = make_header(600);


### PR DESCRIPTION
Closes #2752

## Summary

Mirror the `TempDir`-lifetime fix from `replay.rs` (PR #2749) in the two sibling `make_test_catchup_manager` test helpers in `crates/history/src/catchup/download.rs` and `crates/history/src/catchup/persist.rs`. Each helper now returns `(CatchupManager, tempfile::TempDir)` so the bucket directory is dropped on test exit instead of leaked under `$TMPDIR` via `TempDir::keep()`. All 8 callers (3 in download.rs, 5 in persist.rs) updated to bind the guard as `_tmp_dir`.

Test-only change inside `#[cfg(test)] mod tests`; no production behavior or parity surface affected.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2752#issuecomment-4465547675)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-history --tests -- -D warnings`
- [x] `cargo test -p henyey-history --tests` — 507 unit + 12 integration tests pass

## Deviations from plan

None.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)