### PR TITLE
Port stellar-core prepareForPublish to clear unrepresentable HAS futures

### DIFF
--- a/crates/history/src/archive_state.rs
+++ b/crates/history/src/archive_state.rs
@@ -375,7 +375,7 @@ pub struct BucketLevelVersionInfo {
 
 /// First protocol version where bucket shadows were removed.
 /// Matches stellar-core's `LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED`.
-const FIRST_PROTOCOL_SHADOWS_REMOVED: u32 = 12;
+pub(crate) const FIRST_PROTOCOL_SHADOWS_REMOVED: u32 = 12;
 
 /// Validate bucket list structure and version monotonicity.
 ///
@@ -887,6 +887,102 @@ impl HASBucketLevel {
             curr,
             snap,
             next: HASBucketNext::default(),
+        }
+    }
+}
+
+impl HistoryArchiveState {
+    /// Clear `next` fields that the on-disk HAS format cannot represent.
+    ///
+    /// Mirrors stellar-core's `HistoryArchiveState::prepareForPublish`
+    /// (`stellar-core/src/history/HistoryArchive.cpp:466-507`), restricted to
+    /// the shadows-removed branch (`buckets[i - 1].snap.version >=
+    /// LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED`). On those levels a pending
+    /// merge cannot be persisted, because the consumer rebuilds the merge
+    /// deterministically from `snap` + `curr` at restart (see
+    /// `BucketListBase::restartMerges` and henyey's `restart_merges_from_has`).
+    ///
+    /// # Architectural placement vs. stellar-core
+    ///
+    /// Stellar-core clears lazily inside `ResolveSnapshotWork::doWork`
+    /// (`stellar-core/src/historywork/ResolveSnapshotWork.cpp:30`), invoked
+    /// only on the publish path; in-memory `HistoryArchiveState` instances are
+    /// free to carry pending futures. Henyey clears eagerly here because
+    /// `build_history_archive_state` is the single emission entry point —
+    /// every caller reaching for a HAS at publication time goes through it.
+    /// The observable on-disk contents are identical; the placement just
+    /// matches henyey's narrower API surface. Any future code that constructs
+    /// a HAS for emission outside `build_history_archive_state` must call
+    /// this method (or equivalent) before serialization.
+    ///
+    /// # Skipped branch
+    ///
+    /// Stellar-core's second branch in `prepareForPublish` (the
+    /// `next.hasHashes() && !next.isLive()` → `makeLive` path,
+    /// `HistoryArchive.cpp:490-506`) reconstitutes pending merges loaded from
+    /// an older-protocol persisted HAS that came back in over the wire with
+    /// `state == 2` (inputs). Henyey's `build_history_archive_state` consumes
+    /// live in-memory `BucketLevel` state, never a deserialized HAS
+    /// round-trip, so that data shape cannot arise here and the branch is
+    /// intentionally omitted.
+    ///
+    /// # Arguments
+    ///
+    /// * `live_snap_versions` — protocol version of `snap` at each live level,
+    ///   in level order, length must equal `current_buckets.len()`. Empty or
+    ///   pre-metaentry buckets contribute `0`.
+    /// * `hot_snap_versions` — same shape for `hot_archive_buckets`. Must be
+    ///   `Some` iff `hot_archive_buckets` is `Some`, and same length.
+    ///
+    /// # Panics (debug)
+    ///
+    /// Mirrors stellar-core's `releaseAssert(buckets[0].next.isClear())` at
+    /// `HistoryArchive.cpp:475`: level 0 never has a `next`, on either the
+    /// live or the hot-archive list.
+    pub(crate) fn clear_unrepresentable_futures(
+        &mut self,
+        live_snap_versions: &[u32],
+        hot_snap_versions: Option<&[u32]>,
+    ) {
+        Self::clear_levels(&mut self.current_buckets, live_snap_versions);
+
+        match (self.hot_archive_buckets.as_mut(), hot_snap_versions) {
+            (Some(hot), Some(versions)) => {
+                Self::clear_levels(hot, versions);
+            }
+            (None, None) => {}
+            (Some(_), None) | (None, Some(_)) => {
+                debug_assert!(
+                    false,
+                    "hot_archive_buckets / hot_snap_versions presence mismatch",
+                );
+            }
+        }
+    }
+
+    fn clear_levels(levels: &mut [HASBucketLevel], snap_versions: &[u32]) {
+        debug_assert_eq!(
+            levels.len(),
+            snap_versions.len(),
+            "snap_versions length must match bucket levels",
+        );
+        if levels.is_empty() {
+            return;
+        }
+        debug_assert!(
+            levels[0].next.is_clear(),
+            "level 0 must never carry a pending merge (parity with stellar-core HistoryArchive.cpp:475)",
+        );
+        // Predicate matches the validator's indexing
+        // (`prev_snap_version = levels[j - 1].snap_version`,
+        // archive_state.rs:449) and stellar-core's
+        // `buckets[i - 1].snap` reference at
+        // `stellar-core/src/history/HistoryArchive.cpp:483-489`.
+        for i in 1..levels.len() {
+            let prev_snap_version = snap_versions[i - 1];
+            if prev_snap_version >= FIRST_PROTOCOL_SHADOWS_REMOVED && !levels[i].next.is_clear() {
+                levels[i].next = HASBucketNext::default();
+            }
         }
     }
 }

--- a/crates/history/src/catchup/buckets.rs
+++ b/crates/history/src/catchup/buckets.rs
@@ -68,7 +68,7 @@ pub(super) fn verified_hot_archive_bucket_loader(
 /// `Bucket::protocol_version()` (O(1) after load); empty / metaentry-less
 /// buckets map to version 0, matching stellar-core's
 /// `bucket->isEmpty() ? 0 : bucket->getBucketVersion()` branch.
-pub(super) fn build_live_level_version_infos(
+pub(crate) fn build_live_level_version_infos(
     levels: &[BucketLevel],
     has_levels: &[HASBucketLevel],
 ) -> Result<Vec<BucketLevelVersionInfo>> {

--- a/crates/history/src/catchup/mod.rs
+++ b/crates/history/src/catchup/mod.rs
@@ -46,7 +46,7 @@
 //! - Incremental eviction scan must run each ledger for correct hashes
 //! - Bucket list hash = SHA256(live_hash || hot_archive_hash)
 
-mod buckets;
+pub(crate) mod buckets;
 mod download;
 mod persist;
 mod replay;

--- a/crates/history/src/publish.rs
+++ b/crates/history/src/publish.rs
@@ -223,39 +223,95 @@ pub fn build_history_archive_state(
         })
         .collect();
 
-    let hot_archive_buckets = hot_archive_bucket_list.map(|habl| {
-        habl.levels()
-            .iter()
-            .map(|level| {
-                let next = match level.pending_merge_output_hash() {
-                    Some(hash) => HASBucketNext {
-                        state: HAS_NEXT_STATE_OUTPUT,
-                        output: Some(hash.to_hex()),
-                        curr: None,
-                        snap: None,
-                        shadow: None,
-                    },
-                    None => HASBucketNext::default(),
-                };
-                HASBucketLevel {
-                    curr: level.curr().hash().to_hex(),
-                    snap: level.snap_bucket().hash().to_hex(),
-                    next,
-                }
-            })
-            .collect()
-    });
+    // Per-level snap protocol versions for the shadows-removed
+    // `next`-clearing pass below. `Bucket::protocol_version` returns
+    // `Ok(None)` for empty buckets / buckets without a leading metaentry;
+    // map those to 0 so the validator-equivalent predicate
+    // `prev_snap_version >= FIRST_PROTOCOL_SHADOWS_REMOVED` treats them as
+    // "no constraint" (matching `validate_bucket_list_structure` semantics).
+    let live_snap_versions: Vec<u32> = bucket_list
+        .levels()
+        .iter()
+        .enumerate()
+        .map(|(idx, level)| {
+            level
+                .snap
+                .protocol_version()
+                .map(|v| v.unwrap_or(0))
+                .map_err(|e| {
+                    HistoryError::VerificationFailed(format!(
+                        "failed to read snap protocol version at live level {}: {}",
+                        idx, e
+                    ))
+                })
+        })
+        .collect::<Result<_>>()?;
+
+    let hot_archive_buckets = hot_archive_bucket_list
+        .map(|habl| -> Result<Vec<HASBucketLevel>> {
+            habl.levels()
+                .iter()
+                .map(|level| {
+                    let next = match level.pending_merge_output_hash() {
+                        Some(hash) => HASBucketNext {
+                            state: HAS_NEXT_STATE_OUTPUT,
+                            output: Some(hash.to_hex()),
+                            curr: None,
+                            snap: None,
+                            shadow: None,
+                        },
+                        None => HASBucketNext::default(),
+                    };
+                    Ok(HASBucketLevel {
+                        curr: level.curr().hash().to_hex(),
+                        snap: level.snap_bucket().hash().to_hex(),
+                        next,
+                    })
+                })
+                .collect()
+        })
+        .transpose()?;
+
+    // Hot-archive snap protocol versions. Note the API shape mismatch with
+    // the live path: `HotArchiveBucket::get_protocol_version` returns
+    // `Result<u32>` (no `Option`); empty hot-archive buckets already report 0.
+    let hot_snap_versions: Option<Vec<u32>> = hot_archive_bucket_list
+        .map(|habl| -> Result<Vec<u32>> {
+            habl.levels()
+                .iter()
+                .enumerate()
+                .map(|(idx, level)| {
+                    level.snap_bucket().get_protocol_version().map_err(|e| {
+                        HistoryError::VerificationFailed(format!(
+                            "failed to read snap protocol version at hot-archive level {}: {}",
+                            idx, e
+                        ))
+                    })
+                })
+                .collect()
+        })
+        .transpose()?;
 
     let version = if hot_archive_buckets.is_some() { 2 } else { 1 };
 
-    Ok(HistoryArchiveState {
+    let mut has = HistoryArchiveState {
         version,
         server: Some("rs-stellar-core".to_string()),
         current_ledger: ledger_seq,
         network_passphrase,
         current_buckets,
         hot_archive_buckets,
-    })
+    };
+
+    // Mirror stellar-core's `HistoryArchiveState::prepareForPublish`
+    // shadows-removed branch (HistoryArchive.cpp:483-489). Henyey eager-clears
+    // here rather than lazily in a publish work step so every HAS emission
+    // path runs through this single helper. See
+    // `HistoryArchiveState::clear_unrepresentable_futures` for the full
+    // rationale and the documented skip of stellar-core's `makeLive` branch.
+    has.clear_unrepresentable_futures(&live_snap_versions, hot_snap_versions.as_deref());
+
+    Ok(has)
 }
 
 impl PublishManager {
@@ -1931,5 +1987,185 @@ mod tests {
         let cleaned = delete_published_files(64, publish_dir);
         assert_eq!(cleaned, 1);
         assert!(!dirty_path.exists());
+    }
+
+    // --- Regression tests for #2766 (prepareForPublish port) ---
+
+    use crate::archive_state::{validate_bucket_list_structure, BucketLevelVersionInfo};
+
+    /// Build a fully-populated `current_buckets` vector for a HAS:
+    /// every level gets dummy hex hashes and a clear `next`, then the
+    /// caller injects whatever per-level overrides the test needs.
+    fn make_skeleton_levels() -> Vec<HASBucketLevel> {
+        let zero = "0".repeat(64);
+        let one = "1".repeat(64);
+        (0..BUCKET_LIST_LEVELS)
+            .map(|_| HASBucketLevel {
+                curr: one.clone(),
+                snap: zero.clone(),
+                next: HASBucketNext::default(),
+            })
+            .collect()
+    }
+
+    /// Build matching `BucketLevelVersionInfo`s for the validator from a
+    /// per-level snap-version vector and the HAS levels (curr_version
+    /// is set equal to snap_version because the validator only requires
+    /// monotonicity, not exact values, for this test's purposes).
+    fn version_infos_from(
+        snap_versions: &[u32],
+        has_levels: &[HASBucketLevel],
+    ) -> Vec<BucketLevelVersionInfo> {
+        snap_versions
+            .iter()
+            .zip(has_levels.iter())
+            .map(|(&snap_version, has_level)| BucketLevelVersionInfo {
+                snap_version,
+                curr_version: snap_version,
+                next: has_level.next.clone(),
+            })
+            .collect()
+    }
+
+    fn make_has_with_levels(
+        current_buckets: Vec<HASBucketLevel>,
+        hot_archive_buckets: Option<Vec<HASBucketLevel>>,
+    ) -> HistoryArchiveState {
+        let version = if hot_archive_buckets.is_some() { 2 } else { 1 };
+        HistoryArchiveState {
+            version,
+            server: Some("rs-stellar-core".to_string()),
+            current_ledger: 64,
+            network_passphrase: None,
+            current_buckets,
+            hot_archive_buckets,
+        }
+    }
+
+    /// Regression for #2766: a level whose `prev_snap` is protocol 25 and
+    /// whose own `next` carries state=2 (Inputs) cannot be persisted —
+    /// `validate_bucket_list_structure` rejects it. The clearing pass must
+    /// erase the `next` field, after which the validator passes.
+    #[test]
+    fn test_clear_unrepresentable_futures_clears_inputs_at_shadowless_level() {
+        let mut levels = make_skeleton_levels();
+        // Level 2 is the prev_snap for level 3. Mark level 2's snap as
+        // protocol 25 (>= FIRST_PROTOCOL_SHADOWS_REMOVED = 12).
+        // Inject state=2 (Inputs) on level 3.
+        levels[3].next = HASBucketNext {
+            state: HAS_NEXT_STATE_INPUTS,
+            output: None,
+            curr: Some("a".repeat(64)),
+            snap: Some("b".repeat(64)),
+            shadow: None,
+        };
+        let snap_versions: Vec<u32> = (0..BUCKET_LIST_LEVELS).map(|_| 25u32).collect();
+
+        // Before clearing: validator rejects (this is exactly the symptom
+        // observed at ledger 90 in the bug report).
+        let pre_infos = version_infos_from(&snap_versions, &levels);
+        let pre = validate_bucket_list_structure(&pre_infos, BUCKET_LIST_LEVELS);
+        assert!(
+            pre.is_err(),
+            "validator should reject unrepresentable Inputs future at level 3 before clearing"
+        );
+
+        let mut has = make_has_with_levels(levels, None);
+        has.clear_unrepresentable_futures(&snap_versions, None);
+
+        assert!(
+            has.current_buckets[3].next.is_clear(),
+            "level 3 next must be cleared after prepareForPublish pass"
+        );
+        // After clearing: full round-trip through the real validator must
+        // pass.
+        let post_infos = version_infos_from(&snap_versions, &has.current_buckets);
+        validate_bucket_list_structure(&post_infos, BUCKET_LIST_LEVELS).unwrap();
+    }
+
+    /// Same as above but with state=1 (Output) on the target level.
+    /// Critics A and B both flagged that the clearing rule must apply
+    /// regardless of Inputs vs. Output for prev_snap >= 12.
+    #[test]
+    fn test_clear_unrepresentable_futures_clears_output_at_shadowless_level() {
+        let mut levels = make_skeleton_levels();
+        levels[5].next = HASBucketNext {
+            state: HAS_NEXT_STATE_OUTPUT,
+            output: Some("c".repeat(64)),
+            curr: None,
+            snap: None,
+            shadow: None,
+        };
+        let snap_versions: Vec<u32> = (0..BUCKET_LIST_LEVELS).map(|_| 24u32).collect();
+
+        let pre_infos = version_infos_from(&snap_versions, &levels);
+        assert!(
+            validate_bucket_list_structure(&pre_infos, BUCKET_LIST_LEVELS).is_err(),
+            "validator should reject unrepresentable Output future at level 5 before clearing"
+        );
+
+        let mut has = make_has_with_levels(levels, None);
+        has.clear_unrepresentable_futures(&snap_versions, None);
+
+        assert!(has.current_buckets[5].next.is_clear());
+        let post_infos = version_infos_from(&snap_versions, &has.current_buckets);
+        validate_bucket_list_structure(&post_infos, BUCKET_LIST_LEVELS).unwrap();
+    }
+
+    /// Hot-archive coverage: the same clearing must apply to the
+    /// `hot_archive_buckets` vector when present. Exercises the second
+    /// argument of `clear_unrepresentable_futures` and the
+    /// `HotArchiveBucket::get_protocol_version` API shape (Result<u32>,
+    /// no Option).
+    #[test]
+    fn test_clear_unrepresentable_futures_clears_hot_archive_future() {
+        let live_levels = make_skeleton_levels();
+        let mut hot_levels = make_skeleton_levels();
+        hot_levels[4].next = HASBucketNext {
+            state: HAS_NEXT_STATE_OUTPUT,
+            output: Some("d".repeat(64)),
+            curr: None,
+            snap: None,
+            shadow: None,
+        };
+        let live_snap_versions: Vec<u32> = (0..BUCKET_LIST_LEVELS).map(|_| 25u32).collect();
+        let hot_snap_versions: Vec<u32> = (0..BUCKET_LIST_LEVELS).map(|_| 25u32).collect();
+
+        let mut has = make_has_with_levels(live_levels, Some(hot_levels));
+        has.clear_unrepresentable_futures(&live_snap_versions, Some(&hot_snap_versions));
+
+        let hot = has.hot_archive_buckets.as_ref().unwrap();
+        assert!(
+            hot[4].next.is_clear(),
+            "hot-archive level 4 next must be cleared after prepareForPublish pass"
+        );
+        let post_infos = version_infos_from(&hot_snap_versions, hot);
+        validate_bucket_list_structure(&post_infos, BUCKET_LIST_LEVELS).unwrap();
+    }
+
+    /// End-to-end sanity: fresh-genesis `BucketList::new()` produces an
+    /// all-empty HAS, the per-level `protocol_version()` calls return
+    /// `Ok(None)` (mapped to 0), the clearing pass is a no-op, and the
+    /// resulting HAS satisfies the structural validator. Guards against
+    /// the cache-population edge case noted as a risk in the plan and
+    /// confirms `build_history_archive_state` end-to-end on the empty path.
+    #[test]
+    fn test_build_has_handles_all_empty_bucket_list() {
+        use crate::catchup::buckets::build_live_level_version_infos;
+
+        let bl = BucketList::new();
+        let has = build_history_archive_state(1, &bl, None, None).unwrap();
+
+        assert_eq!(has.current_buckets.len(), BUCKET_LIST_LEVELS);
+        for (i, level) in has.current_buckets.iter().enumerate() {
+            assert!(
+                level.next.is_clear(),
+                "fresh-genesis HAS level {} must have clear next",
+                i
+            );
+        }
+
+        let infos = build_live_level_version_infos(bl.levels(), &has.current_buckets).unwrap();
+        validate_bucket_list_structure(&infos, BUCKET_LIST_LEVELS).unwrap();
     }
 }


### PR DESCRIPTION
Closes #2766

## Summary

`build_history_archive_state` now mirrors stellar-core's
`HistoryArchiveState::prepareForPublish` (HistoryArchive.cpp:466-507)
shadows-removed branch: every emitted HAS clears `next` at any level whose
previous level's `snap` protocol version is ≥ `FIRST_PROTOCOL_SHADOWS_REMOVED`
(12). For protocol 24+ (the only range henyey supports) that means **every**
non-genesis level — the on-disk format cannot represent pending merges past
the shadows-removal boundary and the consumer reconstructs them via
`restart_merges_from_has`.

This unblocks Quickstart catchup, which was regressing on `a0db2c26` (#2683)
because `validate_bucket_list_structure` correctly rejected a legitimate
post-genesis HAS at ledger 90 (`future must be cleared at level 3, prev snap
version 25`). The validator is right; henyey's emitter was wrong.

### Why eager-clear, not lazy-clear

Stellar-core lazy-clears inside `ResolveSnapshotWork::doWork`
(`ResolveSnapshotWork.cpp:30`); in-memory HAS instances freely carry pending
futures. Henyey eager-clears inside `build_history_archive_state` because
that's the single emission entry point — every caller serializing a HAS
goes through it. The on-disk contents are identical; the placement matches
henyey's narrower API surface. A code comment marks this so future
contributors don't introduce a second emission path that bypasses the clear.

The second branch of `prepareForPublish` (the `makeLive` path,
`HistoryArchive.cpp:490-506`) is intentionally skipped: it reconstitutes
pending merges loaded back from an older-protocol on-disk HAS, a data shape
that cannot arise from henyey's live in-memory `BucketLevel` inputs.

### Operator note

Existing stale HAS files in persistent local archives written before this
fix will still trip the validator at catchup. Operators with persisted
archives across the regression boundary need to wipe + republish. CI starts
fresh on each Quickstart run, so the fix unblocks CI immediately.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2766#issuecomment-4466801121)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-history` — all 511 unit tests + 7 catchup + 27 doc tests pass, including the four new regression tests:
  - `test_clear_unrepresentable_futures_clears_inputs_at_shadowless_level` — Inputs (state=2) cleared, validator round-trip passes
  - `test_clear_unrepresentable_futures_clears_output_at_shadowless_level` — Output (state=1) cleared (Critic A & B coverage gap)
  - `test_clear_unrepresentable_futures_clears_hot_archive_future` — second helper argument and `HotArchiveBucket::get_protocol_version` API shape
  - `test_build_has_handles_all_empty_bucket_list` — end-to-end sanity through `build_history_archive_state` + the real validator on a fresh-genesis bucket list
- [x] `cargo test --all` — workspace-wide pass, no other suites regressed.

## Deviations from plan

- The three "via build_history_archive_state" regression tests in the plan called for synthetically injecting pending merges into a real `BucketList` and then round-tripping through `build_history_archive_state`. `BucketLevel::next` is module-private in `henyey-bucket` and cannot be set from outside `crates/bucket` without an unrelated API change. Tests instead exercise the same surface where the bug manifests — `HistoryArchiveState::clear_unrepresentable_futures` followed by `validate_bucket_list_structure` on `BucketLevelVersionInfo`s built from the same `snap_versions` vector the production code passes. The end-to-end sanity test still runs through `build_history_archive_state` on a real `BucketList::new()`, so the full pipeline (incl. `Bucket::protocol_version` cache population) is exercised.
- Made `crate::catchup::buckets` and its `build_live_level_version_infos` helper `pub(crate)` so the regression sanity test in `publish.rs` can re-use the production validator wiring; no external API change.
- `HistoryError` has no `PublishFailed` variant; per-level version-read errors map to `HistoryError::VerificationFailed` ("the closest existing variant" per the plan) with the level index in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)