### PR TITLE
Wire ScpPersistenceManager GC timer into production lifecycle

### DIFF
--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -353,8 +353,17 @@ impl App {
         peer_refresh_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut herder_cleanup_interval = tokio::time::interval(Duration::from_secs(30));
         herder_cleanup_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        let mut tx_set_gc_interval =
-            tokio::time::interval(Duration::from_secs(henyey_herder::TX_SET_GC_DELAY_SECS));
+        // Arm the first tick at +TX_SET_GC_DELAY_SECS rather than firing
+        // immediately on entry, to mirror stellar-core's
+        // VirtualTimer::expires_from_now(TX_SET_GC_DELAY) shape
+        // (HerderImpl.cpp:2442). Functionally harmless either way (the purge
+        // is idempotent and a no-op on an empty DB), but matches upstream
+        // cadence exactly.
+        let tx_set_gc_period = Duration::from_secs(henyey_herder::TX_SET_GC_DELAY_SECS);
+        let mut tx_set_gc_interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + tx_set_gc_period,
+            tx_set_gc_period,
+        );
         tx_set_gc_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         // Get mutable access to SCP envelope receiver

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -353,6 +353,9 @@ impl App {
         peer_refresh_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut herder_cleanup_interval = tokio::time::interval(Duration::from_secs(30));
         herder_cleanup_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut tx_set_gc_interval =
+            tokio::time::interval(Duration::from_secs(henyey_herder::TX_SET_GC_DELAY_SECS));
+        tx_set_gc_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         // Get mutable access to SCP envelope receiver
         let mut scp_rx = self.scp_envelope_rx.lock().await;
@@ -1102,6 +1105,17 @@ impl App {
                 _ = herder_cleanup_interval.tick() => {
                     self.set_phase(30); // 30 = herder_cleanup
                     self.herder.cleanup();
+                }
+
+                // Periodic GC of unreferenced persisted SCP tx sets.
+                // Parity: stellar-core HerderImpl::startTxSetGCTimer() at
+                // HerderImpl.cpp:2440-2444. Called inline (no spawn_blocking)
+                // to match stellar-core's strictly serial reschedule cadence
+                // and to avoid a fire-and-forget task surviving select! exit
+                // on shutdown.
+                _ = tx_set_gc_interval.tick() => {
+                    self.set_phase(33); // 33 = tx_set_gc
+                    self.herder.purge_persisted_tx_sets();
                 }
 
                 // Shutdown signal (lowest priority)

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -902,7 +902,8 @@ pub struct App {
     ///        12=try_apply_buffered, 13=maybe_buffered_catchup,
     ///        14=catchup_running, 15=heartbeat,
     ///        31=scp_verifier (pump_scp_intake: pre-filter + verifier enqueue),
-    ///        32=scp_verified (draining verified envelopes)
+    ///        32=scp_verified (draining verified envelopes),
+    ///        33=tx_set_gc (purge unreferenced persisted tx sets)
     event_loop_phase: Arc<AtomicU64>,
 
     /// Fine-grained sub-phase code for pinpointing a stall inside a
@@ -1618,6 +1619,17 @@ impl App {
             .set_account_provider(Arc::new(types::LedgerAccountProvider {
                 ledger_manager: ledger_manager.clone(),
             }));
+
+        // Wire SCP state persistence so the app event loop's tx_set_gc timer
+        // (lifecycle.rs, phase 33) has something to purge. Parity:
+        // stellar-core `HerderImpl::startTxSetGCTimer()` (HerderImpl.cpp:2440).
+        let scp_persistence = henyey_herder::SqliteScpPersistence::new(db.clone());
+        let scp_persistence_manager = Arc::new(henyey_herder::ScpPersistenceManager::new(
+            Box::new(scp_persistence),
+        ));
+        if herder.set_scp_persistence(scp_persistence_manager).is_err() {
+            panic!("set_scp_persistence called more than once");
+        }
 
         if let Some(qs) = herder.local_quorum_set() {
             let hash = hash_quorum_set(&qs);
@@ -3399,7 +3411,8 @@ pub(crate) const WATCHDOG_PHASE_LEGEND: &str = "\
     20=stats, 21=tx_advert, 22=tx_demand, 23=survey, \
     24=survey_req, 25=survey_phase, 26=scp_timeout, \
     27=ping, 28=peer_maint, 29=peer_refresh, \
-    30=herder_cleanup, 31=scp_verifier, 32=scp_verified.";
+    30=herder_cleanup, 31=scp_verifier, 32=scp_verified, \
+    33=tx_set_gc.";
 
 /// Name of the structured tracing field emitted by
 /// [`WatchdogSnapshot::emit_error()`].
@@ -6841,6 +6854,7 @@ mod tests {
             "30=herder_cleanup",
             "31=scp_verifier",
             "32=scp_verified",
+            "33=tx_set_gc",
         ];
         for entry in &expected {
             assert!(

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -126,8 +126,13 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `verifyEnvelope()` | `scp_driver.verify_envelope()` | Full |
 | `signEnvelope()` | `scp_driver.sign_envelope()` | Full |
 | `verifyStellarValueSignature()` | `scp_driver.verify_stellar_value_signature()` | Full |
-| `startTxSetGCTimer()` | `ScpPersistenceManager::purge_unreferenced_tx_sets()` | Partial |
+| `startTxSetGCTimer()` | `ScpPersistenceManager::purge_unreferenced_tx_sets()` | Full[^txset-gc] |
 | `recomputeKeysToFilter()` | _(not implemented)_ | None |
+
+[^txset-gc]: GC timer + purge wired in #2698 (driven by app event-loop phase
+33 every `TX_SET_GC_DELAY_SECS` = 60s). The broader SCP persist/restore story
+is still incomplete: `persist_scp_state` wiring is tracked in #2768 and
+`restore_scp_state` wiring in #2769.
 
 ### SCP Driver (`scp_driver.rs`)
 
@@ -515,7 +520,6 @@ Features not yet implemented. These ARE counted against parity %.
 | `maxScaledLedgerResources()` | Low | Removed during simplification; re-add if needed |
 | `getTotalResourcesToFlood()` | Low | Flood resource tracking |
 | `stateChanged()` | Low | SCP state change callback |
-| `startTxSetGCTimer()` | Medium | GC logic implemented; periodic timer not yet wired |
 
 ## Architectural Differences
 

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -123,9 +123,8 @@ const PENDING_TX_SET_MAX_AGE_SECS: u64 = 120;
 /// Interval for garbage-collecting unreferenced persisted transaction sets.
 ///
 /// Parity: stellar-core `Herder.cpp:22` — `TX_SET_GC_DELAY = 1 minute`.
-/// Not yet used by a runtime timer (persistence manager is not wired into
-/// the production lifecycle loop). Defined here for parity documentation.
-#[allow(dead_code)]
+/// Driven by the app event loop, which calls
+/// [`Herder::purge_persisted_tx_sets`] on a tokio interval.
 pub const TX_SET_GC_DELAY_SECS: u64 = 60;
 
 /// Result of receiving an SCP envelope.
@@ -497,6 +496,14 @@ pub struct Herder {
     >,
     /// Shared SCP metrics counters.
     scp_metrics: Arc<crate::metrics::ScpMetrics>,
+    /// SCP state persistence manager, installed after construction via
+    /// [`Self::set_scp_persistence`]. Used by [`Self::purge_persisted_tx_sets`]
+    /// to GC unreferenced tx sets on the app event loop's 60s timer.
+    ///
+    /// `OnceLock` enforces single-installer at the type level: tests that
+    /// don't install a manager simply leave it empty (purge becomes a no-op),
+    /// while production install exactly once in `init_herder`.
+    scp_persistence: std::sync::OnceLock<Arc<crate::persistence::ScpPersistenceManager>>,
 }
 
 impl Herder {
@@ -699,6 +706,7 @@ impl Herder {
             scp_verifier_handle,
             verified_rx: std::sync::Mutex::new(verified_rx),
             scp_metrics,
+            scp_persistence: std::sync::OnceLock::new(),
         }
     }
 
@@ -716,6 +724,42 @@ impl Herder {
         &self,
     ) -> Option<tokio::sync::mpsc::UnboundedReceiver<crate::scp_verify::VerifiedEnvelope>> {
         self.verified_rx.lock().ok()?.take()
+    }
+
+    /// Install the SCP state persistence manager.
+    ///
+    /// Called once from `init_herder` after the `Arc<Herder>` is constructed.
+    /// `OnceLock` enforces single-installer at the type-system level: a second
+    /// call returns `Err` with the supplied manager so the caller can fail loud.
+    pub fn set_scp_persistence(
+        &self,
+        manager: Arc<crate::persistence::ScpPersistenceManager>,
+    ) -> std::result::Result<(), Arc<crate::persistence::ScpPersistenceManager>> {
+        self.scp_persistence.set(manager)
+    }
+
+    /// Purge persisted tx sets that are no longer referenced by any persisted
+    /// SCP state. No-op if no persistence manager has been installed.
+    ///
+    /// Called inline from the app event loop's `tx_set_gc_interval` branch
+    /// (every [`TX_SET_GC_DELAY_SECS`] seconds), matching stellar-core's
+    /// `HerderImpl::startTxSetGCTimer()` (`HerderImpl.cpp:2440-2444`) /
+    /// `purgeOldPersistedTxSets()` (`HerderImpl.cpp:2448-2487`) cadence.
+    ///
+    /// TODO(#2770): the underlying `purge_unreferenced_tx_sets()` performs
+    /// three serial connection checkouts — `get_all_tx_set_hashes`,
+    /// `load_all_scp_states`, `delete_tx_sets_by_hashes` — without a single
+    /// SQLite transaction. Today this is harmless because `persist_scp_state`
+    /// (#2768) is unwired; once it is wired, a concurrent persist between
+    /// steps 2 and 3 could mark a fresh tx-set as orphan. Make transactional
+    /// when persist is wired.
+    pub fn purge_persisted_tx_sets(&self) {
+        let Some(manager) = self.scp_persistence.get() else {
+            return;
+        };
+        if let Err(e) = manager.purge_unreferenced_tx_sets() {
+            error!(error = %e, "Failed to purge unreferenced persisted tx sets");
+        }
     }
 
     /// Set runtime upgrade parameters (called from HTTP `/upgrades?mode=set`).
@@ -7393,6 +7437,107 @@ mod tests {
              is_current_ledger path returns FullyValidated which does not \
              clear the slot's fully_validated flag"
         );
+    }
+
+    // -------- Tests for SCP persistence wiring (#2698) --------
+
+    fn make_persist_envelope_with_tx_set_hash(
+        slot: u64,
+        tx_set_hash: stellar_xdr::curr::Hash,
+    ) -> stellar_xdr::curr::ScpEnvelope {
+        let stellar_value = StellarValue {
+            tx_set_hash,
+            close_time: TimePoint(0),
+            upgrades: vec![].try_into().unwrap(),
+            ext: StellarValueExt::Basic,
+        };
+        let value = stellar_value.to_xdr(Limits::none()).unwrap();
+        stellar_xdr::curr::ScpEnvelope {
+            statement: ScpStatement {
+                node_id: XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::curr::Uint256([0u8; 32]),
+                )),
+                slot_index: slot,
+                pledges: ScpStatementPledges::Nominate(ScpNomination {
+                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    votes: vec![Value(value.try_into().unwrap())].try_into().unwrap(),
+                    accepted: vec![].try_into().unwrap(),
+                }),
+            },
+            signature: XdrSignature::default(),
+        }
+    }
+
+    #[test]
+    fn test_purge_persisted_tx_sets_no_manager() {
+        let herder = make_test_herder();
+        // No persistence manager installed — must be a guarded no-op.
+        herder.purge_persisted_tx_sets();
+    }
+
+    #[test]
+    fn test_purge_persisted_tx_sets_with_manager_removes_orphans() {
+        let herder = make_test_herder();
+        let manager = Arc::new(crate::persistence::ScpPersistenceManager::in_memory());
+        assert!(
+            herder.set_scp_persistence(Arc::clone(&manager)).is_ok(),
+            "first install should succeed"
+        );
+
+        let referenced_hash = stellar_xdr::curr::Hash([1u8; 32]);
+        let orphan_hash = stellar_xdr::curr::Hash([2u8; 32]);
+
+        // Drive setup through the public manager API: persist an envelope
+        // referencing `referenced_hash`, but pass BOTH tx sets through so the
+        // backend stores both (only `referenced_hash` is reachable from the
+        // envelope).
+        let env = make_persist_envelope_with_tx_set_hash(100, referenced_hash.clone());
+        manager
+            .persist_scp_state(
+                100,
+                &[env],
+                &[
+                    (referenced_hash.clone(), vec![10]),
+                    (orphan_hash.clone(), vec![20]),
+                ],
+                &[],
+            )
+            .expect("persist_scp_state");
+
+        // Sanity check: both tx sets should currently be present.
+        assert!(manager.has_tx_set(&referenced_hash).unwrap());
+        assert!(manager.has_tx_set(&orphan_hash).unwrap());
+
+        // Run the production GC entry point.
+        herder.purge_persisted_tx_sets();
+
+        assert!(
+            manager.has_tx_set(&referenced_hash).unwrap(),
+            "referenced tx set must be retained"
+        );
+        assert!(
+            !manager.has_tx_set(&orphan_hash).unwrap(),
+            "orphan tx set must be purged"
+        );
+    }
+
+    #[test]
+    fn test_set_scp_persistence_rejects_double_install() {
+        let herder = make_test_herder();
+        let manager1 = Arc::new(crate::persistence::ScpPersistenceManager::in_memory());
+        let manager2 = Arc::new(crate::persistence::ScpPersistenceManager::in_memory());
+
+        assert!(
+            herder.set_scp_persistence(manager1).is_ok(),
+            "first install must succeed"
+        );
+        let returned = herder
+            .set_scp_persistence(manager2)
+            .err()
+            .expect("second install must fail");
+        // OnceLock::set returns the supplied value back on Err; verify we
+        // got the same Arc back uniquely.
+        assert_eq!(Arc::strong_count(&returned), 1);
     }
 }
 

--- a/crates/herder/src/lib.rs
+++ b/crates/herder/src/lib.rs
@@ -149,7 +149,7 @@ pub use fetching_envelopes::{
 };
 pub use herder::{
     EnvelopeState, Herder, HerderConfig, HerderStats, LastExternalizedLedger, LedgerCloseInfo,
-    NextConsensusSlot, TimeoutOutcome, TriggerOutcome,
+    NextConsensusSlot, TimeoutOutcome, TriggerOutcome, TX_SET_GC_DELAY_SECS,
 };
 pub use metrics::{ScpMetrics, ScpMetricsSnapshot};
 pub use pending::{PendingConfig, PendingEnvelopes, PendingResult, PendingStats};

--- a/crates/herder/src/persistence.rs
+++ b/crates/herder/src/persistence.rs
@@ -369,6 +369,12 @@ impl ScpPersistenceManager {
         *self.last_slot_saved.read()
     }
 
+    /// Check whether a tx set with the given hash is present in the backing
+    /// store. Primarily used by tests to assert post-purge state.
+    pub fn has_tx_set(&self, hash: &Hash) -> Result<bool> {
+        self.storage.has_tx_set(hash)
+    }
+
     /// Persist SCP state for a slot.
     ///
     /// This saves the given envelopes, their referenced transaction sets, and


### PR DESCRIPTION
Closes #2698

## Summary

Construct `ScpPersistenceManager` from `SqliteScpPersistence` in `init_herder`, install it on the `Herder` via a `OnceLock`-backed setter, and run `purge_unreferenced_tx_sets()` inline from a 60s tokio interval branch in the app event loop. Matches stellar-core's `HerderImpl::startTxSetGCTimer()` (`HerderImpl.cpp:2440-2444`) cadence.

The GC timer is correct and useful even before `persist_scp_state` (#2768) and `restore_scp_state` (#2769) are wired: it will simply find an empty hash set and return immediately. The non-transactional purge (three serial connection checkouts) is documented with a TODO pointing at #2770.

Adds new watchdog phase `33=tx_set_gc` in all three legend locations (rustdoc, `WATCHDOG_PHASE_LEGEND` const, `watchdog_phase_legend_coverage` test).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2698#issuecomment-4465723324)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-herder --tests` (1110 passed; includes new `test_purge_persisted_tx_sets_no_manager`, `test_purge_persisted_tx_sets_with_manager_removes_orphans`, `test_set_scp_persistence_rejects_double_install`)
- [x] `cargo test -p henyey-app --tests` (938 passed; `watchdog_phase_legend_coverage` and `test_herder_cleanup_method_exists` both green)

## Deviations from plan

- The plan called for `expect("set_scp_persistence called twice")` in `init_herder` and `expect_err("...")` in tests, but `Result<(), Arc<ScpPersistenceManager>>` is not `Debug` (the manager holds `dyn ScpStatePersistence`). Replaced with `if ... .is_err() { panic!(...) }` and `Result::err().expect(...)` respectively. Same single-installer guarantee, no API surface change.
- Added `pub fn has_tx_set` on `ScpPersistenceManager` to support test verification through the public manager API (per Critic A's guidance: "do not bypass the manager into the underlying `InMemoryScpPersistence`").
- Re-exported `TX_SET_GC_DELAY_SECS` from `crates/herder/src/lib.rs` so the app crate can depend on it (the previous `#[allow(dead_code)]` masked the missing re-export).
- Used `henyey_herder::SqliteScpPersistence` (the herder-side wrapper that implements `ScpStatePersistence`) instead of `henyey_db::SqliteScpPersistence` directly — the plan's text was correct in intent but the trait impl lives on the wrapper.

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot)