### PR TITLE
Quote parameter-expansion pattern in _enumerate_henyey_processes

### DIFF
--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -34,7 +34,7 @@ _enumerate_henyey_processes() {
     exe=$(readlink "$p/exe" 2>/dev/null || true)
     [[ -z "$exe" ]] && continue
     # Strip " (deleted)" suffix
-    local clean_exe="${exe% (deleted)}"
+    local clean_exe="${exe%' (deleted)'}"
     # Prefix check: must be under data_root
     [[ "$clean_exe" == "$data_root"/* ]] || continue
     local after_root="${clean_exe#"$data_root"/}"


### PR DESCRIPTION
Closes #2726

## Summary

In `scripts/lib/monitor-decisions.sh`, `_enumerate_henyey_processes` used an unquoted parameter-expansion pattern `${exe% (deleted)}`. Under zsh the ` (deleted)` portion is treated as a glob (the space + parentheses are pattern characters), so the suffix-strip silently no-ops, the prefix-check on the next line fails, and the henyey process is never enumerated. The monitor then concludes no instance is running and risks double-launching the validator.

Fix: quote the pattern as `${exe%' (deleted)'}` to force literal matching in both bash and zsh.

Reproducer (zsh):
```
% exe="/foo/bar/henyey (deleted)"
% echo "[${exe% (deleted)}]"        # unquoted — buggy
[/foo/bar/henyey (deleted)]
% echo "[${exe%' (deleted)'}]"      # quoted — fixed
[/foo/bar/henyey]
```

## Plan reference

[Triage Report (trivial short-circuit)](https://github.com/stellar-experimental/henyey/issues/2726#issuecomment-4466505478)

## Test plan

- [x] zsh reproducer confirms unquoted form leaves the suffix; quoted form strips it
- [x] pre-commit (cargo fmt + clippy --all -- -D warnings) passes
- [x] Audited the rest of `scripts/lib/monitor-decisions.sh` for similar unquoted `${var%…}` / `${var#…}` patterns:
  - Lines 40, 44 already use quoted patterns (`${clean_exe#"$data_root"/}`, `${after_root%"$suffix"}`)
  - Lines 100-101 strip literal `--config=` / `--conf=` prefixes (no glob-significant characters)
  - No other occurrences need changes

## Deviations from plan

None.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)