### PR TITLE
Raise overlay-errors-high alarm threshold from 50 to 100

### DIFF
--- a/.claude/skills/monitor-loop/SKILL.md
+++ b/.claude/skills/monitor-loop/SKILL.md
@@ -232,7 +232,7 @@ table is the human reference.
 | `stellar_herder_lost_sync_total` | ≥ 1 | SYNC | Node fell out of Tracking — always a bug on a steady-state node |
 | `henyey_post_catchup_hard_reset_total` | ≥ 1 | ACTION | Recovery fired |
 | `stellar_overlay_timeout_idle_total` + `_straggler_total` (sum) | 5× prior-tick sum | WARN | Overlay churn burst |
-| `stellar_overlay_error_read_total` + `_write_total` (sum) | ≥ 50 | WARN | Overlay I/O errors |
+| `stellar_overlay_error_read_total` + `_write_total` (sum) | ≥ 100 | WARN | Overlay I/O errors |
 | `henyey_archive_cache_refresh_error_total` | ≥ 1 | NONC | Archive fetch failing |
 | `henyey_archive_cache_refresh_timeout_total` | ≥ 3 | NONC | Archive fetch slow |
 

--- a/.claude/skills/shared/metric-alarms.toml
+++ b/.claude/skills/shared/metric-alarms.toml
@@ -93,7 +93,7 @@ metric_sum = [
 extraction = "form3"
 labels = []
 op = ">="
-threshold = 50
+threshold = 100
 severity = "WARN"
 gates = ["warmup-2-ticks"]
 cooldown_key = "overlay_error_total"

--- a/.claude/skills/shared/metric-alarms.toml
+++ b/.claude/skills/shared/metric-alarms.toml
@@ -85,6 +85,8 @@ notes = ""
 
 [[alarm]]
 name = "overlay-errors-high"
+baseline_version = 2  # bumped in #2779: raise threshold 50→100 to absorb steady-state overlay churn
+semantic_change_date = "2026-05-16T00:00:00Z"
 kind = "counter"
 metric_sum = [
     "stellar_overlay_error_read_total",


### PR DESCRIPTION
Closes #2710

## Summary

Calibrate the `overlay-errors-high` alarm so steady-state overlay churn (~57 errors / 31m on a healthy validator) does not trip it. Raise the per-tick delta threshold from 50 to 100, which still catches genuine 2x+ spikes.

## Plan reference

Trivial short-circuit — see [Triage Report](https://github.com/stellar-experimental/henyey/issues/2710#issuecomment-4466275313) → Implementation Notes.

## Test plan

- [x] Pre-commit fmt + clippy passed (config-only change)
- [x] No code paths affected; alarm threshold is read at runtime by the monitor skill

## Deviations from plan

None.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>