### PR TITLE
Reorder (Owner, TempDir) test helpers to (TempDir, Owner)

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -4315,7 +4315,11 @@ mod tests {
     /// - schedule_due=true (last_recovery_attempt 15s ago)
     ///
     /// Caller sets `last_hard_reset_offset` to control cooldown state.
-    async fn mk_app_for_cooldown_livelock_scenario() -> (App, tempfile::TempDir) {
+    ///
+    /// Returns `(TempDir, App)`; the `TempDir` guard is first so the `App`
+    /// (which holds open database handles into the directory) is dropped
+    /// before the directory it backs is removed.
+    async fn mk_app_for_cooldown_livelock_scenario() -> (tempfile::TempDir, App) {
         use std::time::Duration;
 
         let dir = tempfile::tempdir().expect("temp dir");
@@ -4384,7 +4388,7 @@ mod tests {
         // recovery_attempts_without_progress stays at 0 (default),
         // below RECOVERY_ESCALATION_CATCHUP=6.
 
-        (app, dir)
+        (dir, app)
     }
 
     /// #1844 regression: when HardReset cooldown is active, the livelock
@@ -4395,7 +4399,7 @@ mod tests {
         use std::sync::atomic::Ordering;
         use std::time::Duration;
 
-        let (app, _dir) = mk_app_for_cooldown_livelock_scenario().await;
+        let (_dir, app) = mk_app_for_cooldown_livelock_scenario().await;
 
         // Activate cooldown: store a recent hard-reset offset.
         // max(1) because 0 is the sentinel for "no previous reset".
@@ -4476,7 +4480,7 @@ mod tests {
     async fn test_no_previous_reset_routes_to_hard_reset() {
         use std::sync::atomic::Ordering;
 
-        let (app, _dir) = mk_app_for_cooldown_livelock_scenario().await;
+        let (_dir, app) = mk_app_for_cooldown_livelock_scenario().await;
 
         // last_hard_reset_offset stays at 0 (default) → "no previous reset"
         // → cooldown is inactive → HardReset fires.
@@ -4688,7 +4692,11 @@ mod tests {
     /// target=88, checkpoint_containing(88)=128 > 100 → enters cache check.
     /// No cooldown stamp → cooldown skipped. No cached externalized for
     /// slot 1 → `should_skip_externalized_catchup_cooldown` returns false.
-    async fn mk_app_for_externalized_catchup_cache_test() -> (App, u64, tempfile::TempDir) {
+    ///
+    /// Returns `(TempDir, App, latest_externalized)`; the `TempDir` guard is
+    /// first so the `App` (which holds open database handles into the
+    /// directory) is dropped before the directory it backs is removed.
+    async fn mk_app_for_externalized_catchup_cache_test() -> (tempfile::TempDir, App, u64) {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("ext-catchup-cache-test.db");
         let config = crate::config::ConfigBuilder::new()
@@ -4706,7 +4714,7 @@ mod tests {
         // No last_catchup_completed_at → cooldown check passes.
         // No cached externalized for slot 1 → skip cooldown returns false.
 
-        (app, latest_externalized, dir)
+        (dir, app, latest_externalized)
     }
 
     #[tokio::test]
@@ -4714,7 +4722,7 @@ mod tests {
         // Regression test for #1863: when the archive cache is cold (None),
         // externalized catchup should spawn a ProbeAhead escalation and set
         // urgent mode, NOT stamp last_catchup_completed_at.
-        let (app, latest_externalized, _dir) = mk_app_for_externalized_catchup_cache_test().await;
+        let (_dir, app, latest_externalized) = mk_app_for_externalized_catchup_cache_test().await;
 
         // Precondition: cache is cold.
         assert_eq!(
@@ -4762,7 +4770,7 @@ mod tests {
     async fn test_externalized_catchup_archive_behind_does_not_stamp_completion() {
         // Regression test for #1863: when archive_latest <= current_ledger,
         // externalized catchup should NOT stamp last_catchup_completed_at.
-        let (app, latest_externalized, _dir) = mk_app_for_externalized_catchup_cache_test().await;
+        let (_dir, app, latest_externalized) = mk_app_for_externalized_catchup_cache_test().await;
 
         // Seed archive cache at 0 (at current_ledger, which is 0 for
         // uninitialized ledger_manager).
@@ -4807,7 +4815,7 @@ mod tests {
         // should also NOT stamp last_catchup_completed_at. This is the same
         // behavior as the fresh-cache-behind case — stale values that show
         // "behind" are handled identically.
-        let (app, latest_externalized, _dir) = mk_app_for_externalized_catchup_cache_test().await;
+        let (_dir, app, latest_externalized) = mk_app_for_externalized_catchup_cache_test().await;
 
         // Use seed_stale so the cache actually returns Stale(0), exercising
         // the CacheResult::Stale arm in maybe_start_externalized_catchup.
@@ -4852,7 +4860,7 @@ mod tests {
         use std::time::Duration;
         use tokio::sync::Notify;
 
-        let (app, _dir) = mk_app_for_cooldown_livelock_scenario().await;
+        let (_dir, app) = mk_app_for_cooldown_livelock_scenario().await;
         let app = Arc::new(app);
 
         // Shared signal: the spawned task holds `archive_recovery_status.write()`

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -3097,7 +3097,11 @@ mod restore_result_tests {
     }
 
     /// Helper: create a minimal App for load_last_known_ledger tests.
-    async fn test_app() -> (Arc<App>, tempfile::TempDir) {
+    ///
+    /// Returns `(TempDir, App)`; the `TempDir` guard is first so the `App`
+    /// (which holds open database and bucket file handles into the directory)
+    /// is dropped before the directory it backs is removed.
+    async fn test_app() -> (tempfile::TempDir, Arc<App>) {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("test.db");
         let bucket_dir = dir.path().join("buckets");
@@ -3109,12 +3113,12 @@ mod restore_result_tests {
         let app = App::new(config).await.unwrap();
         let app = Arc::new(app);
         app.set_self_arc().await;
-        (app, dir)
+        (dir, app)
     }
 
     #[tokio::test]
     async fn test_no_lcl_returns_no_state() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
         // Fresh DB has no LCL — should return NoState.
         let result = app.load_last_known_ledger().await.unwrap();
         assert_eq!(result, RestoreResult::NoState);
@@ -3122,7 +3126,7 @@ mod restore_result_tests {
 
     #[tokio::test]
     async fn test_lcl_zero_returns_err() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
         // Set LCL to 0 (anomalous — genesis is seq 1).
         app.db_blocking("test-set-lcl", |db| {
             db.with_connection(|conn| {
@@ -3144,7 +3148,7 @@ mod restore_result_tests {
 
     #[tokio::test]
     async fn test_lcl_exists_but_no_has_returns_err() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
         // Set LCL but no HAS — inconsistent state.
         app.db_blocking("test-set-lcl", |db| {
             db.with_connection(|conn| {
@@ -3166,7 +3170,7 @@ mod restore_result_tests {
 
     #[tokio::test]
     async fn test_lcl_has_mismatch_returns_err() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
         // Set LCL=100 but HAS says current_ledger=50.
         app.db_blocking("test-set-lcl-has", |db| {
             db.with_connection(|conn| {
@@ -3190,7 +3194,7 @@ mod restore_result_tests {
 
     #[tokio::test]
     async fn test_malformed_has_json_returns_err() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
         app.db_blocking("test-set-lcl-has", |db| {
             db.with_connection(|conn| {
                 use henyey_db::queries::StateQueries;
@@ -3211,10 +3215,14 @@ mod restore_result_tests {
     }
 
     /// Helper: create a test App with custom validator/archive settings.
+    ///
+    /// Returns `(TempDir, App)`; the `TempDir` guard is first so the `App`
+    /// (which holds open database and bucket file handles into the directory)
+    /// is dropped before the directory it backs is removed.
     async fn test_app_with_publish_config(
         is_validator: bool,
         writable_archive: bool,
-    ) -> (Arc<App>, tempfile::TempDir) {
+    ) -> (tempfile::TempDir, Arc<App>) {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("test.db");
         let bucket_dir = dir.path().join("buckets");
@@ -3243,7 +3251,7 @@ mod restore_result_tests {
         let app = App::new(config).await.unwrap();
         let app = Arc::new(app);
         app.set_self_arc().await;
-        (app, dir)
+        (dir, app)
     }
 
     /// Regression test for #1989: startup drain clears stale publish queue
@@ -3251,7 +3259,7 @@ mod restore_result_tests {
     #[tokio::test]
     async fn test_startup_drain_clears_queue_when_not_validator() {
         // Non-validator with writable archives — can_publish should be false.
-        let (app, _dir) = test_app_with_publish_config(false, true).await;
+        let (_dir, app) = test_app_with_publish_config(false, true).await;
 
         // Seed DB with LCL and stale publish queue entries.
         app.db_blocking("seed-db", |db| {
@@ -3299,7 +3307,7 @@ mod restore_result_tests {
     #[tokio::test]
     async fn test_startup_drain_clears_queue_when_no_writable_archives() {
         // Validator with NO writable archives — can_publish should be false.
-        let (app, _dir) = test_app_with_publish_config(true, false).await;
+        let (_dir, app) = test_app_with_publish_config(true, false).await;
 
         // Seed DB with stale entries.
         app.db_blocking("seed-db", |db| {
@@ -3330,7 +3338,7 @@ mod restore_result_tests {
     #[tokio::test]
     async fn test_startup_preserves_queue_when_can_publish() {
         // Validator with writable archives — can_publish should be true.
-        let (app, _dir) = test_app_with_publish_config(true, true).await;
+        let (_dir, app) = test_app_with_publish_config(true, true).await;
 
         // Seed DB with entries that should be preserved.
         app.db_blocking("seed-db", |db| {
@@ -3365,7 +3373,7 @@ mod restore_result_tests {
     /// references but the actual bucket files were cleaned up.
     #[tokio::test]
     async fn test_missing_buckets_returns_no_state_and_clears_db() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
 
         // Build a HAS with one non-zero bucket hash (curr of level 0).
         let fake_hash = "a".repeat(64);
@@ -3476,7 +3484,11 @@ mod fatal_shutdown_tests {
     use std::sync::atomic::Ordering;
 
     /// Helper: create a minimal App for fatal-shutdown tests.
-    async fn test_app() -> (Arc<App>, tempfile::TempDir) {
+    ///
+    /// Returns `(TempDir, App)`; the `TempDir` guard is first so the `App`
+    /// (which holds open database and bucket file handles into the directory)
+    /// is dropped before the directory it backs is removed.
+    async fn test_app() -> (tempfile::TempDir, Arc<App>) {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("test.db");
         let bucket_dir = dir.path().join("buckets");
@@ -3488,7 +3500,7 @@ mod fatal_shutdown_tests {
         let app = App::new(config).await.unwrap();
         let app = Arc::new(app);
         app.set_self_arc().await;
-        (app, dir)
+        (dir, app)
     }
 
     /// Once `fatal_state_failure` is set, `try_start_ledger_close` must
@@ -3496,7 +3508,7 @@ mod fatal_shutdown_tests {
     /// the node has detected an unrecoverable state failure.
     #[tokio::test]
     async fn test_try_start_ledger_close_blocked_after_fatal() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
 
         // Pre-set the fatal flag to simulate a prior fatal failure.
         app.fatal_state_failure.store(true, Ordering::SeqCst);
@@ -3518,7 +3530,11 @@ mod refresh_stale_buffer_tests {
     use stellar_xdr::curr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
 
     /// Helper: create a minimal App for testing.
-    async fn test_app() -> (Arc<App>, tempfile::TempDir) {
+    ///
+    /// Returns `(TempDir, App)`; the `TempDir` guard is first so the `App`
+    /// (which holds open database and bucket file handles into the directory)
+    /// is dropped before the directory it backs is removed.
+    async fn test_app() -> (tempfile::TempDir, Arc<App>) {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("test.db");
         let bucket_dir = dir.path().join("buckets");
@@ -3530,7 +3546,7 @@ mod refresh_stale_buffer_tests {
         let app = App::new(config).await.unwrap();
         let app = Arc::new(app);
         app.set_self_arc().await;
-        (app, dir)
+        (dir, app)
     }
 
     /// When syncing_ledgers has an entry with tx_set=None but the herder's
@@ -3538,7 +3554,7 @@ mod refresh_stale_buffer_tests {
     /// refresh the entry and proceed with the close.
     #[tokio::test]
     async fn test_refresh_stale_syncing_ledgers_entry() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
 
         // The fresh app has current_ledger = 0, so next_seq = 1.
         let next_seq: u32 = 1;
@@ -3604,7 +3620,7 @@ mod refresh_stale_buffer_tests {
     /// buffered, the refresh must be rejected (no-op).
     #[tokio::test]
     async fn test_refresh_rejected_on_hash_mismatch() {
-        let (app, _dir) = test_app().await;
+        let (_dir, app) = test_app().await;
 
         let next_seq: u32 = 1;
         let slot: u64 = next_seq as u64;

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -11032,7 +11032,11 @@ mod tests {
 
     /// Helper: create an App with overlay started for scheduler tests that
     /// need to capture outbound messages via inject_test_peer.
-    async fn survey_test_app_with_overlay() -> (Arc<App>, tempfile::TempDir) {
+    ///
+    /// Returns `(TempDir, App)`; the `TempDir` guard is first so the `App`
+    /// (which holds open database handles into the directory) is dropped
+    /// before the directory it backs is removed.
+    async fn survey_test_app_with_overlay() -> (tempfile::TempDir, Arc<App>) {
         let dir = tempfile::tempdir().unwrap();
         let mut config = crate::config::ConfigBuilder::new()
             .database_path(dir.path().join("survey-test.db"))
@@ -11041,7 +11045,7 @@ mod tests {
         config.is_compat_config = true;
         let app = Arc::new(App::new(config).await.unwrap());
         app.start_overlay().await.unwrap();
-        (app, dir)
+        (dir, app)
     }
 
     /// Regression test for commit 2cbb6bb: each scheduler phase must read
@@ -11054,7 +11058,7 @@ mod tests {
     /// message carries N+2.
     #[tokio::test]
     async fn test_advance_survey_scheduler_ledger_restamping_across_phases() {
-        let (app, _dir) = survey_test_app_with_overlay().await;
+        let (_dir, app) = survey_test_app_with_overlay().await;
         let overlay = app.overlay().await.unwrap();
         let now = app.clock.now();
 
@@ -11297,7 +11301,7 @@ mod tests {
     /// must carry ledger_num = 15.
     #[tokio::test]
     async fn test_top_off_survey_requests_fresh_ledger_after_secret_resolution() {
-        let (app, _dir) = survey_test_app_with_overlay().await;
+        let (_dir, app) = survey_test_app_with_overlay().await;
         let overlay = app.overlay().await.unwrap();
 
         let peer_id = PeerId::from_bytes([7u8; 32]);
@@ -11417,7 +11421,7 @@ mod tests {
     /// message must carry 20 and the stop message must carry 25.
     #[tokio::test]
     async fn test_start_stop_survey_collecting_fresh_ledger() {
-        let (app, _dir) = survey_test_app_with_overlay().await;
+        let (_dir, app) = survey_test_app_with_overlay().await;
         let overlay = app.overlay().await.unwrap();
 
         let peer_id = PeerId::from_bytes([9u8; 32]);

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -1730,7 +1730,11 @@ mod tests {
     // ── handle_flood_demand regression tests ─────────────────────────────
 
     /// Helper: create a test App with overlay started, no port binding, no seed peers.
-    async fn create_test_app_with_overlay() -> (crate::app::App, tempfile::TempDir) {
+    ///
+    /// Returns `(TempDir, App)`; the `TempDir` guard is first so the `App`
+    /// (which holds open database handles into the directory) is dropped
+    /// before the directory it backs is removed.
+    async fn create_test_app_with_overlay() -> (tempfile::TempDir, crate::app::App) {
         let dir = tempfile::tempdir().expect("temp dir");
         let mut config = crate::config::ConfigBuilder::new()
             .database_path(dir.path().join("test.db"))
@@ -1739,7 +1743,7 @@ mod tests {
         config.is_compat_config = true;
         let app = crate::app::App::new(config).await.unwrap();
         app.start_overlay().await.unwrap();
-        (app, dir)
+        (dir, app)
     }
 
     /// Regression test for commit 2b8d4801: handle_flood_demand must only send
@@ -1747,7 +1751,7 @@ mod tests {
     /// banned/unknown hashes, and must continue processing past misses.
     #[tokio::test]
     async fn test_handle_flood_demand_mixed_hashes() {
-        let (app, _dir) = create_test_app_with_overlay().await;
+        let (_dir, app) = create_test_app_with_overlay().await;
         let overlay = app.overlay().await.unwrap();
 
         // Inject a test peer with plenty of channel capacity.
@@ -1835,7 +1839,7 @@ mod tests {
     /// outbound channel is full (backpressure via try_send).
     #[tokio::test]
     async fn test_handle_flood_demand_channel_full_stops() {
-        let (app, _dir) = create_test_app_with_overlay().await;
+        let (_dir, app) = create_test_app_with_overlay().await;
         let overlay = app.overlay().await.unwrap();
 
         // Inject a peer with capacity for only 1 message.
@@ -1985,7 +1989,7 @@ mod tests {
             TransactionSetV1, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
         };
 
-        let (app, _dir) = create_test_app_with_overlay().await;
+        let (_dir, app) = create_test_app_with_overlay().await;
         let overlay = app.overlay().await.unwrap();
 
         // Inject a test peer.

--- a/crates/app/src/http/handlers/info.rs
+++ b/crates/app/src/http/handlers/info.rs
@@ -314,9 +314,10 @@ mod tests {
     use crate::http::{build_router, ServerState};
 
     /// Build a `ServerState` backed by a real (minimal) `App` with the given
-    /// `commit_hash`. Returns the state and the `TempDir` whose lifetime keeps
-    /// the on-disk database valid.
-    async fn test_server_state(commit_hash: &str) -> (Arc<ServerState>, tempfile::TempDir) {
+    /// `commit_hash`. Returns `(TempDir, ServerState)`; the `TempDir` guard is
+    /// first so the `ServerState` (which holds open database handles) is
+    /// dropped before the directory it backs is removed.
+    async fn test_server_state(commit_hash: &str) -> (tempfile::TempDir, Arc<ServerState>) {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("test.db");
         let mut config = ConfigBuilder::new().database_path(db_path).build();
@@ -337,7 +338,7 @@ mod tests {
             #[cfg(feature = "loadgen")]
             loadgen_state: None,
         });
-        (state, dir)
+        (dir, state)
     }
 
     /// Collect an axum response body and parse it as JSON.
@@ -349,7 +350,7 @@ mod tests {
     #[tokio::test]
     async fn test_info_handler_commit_hash_present() {
         let commit = "abc123def456";
-        let (state, _dir) = test_server_state(commit).await;
+        let (_dir, state) = test_server_state(commit).await;
         let app = build_router(state);
 
         let response = app
@@ -370,7 +371,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_info_handler_commit_hash_absent() {
-        let (state, _dir) = test_server_state("").await;
+        let (_dir, state) = test_server_state("").await;
         let app = build_router(state);
 
         let response = app


### PR DESCRIPTION
Closes #2761

## Summary

Audits and corrects the latent `(Owner, TempDir)` drop-order anti-pattern across 10 test helpers and 29 destructuring callsites in `crates/app` and `crates/history`. With the new tuple shape, destructuring as `let (_dir, owner) = helper()` declares `_dir` first, so `owner` drops first (releasing SQLite / bucket file handles) and `_dir` drops last (removing the directory). Per the Rust Reference, local bindings drop in reverse declaration order.

Helpers reordered:
- `history/catchup/replay.rs`: `make_test_catchup_manager`
- `app/http/handlers/info.rs`: `test_server_state`
- `app/app/mod.rs`: `survey_test_app_with_overlay`
- `app/app/tx_flooding.rs`: `create_test_app_with_overlay`
- `app/app/ledger_close.rs`: three sibling `test_app` + `test_app_with_publish_config`
- `app/app/catchup_impl.rs`: `mk_app_for_cooldown_livelock_scenario` and `mk_app_for_externalized_catchup_cache_test` (`(TempDir, App, u64)`)

This **corrects** (not generalizes) PR #2749, which converted an intentional `tmp_dir.keep()` leak into a returned `(CatchupManager, TempDir)` tuple — it stopped the leak but planted the wrong drop order. All sibling helpers flagged by Critic C on #2751 now follow the same correct shape.

All affected helpers are inside `#[cfg(test)]` modules; no production code or observable wire behavior changes.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2761#issuecomment-4466867442)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-history --tests` (all pass)
- [x] `cargo test -p henyey-app --tests` (938 + integration tests, all pass)

## Deviations from plan

None.

🤖 Generated with [GitHub Copilot CLI](https://github.com/cli/cli)