### PR TITLE
Implement event-driven consensus trigger scheduling (Phase 2)

### DIFF
--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -382,6 +382,74 @@ impl App {
         }
     }
 
+    /// Arm the event-driven consensus-trigger timer for the next ledger (#2702).
+    ///
+    /// Port of stellar-core's `HerderImpl::setupTriggerNextLedger`
+    /// (HerderImpl.cpp:1236-1303): compute the instant at which the next ledger
+    /// should be nominated (`prepareStart(lastSlot) + expectedClose`, clamped to
+    /// `now`, plus any `ctValidityOffset` delay) and arm a single-shot
+    /// `TimerType::TriggerNextLedger` timer for that delay. When the timer fires,
+    /// the main loop calls [`Self::try_trigger_consensus`] for the slot.
+    ///
+    /// This is the *primary* nomination scheduler. The 1-second maintenance tick
+    /// retains a now-idempotent `try_trigger_consensus()` call as a safety-net:
+    /// because `try_trigger_consensus` self-gates on the same trigger-time /
+    /// `ctValidityOffset` boundary (#2816), the tick can never trigger earlier
+    /// than this timer would, and a redundant call is absorbed by the herder's
+    /// `AlreadyNominating` guard / the watcher per-slot latch.
+    ///
+    /// Self-gates on `manual_close` (stellar-core skips `async_wait` under
+    /// MANUAL_CLOSE, HerderImpl.cpp:1298-1303) and on `is_tracking`. Always
+    /// cancels any prior trigger timer for the next slot before re-arming.
+    pub(super) async fn setup_trigger_next_ledger(&self) {
+        // Parity: MANUAL_CLOSE skips arming the trigger timer.
+        if self.config.node.manual_close {
+            return;
+        }
+        // Only arm while tracking — mirrors stellar-core arming the trigger from
+        // `lastClosedLedgerIncreased`, which only runs once the node is in-sync.
+        if !self.herder.is_tracking() {
+            return;
+        }
+
+        let current_ledger = self.current_ledger_seq();
+        let next_slot = current_ledger as u64 + 1;
+
+        // Compute the trigger instant exactly as `try_trigger_consensus` does
+        // (kept in lock-step so the timer and the safety-net agree on timing).
+        let expected_close = self.herder.ledger_close_duration();
+        let last_slot = current_ledger as u64;
+        let now_instant = std::time::Instant::now();
+        let trigger_time = match self.herder.prepare_start(last_slot) {
+            Some(ballot_start) => ballot_start + expected_close,
+            None => now_instant,
+        };
+        // Base delay from prepareStart + expectedClose, clamped to "now".
+        let base_delay = trigger_time.saturating_duration_since(now_instant);
+        // ctValidityOffset (seconds) — additional delay when the proposed close
+        // time (lcl.closeTime + 1) is still ahead of the wall-clock validity
+        // window. Mirrors HerderImpl.cpp:1281-1291.
+        let ct_offset_secs = self
+            .herder
+            .ct_validity_offset(self.herder.lcl_close_time().saturating_add(1), 0);
+        let delay = base_delay + std::time::Duration::from_secs(ct_offset_secs);
+
+        // Always cancel any prior trigger timer for this slot before re-arming
+        // (parity: `mTriggerTimer.cancel()` at the top of setupTriggerNextLedger).
+        self.timer_manager_handle
+            .cancel_trigger_next_ledger(next_slot)
+            .await;
+        self.timer_manager_handle
+            .schedule_trigger_next_ledger(next_slot, delay)
+            .await;
+        tracing::debug!(
+            next_slot,
+            delay_ms = delay.as_millis(),
+            ct_offset_secs,
+            "Armed event-driven consensus trigger timer (setupTriggerNextLedger)"
+        );
+    }
+
     /// Perform out-of-sync recovery matching stellar-core's outOfSyncRecovery().
     ///
     /// This broadcasts recent SCP messages to peers and requests SCP state,
@@ -1385,14 +1453,30 @@ impl App {
     ///
     /// This replaces the 500ms polling `check_scp_timeouts()` with precise
     /// single-shot timer delivery matching stellar-core's VirtualTimer pattern.
-    pub(super) async fn handle_scp_timer_event(&self, event: scp_timer_bridge::ScpTimerEvent) {
+    ///
+    /// Returns `true` if the caller should pump the close pipeline
+    /// (`process_externalized_slots()` + `try_start_ledger_close()`) after this
+    /// event. This is `true` only for a fired `TriggerNextLedger` event (#2702):
+    /// on a solo validator, `try_trigger_consensus()` externalizes the node's
+    /// *own* slot synchronously, and `publish_externalized()` does NOT wake the
+    /// event loop (unlike a network EXTERNALIZE arriving over `scp_message_rx`,
+    /// which the corresponding select arm already follows with a pipeline pump).
+    /// Without this signal, a self-externalized slot would not be applied until
+    /// the next 1-second maintenance tick — the cold-start ledger-production
+    /// stall behind the `test_horizon_ingesting` Quickstart failure. stellar-core
+    /// has no analog because its asio externalize callback drives the close
+    /// directly; this return is henyey-specific glue, not a parity divergence.
+    pub(super) async fn handle_scp_timer_event(
+        &self,
+        event: scp_timer_bridge::ScpTimerEvent,
+    ) -> bool {
         // Gate: only validators process SCP timeouts
         if !self.is_validator {
-            return;
+            return false;
         }
         // Gate: must be in a state that can receive SCP messages
         if !self.herder.state().can_receive_scp() {
-            return;
+            return false;
         }
         // Gate: reject events from a prior tracking epoch. These were already
         // queued in scp_timer_rx before on_lost_sync() incremented the epoch,
@@ -1405,7 +1489,26 @@ impl App {
                 current_epoch,
                 "Dropping stale timer event from prior tracking epoch"
             );
-            return;
+            return false;
+        }
+
+        // Event-driven consensus trigger (#2702). This is NOT an SCP
+        // nomination/ballot timeout, so it bypasses the future-slot defer /
+        // old-slot drop classification below (which is specific to SCP timers).
+        // A trigger for a stale slot (already closed) is harmlessly absorbed by
+        // try_trigger_consensus's own LCL/tracking gates.
+        if event.timer_type == henyey_herder::TimerType::TriggerNextLedger {
+            self.consensus_trigger_timer_fires
+                .fetch_add(1, Ordering::Relaxed);
+            self.try_trigger_consensus().await;
+            // Re-arm the trigger for the following slot so the event-driven
+            // schedule continues even if this attempt did not (yet) externalize
+            // (e.g. multi-node nomination still in flight, or a gated skip).
+            // setup_trigger_next_ledger is idempotent w.r.t. the per-slot timer.
+            self.setup_trigger_next_ledger().await;
+            // Signal the caller to pump the close pipeline for a possible
+            // self-externalized slot (see the doc comment).
+            return true;
         }
 
         // Use max(tracking_slot, current_ledger + 1) as the effective next slot.
@@ -1466,6 +1569,9 @@ impl App {
                             )
                             .await;
                     }
+                    // TriggerNextLedger is handled by the early return above and
+                    // never reaches the SCP-timeout defer/drop classification.
+                    henyey_herder::TimerType::TriggerNextLedger => {}
                 }
             }
             TimerEventAction::Fire => {
@@ -1487,9 +1593,14 @@ impl App {
                         self.ballot_timeout_fires.fetch_add(1, Ordering::Relaxed);
                         self.herder.handle_ballot_timeout(event.slot);
                     }
+                    // TriggerNextLedger is handled by the early return above.
+                    henyey_herder::TimerType::TriggerNextLedger => {}
                 }
             }
         }
+        // SCP nomination/ballot timeouts do not externalize a new slot, so the
+        // caller need not pump the close pipeline.
+        false
     }
 
     /// Trigger a recovery catchup: clear stale state and run catchup to current.
@@ -2766,6 +2877,112 @@ mod tests {
             app.nomination_timeout_fires.load(Ordering::Relaxed),
             nom_fires_before,
             "re-delivered timer from the prior epoch must be dropped after sync loss, not fired"
+        );
+    }
+
+    // ── Event-driven consensus trigger (#2702) ──────────────────────────
+
+    /// #2702: once tracking, `setup_trigger_next_ledger` arms a single-shot
+    /// `TriggerNextLedger` timer that fires back through the bridge as a
+    /// `TriggerNextLedger` event. Drives the primary event-driven nomination
+    /// schedule (replacing the 1-second poll as the primary trigger).
+    #[tokio::test(start_paused = true)]
+    async fn test_setup_trigger_next_ledger_arms_timer_when_tracking() {
+        let (_dir, app) = mk_validator_app().await;
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+
+        app.setup_trigger_next_ledger().await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // prepare_start is None on cold start, so the delay is just the
+        // ctValidityOffset (0 here) → fires effectively immediately.
+        let mut rx = app.scp_timer_rx.lock().await;
+        tokio::time::advance(std::time::Duration::from_secs(2)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        let delivered = rx
+            .try_recv()
+            .expect("expected a TriggerNextLedger timer event to be delivered");
+        assert_eq!(
+            delivered.timer_type,
+            henyey_herder::TimerType::TriggerNextLedger
+        );
+        // Slot is current_ledger + 1 (LCL 1 → slot 2).
+        assert_eq!(delivered.slot, 2);
+    }
+
+    /// #2702: `setup_trigger_next_ledger` is a no-op before the herder is
+    /// tracking (cold start before bootstrap) — mirrors stellar-core arming
+    /// only from `lastClosedLedgerIncreased` while in-sync.
+    #[tokio::test(start_paused = true)]
+    async fn test_setup_trigger_next_ledger_skips_when_not_tracking() {
+        let (_dir, app) = mk_validator_app().await;
+        // No bootstrap → not tracking.
+        assert!(!app.herder.is_tracking());
+
+        app.setup_trigger_next_ledger().await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        let mut rx = app.scp_timer_rx.lock().await;
+        tokio::time::advance(std::time::Duration::from_secs(5)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "no trigger timer should be armed while not tracking"
+        );
+    }
+
+    /// #2702: handling a fired `TriggerNextLedger` event increments the
+    /// `consensus_trigger_timer_fires` counter and returns `true` to signal the
+    /// caller to pump the close pipeline (the cold-start self-externalize fix).
+    #[tokio::test(start_paused = true)]
+    async fn test_trigger_next_ledger_event_fires_counter_and_signals_pump() {
+        let (_dir, app) = mk_validator_app().await;
+        app.herder.bootstrap(1);
+
+        let fires_before = app.consensus_trigger_timer_fires.load(Ordering::Relaxed);
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: 2,
+            timer_type: henyey_herder::TimerType::TriggerNextLedger,
+            epoch: 0,
+        };
+        let pump = app.handle_scp_timer_event(event).await;
+
+        assert!(
+            pump,
+            "a fired TriggerNextLedger event must signal the caller to pump the close pipeline"
+        );
+        assert_eq!(
+            app.consensus_trigger_timer_fires.load(Ordering::Relaxed),
+            fires_before + 1,
+            "consensus_trigger_timer_fires must increment on a fired trigger event"
+        );
+    }
+
+    /// #2702: an SCP nomination/ballot timeout event must NOT signal a
+    /// close-pipeline pump (only the trigger event does).
+    #[tokio::test(start_paused = true)]
+    async fn test_scp_timeout_event_does_not_signal_pump() {
+        let (_dir, app) = mk_validator_app().await;
+        app.herder.bootstrap(1);
+        let next_slot = app.herder.next_consensus_ledger_index().get();
+
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: next_slot,
+            timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0,
+        };
+        let pump = app.handle_scp_timer_event(event).await;
+        assert!(
+            !pump,
+            "SCP nomination timeout must not signal a close-pipeline pump"
         );
     }
 }

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -1851,6 +1851,9 @@ impl App {
             // Trigger consensus immediately after close, matching stellar-core.
             // Both validators and watchers participate (HERDER §5.2).
             self.try_trigger_consensus().await;
+            // Arm the event-driven trigger for the next ledger (#2702), the
+            // henyey analog of lastClosedLedgerIncreased → setupTriggerNextLedger.
+            self.setup_trigger_next_ledger().await;
 
             *self.last_externalized_at.write().await = self.clock.now();
             self.reset_tx_set_tracking().await;

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -422,6 +422,14 @@ impl App {
             self.reset_tx_set_tracking().await;
         }
 
+        // Cold-start arm of the event-driven consensus trigger (#2702). Runs
+        // after restore_operational_state() (which set herder tracking state)
+        // and after the pre-loop process_externalized_slots(), so by now a
+        // tracking validator has a stable LCL to schedule the next ledger from.
+        // Self-gates on is_tracking()/manual_close; if not yet tracking, it is a
+        // no-op and the post-close path / 1-second tick safety-net arm it later.
+        self.setup_trigger_next_ledger().await;
+
         tracing::info!("Entering main event loop");
 
         // Start the std::thread watchdog (independent of tokio runtime).
@@ -531,6 +539,14 @@ impl App {
                         // (parity: HERDER §5.2).
                         self.set_phase_sub(super::phase::PHASE_6_10_TRY_TRIGGER_CONSENSUS);
                         self.try_trigger_consensus().await;
+
+                        // Arm the event-driven trigger for the *next* ledger
+                        // (#2702). This is the henyey analog of stellar-core's
+                        // `lastClosedLedgerIncreased` → `setupTriggerNextLedger`:
+                        // a close just advanced LCL, so schedule the next
+                        // nomination via a single-shot timer instead of relying
+                        // on the 1-second poll.
+                        self.setup_trigger_next_ledger().await;
 
                         // Drain SCP + fetch response channels.
                         // Timed (#1759 diagnostics): if either drain takes
@@ -1042,8 +1058,18 @@ impl App {
                         self.maybe_publish_history().await;
                     }
 
-                    // Try to trigger next round (validators nominate; watchers
-                    // build/cache the next-slot tx set per HERDER §5.2).
+                    // Safety-net trigger (#2702). The *primary* nomination
+                    // scheduler is now the event-driven TriggerNextLedger timer
+                    // (armed by setup_trigger_next_ledger after each close and at
+                    // cold start). This retained 1-second call is an idempotent
+                    // backstop: try_trigger_consensus self-gates on the same
+                    // prepareStart + expectedClose + ctValidityOffset boundary
+                    // (#2816), so it can never trigger earlier than the timer
+                    // would, and a redundant attempt is absorbed by the herder's
+                    // AlreadyNominating guard / the watcher per-slot latch. It
+                    // covers the case where a trigger timer was never armed (e.g.
+                    // arming was gated out at cold start before tracking settled)
+                    // — without it, a missed arm could stall ledger production.
                     self.try_trigger_consensus().await;
                 }
 
@@ -1089,10 +1115,29 @@ impl App {
                     self.update_survey_phase().await;
                 }
 
-                // SCP nomination/ballot timeouts (single-shot via TimerManager)
+                // SCP nomination/ballot timeouts + event-driven consensus
+                // trigger (#2702), single-shot via TimerManager.
                 Some(event) = scp_timer_rx.recv() => {
                     self.set_phase(26); // 26 = scp_timeout
-                    self.handle_scp_timer_event(event).await;
+                    let pump = self.handle_scp_timer_event(event).await;
+                    // A fired TriggerNextLedger may have self-externalized this
+                    // node's own slot (solo validator). publish_externalized()
+                    // does not wake the loop, so pump the close pipeline here —
+                    // mirroring what the scp_message_rx / verified_rx arms do
+                    // after a network EXTERNALIZE. Without this, a solo
+                    // validator stalls until the 1-second maintenance tick
+                    // (the test_horizon_ingesting cold-start failure mode).
+                    if pump {
+                        if pending_catchup.is_none() {
+                            if let Some(pc) = self.process_externalized_slots().await {
+                                pending_catchup = Some(pc);
+                            }
+                        }
+                        if close_pipeline.is_idle() && pending_catchup.is_none() {
+                            let next = self.try_start_ledger_close().await;
+                            close_pipeline.try_start_close(next);
+                        }
+                    }
                 }
 
                 // Ping peers for latency measurements

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -676,6 +676,11 @@ pub struct App {
     /// rebuilds from periodic polling (henyey's equivalent of stellar-core's
     /// one-shot timer scheduling in `setupTriggerNextLedger`).
     pub(crate) watcher_last_triggered_slot: AtomicU64,
+    /// Number of event-driven consensus-trigger timer firings (#2702). Each
+    /// fire of the `TimerType::TriggerNextLedger` timer drives one
+    /// `try_trigger_consensus()` attempt, mirroring stellar-core's
+    /// `mTriggerTimer` → `triggerNextLedger`.
+    pub(crate) consensus_trigger_timer_fires: AtomicU64,
     /// Number of nomination timeout firings.
     nomination_timeout_fires: AtomicU64,
     /// Number of nomination timeout invocations that returned
@@ -1361,6 +1366,7 @@ impl App {
             consensus_trigger_skipped_applying: AtomicU64::new(0),
             consensus_trigger_skipped_stale: AtomicU64::new(0),
             watcher_last_triggered_slot: AtomicU64::new(0),
+            consensus_trigger_timer_fires: AtomicU64::new(0),
             nomination_timeout_fires: AtomicU64::new(0),
             nomination_timeout_skipped_stale: AtomicU64::new(0),
             ballot_timeout_fires: AtomicU64::new(0),
@@ -2497,6 +2503,9 @@ impl App {
             heard_from_quorum: self.herder.heard_from_quorum(quorum_slot),
             is_v_blocking: self.herder.is_v_blocking(quorum_slot),
             slot: slot_state.map(Into::into),
+            consensus_trigger_timer_fires: self
+                .consensus_trigger_timer_fires
+                .load(Ordering::Relaxed),
             nomination_timeout_fires: self.nomination_timeout_fires.load(Ordering::Relaxed),
             ballot_timeout_fires: self.ballot_timeout_fires.load(Ordering::Relaxed),
             scp_messages_sent: self.scp_messages_sent.load(Ordering::Relaxed),
@@ -2860,6 +2869,9 @@ impl App {
             scp: self.herder.scp_metrics_snapshot(),
             scp_phase: self.herder.tracking_slot_ballot_phase(),
             scp_cumulative_statements: self.herder.scp_cumulative_statement_count() as u64,
+            consensus_trigger_timer_fires: self
+                .consensus_trigger_timer_fires
+                .load(Ordering::Relaxed),
             nomination_timeout_fires: self.nomination_timeout_fires.load(Ordering::Relaxed),
             ballot_timeout_fires: self.ballot_timeout_fires.load(Ordering::Relaxed),
             consensus_trigger_skipped_applying: self

--- a/crates/app/src/app/scp_timer_bridge.rs
+++ b/crates/app/src/app/scp_timer_bridge.rs
@@ -49,4 +49,12 @@ impl TimerCallback for ScpTimerBridge {
             epoch,
         });
     }
+
+    fn on_trigger_next_ledger(&self, slot: SlotIndex, epoch: u64) {
+        let _ = self.sender.send(ScpTimerEvent {
+            slot,
+            timer_type: TimerType::TriggerNextLedger,
+            epoch,
+        });
+    }
 }

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -171,6 +171,8 @@ pub struct SimulationDebugStats {
     pub heard_from_quorum: bool,
     pub is_v_blocking: bool,
     pub slot: Option<ScpSlotDebugStats>,
+    /// Event-driven consensus-trigger timer firings (#2702).
+    pub consensus_trigger_timer_fires: u64,
     pub nomination_timeout_fires: u64,
     pub ballot_timeout_fires: u64,
     pub scp_messages_sent: u64,
@@ -380,6 +382,8 @@ pub struct AppMetricsSnapshot {
     pub scp: henyey_herder::ScpMetricsSnapshot,
     pub scp_phase: u8,
     pub scp_cumulative_statements: u64,
+    /// Event-driven consensus-trigger timer firings (#2702).
+    pub consensus_trigger_timer_fires: u64,
     pub nomination_timeout_fires: u64,
     pub ballot_timeout_fires: u64,
     /// Times `try_trigger_consensus` skipped because a ledger close was in

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -715,6 +715,11 @@ metric_catalog! {
             "henyey_nomination_timeout_skipped_stale_total"
             => "Total handle_nomination_timeout invocations that returned \
                 SkippedStale because LCL advanced during build/drain";
+        CONSENSUS_TRIGGER_TIMER_FIRES_TOTAL =
+            "henyey_consensus_trigger_timer_fires_total"
+            => "Total event-driven consensus-trigger timer firings (#2702); each \
+                drives one try_trigger_consensus attempt, mirroring stellar-core's \
+                mTriggerTimer → triggerNextLedger";
 
         // Stage E: History archive lifecycle counters (10334 dashboard).
         // All count terminal outcomes; retries within an operation are not counted.
@@ -1269,6 +1274,7 @@ pub(crate) async fn refresh_gauges(state: &ServerState) {
     CONSENSUS_TRIGGER_SKIPPED_APPLYING_TOTAL.absolute(snap.consensus_trigger_skipped_applying);
     CONSENSUS_TRIGGER_SKIPPED_STALE_TOTAL.absolute(snap.consensus_trigger_skipped_stale);
     NOMINATION_TIMEOUT_SKIPPED_STALE_TOTAL.absolute(snap.nomination_timeout_skipped_stale);
+    CONSENSUS_TRIGGER_TIMER_FIRES_TOTAL.absolute(snap.consensus_trigger_timer_fires);
     SCP_ENVELOPE_VALIDSIG_TOTAL.absolute(snap.scp.envelope_validsig_total);
     SCP_ENVELOPE_INVALIDSIG_TOTAL.absolute(snap.scp.envelope_invalidsig_total);
     SCP_ENVELOPE_SIGN_TOTAL.absolute(snap.scp.envelope_sign_total);

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -104,8 +104,8 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `emitEnvelope()` | handled by `ScpDriver` | Full |
 | `lostSync()` | `SyncRecoveryManager::record_lost_sync()` | Full |
 | `checkCloseTime()` | `check_envelope_close_time()` | Full |
-| `ctValidityOffset()` | `Herder::ct_validity_offset()` | Partial | Close-time validity offset (#2816) computed per stellar-core HerderImpl.cpp:1158-1172 and used by both the app-side trigger delay (`try_trigger_consensus`) and the herder-side far-ahead abort (`trigger_next_ledger`); exact event-driven timer scheduling remains in #2702. |
-| `setupTriggerNextLedger()` | Split: `App::try_trigger_consensus()` + `Herder::trigger_next_ledger()` | Partial | App-side polling loop now enforces the `prepareStart + expectedClose` trigger-time delay and the `ctValidityOffset` adjustment before calling `trigger_next_ledger()` (#2816), so henyey never triggers earlier than stellar-core's computed boundary (it may trigger up to one poll tick later). Pre-entry behind/applying/not-tracking guards match; `LCL >= tracking` uses corrective recovery instead of stellar-core's fail-fast assertion, and `is_applying()` is re-checked post-build inside `trigger_next_ledger`. Exact timer-based (event-driven) scheduling remains in #2702. |
+| `ctValidityOffset()` | `Herder::ct_validity_offset()` | Full | Close-time validity offset (#2816) computed per stellar-core HerderImpl.cpp:1158-1172 and used by both the event-driven trigger arming (`setup_trigger_next_ledger`, #2702) and the herder-side far-ahead abort (`trigger_next_ledger`). |
+| `setupTriggerNextLedger()` | `App::setup_trigger_next_ledger()` (arms `TimerType::TriggerNextLedger`) + `App::try_trigger_consensus()` + `Herder::trigger_next_ledger()` | Full | Event-driven (#2702): a single-shot `TriggerNextLedger` timer is armed (via `TimerManager`) at `prepareStart + expectedClose + ctValidityOffset` from the post-close path (henyey analog of `lastClosedLedgerIncreased`) and at cold start once tracking; on fire the main loop calls `try_trigger_consensus()` and pumps the close pipeline (henyey-specific glue — `publish_externalized()` does not wake the loop, unlike stellar-core's asio externalize callback). The 1-second maintenance tick retains an idempotent `try_trigger_consensus()` safety-net (self-gated on the same trigger-time / `ctValidityOffset` boundary, so it can never trigger earlier than the timer). Pre-entry behind/applying/not-tracking guards match; `LCL >= tracking` uses corrective recovery instead of stellar-core's fail-fast assertion; `is_applying()` is re-checked post-build inside `trigger_next_ledger`. |
 | `startOutOfSyncTimer()` | `SyncRecoveryManager` | Full |
 | `outOfSyncRecovery()` | `out_of_sync_recovery()` | Full |
 | `broadcast()` | `flush_tx_adverts()` in `App` | Partial — priority-ordered via `TransactionQueue::broadcast_with_visitor()` with DEX-lane flood budget, budget-neutral skipped txs, arb flood damping, and ban-on-damping; broadcast period uses `flood_tx_period_ms` (200 ms) matching stellar-core `FLOOD_TX_PERIOD_MS`; missing dedicated flood queue, mark-on-attempt, separate advert flush timer |
@@ -576,12 +576,16 @@ Features not yet implemented. These ARE counted against parity %.
      before peer envelopes for the next tracking slot are processed.
      `setupTriggerNextLedger` (`HerderImpl.cpp:1237-1254`) asserts that
      apply is not in flight and tracking equals the LCL. As of #2816,
-     henyey's `try_trigger_consensus()` enforces the `prepareStart +
-     expectedClose` delay and `ctValidityOffset` check before calling
+     henyey's trigger path enforces the `prepareStart + expectedClose`
+     delay and `ctValidityOffset` check before calling
      `trigger_next_ledger()`, and the herder-side far-ahead abort in
      `trigger_next_ledger()` refuses to build/nominate when the proposed
-     close time exceeds `now + MAX_TIME_SLIP_SECONDS`. Full event-driven
-     timer scheduling (#2702) is not yet ported.
+     close time exceeds `now + MAX_TIME_SLIP_SECONDS`. As of #2702 the
+     scheduling is event-driven: `App::setup_trigger_next_ledger()` arms a
+     single-shot `TimerType::TriggerNextLedger` timer at that computed
+     instant (from the post-close path and at cold start), with the
+     1-second maintenance tick retaining an idempotent
+     `try_trigger_consensus()` safety-net.
    - **Rust**: `process_scp_envelope` forwards peer EXTERNALIZE to SCP
      before the tx_set is fetched, so tracking advance can proceed
      during catchup (#1795). Pending envelope drain now runs post-apply

--- a/crates/herder/src/timer_manager.rs
+++ b/crates/herder/src/timer_manager.rs
@@ -77,6 +77,18 @@ pub enum TimerCommand {
         duration: Duration,
         epoch: Option<u64>,
     },
+    /// Schedule the event-driven consensus trigger timer for a slot
+    /// (overwrites existing timer). Mirrors stellar-core's `mTriggerTimer`
+    /// armed by `setupTriggerNextLedger` (#2702). Unlike the SCP
+    /// nomination/ballot timers, this is not subject to the future-slot defer
+    /// loop — it is the primary "time to nominate slot N" wake-up.
+    ScheduleTriggerNextLedger {
+        slot: SlotIndex,
+        duration: Duration,
+        epoch: Option<u64>,
+    },
+    /// Cancel the consensus trigger timer for a slot (#2702).
+    CancelTriggerNextLedger { slot: SlotIndex },
     /// Cancel all timers for a slot.
     CancelSlotTimers { slot: SlotIndex },
     /// Cancel the nomination timer for a slot (but keep ballot timer).
@@ -132,6 +144,25 @@ impl TimerManagerHandle {
             duration,
             epoch: None,
         });
+    }
+
+    /// Schedule the event-driven consensus trigger timer for a slot (#2702).
+    ///
+    /// Mirrors stellar-core's `setupTriggerNextLedger` arming `mTriggerTimer`:
+    /// when it fires, the app calls `try_trigger_consensus()` for `slot`.
+    pub async fn schedule_trigger_next_ledger(&self, slot: SlotIndex, duration: Duration) {
+        let _ = self.sender.send(TimerCommand::ScheduleTriggerNextLedger {
+            slot,
+            duration,
+            epoch: None,
+        });
+    }
+
+    /// Cancel the consensus trigger timer for a slot (#2702).
+    pub async fn cancel_trigger_next_ledger(&self, slot: SlotIndex) {
+        let _ = self
+            .sender
+            .send(TimerCommand::CancelTriggerNextLedger { slot });
     }
 
     /// Re-arm a nomination timeout for a slot, preserving the originating
@@ -237,6 +268,33 @@ impl TimerManagerHandle {
         }
     }
 
+    /// Schedule the consensus trigger timer (non-blocking). Used from the
+    /// synchronous post-close / cold-start arming paths (#2702).
+    pub fn schedule_trigger_next_ledger_nonblocking(&self, slot: SlotIndex, duration: Duration) {
+        if self
+            .sender
+            .send(TimerCommand::ScheduleTriggerNextLedger {
+                slot,
+                duration,
+                epoch: None,
+            })
+            .is_err()
+        {
+            tracing::warn!(slot, "timer channel closed: schedule trigger dropped");
+        }
+    }
+
+    /// Cancel the consensus trigger timer for a slot (non-blocking) (#2702).
+    pub fn cancel_trigger_next_ledger_nonblocking(&self, slot: SlotIndex) {
+        if self
+            .sender
+            .send(TimerCommand::CancelTriggerNextLedger { slot })
+            .is_err()
+        {
+            tracing::warn!(slot, "timer channel closed: cancel trigger dropped");
+        }
+    }
+
     /// Cancel all timers for a slot (non-blocking).
     pub fn cancel_slot_timers_nonblocking(&self, slot: SlotIndex) {
         if self
@@ -293,6 +351,13 @@ pub trait TimerCallback: Send + Sync + 'static {
     /// Called when a ballot timeout expires.
     /// `epoch` is the tracking epoch that was current when this timer was scheduled.
     fn on_ballot_timeout(&self, slot: SlotIndex, epoch: u64);
+
+    /// Called when the event-driven consensus trigger timer expires (#2702).
+    /// The receiver should attempt to trigger consensus for `slot`.
+    ///
+    /// Default no-op so callbacks that predate the trigger timer (and tests
+    /// that only exercise SCP timeouts) continue to compile unchanged.
+    fn on_trigger_next_ledger(&self, _slot: SlotIndex, _epoch: u64) {}
 }
 
 /// Timer type for a slot.
@@ -300,6 +365,9 @@ pub trait TimerCallback: Send + Sync + 'static {
 pub enum TimerType {
     Nomination,
     Ballot,
+    /// Event-driven consensus trigger (#2702): mirrors stellar-core's
+    /// `mTriggerTimer`. Fires when it is time to nominate the next ledger.
+    TriggerNextLedger,
 }
 
 /// Active timer state.
@@ -398,6 +466,16 @@ impl<C: TimerCallback> TimerManager<C> {
             } => {
                 self.schedule_timer(slot, TimerType::Ballot, duration, epoch);
             }
+            TimerCommand::ScheduleTriggerNextLedger {
+                slot,
+                duration,
+                epoch,
+            } => {
+                self.schedule_timer(slot, TimerType::TriggerNextLedger, duration, epoch);
+            }
+            TimerCommand::CancelTriggerNextLedger { slot } => {
+                self.cancel_timer(slot, TimerType::TriggerNextLedger);
+            }
             TimerCommand::CancelSlotTimers { slot } => {
                 self.cancel_slot_timers(slot);
             }
@@ -464,8 +542,14 @@ impl<C: TimerCallback> TimerManager<C> {
     fn cancel_slot_timers(&mut self, slot: SlotIndex) {
         let removed_nom = self.timers.remove(&(slot, TimerType::Nomination)).is_some();
         let removed_bal = self.timers.remove(&(slot, TimerType::Ballot)).is_some();
+        // The consensus trigger timer (#2702) is keyed per-slot too; clear it
+        // alongside the SCP timers so a stale slot leaves no lingering trigger.
+        let removed_trig = self
+            .timers
+            .remove(&(slot, TimerType::TriggerNextLedger))
+            .is_some();
 
-        if removed_nom || removed_bal {
+        if removed_nom || removed_bal || removed_trig {
             debug!(slot, "Cancelled slot timers");
         }
     }
@@ -517,6 +601,9 @@ impl<C: TimerCallback> TimerManager<C> {
                 }
                 TimerType::Ballot => {
                     self.callback.on_ballot_timeout(slot, epoch);
+                }
+                TimerType::TriggerNextLedger => {
+                    self.callback.on_trigger_next_ledger(slot, epoch);
                 }
             }
         }

--- a/crates/herder/src/timer_manager.rs
+++ b/crates/herder/src/timer_manager.rs
@@ -618,6 +618,8 @@ mod tests {
     struct TestCallback {
         nomination_fired: AtomicU64,
         ballot_fired: AtomicU64,
+        /// Slot of the most recent trigger-next-ledger callback (#2702).
+        trigger_fired: AtomicU64,
         /// Epoch carried by the most recent nomination callback. Sentinel
         /// `u64::MAX` means "no nomination has fired yet".
         last_nomination_epoch: AtomicU64,
@@ -631,6 +633,7 @@ mod tests {
             Self {
                 nomination_fired: AtomicU64::new(0),
                 ballot_fired: AtomicU64::new(0),
+                trigger_fired: AtomicU64::new(0),
                 last_nomination_epoch: AtomicU64::new(u64::MAX),
                 last_ballot_epoch: AtomicU64::new(u64::MAX),
             }
@@ -647,6 +650,114 @@ mod tests {
             self.ballot_fired.store(slot, Ordering::SeqCst);
             self.last_ballot_epoch.store(epoch, Ordering::SeqCst);
         }
+
+        fn on_trigger_next_ledger(&self, slot: SlotIndex, _epoch: u64) {
+            self.trigger_fired.store(slot, Ordering::SeqCst);
+        }
+    }
+
+    /// #2702: the event-driven consensus trigger timer (`TriggerNextLedger`)
+    /// must fire its callback after the scheduled duration. Fails to compile on
+    /// pre-#2702 main because `TimerType::TriggerNextLedger`,
+    /// `schedule_trigger_next_ledger`, and `on_trigger_next_ledger` do not exist.
+    #[tokio::test]
+    async fn test_trigger_next_ledger_fires() {
+        let callback = Arc::new(TestCallback::new());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
+
+        let manager_task = tokio::spawn(manager.run());
+
+        handle
+            .schedule_trigger_next_ledger(7, Duration::from_millis(50))
+            .await;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(callback.trigger_fired.load(Ordering::SeqCst), 7);
+
+        handle.shutdown().await;
+        let _ = timeout(Duration::from_millis(100), manager_task).await;
+    }
+
+    /// #2702: rescheduling the trigger timer cancels the prior arming, and
+    /// `cancel_trigger_next_ledger` prevents an armed trigger from firing.
+    #[tokio::test]
+    async fn test_trigger_next_ledger_cancel_prevents_firing() {
+        let callback = Arc::new(TestCallback::new());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
+
+        let manager_task = tokio::spawn(manager.run());
+
+        handle
+            .schedule_trigger_next_ledger(9, Duration::from_millis(100))
+            .await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        handle.cancel_trigger_next_ledger(9).await;
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        assert_eq!(callback.trigger_fired.load(Ordering::SeqCst), 0);
+
+        handle.shutdown().await;
+        let _ = timeout(Duration::from_millis(100), manager_task).await;
+    }
+
+    /// #2702: a trigger timer is independent of the nomination/ballot timers for
+    /// the same slot — cancelling the trigger leaves SCP timers intact and vice
+    /// versa, and `cancel_slot_timers` / `cancel_all_timers` / `purge_old_slots`
+    /// all account for the trigger variant.
+    #[tokio::test]
+    async fn test_trigger_next_ledger_independent_of_scp_timers() {
+        let callback = Arc::new(TestCallback::new());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
+
+        let manager_task = tokio::spawn(manager.run());
+
+        // Arm both a nomination timer and a trigger timer for slot 5.
+        handle
+            .schedule_nomination_timeout(5, Duration::from_millis(60))
+            .await;
+        handle
+            .schedule_trigger_next_ledger(5, Duration::from_millis(60))
+            .await;
+        // Cancelling just the trigger leaves the nomination timer to fire.
+        handle.cancel_trigger_next_ledger(5).await;
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+
+        assert_eq!(callback.nomination_fired.load(Ordering::SeqCst), 5);
+        assert_eq!(callback.trigger_fired.load(Ordering::SeqCst), 0);
+
+        handle.shutdown().await;
+        let _ = timeout(Duration::from_millis(100), manager_task).await;
+    }
+
+    /// #2702: `cancel_all_timers` and `purge_old_slots` must remove trigger
+    /// timers along with SCP timers.
+    #[tokio::test]
+    async fn test_trigger_next_ledger_purged_by_cancel_all_and_purge() {
+        let callback = Arc::new(TestCallback::new());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
+        let manager_task = tokio::spawn(manager.run());
+
+        // purge_old_slots removes a stale trigger timer.
+        handle
+            .schedule_trigger_next_ledger(3, Duration::from_millis(80))
+            .await;
+        handle.purge_old_slots(10).await;
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(callback.trigger_fired.load(Ordering::SeqCst), 0);
+
+        // cancel_all_timers removes a live trigger timer.
+        handle
+            .schedule_trigger_next_ledger(11, Duration::from_millis(80))
+            .await;
+        handle.cancel_all_timers().await;
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(callback.trigger_fired.load(Ordering::SeqCst), 0);
+
+        handle.shutdown().await;
+        let _ = timeout(Duration::from_millis(100), manager_task).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #2702

Implements Phase 2 of the herder consensus-trigger redesign: replace the 1-second poll as the **primary** consensus-trigger scheduler with an event-driven single-shot timer, building on the trigger-time / `ctValidityOffset` math already merged in #2816 / #2835.

> **Rebuilt on current `main`.** The prior 4 commits (pre-#2835) re-implemented the ctValidityOffset math that has since landed independently and conflicted with `main`. This branch was reset to `origin/main` and re-implements the *residual* event-driven scheduling on top of the merged math (the PARITY_STATUS residual was explicitly "event-driven timer scheduling remains in #2702").

## Summary

- New `TimerType::TriggerNextLedger` in the herder `TimerManager` (schedule/cancel handle methods + a `TimerCallback` method with a default no-op; covered in `cancel_slot_timers` / `purge_old_slots` / `cancel_all_timers`).
- `App::setup_trigger_next_ledger()` ports `HerderImpl::setupTriggerNextLedger`: arms the timer at `prepareStart + expectedClose` (clamped to now) `+ ctValidityOffset`. Self-gates on `manual_close` / `is_tracking`; cancels the prior trigger before re-arming. Called from the post-close path (henyey analog of `lastClosedLedgerIncreased`), the post-burst-close path, and once at cold start after `restore_operational_state()`.
- `handle_scp_timer_event` handles `TriggerNextLedger` ahead of the SCP-timeout defer/drop classification: bumps `consensus_trigger_timer_fires`, calls `try_trigger_consensus()`, re-arms the next trigger, and returns `true` to signal the main loop to pump the close pipeline.

## test_horizon_ingesting root-cause fix (the convergence blocker)

On a **solo validator**, `try_trigger_consensus()` externalizes the node's *own* slot synchronously, and `publish_externalized()` does **not** wake the event loop — unlike a network EXTERNALIZE over `scp_message_rx`, whose select arm already pumps the close pipeline. The original plan removed the poll's trigger role but left the close-pipeline pump dependent on the 1-second tick, stalling cold-start ledger production ("Synced!" but zero ledgers — the Quickstart `test_horizon_ingesting` timeout).

Fix: the `TriggerNextLedger` event arm now pumps `process_externalized_slots()` + `try_start_ledger_close()` directly. The 1-second tick **retains** an idempotent `try_trigger_consensus()` safety-net (self-gated on the same trigger-time / `ctValidityOffset` boundary, so it can never trigger early) **and** keeps its close-pipeline pump — making this change purely additive on the hot path and non-regressing.

## Deviation from the original converged plan

The original plan called for **removing** `try_trigger_consensus` from the 1-second tick. Cycle-3 (`Do: Plan Wrong`) proved that removal stalls solo ledger production. Per the round-1 re-plan, this implementation **keeps** the tick call as a documented idempotent safety-net. Full root-cause writeup: issue #2702 [diagnosis comment](https://github.com/stellar-experimental/henyey/issues/2702#issuecomment-4616978969).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all` — full workspace green (0 failures)
- New `timer_manager` tests: TriggerNextLedger schedule/cancel/independence/purge.
- New `consensus.rs` tests: `setup_trigger_next_ledger` arms when tracking / skips when not tracking; trigger-event fires counter and signals pump; SCP-timeout event does NOT signal pump.

## Regression test (kind: bug-fix)

- **Test:** `crates/herder/src/timer_manager.rs` TriggerNextLedger tests (commit 1) + `consensus.rs::test_trigger_next_ledger_event_fires_counter_and_signals_pump` (captures the solo self-externalize pump contract that the cold-start failure violated).
- **Pre-fix:** committed as `a459a73e` — verified FAILED to compile (`TimerType::TriggerNextLedger` etc. do not exist on main).
- **Post-fix:** verified PASSES after `03f198b9`.

## New metric

- `henyey_consensus_trigger_timer_fires_total`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
