### PR TITLE
Extract bounce-cap algorithm into shell script (#2787)

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -72,50 +72,48 @@ Capture:
 
 The bounce-back cap is **scoped to the current code**, not the issue's lifetime. Old bounces against earlier commits don't carry forward forever — they represent failed merge attempts on code that has since been rebased or replaced.
 
-Compute the **baseline timestamp** for counting:
+**The script computes this. Do not re-implement or override.** Invoke `bounce-cap-check.sh` — its exit code IS the verdict:
 
 ```bash
-# When was the current PR head commit pushed/committed? Fresh push = new baseline.
-HEAD_PUSHED_ISO=$(gh pr view $PR_NUM --repo stellar-experimental/henyey \
-  --json commits --jq '.commits | sort_by(.committedDate) | last | .committedDate')
+# Exit 0 = under cap, proceed. Exit 1 = at/over cap (≥3), block.
+# Stdout: single human-readable line with the count and baseline source
+# (e.g. "COUNT=2/3 BASELINE=HEAD_PUSHED@2026-05-17T12:34:56Z (no Reset marker)").
+# Capture into BOUNCE_CAP_OUTPUT for embedding in the bounce/block comment.
+#
+# Use the `cmd || { ... }` pattern (NOT a separate `$?` capture) so `set -e`
+# in the parent shell doesn't trip on the non-zero exit before we can react.
+BOUNCE_CAP_OUTPUT=""
+BOUNCE_CAP_EXIT=0
+BOUNCE_CAP_OUTPUT=$(bash .github/skills/shared/scripts/bounce-cap-check.sh "$ISSUE" "$PR_NUM") \
+  || BOUNCE_CAP_EXIT=$?
 
-# Has the operator (or recovery script) posted a Reset marker?
-# This is the escape hatch for cases where the head didn't change but the
-# external cause did — e.g., main was broken, now it's green; same code,
-# fresh chance.
-RESET_AT_ISO=$(gh api repos/stellar-experimental/henyey/issues/$ISSUE/comments --paginate \
-  --jq '[.[] | select(.body | startswith("## Review: Reset"))] | sort_by(.created_at) | last.created_at // ""')
+if [ "$BOUNCE_CAP_EXIT" -ne 0 ]; then
+  # Cap reached — post block comment, move to `blocked`, exit.
+  # The script's stdout is the audit summary; include it verbatim.
+  gh issue comment "$ISSUE" --repo stellar-experimental/henyey --body "$(cat <<EOF
+## Review: Cycle Cap Reached
 
-# Convert both to epoch seconds for unambiguous numeric comparison
-# (ISO strings can drift in format — fractional seconds, +00:00 vs Z, etc.).
-HEAD_PUSHED_EPOCH=$(date -u -d "$HEAD_PUSHED_ISO" +%s)
-if [ -n "$RESET_AT_ISO" ]; then
-  RESET_AT_EPOCH=$(date -u -d "$RESET_AT_ISO" +%s)
-else
-  RESET_AT_EPOCH=0
+**Status:** blocked
+**Audit:** \`$BOUNCE_CAP_OUTPUT\`
+
+This PR has cycled too many times against the current code (head-scoped
+count, Reset markers honored). Human review required to break the tie.
+EOF
+)"
+  bash .github/skills/shared/scripts/move-issue-status.sh "$ISSUE" blocked
+  gh issue edit "$ISSUE" --repo stellar-experimental/henyey --remove-assignee @me
+  exit 0
 fi
 
-# Baseline = max(HEAD_PUSHED, RESET_AT) as epoch seconds.
-if [ "$RESET_AT_EPOCH" -gt "$HEAD_PUSHED_EPOCH" ]; then
-  BASELINE_EPOCH=$RESET_AT_EPOCH
-else
-  BASELINE_EPOCH=$HEAD_PUSHED_EPOCH
-fi
+# Under cap — proceed. $BOUNCE_CAP_OUTPUT is available for the eventual
+# bounce comment (Step 7) to report the current count.
 ```
 
-Then count bounce comments STRICTLY AFTER the baseline (jq's `fromdate` parses ISO-8601 into epoch seconds, so the comparison is numeric, not lexical):
+The script encodes the head-scoped + Reset-marker algorithm (see issue #2787 for why it lives in a script, not prose). The rest of this section documents **how operators use** the Reset escape hatch — it is reference material for humans, NOT an algorithm spec; the algorithm lives exclusively in `bounce-cap-check.sh`.
 
-```bash
-COUNT=$(gh api repos/stellar-experimental/henyey/issues/$ISSUE/comments --paginate \
-  --jq "[.[] | select(.body | startswith(\"## Review: Bounce-Back Cycle\")) |
-        select((.created_at | fromdate) > $BASELINE_EPOCH)] | length")
-```
+---
 
-If `COUNT >= 3`, this is the 4th cycle on the current code — the PR has genuinely cycled too many times against this exact state. Post `## Review: Cycle Cap Reached` summarizing the disagreement pattern, move the issue to `blocked`, unassign, and exit.
-
-Otherwise (COUNT < 3) → proceed with the review.
-
-**Recovery semantics:**
+**Recovery semantics (operator reference, not algorithm spec):**
 
 - **Fresh `/do` Mode B push** → new commit `committedDate` advances the baseline → counter naturally resets to 0. Most recoveries (rebase after CI red, address review feedback) hit this path automatically.
 - **`## Review: Reset` comment** → manual escape hatch. Operator (or recovery script) posts this when the head hasn't changed but the external cause has (e.g., a broken-main outage that has since cleared). Everything before the Reset comment is excluded from the count. Post format:

--- a/.github/skills/shared/scripts/bounce-cap-check.sh
+++ b/.github/skills/shared/scripts/bounce-cap-check.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Usage: bounce-cap-check.sh <issue_number> <pr_number>
+#
+# Counts /review-pr "Bounce-Back Cycle" comments on issue $ISSUE that are
+# newer than the current PR head commit OR newer than the latest
+# "## Review: Reset" marker comment (whichever is later). Used by the
+# /review-pr skill to decide whether the bounce-back cap (≥3) has been
+# reached for the CURRENT code, not for the issue's lifetime.
+#
+# Exit code IS the verdict:
+#   0  count < 3  (proceed with normal review)
+#   1  count ≥ 3  (cycle cap reached — caller must post block comment)
+#
+# Stdout: single human-readable line with the count and baseline source,
+# intended to be embedded verbatim in the caller's bounce/block PR comment.
+# Example:
+#   COUNT=2/3 BASELINE=HEAD_PUSHED@2026-05-17T12:34:56Z (no Reset marker)
+#   COUNT=3/3 BASELINE=RESET_MARKER@2026-05-18T01:23:45Z (head pushed earlier)
+#
+# The algorithm and jq queries are copied VERBATIM from
+# .github/skills/review-pr/SKILL.md (Step 2 as of commit c51e8ac9) so the
+# script is the single source of truth — the SKILL.md prose should not
+# re-describe the algorithm, only invoke this script. See issue #2787 for
+# the rationale (agents paraphrased the prose into the old lifetime-count
+# rule when the prose drifted from a simpler interpretation).
+set -euo pipefail
+
+ISSUE="${1:?issue number required}"
+PR_NUM="${2:?PR number required}"
+
+OWNER="stellar-experimental"
+REPO="henyey"
+
+# ── Step 1: head-commit pushed-at timestamp ──────────────────────────────────
+# Fresh push = new baseline; old bounces against earlier commits don't carry
+# forward.
+HEAD_PUSHED_ISO=$(gh pr view "$PR_NUM" --repo "$OWNER/$REPO" \
+  --json commits --jq '.commits | sort_by(.committedDate) | last | .committedDate')
+
+if [ -z "$HEAD_PUSHED_ISO" ]; then
+  echo "ERROR: could not fetch HEAD_PUSHED_ISO for PR #$PR_NUM" >&2
+  exit 2
+fi
+
+# ── Step 2: latest "## Review: Reset" marker, if any ─────────────────────────
+# Manual escape hatch for cases where the head didn't change but the external
+# cause did (e.g., main was broken, now green).
+RESET_AT_ISO=$(gh api "repos/$OWNER/$REPO/issues/$ISSUE/comments" --paginate \
+  --jq '[.[] | select(.body | startswith("## Review: Reset"))] | sort_by(.created_at) | last.created_at // ""')
+
+# ── Step 3: convert both to epoch for unambiguous numeric comparison ─────────
+HEAD_PUSHED_EPOCH=$(date -u -d "$HEAD_PUSHED_ISO" +%s)
+if [ -n "$RESET_AT_ISO" ]; then
+  RESET_AT_EPOCH=$(date -u -d "$RESET_AT_ISO" +%s)
+else
+  RESET_AT_EPOCH=0
+fi
+
+# ── Step 4: baseline = max(HEAD_PUSHED, RESET_AT) ────────────────────────────
+if [ "$RESET_AT_EPOCH" -gt "$HEAD_PUSHED_EPOCH" ]; then
+  BASELINE_EPOCH=$RESET_AT_EPOCH
+  BASELINE_SOURCE="RESET_MARKER@$RESET_AT_ISO (head pushed earlier)"
+else
+  BASELINE_EPOCH=$HEAD_PUSHED_EPOCH
+  if [ -n "$RESET_AT_ISO" ]; then
+    BASELINE_SOURCE="HEAD_PUSHED@$HEAD_PUSHED_ISO (newer than Reset marker)"
+  else
+    BASELINE_SOURCE="HEAD_PUSHED@$HEAD_PUSHED_ISO (no Reset marker)"
+  fi
+fi
+
+# ── Step 5: count bounces strictly newer than baseline ───────────────────────
+# jq's fromdate parses ISO-8601 into epoch seconds — numeric, not lexical.
+COUNT=$(gh api "repos/$OWNER/$REPO/issues/$ISSUE/comments" --paginate \
+  --jq "[.[] | select(.body | startswith(\"## Review: Bounce-Back Cycle\")) |
+        select((.created_at | fromdate) > $BASELINE_EPOCH)] | length")
+
+# ── Step 6: emit verdict ─────────────────────────────────────────────────────
+echo "COUNT=$COUNT/3 BASELINE=$BASELINE_SOURCE"
+
+if [ "$COUNT" -ge 3 ]; then
+  exit 1
+fi
+exit 0

--- a/.github/skills/shared/tests/bounce-cap-check.bats
+++ b/.github/skills/shared/tests/bounce-cap-check.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+#
+# Tests for .github/skills/shared/scripts/bounce-cap-check.sh
+#
+# This file is written in a BATS-compatible style (each test is a function
+# named test_*) but also runs as a plain-bash script: if BATS is installed
+# it can be invoked as `bats bounce-cap-check.bats`; otherwise this file is
+# executed directly as a plain-bash TAP-style runner.
+#
+# Why both: the converged plan (issue #2787) prefers BATS but explicitly
+# allows a plain-bash fallback when BATS isn't installed. We default to the
+# fallback since BATS isn't part of the project's required toolchain.
+#
+# Mocking strategy: each test creates a temp dir, drops a `gh` shim script
+# into it, prepends that dir to PATH, and runs the script under test. The
+# shim reads the request URL/args from $@ and emits canned JSON. Tests assert
+# on exit code and stdout summary.
+#
+# Usage:
+#   bash .github/skills/shared/tests/bounce-cap-check.bats           # plain
+#   bats .github/skills/shared/tests/bounce-cap-check.bats           # BATS
+#
+# Output: TAP (Test Anything Protocol) when run as plain bash.
+# Exit: 0 if all tests pass, non-zero otherwise.
+
+set -uo pipefail
+
+# ── Locate the script under test ─────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/.github/skills/shared/scripts/bounce-cap-check.sh"
+
+# ── TAP state ────────────────────────────────────────────────────────────────
+TAP_CURRENT=0
+TAP_FAILURES=0
+TAP_OUTPUT=()
+
+tap_ok() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  TAP_OUTPUT+=("ok $TAP_CURRENT - $1")
+}
+
+tap_fail() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  TAP_FAILURES=$((TAP_FAILURES + 1))
+  TAP_OUTPUT+=("not ok $TAP_CURRENT - $1")
+  if [ -n "${2:-}" ]; then
+    TAP_OUTPUT+=("  ---")
+    TAP_OUTPUT+=("  $2")
+    TAP_OUTPUT+=("  ...")
+  fi
+}
+
+# ── Mock gh shim builder ─────────────────────────────────────────────────────
+# Creates a temp dir, writes a `gh` shim that returns canned JSON based on
+# the request path, and prepends the temp dir to PATH. The shim distinguishes
+# four request shapes used by the script:
+#
+#   1. `gh pr view <pr> --repo ... --json commits ...`
+#        → emit COMMITS_JSON or HEAD_PUSHED_ISO
+#   2. `gh api repos/.../issues/<n>/comments --paginate ...` matching Reset
+#        → emit RESET_AT_ISO (string or empty)
+#   3. `gh api repos/.../issues/<n>/comments --paginate ...` matching count
+#        → emit COMMENT_COUNT (number)
+#
+# The shim pre-processes args to figure out which call this is; the test
+# preloads the canned responses via env vars.
+make_gh_shim() {
+  local tmpdir="$1"
+  local head_pushed_iso="$2"
+  local reset_at_iso="$3"
+  local bounces_after_baseline="$4"   # space-separated list of ISO timestamps
+  local bounces_before_baseline="$5"  # space-separated list of ISO timestamps
+
+  mkdir -p "$tmpdir"
+  cat > "$tmpdir/gh" <<EOF
+#!/usr/bin/env bash
+# Mock gh — dispatch on argument shape.
+
+# Concatenate all args for pattern matching.
+args="\$*"
+
+# Shape 1: pr view --json commits
+if [[ "\$args" == *"pr view"* ]] && [[ "\$args" == *"--json commits"* ]]; then
+  # The script applies a jq filter via --jq to extract the last committedDate.
+  # We just emit the raw committedDate (the --jq is part of the command, gh
+  # would normally apply it, but our shim returns the post-jq output for
+  # simplicity). Look for --jq in args — if present, return the string;
+  # otherwise return raw JSON.
+  if [[ "\$args" == *"--jq"* ]]; then
+    echo '$head_pushed_iso'
+  else
+    # Raw JSON form (not currently used by the script under test).
+    echo '{"commits":[{"committedDate":"$head_pushed_iso"}]}'
+  fi
+  exit 0
+fi
+
+# Shape 2 & 3: gh api repos/.../issues/<n>/comments --paginate --jq ...
+if [[ "\$args" == *"api"* ]] && [[ "\$args" == *"/comments"* ]]; then
+  # Distinguish Reset query from Bounce-Back count query via the --jq body.
+  if [[ "\$args" == *"Review: Reset"* ]]; then
+    # Reset timestamp query — return the canned value or empty.
+    echo '$reset_at_iso'
+    exit 0
+  fi
+  if [[ "\$args" == *"Bounce-Back Cycle"* ]]; then
+    # Count bounces — the script's --jq does a numeric comparison against
+    # \$BASELINE_EPOCH. To keep the shim simple, we expose a pre-computed
+    # answer instead of synthesizing JSON: the test pre-counts how many of
+    # its bounces should be > BASELINE_EPOCH and passes that as a literal.
+    # We do this by detecting the BASELINE_EPOCH in the jq query and
+    # returning the right count. The query has the form:
+    #   [.[] | select(.body | startswith("## Review: Bounce-Back Cycle")) |
+    #          select((.created_at | fromdate) > <EPOCH>)] | length
+    # which we match against to extract the epoch.
+    baseline_epoch=\$(echo "\$args" | grep -oE 'fromdate\) > [0-9]+' | grep -oE '[0-9]+\$' || echo 0)
+    # Count how many bounces have iso → epoch > baseline_epoch.
+    count=0
+    for iso in $bounces_after_baseline; do
+      ep=\$(date -u -d "\$iso" +%s)
+      if [ "\$ep" -gt "\$baseline_epoch" ]; then
+        count=\$((count + 1))
+      fi
+    done
+    for iso in $bounces_before_baseline; do
+      ep=\$(date -u -d "\$iso" +%s)
+      if [ "\$ep" -gt "\$baseline_epoch" ]; then
+        count=\$((count + 1))
+      fi
+    done
+    echo "\$count"
+    exit 0
+  fi
+  # Other api/comments query — unexpected.
+  echo "unexpected gh api call: \$args" >&2
+  exit 99
+fi
+
+echo "unexpected gh call: \$args" >&2
+exit 99
+EOF
+  chmod +x "$tmpdir/gh"
+}
+
+# ── Test driver ──────────────────────────────────────────────────────────────
+# run_script_with_mock <tmpdir>
+#   Prepends tmpdir to PATH and invokes the script with stub args. Captures
+#   exit code in $LAST_EXIT and stdout in $LAST_STDOUT.
+run_script_with_mock() {
+  local tmpdir="$1"
+  LAST_STDOUT=$(PATH="$tmpdir:$PATH" bash "$SCRIPT_UNDER_TEST" 1234 5678 2>&1)
+  LAST_EXIT=$?
+}
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+# Test 1: zero bounces after baseline → exit 0, count 0.
+test_bounce_cap_zero_bounces() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+  # Head pushed 2026-01-01, no Reset, no bounces.
+  make_gh_shim "$tmpdir" "2026-01-01T00:00:00Z" "" "" ""
+  run_script_with_mock "$tmpdir"
+  if [ "$LAST_EXIT" -eq 0 ] && echo "$LAST_STDOUT" | grep -q "0"; then
+    tap_ok "test_bounce_cap_zero_bounces — exit 0, count 0 reported"
+  else
+    tap_fail "test_bounce_cap_zero_bounces — exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 2: 2 bounces BEFORE baseline (all older than head_pushed) → exit 0.
+test_bounce_cap_bounces_before_baseline() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+  # Head pushed 2026-06-01. Bounces from 2026-01-01 and 2026-02-01 — both
+  # before head, so not counted.
+  make_gh_shim "$tmpdir" "2026-06-01T00:00:00Z" "" "" "2026-01-01T00:00:00Z 2026-02-01T00:00:00Z"
+  run_script_with_mock "$tmpdir"
+  if [ "$LAST_EXIT" -eq 0 ]; then
+    tap_ok "test_bounce_cap_bounces_before_baseline — exit 0 (bounces excluded)"
+  else
+    tap_fail "test_bounce_cap_bounces_before_baseline — exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 3: 2 bounces AFTER baseline → exit 0, count 2.
+test_bounce_cap_bounces_after_baseline() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+  make_gh_shim "$tmpdir" "2026-01-01T00:00:00Z" "" "2026-02-01T00:00:00Z 2026-03-01T00:00:00Z" ""
+  run_script_with_mock "$tmpdir"
+  if [ "$LAST_EXIT" -eq 0 ] && echo "$LAST_STDOUT" | grep -q "2"; then
+    tap_ok "test_bounce_cap_bounces_after_baseline — exit 0, count 2"
+  else
+    tap_fail "test_bounce_cap_bounces_after_baseline — exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 4: exact cap (3 bounces) → exit 1.
+test_bounce_cap_exact_cap() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+  make_gh_shim "$tmpdir" "2026-01-01T00:00:00Z" "" \
+    "2026-02-01T00:00:00Z 2026-03-01T00:00:00Z 2026-04-01T00:00:00Z" ""
+  run_script_with_mock "$tmpdir"
+  if [ "$LAST_EXIT" -eq 1 ]; then
+    tap_ok "test_bounce_cap_exact_cap — exit 1 (at cap)"
+  else
+    tap_fail "test_bounce_cap_exact_cap — exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 5: over cap (4 bounces) → exit 1.
+test_bounce_cap_over_cap() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+  make_gh_shim "$tmpdir" "2026-01-01T00:00:00Z" "" \
+    "2026-02-01T00:00:00Z 2026-03-01T00:00:00Z 2026-04-01T00:00:00Z 2026-05-01T00:00:00Z" ""
+  run_script_with_mock "$tmpdir"
+  if [ "$LAST_EXIT" -eq 1 ]; then
+    tap_ok "test_bounce_cap_over_cap — exit 1 (over cap)"
+  else
+    tap_fail "test_bounce_cap_over_cap — exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 6: Reset marker NEWER than head → baseline = Reset, bounces before
+# Reset are excluded.
+test_bounce_cap_reset_marker_newer_than_head() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+  # Head: 2026-01-01. Reset: 2026-06-01. Bounces: 2 between head and Reset
+  # (should NOT count), 1 after Reset (should count).
+  make_gh_shim "$tmpdir" "2026-01-01T00:00:00Z" "2026-06-01T00:00:00Z" \
+    "2026-07-01T00:00:00Z" \
+    "2026-02-01T00:00:00Z 2026-03-01T00:00:00Z"
+  run_script_with_mock "$tmpdir"
+  # Expected: count = 1, exit 0.
+  if [ "$LAST_EXIT" -eq 0 ] && echo "$LAST_STDOUT" | grep -q "1"; then
+    tap_ok "test_bounce_cap_reset_marker_newer_than_head — baseline=Reset, only post-Reset bounces count"
+  else
+    tap_fail "test_bounce_cap_reset_marker_newer_than_head — exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 7: HEAD newer than Reset → baseline = HEAD (Reset ignored). Also
+# implicitly tests empty Reset case if you pass empty Reset.
+test_bounce_cap_head_newer_than_reset() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap "rm -rf '$tmpdir'" RETURN
+  # Head: 2026-06-01. Reset: 2026-01-01 (older). Bounces: 2 between Reset
+  # and Head (should NOT count), 1 after Head (should count).
+  make_gh_shim "$tmpdir" "2026-06-01T00:00:00Z" "2026-01-01T00:00:00Z" \
+    "2026-07-01T00:00:00Z" \
+    "2026-02-01T00:00:00Z 2026-03-01T00:00:00Z"
+  run_script_with_mock "$tmpdir"
+  # Expected: count = 1 (only the post-head bounce), exit 0.
+  if [ "$LAST_EXIT" -eq 0 ] && echo "$LAST_STDOUT" | grep -q "1"; then
+    tap_ok "test_bounce_cap_head_newer_than_reset — baseline=HEAD, Reset ignored"
+  else
+    tap_fail "test_bounce_cap_head_newer_than_reset — exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# ── Runner ───────────────────────────────────────────────────────────────────
+main() {
+  # Detect BATS — if running under BATS, individual @test blocks would have
+  # been declared and this main() wouldn't fire. Since we're using the
+  # plain-bash fallback, just call each test_* function in order.
+  test_bounce_cap_zero_bounces
+  test_bounce_cap_bounces_before_baseline
+  test_bounce_cap_bounces_after_baseline
+  test_bounce_cap_exact_cap
+  test_bounce_cap_over_cap
+  test_bounce_cap_reset_marker_newer_than_head
+  test_bounce_cap_head_newer_than_reset
+
+  echo "1..$TAP_CURRENT"
+  for line in "${TAP_OUTPUT[@]}"; do
+    echo "$line"
+  done
+  echo "# tests: $TAP_CURRENT  failures: $TAP_FAILURES"
+  if [ "$TAP_FAILURES" -ne 0 ]; then
+    exit 1
+  fi
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
Closes #2787

## Summary

Extracts the `/review-pr` bounce-cap algorithm out of SKILL.md Step 2 prose and into an executable shell script `bounce-cap-check.sh`. The script encodes the head-scoped + Reset-marker counting algorithm exactly as it was previously written in prose (jq queries copied verbatim from `c51e8ac9`), exits 1 when the cap (≥3) is reached, and exits 0 otherwise. SKILL.md Step 2 now invokes the script and treats its exit code as the verdict — with a bold "do not re-implement or override" callout — so agents cannot paraphrase the rule.

Recovery-semantics prose (what `## Review: Reset` means, when operators post it) is kept in SKILL.md as operator reference, clearly separated from the algorithm block. All algorithm-specifying prose is removed.

Issue #2787 documented that agents paraphrased the head-scoped bounce-cap rule into the older lifetime-count rule, leading to false caps on issues that should not have been capped (e.g., #2726, #2751 after the fix at `c51e8ac9` landed). Moving the algorithm into a script eliminates the paraphrasing vector for this rule.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2787#issuecomment-4474453525)

## Test plan

- [x] 7-case TAP-style runner at `.github/skills/shared/tests/bounce-cap-check.bats` covering: zero bounces, bounces before/after baseline, exact-cap (3), over-cap (4), Reset-newer-than-head, head-newer-than-Reset. All 7 pass.
- [x] Manual dry-run against open PR #2795: `bash .github/skills/shared/scripts/bounce-cap-check.sh 2768 2795` → `COUNT=0/3 BASELINE=HEAD_PUSHED@2026-05-18T05:57:07Z (no Reset marker)`, exit 0.
- [x] `cargo fmt --check` — passes (no Rust changes; verified during pre-commit hook).
- [x] `cargo clippy --all -- -D warnings` — passes (no new warnings).

## Regression test

n/a — `kind: feature` per triage, not `kind: bug-fix`. The 7 new-coverage tests in `.github/skills/shared/tests/bounce-cap-check.bats` are the test obligation for this feature. Commit `161f5715` adds the tests with the script absent (all 7 fail with exit 127); commit `1deb3b55` adds the script (all 7 pass).

## Deviations from plan

- **BATS unavailable in the dev environment** — the plan called for a BATS test file (`.bats` extension) with a plain-bash fallback if BATS isn't installed. BATS is not installed and there is no sudo available to install it. The test file keeps the `.bats` extension (so the BATS DSL can be added later when the toolchain ships it) but is written as a plain-bash TAP-style runner so it runs end-to-end today without external dependencies. Each test function is named `test_*` per the plan and uses a PATH-overridden `gh` shim to mock GH API responses — same approach the plan describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)