### PR TITLE
Use henyey version string for HAS server field

### DIFF
--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -1154,11 +1154,18 @@ mod archive_manager_tests {
         );
 
         // The pre-existing stale bytes must have been overwritten with the
-        // canonical empty HAS (version=1, server=rs-stellar-core, ...).
+        // canonical empty HAS (version=1, server=henyey-v<version>, ...).
         let has: HistoryArchiveState = serde_json::from_slice(&pseudo_bytes).unwrap();
         assert_eq!(has.version, 1);
         assert_eq!(has.current_ledger, 0);
-        assert_eq!(has.server.as_deref(), Some("rs-stellar-core"));
+        let expected_server =
+            henyey_common::version::build_version_string(env!("CARGO_PKG_VERSION"));
+        assert!(
+            has.server.as_deref().unwrap().starts_with("henyey-v"),
+            "server must start with henyey-v, got: {:?}",
+            has.server
+        );
+        assert_eq!(has.server.as_deref(), Some(expected_server.as_str()));
         assert_eq!(has.network_passphrase.as_deref(), Some(passphrase));
         assert!(has.hot_archive_buckets.is_none());
         assert_eq!(

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -720,7 +720,9 @@ impl HistoryArchiveManager {
 
         let has = HistoryArchiveState {
             version: 1,
-            server: Some("rs-stellar-core".to_string()),
+            server: Some(henyey_common::version::build_version_string(env!(
+                "CARGO_PKG_VERSION"
+            ))),
             current_ledger: 0,
             network_passphrase: Some(self.network_passphrase.clone()),
             current_buckets: vec![empty_level; henyey_bucket::BUCKET_LIST_LEVELS],
@@ -1001,7 +1003,14 @@ mod archive_manager_tests {
 
         assert_eq!(has.version, 1, "empty HAS must use version 1");
         assert_eq!(has.current_ledger, 0);
-        assert_eq!(has.server.as_deref(), Some("rs-stellar-core"));
+        let expected_server =
+            henyey_common::version::build_version_string(env!("CARGO_PKG_VERSION"));
+        assert!(
+            has.server.as_deref().unwrap().starts_with("henyey-v"),
+            "server must start with henyey-v, got: {:?}",
+            has.server
+        );
+        assert_eq!(has.server.as_deref(), Some(expected_server.as_str()));
         assert_eq!(has.network_passphrase.as_deref(), Some(passphrase));
         assert!(
             has.hot_archive_buckets.is_none(),

--- a/crates/history/src/publish.rs
+++ b/crates/history/src/publish.rs
@@ -296,7 +296,9 @@ pub fn build_history_archive_state(
 
     let mut has = HistoryArchiveState {
         version,
-        server: Some("rs-stellar-core".to_string()),
+        server: Some(henyey_common::version::build_version_string(env!(
+            "CARGO_PKG_VERSION"
+        ))),
         current_ledger: ledger_seq,
         network_passphrase,
         current_buckets,
@@ -2167,5 +2169,23 @@ mod tests {
 
         let infos = build_live_level_version_infos(bl.levels(), &has.current_buckets).unwrap();
         validate_bucket_list_structure(&infos, BUCKET_LIST_LEVELS).unwrap();
+    }
+
+    /// HAS `server` field must self-identify as henyey, matching stellar-core's
+    /// `HistoryArchiveState() : server(STELLAR_CORE_VERSION)` convention
+    /// (HistoryArchive.cpp:533). Issue #2755.
+    #[test]
+    fn test_build_history_archive_state_server_field() {
+        let bl = BucketList::new();
+        let has = build_history_archive_state(0, &bl, None, None).unwrap();
+        let server = has.server.as_deref().expect("server must be set");
+        assert!(
+            server.starts_with("henyey-v"),
+            "server must start with henyey-v, got: {server:?}"
+        );
+        assert_eq!(
+            server,
+            henyey_common::version::build_version_string(env!("CARGO_PKG_VERSION"))
+        );
     }
 }


### PR DESCRIPTION
Closes #2755

## Summary


This mirrors stellar-core's `HistoryArchiveState() : server(STELLAR_CORE_VERSION)` convention (`HistoryArchive.cpp:517` and `:533`): the HAS self-identifies as the producing build's version string. The field is informational only — stellar-core's only consumer is a `CLOG_INFO` in `HistoryArchiveReportWork.cpp:38`, and the value is not hashed, not validated, and has no effect on consensus, catchup, or archive verification. Divergence in value is intentional: a henyey-written archive should honestly identify as henyey.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2755#issuecomment-4466133333)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-history --all-targets -- -D warnings`
- [x] `cargo test -p henyey-history --tests` — all 508 unit tests + integration tests pass, including the updated `test_initialize_history_archive` assertion and the new `test_build_history_archive_state_server_field` unit test in `publish.rs`.

## Deviations from plan

None.