### PR TITLE
Diagnose missing PROJECT_BOARD_TOKEN with structured error

### DIFF
--- a/.github/skills/shared/scripts/archive-stale-done.sh
+++ b/.github/skills/shared/scripts/archive-stale-done.sh
@@ -29,6 +29,36 @@ OWNER="stellar-experimental"
 PROJECT_NUM=2
 PROJECT_ID="PVT_kwDOD-vqsM4BWQnL"
 
+# Pre-flight: probe whether GH_TOKEN has org-level project scope. The default
+# GITHUB_TOKEN granted to GitHub Actions runs lacks the org-level read:project
+# scope required for `organization(login:...).projectV2(...)` GraphQL queries —
+# the `repository-projects: write` workflow permission only grants repo-level
+# classic Projects access and does not help here. When the token is
+# underprivileged, the GraphQL call below would fail with the opaque
+# "Could not resolve to a ProjectV2 with the number 2." error, which doesn't
+# tell the operator what to fix. This probe catches that case and emits a
+# structured, actionable error message instead.
+#
+# SKIP_PREFLIGHT=1 is for test harnesses only; do not document or rely on it
+# in production paths.
+if [ "${SKIP_PREFLIGHT:-0}" != "1" ]; then
+  probe_exit=0
+  probe_output=$(gh api graphql -f query='
+    query($org: String!, $proj: Int!) {
+      organization(login: $org) { projectV2(number: $proj) { id } }
+    }' -f org="$OWNER" -F proj="$PROJECT_NUM" 2>&1) || probe_exit=$?
+  if [ "$probe_exit" -ne 0 ]; then
+    if grep -q "Could not resolve to a ProjectV2" <<<"$probe_output"; then
+      echo "ERROR: GH_TOKEN lacks org project scope — set PROJECT_BOARD_TOKEN secret with Projects:Read+Write on stellar-experimental" >&2
+      exit 1
+    fi
+    # Different failure (network, 401, etc.) — surface it and exit so the
+    # main fetch doesn't paper over a real error.
+    echo "ERROR: pre-flight probe failed: $probe_output" >&2
+    exit 1
+  fi
+fi
+
 # Fetch all project items + their issue/PR state and closedAt.
 # `--paginate` requires the cursor variable to be named $endCursor; jq -s
 # is required because gh emits one JSON object per page.

--- a/.github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh
+++ b/.github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# test-archive-stale-done-auth.sh — regression tests for archive-stale-done.sh
+# auth pre-flight behavior.
+#
+# Tests:
+#   1. test_preflight_fails_with_bad_token
+#        Runs the script with GH_TOKEN set to an invalid value. Asserts the
+#        script exits non-zero AND output contains the structured
+#        "ERROR: GH_TOKEN lacks org project scope" message rather than the
+#        opaque GraphQL "Could not resolve to a ProjectV2" error. This is the
+#        regression for issue #2777.
+#   2. test_preflight_succeeds_with_dry_run
+#        Runs with SKIP_PREFLIGHT=1 and --dry-run, mocking the gh binary so
+#        no network call is made. Asserts exit 0 and no ERROR: in output.
+#        Covers the happy path with the probe bypassed.
+#
+# Usage:
+#   bash .github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh
+#
+# Exits 0 if all tests pass, non-zero on any failure.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_SCRIPT="$SCRIPT_DIR/../archive-stale-done.sh"
+
+if [ ! -x "$TARGET_SCRIPT" ]; then
+  echo "FAIL: target script not found or not executable: $TARGET_SCRIPT" >&2
+  exit 1
+fi
+
+FAILED=0
+PASSED=0
+
+# ---------------------------------------------------------------------------
+# Test 1: pre-flight fails with bad token → structured error message
+# ---------------------------------------------------------------------------
+test_preflight_fails_with_bad_token() {
+  local name="test_preflight_fails_with_bad_token"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  # Mock `gh` to simulate the "Could not resolve to a ProjectV2" failure that
+  # occurs when GH_TOKEN lacks org project scope. The real failure mode is a
+  # non-zero exit with that exact stderr message; we reproduce it.
+  cat >"$tmpdir/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock gh: simulate the underprivileged-token GraphQL failure.
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+  echo "gh: Could not resolve to a ProjectV2 with the number 2." >&2
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$tmpdir/gh"
+
+  local output
+  local exit_code
+  output=$(PATH="$tmpdir:$PATH" GH_TOKEN="dummy" bash "$TARGET_SCRIPT" --dry-run 2>&1)
+  exit_code=$?
+
+  if [ "$exit_code" -eq 0 ]; then
+    echo "FAIL: $name — expected non-zero exit, got 0"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return
+  fi
+
+  if ! grep -q "ERROR: GH_TOKEN lacks org project scope" <<<"$output"; then
+    echo "FAIL: $name — output missing 'ERROR: GH_TOKEN lacks org project scope'"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return
+  fi
+
+  echo "PASS: $name"
+  PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: SKIP_PREFLIGHT=1 + --dry-run → happy path, no error
+# ---------------------------------------------------------------------------
+test_preflight_succeeds_with_dry_run() {
+  local name="test_preflight_succeeds_with_dry_run"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  # Mock `gh` to return a minimal valid items page (empty nodes) so the main
+  # GraphQL fetch in the script succeeds; the script should print
+  # "No items to archive" and exit 0.
+  cat >"$tmpdir/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock gh: return an empty items page for the main fetch.
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+  cat <<'JSON'
+{"data":{"organization":{"projectV2":{"items":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[]}}}}}
+JSON
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$tmpdir/gh"
+
+  local output
+  local exit_code
+  output=$(PATH="$tmpdir:$PATH" GH_TOKEN="dummy" SKIP_PREFLIGHT=1 \
+           bash "$TARGET_SCRIPT" --dry-run 2>&1)
+  exit_code=$?
+
+  if [ "$exit_code" -ne 0 ]; then
+    echo "FAIL: $name — expected exit 0, got $exit_code"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return
+  fi
+
+  if grep -q "^ERROR:" <<<"$output"; then
+    echo "FAIL: $name — unexpected ERROR: line in output"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return
+  fi
+
+  echo "PASS: $name"
+  PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests.
+# ---------------------------------------------------------------------------
+test_preflight_fails_with_bad_token
+test_preflight_succeeds_with_dry_run
+
+echo
+echo "Results: ${PASSED} passed, ${FAILED} failed"
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.github/workflows/archive-done.yml
+++ b/.github/workflows/archive-done.yml
@@ -34,6 +34,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Diagnostic: surface secret state before the script runs. This is
+      # purely informational; the script's pre-flight probe is what actually
+      # fails fast with an actionable error when the token is unscoped.
+      #
+      # Note: the `repository-projects: write` permission above grants
+      # repo-level classic Projects access only; it does NOT grant the
+      # org-level ProjectV2 scope required by archive-stale-done.sh. That
+      # requires a fine-grained PAT with Projects:Read+Write on
+      # stellar-experimental, set as the PROJECT_BOARD_TOKEN secret.
+      - name: Check PROJECT_BOARD_TOKEN secret
+        env:
+          HAS_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN != '' }}
+        run: |
+          if [ "$HAS_TOKEN" != "true" ]; then
+            echo "::warning::PROJECT_BOARD_TOKEN secret is not configured; falling back to GITHUB_TOKEN, which lacks org-level ProjectV2 scope. The next step will fail with a diagnostic message. See issue #2777."
+          else
+            echo "PROJECT_BOARD_TOKEN is configured."
+          fi
+
       - name: Run archive-stale-done.sh
         env:
           GH_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #2777

## Summary

The daily `Archive Done Project Items` workflow has been failing on every scheduled run with the opaque GraphQL error `gh: Could not resolve to a ProjectV2 with the number 2.` This happens because `PROJECT_BOARD_TOKEN` is unset, the workflow falls back to `GITHUB_TOKEN`, and `GITHUB_TOKEN` lacks the org-level `read:project` scope required for the `organization.projectV2` query. The `repository-projects: write` permission in the workflow grants only repo-level classic Projects access — it does not help here.

This PR doesn't configure the secret (that's an operator action against repo settings), but it makes the failure self-diagnosing:

- `archive-stale-done.sh` now runs a pre-flight GraphQL probe before the paginated fetch. When the probe sees the `Could not resolve to a ProjectV2` failure pattern, it emits `ERROR: GH_TOKEN lacks org project scope — set PROJECT_BOARD_TOKEN secret with Projects:Read+Write on stellar-experimental` and exits 1. Other failures (network, 401) are also surfaced rather than papered over.
- `SKIP_PREFLIGHT=1` bypasses the probe for test harnesses (not for production).
- `archive-done.yml` adds a diagnostic step before the run step that emits a GitHub Actions `::warning::` when `PROJECT_BOARD_TOKEN` is empty, plus an inline comment explaining the `repository-projects: write` vs org ProjectV2 scope distinction.
- New regression test `test-archive-stale-done-auth.sh` covers both the failure path (asserts structured error) and the happy path (SKIP_PREFLIGHT + dry-run).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2777#issuecomment-4474472259)

## Test plan

- [x] `bash .github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh` — 2 passed, 0 failed
- [x] `bash -n` syntax check on both shell scripts
- [x] `python3 yaml.safe_load` on archive-done.yml
- [x] `cargo fmt --check` (no Rust changes — sanity check only)

## Regression test (bug-fix)

- **Test:** `.github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh::test_preflight_fails_with_bad_token`
- **Pre-fix:** committed as `b7ae7eab` — verified FAILED with: `output missing 'ERROR: GH_TOKEN lacks org project scope'` (the script emitted only the opaque `gh: Could not resolve to a ProjectV2 with the number 2.`)
- **Post-fix:** verified PASSES after `0815b21b`

## Deviations from plan

None.

## Operator follow-up (out of scope for this PR)

The actual remediation — configuring `PROJECT_BOARD_TOKEN` as a fine-grained PAT with `Projects: Read+Write` on `stellar-experimental` — must be done in repo settings. After this PR merges, the daily workflow will still fail until the secret is set, but the failure will now be self-explanatory (structured error in the script + a `::warning::` in the Actions summary). Reference issue #2777 from the PAT configuration commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)