### PR TITLE
Wire ScpPersistenceManager::persist_scp_state into ScpDriver::emit (#2768)

### DIFF
--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -114,7 +114,7 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `maybeSetupSorobanQueue()` | Integrated via lane-based `TransactionQueue` | Full |
 | `herderOutOfSync()` | `SyncRecoveryManager` | Full |
 | `getMoreSCPState()` | _(not implemented)_ | None |
-| `persistSCPState()` | `ScpPersistenceManager.persist()` | Full |
+| `persistSCPState()` | `ScpPersistenceManager.persist_scp_state()` wired via `ScpDriver::emit` persist callback | Full[^persist-scp] |
 | `restoreSCPState()` | `ScpPersistenceManager.restore()` | Full |
 | `persistUpgrades()` | `UpgradeParameters` with Serde persistence | Full |
 | `restoreUpgrades()` | `UpgradeParameters` with Serde persistence | Full |
@@ -130,9 +130,22 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `recomputeKeysToFilter()` | _(not implemented)_ | None |
 
 [^txset-gc]: GC timer + purge wired in #2698 (driven by app event-loop phase
-33 every `TX_SET_GC_DELAY_SECS` = 60s). The broader SCP persist/restore story
-is still incomplete: `persist_scp_state` wiring is tracked in #2768 and
-`restore_scp_state` wiring in #2769.
+33 every `TX_SET_GC_DELAY_SECS` = 60s). The `persist_scp_state` wiring was
+completed in #2768 (`ScpDriver::emit` invokes the persist callback installed
+by `Herder::set_scp_persistence`). The `restore_scp_state` wiring remains
+tracked in #2769.
+
+[^persist-scp]: Wired in #2768 via a deferred persist callback on `ScpDriver`.
+Each call to `ScpDriver::emit` (which mirrors stellar-core's
+`HerderImpl::emitEnvelope`) fires the callback installed by
+`Herder::set_scp_persistence`; the callback spawns a worker thread that
+gathers `get_latest_messages_send(slot)` envelopes plus referenced tx-sets
+and quorum-sets and invokes `ScpPersistenceManager::persist_scp_state`. The
+work is deferred to a worker thread (not synchronous as in stellar-core)
+because henyey's `SCP` holds a `parking_lot::RwLock` write guard on its
+slots map while `emit` runs, and a synchronous `get_latest_messages_send`
+would deadlock against the same lock. Persistence remains best-effort:
+errors are logged but not propagated.
 
 ### SCP Driver (`scp_driver.rs`)
 

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -456,7 +456,12 @@ pub struct Herder {
     /// SCP consensus protocol instance.
     /// Always created — observers run SCP with `is_validator: false` (same as stellar-core),
     /// which means `fully_validated` is false on slots and `send_latest_envelope` won't emit.
-    scp: SCP<HerderScpCallback>,
+    ///
+    /// Wrapped in `Arc` so [`Self::set_scp_persistence`] can clone a handle
+    /// into the persist callback installed on [`Self::scp_driver`]. The
+    /// callback fires from [`crate::scp_driver::ScpDriver::emit`] after
+    /// each envelope broadcast and needs read-access to `get_latest_messages_send`.
+    scp: Arc<SCP<HerderScpCallback>>,
     /// Shared tracking consensus state (also read by ScpDriver for value validation).
     tracking_state: Arc<RwLock<SharedTrackingState>>,
     /// When we started tracking.
@@ -640,12 +645,12 @@ impl Herder {
             warn!("Validator mode requested but no quorum set configured");
         }
         let callback = HerderScpCallback::new(Arc::clone(&scp_driver));
-        let scp = SCP::new(
+        let scp = Arc::new(SCP::new(
             node_id.clone(),
             is_validator,
             quorum_set,
             Arc::new(callback),
-        );
+        ));
 
         let slot_quorum_tracker =
             SlotQuorumTracker::new(config.local_quorum_set.clone(), max_slots);
@@ -738,11 +743,123 @@ impl Herder {
     /// Called once from `init_herder` after the `Arc<Herder>` is constructed.
     /// `OnceLock` enforces single-installer at the type-system level: a second
     /// call returns `Err` with the supplied manager so the caller can fail loud.
+    ///
+    /// On first install, also wires the persist callback into
+    /// [`crate::scp_driver::ScpDriver::set_persist_callback`] so each emitted
+    /// envelope triggers a `persist_scp_state` call on the manager. The
+    /// callback captures `Arc<SCP>`, `Arc<ScpDriver>`, and
+    /// `Arc<ScpPersistenceManager>` (an intentional Arc cycle mirroring
+    /// the existing `envelope_sender` cycle — benign because all three
+    /// are dropped together with the owning `Herder`).
     pub fn set_scp_persistence(
         &self,
         manager: Arc<crate::persistence::ScpPersistenceManager>,
     ) -> std::result::Result<(), Arc<crate::persistence::ScpPersistenceManager>> {
-        self.scp_persistence.set(manager)
+        // Set first; if this fails, do NOT install the callback (we're a
+        // double-install and the existing manager is already wired).
+        self.scp_persistence.set(Arc::clone(&manager))?;
+
+        // Capture handles for the persist closure. Each call to the closure
+        // re-clones these Arcs onto a worker thread; the thread does the
+        // gather + persist work AFTER returning from `emit()` so SCP's
+        // internal slots write-lock has been released (otherwise the
+        // closure's `scp.get_latest_messages_send` would deadlock against
+        // the writer chain that invoked `emit`).
+        let scp = Arc::clone(&self.scp);
+        let driver = Arc::clone(&self.scp_driver);
+        let manager_for_cb = Arc::clone(&manager);
+
+        // Parity: stellar-core HerderImpl::persistSCPState (HerderImpl.cpp:2152-2186):
+        //   1. getSCP().getLatestMessagesSend(slotIndex) → envelopes
+        //   2. for each envelope: mPendingEnvelopes.getTxSet(h) → encode StoredTransactionSet
+        //   3. mPendingEnvelopes.getQSet(qsHash) → ScpQuorumSet
+        //   4. persistentState.setSCPstate(slot, ..., txSets, ...)
+        //
+        // Deviation: stellar-core runs this synchronously inside `emitEnvelope`.
+        // henyey's `SCP::nominate`/`process_envelope`/etc hold a
+        // `parking_lot::RwLock` write guard on `slots` while the driver
+        // emits, so a synchronous `get_latest_messages_send` (which takes
+        // the same RwLock for reading) would deadlock. We spawn a worker
+        // thread instead; the thread acquires the read lock after the
+        // writer chain unwinds. `pending_persist_begin`/`_end` provide
+        // synchronization for tests (`wait_for_pending_persists`).
+        self.scp_driver.set_persist_callback(move |slot| {
+            let scp = Arc::clone(&scp);
+            let driver = Arc::clone(&driver);
+            let manager_for_thread = Arc::clone(&manager_for_cb);
+
+            // Increment BEFORE spawn so a tightly-following
+            // `wait_for_pending_persists` cannot race past us.
+            manager_for_thread.pending_persist_begin();
+
+            // Worker thread: gather state + persist outside the SCP slot
+            // write-lock. Errors are best-effort logged.
+            std::thread::Builder::new()
+                .name(format!("scp-persist-{}", slot))
+                .spawn(move || {
+                    // Decrement on any exit path.
+                    struct Guard<'a>(&'a crate::persistence::ScpPersistenceManager);
+                    impl<'a> Drop for Guard<'a> {
+                        fn drop(&mut self) {
+                            self.0.pending_persist_end();
+                        }
+                    }
+                    let _guard = Guard(&manager_for_thread);
+
+                    use stellar_xdr::curr::{Limits, WriteXdr};
+
+                    let envelopes = scp.get_latest_messages_send(slot);
+
+                    let mut tx_sets: Vec<(stellar_xdr::curr::Hash, Vec<u8>)> = Vec::new();
+                    let mut quorum_sets: Vec<(
+                        stellar_xdr::curr::Hash,
+                        stellar_xdr::curr::ScpQuorumSet,
+                    )> = Vec::new();
+
+                    for envelope in &envelopes {
+                        for hash in crate::persistence::get_tx_set_hashes(envelope) {
+                            let hash256 = henyey_common::Hash256(hash.0);
+                            if let Some(tx_set) = driver.get_tx_set(&hash256) {
+                                let stored = tx_set.to_xdr_stored_set();
+                                match stored.to_xdr(Limits::none()) {
+                                    Ok(bytes) => tx_sets.push((hash, bytes)),
+                                    Err(e) => {
+                                        warn!(
+                                            error = %e,
+                                            slot,
+                                            "persist_scp_state: failed to encode \
+                                             StoredTransactionSet"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        if let Some(qhash) = crate::persistence::get_quorum_set_hash(envelope) {
+                            let qhash256 = henyey_common::Hash256(qhash.0);
+                            if let Some(qs) = driver.get_quorum_set_by_hash(&qhash256) {
+                                quorum_sets.push((qhash, qs));
+                            }
+                        }
+                    }
+
+                    if let Err(e) = manager_for_thread.persist_scp_state(
+                        slot,
+                        &envelopes,
+                        &tx_sets,
+                        &quorum_sets,
+                    ) {
+                        warn!(error = %e, slot, "persist_scp_state failed");
+                    }
+                })
+                .map_err(|e| {
+                    // If spawn fails we still need to drop the pending count.
+                    manager_for_cb.pending_persist_end();
+                    warn!(error = %e, slot, "failed to spawn scp-persist worker");
+                })
+                .ok();
+        });
+
+        Ok(())
     }
 
     /// Purge persisted tx sets that are no longer referenced by any persisted
@@ -756,10 +873,9 @@ impl Herder {
     /// TODO(#2770): the underlying `purge_unreferenced_tx_sets()` performs
     /// three serial connection checkouts — `get_all_tx_set_hashes`,
     /// `load_all_scp_states`, `delete_tx_sets_by_hashes` — without a single
-    /// SQLite transaction. Today this is harmless because `persist_scp_state`
-    /// (#2768) is unwired; once it is wired, a concurrent persist between
-    /// steps 2 and 3 could mark a fresh tx-set as orphan. Make transactional
-    /// when persist is wired.
+    /// SQLite transaction. With `persist_scp_state` now wired (#2768), a
+    /// concurrent persist between steps 2 and 3 could mark a fresh tx-set
+    /// as orphan. Tracked in #2770; make transactional there.
     pub fn purge_persisted_tx_sets(&self) {
         let Some(manager) = self.scp_persistence.get() else {
             return;
@@ -7637,6 +7753,13 @@ mod tests {
             "solo validator must externalize slot 1"
         );
 
+        // The persist callback dispatches work to a background thread (to
+        // avoid deadlocking on SCP's slot RwLock); wait for it to settle.
+        assert!(
+            manager.wait_for_pending_persists(std::time::Duration::from_secs(5)),
+            "persist worker threads must drain within 5s"
+        );
+
         // KEY ASSERTION: the persist callback fired, so `last_slot_saved`
         // is now >0. On unmodified main this is 0 because nothing ever
         // calls `persist_scp_state()`.
@@ -7683,6 +7806,13 @@ mod tests {
         herder
             .trigger_next_ledger(1)
             .expect("trigger_next_ledger should succeed");
+
+        // Wait for the deferred persist workers spawned by the emit
+        // callback to finish before observing manager state.
+        assert!(
+            manager.wait_for_pending_persists(std::time::Duration::from_secs(5)),
+            "persist worker threads must drain within 5s"
+        );
 
         // KEY ASSERTION: the real emit triggered a real persist; capture
         // last_slot_saved BEFORE injecting any orphan slot so we don't

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -7601,6 +7601,129 @@ mod tests {
         // got the same Arc back uniquely.
         assert_eq!(Arc::strong_count(&returned), 1);
     }
+
+    // -------- Regression tests for SCP persist wiring (#2768) --------
+
+    /// Drives a full solo-validator nomination → externalize round through
+    /// the herder and asserts that the persistence manager observed the
+    /// slot via `persist_scp_state()` (i.e. `last_slot_saved > 0`).
+    ///
+    /// Fails on `origin/main` because `persist_scp_state` is never called
+    /// from the emit hot path. Passes once #2768 wires the persist
+    /// callback into `ScpDriver::emit()`.
+    #[tokio::test]
+    async fn test_persist_scp_state_called_on_emit() {
+        let (herder, _secret) = make_validator_herder();
+        let manager = Arc::new(crate::persistence::ScpPersistenceManager::in_memory());
+        assert!(
+            herder.set_scp_persistence(Arc::clone(&manager)).is_ok(),
+            "install scp persistence"
+        );
+
+        herder.bootstrap(0);
+        assert_eq!(herder.state(), HerderState::Tracking);
+
+        // Solo validator (1-of-1 quorum) — nomination → ballot → externalize
+        // happens synchronously inside `trigger_next_ledger`, emitting at
+        // least one envelope. Each emit must call into the persist callback.
+        let outcome = herder
+            .trigger_next_ledger(1)
+            .expect("trigger_next_ledger should succeed");
+        let _ = outcome;
+
+        // Sanity: slot 1 actually externalized.
+        assert!(
+            herder.scp_driver.get_externalized(1).is_some(),
+            "solo validator must externalize slot 1"
+        );
+
+        // KEY ASSERTION: the persist callback fired, so `last_slot_saved`
+        // is now >0. On unmodified main this is 0 because nothing ever
+        // calls `persist_scp_state()`.
+        assert!(
+            manager.last_slot_saved() > 0,
+            "persist_scp_state must be invoked from the emit hot path; \
+             last_slot_saved = {}",
+            manager.last_slot_saved()
+        );
+    }
+
+    /// When no persistence manager is installed, `ScpDriver::emit()` must
+    /// still be a no-op for persistence (the OnceLock guard). Drives a
+    /// full nomination round and asserts no panic and no externalize loss.
+    #[tokio::test]
+    async fn test_persist_scp_state_no_manager_no_panic() {
+        let (herder, _secret) = make_validator_herder();
+        // Intentionally DO NOT install a persistence manager.
+
+        herder.bootstrap(0);
+        herder
+            .trigger_next_ledger(1)
+            .expect("trigger_next_ledger should succeed without persistence");
+
+        assert!(
+            herder.scp_driver.get_externalized(1).is_some(),
+            "solo validator must externalize even without persistence"
+        );
+    }
+
+    /// End-to-end check: after a real emit triggers a real persist, the
+    /// GC purge must keep referenced tx sets and remove orphans. Validates
+    /// the full #2698 + #2768 persistence loop.
+    #[tokio::test]
+    async fn test_persist_scp_state_gc_sees_persisted_rows() {
+        let (herder, _secret) = make_validator_herder();
+        let manager = Arc::new(crate::persistence::ScpPersistenceManager::in_memory());
+        assert!(
+            herder.set_scp_persistence(Arc::clone(&manager)).is_ok(),
+            "install scp persistence"
+        );
+
+        herder.bootstrap(0);
+        herder
+            .trigger_next_ledger(1)
+            .expect("trigger_next_ledger should succeed");
+
+        // KEY ASSERTION: the real emit triggered a real persist; capture
+        // last_slot_saved BEFORE injecting any orphan slot so we don't
+        // measure the orphan injection itself.
+        let last_after_real_emit = manager.last_slot_saved();
+        assert!(
+            last_after_real_emit >= 1,
+            "real emit must have persisted; last_slot_saved = {}",
+            last_after_real_emit
+        );
+
+        // Inject an orphan tx set directly via the manager (not referenced
+        // by any persisted envelope).
+        let orphan_hash = stellar_xdr::curr::Hash([0xAAu8; 32]);
+        let orphan_env = make_persist_envelope_with_tx_set_hash(
+            999_999,
+            stellar_xdr::curr::Hash([0xBBu8; 32]), // some unrelated hash
+        );
+        manager
+            .persist_scp_state(
+                999_999,
+                &[orphan_env],
+                &[(orphan_hash.clone(), vec![42])],
+                &[],
+            )
+            .expect("persist orphan");
+        // Sanity: orphan is present pre-purge.
+        assert!(
+            manager.has_tx_set(&orphan_hash).unwrap(),
+            "orphan tx set must be stored before purge"
+        );
+
+        // Run the production GC entry point.
+        herder.purge_persisted_tx_sets();
+
+        // Orphan must be gone.
+        assert!(
+            !manager.has_tx_set(&orphan_hash).unwrap(),
+            "orphan tx set must be purged by GC"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/herder/src/persistence.rs
+++ b/crates/herder/src/persistence.rs
@@ -348,6 +348,16 @@ pub struct ScpPersistenceManager {
     storage: Box<dyn ScpStatePersistence>,
     /// Last slot that was persisted.
     last_slot_saved: parking_lot::RwLock<u64>,
+    /// Number of persist worker threads spawned by [`crate::herder::Herder`]'s
+    /// SCP-emit callback that have not yet returned. The callback defers the
+    /// gather + persist work onto a dedicated thread to avoid deadlocking on
+    /// SCP's internal slots lock (which is write-held while `emit` fires).
+    ///
+    /// Tests use [`Self::wait_for_pending_persists`] to synchronize on the
+    /// background work completing before asserting `last_slot_saved`.
+    pending_persists: std::sync::Mutex<usize>,
+    /// Condvar signaled when `pending_persists` reaches zero.
+    pending_persists_cv: std::sync::Condvar,
 }
 
 impl ScpPersistenceManager {
@@ -356,6 +366,8 @@ impl ScpPersistenceManager {
         Self {
             storage,
             last_slot_saved: parking_lot::RwLock::new(0),
+            pending_persists: std::sync::Mutex::new(0),
+            pending_persists_cv: std::sync::Condvar::new(),
         }
     }
 
@@ -373,6 +385,58 @@ impl ScpPersistenceManager {
     /// store. Primarily used by tests to assert post-purge state.
     pub fn has_tx_set(&self, hash: &Hash) -> Result<bool> {
         self.storage.has_tx_set(hash)
+    }
+
+    /// Increment the pending-persist counter. Called by the emit callback's
+    /// worker thread spawner BEFORE the thread is detached.
+    pub(crate) fn pending_persist_begin(&self) {
+        let mut pending = self
+            .pending_persists
+            .lock()
+            .expect("pending mutex poisoned");
+        *pending += 1;
+    }
+
+    /// Decrement the pending-persist counter and notify waiters. Called by
+    /// the worker thread on completion (success or error).
+    pub(crate) fn pending_persist_end(&self) {
+        let mut pending = self
+            .pending_persists
+            .lock()
+            .expect("pending mutex poisoned");
+        *pending = pending.saturating_sub(1);
+        if *pending == 0 {
+            self.pending_persists_cv.notify_all();
+        }
+    }
+
+    /// Wait for all in-flight persist worker threads to finish, up to
+    /// `timeout`. Returns `true` if the queue drained, `false` on timeout.
+    ///
+    /// Tests use this after `trigger_next_ledger` to ensure persist threads
+    /// spawned by the emit hot path have completed before asserting state.
+    pub fn wait_for_pending_persists(&self, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut pending = self
+            .pending_persists
+            .lock()
+            .expect("pending mutex poisoned");
+        while *pending > 0 {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let remaining = deadline - now;
+            let (next, wait_result) = self
+                .pending_persists_cv
+                .wait_timeout(pending, remaining)
+                .expect("pending cv poisoned");
+            pending = next;
+            if wait_result.timed_out() && *pending > 0 {
+                return false;
+            }
+        }
+        true
     }
 
     /// Persist SCP state for a slot.

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -423,6 +423,22 @@ pub struct ScpDriverCacheSizes {
 /// Callback type for broadcasting SCP envelopes to peers.
 type EnvelopeSender = Box<dyn Fn(ScpEnvelope) + Send + Sync>;
 
+/// Callback type for persisting SCP state after an envelope emission.
+///
+/// Receives the slot index whose envelopes were just emitted. The closure
+/// is responsible for gathering the slot's `getLatestMessagesSend` envelopes
+/// plus their referenced tx-sets and quorum-sets, and handing them to
+/// `ScpPersistenceManager::persist_scp_state()`. See
+/// [`crate::herder::Herder::set_scp_persistence`] for the installation
+/// site and the captured Arcs.
+///
+/// Parity: stellar-core fires `HerderImpl::persistSCPState(slotIndex)`
+/// from `HerderImpl::emitEnvelope()` (HerderImpl.cpp:599-612) BEFORE
+/// broadcasting. henyey fires it AFTER broadcasting (inside
+/// [`ScpDriver::emit`]). The ordering difference has no crash-safety
+/// implication — both can be interrupted between persist and broadcast.
+type PersistCallback = Box<dyn Fn(u64) + Send + Sync>;
+
 /// Per-slot SCP timing timestamps (first-seen, nomination start, ballot start).
 /// Consolidates what were previously three parallel `HashMap<SlotIndex, Instant>` fields
 /// so cleanup paths cannot drift.
@@ -460,6 +476,17 @@ pub struct ScpDriver {
     latest_externalized: RwLock<Option<SlotIndex>>,
     /// Envelope broadcast callback.
     envelope_sender: OnceLock<EnvelopeSender>,
+    /// SCP-state persist callback. Installed by
+    /// [`crate::herder::Herder::set_scp_persistence`] when a persistence
+    /// manager is configured. Captures `Arc<SCP>`, `Arc<ScpDriver>`,
+    /// `Arc<ScpPersistenceManager>` (intentional Arc cycle mirroring
+    /// `envelope_sender`, benign because both are dropped together with
+    /// the owning `Herder`).
+    ///
+    /// Fires from [`Self::emit`] after the broadcast. No-op when the
+    /// `OnceLock` is empty (tests / standalone) or when `suppress_scp`
+    /// short-circuited `emit`.
+    persist_callback: OnceLock<PersistCallback>,
     /// Network ID for signing.
     network_id: Hash256,
     /// Ledger manager for network configuration lookups.
@@ -582,6 +609,7 @@ impl ScpDriver {
             externalized: RwLock::new(HashMap::new()),
             latest_externalized: RwLock::new(None),
             envelope_sender: OnceLock::new(),
+            persist_callback: OnceLock::new(),
             network_id,
             ledger_manager,
             upgrades,
@@ -665,6 +693,21 @@ impl ScpDriver {
         F: Fn(ScpEnvelope) + Send + Sync + 'static,
     {
         let _ = self.envelope_sender.set(Box::new(sender));
+    }
+
+    /// Set the SCP-state persist callback. Fires from [`Self::emit`] after
+    /// the broadcast, mirroring stellar-core's `HerderImpl::persistSCPState`
+    /// call from `HerderImpl::emitEnvelope` (HerderImpl.cpp:599-612).
+    ///
+    /// Single-install via `OnceLock`: a second `set_persist_callback` call
+    /// is silently ignored (returns the supplied closure on `Err`, which
+    /// we drop). Installed at most once per [`ScpDriver`] from
+    /// [`crate::herder::Herder::set_scp_persistence`].
+    pub fn set_persist_callback<F>(&self, cb: F)
+    where
+        F: Fn(u64) + Send + Sync + 'static,
+    {
+        let _ = self.persist_callback.set(Box::new(cb));
     }
 
     /// Clear the tx set validity cache (call on ledger close).
@@ -2463,8 +2506,19 @@ impl ScpDriver {
         if self.config.suppress_scp {
             return;
         }
+        let slot = envelope.statement.slot_index;
         if let Some(sender) = self.envelope_sender.get() {
             sender(envelope);
+        }
+        // Parity: stellar-core HerderImpl::emitEnvelope (HerderImpl.cpp:599-612)
+        // calls persistSCPState(slotIndex) BEFORE broadcast(); we fire it
+        // after the broadcast for simpler ownership (the persist closure
+        // captures Arc<SCP>, which is set up post-construction). Either
+        // ordering can be interrupted between persist and broadcast, so
+        // crash-safety is unchanged. No-op when the OnceLock is empty
+        // (tests, observer mode without a persistence manager).
+        if let Some(cb) = self.persist_callback.get() {
+            cb(slot);
         }
     }
 


### PR DESCRIPTION
Closes #2768

## Summary

- Wires `ScpPersistenceManager::persist_scp_state()` into the `ScpDriver::emit` hot path via a new persist callback on `ScpDriver` installed by `Herder::set_scp_persistence`. After this PR every emitted envelope produces a durable SCP-state write (envelopes + referenced tx-sets + quorum-sets), completing the persistence loop started in #2698 — the GC timer added in #2698 finally has rows to act on.
- Mirrors stellar-core's `HerderImpl::emitEnvelope` → `persistSCPState(slotIndex)` chain (`stellar-core/src/herder/HerderImpl.cpp:599-2186`).
- Deferral deviation: henyey's `SCP` holds a `parking_lot::RwLock` write guard on its slots map while `emit` runs, so calling `get_latest_messages_send` synchronously inside the callback would deadlock against the writer chain. The callback therefore spawns a worker thread (`scp-persist-<slot>`) to do the gather + persist work AFTER the writer unwinds. Persistence remains best-effort (`warn!` on error, no propagation). `ScpPersistenceManager` exposes `wait_for_pending_persists(timeout)` so tests can synchronize.

Converged plan: https://github.com/stellar-experimental/henyey/issues/2768#issuecomment-4474401347

## Regression tests

- **Test-only commit** [`23719a2d`](https://github.com/stellar-experimental/henyey/commit/23719a2de4cd8bb888c4d7af67be92cd5c2a3bb2) — three solo-validator regression tests that on `origin/main`:
  - `test_persist_scp_state_called_on_emit` — FAILS (`last_slot_saved=0` after a real externalize)
  - `test_persist_scp_state_gc_sees_persisted_rows` — FAILS at the same precondition
  - `test_persist_scp_state_no_manager_no_panic` — passes (negative test, OnceLock no-op)
- **Fix commit** [`d0daad20`](https://github.com/stellar-experimental/henyey/commit/d0daad2002f763c35a039679adb4f034757d9e29) — wires the persist callback. The two previously-failing tests now PASS once they call `wait_for_pending_persists` (needed because the persist is deferred to a worker thread; see deviation above).

## Test plan

- [x] `cargo test -p henyey-herder --lib test_persist_scp_state` — 3 passed
- [x] `cargo test -p henyey-herder` — 1118 lib + 7 + 1 + 1 + 3 integration tests passed
- [x] `cargo fmt --check` — clean (applied post-edit)
- [x] `cargo clippy --all -- -D warnings` — clean
- [ ] CI must pass on the new branch

## Parity

- stellar-core `HerderImpl.cpp:599-612` `emitEnvelope` → `persistSCPState(slotIndex)` → broadcast
- henyey `ScpDriver::emit` → broadcast → persist callback (deferred to worker thread)
- Mapping: `getSCP().getLatestMessagesSend(slot)` → `Arc<SCP>::get_latest_messages_send`; `mPendingEnvelopes.getTxSet(h)` → `Arc<ScpDriver>::get_tx_set`; `mPendingEnvelopes.getQSet(qsHash)` → `Arc<ScpDriver>::get_quorum_set_by_hash`; `StoredTransactionSet` XDR → `TransactionSet::to_xdr_stored_set()` + `WriteXdr::to_xdr(Limits::none())`.
- `PARITY_STATUS.md` updated: `persistSCPState()` row points at the wired callback; `[^persist-scp]` footnote documents the worker-thread deviation; `[^txset-gc]` footnote notes #2768 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)