### PR TITLE
Soften "matches stellar-core source order" framing for two-file write

### DIFF
--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -736,10 +736,14 @@ impl HistoryArchiveManager {
         let temp_file = tempfile::NamedTempFile::new()?;
         std::fs::write(temp_file.path(), &json)?;
 
-        // Upload to the §4.3 pseudo-checkpoint path first (matches
-        // stellar-core's source order in
-        // PutHistoryArchiveStateWork::spawnPublishWork; functionally the
-        // two writes are independent).
+        // Upload to the §4.3 pseudo-checkpoint path first, then to the
+        // well-known root HAS path. The two writes are independent and the
+        // final archive state is identical regardless of order. Stellar-core
+        // schedules these as two separate `WorkSequence`s in
+        // `PutHistoryArchiveStateWork::spawnPublishWork`
+        // (PutHistoryArchiveStateWork.cpp:69), which the scheduler may run
+        // concurrently — so ordering here is not a parity-observable
+        // property.
         remote
             .put_file_with_mkdir(temp_file.path(), paths::pseudo_checkpoint_has_path())
             .await?;


### PR DESCRIPTION
Closes #2756

## Summary

Reword the inline comment in `crates/history/src/lib.rs` near `init_history_archive`'s two HAS writes. The previous wording claimed the write order strictly "matches stellar-core's source order", but upstream `PutHistoryArchiveStateWork::spawnPublishWork` (PutHistoryArchiveStateWork.cpp:69) schedules the two writes as independent `WorkSequence`s that the scheduler may run concurrently — so ordering is not a parity-observable property. The final archive state is identical regardless of order. Comment-only change; no behavior impact.

## Plan reference

[Triage Report (trivial short-circuit)](https://github.com/stellar-experimental/henyey/issues/2756#issuecomment-4466168069)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-history --all-targets -- -D warnings
- [x] cargo test -p henyey-history --tests passes

## Deviations from plan

None.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>