### PR TITLE
Make SCP tx-set purge transactional

### DIFF
--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -23,5 +23,12 @@ tracing.workspace = true
 hex.workspace = true
 base64.workspace = true
 
+# JSON decoding of persisted SCP slot states for atomic purge
+# (PersistedSlotState is JSON-encoded by the herder; the atomic purge
+# parses it on the same connection inside a transaction). Only `Value`
+# is used so the herder's `PersistedSlotState` shape doesn't have to be
+# duplicated here.
+serde_json.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/db/src/pool.rs
+++ b/crates/db/src/pool.rs
@@ -100,6 +100,30 @@ impl Database {
         Ok(result)
     }
 
+    /// Executes a closure within a `BEGIN IMMEDIATE` SQLite transaction.
+    ///
+    /// Unlike [`transaction`](Self::transaction) which uses `BEGIN DEFERRED`
+    /// (acquiring a write lock lazily on first write), this method acquires
+    /// the RESERVED write lock up-front. This means concurrent writers on
+    /// other pool connections are blocked for the entire duration of the
+    /// closure — useful when read-then-write sequences must be serialized
+    /// w.r.t. all other writers.
+    ///
+    /// Used by the atomic SCP-tx-set purge (#2770): without an immediate
+    /// lock, a concurrent `save_tx_set` on another connection can interleave
+    /// between the purge's reads and lead to the freshly-inserted tx-set
+    /// being deleted as an orphan.
+    pub fn transaction_immediate<T, F>(&self, f: F) -> Result<T, DbError>
+    where
+        F: FnOnce(&rusqlite::Transaction) -> Result<T, DbError>,
+    {
+        let mut conn = self.connection()?;
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let result = f(&tx)?;
+        tx.commit()?;
+        Ok(result)
+    }
+
     /// Executes a closure with a database connection.
     ///
     /// This is useful for read operations or simple writes that don't

--- a/crates/db/src/queries/scp.rs
+++ b/crates/db/src/queries/scp.rs
@@ -647,6 +647,117 @@ mod tests {
         assert!(conn.has_tx_set_data(&hash1).unwrap());
     }
 
+    /// Builds a JSON-encoded `PersistedSlotState` whose single envelope
+    /// references `tx_set_hash`. Mirrors the herder-side
+    /// `PersistedSlotState::to_json` output, so the on-disk encoding here
+    /// matches what `ScpPersistenceManager` would write at runtime.
+    fn persisted_state_json_referencing(tx_set_hash: &Hash) -> String {
+        // Construct a NOMINATE envelope referencing `tx_set_hash` via a
+        // StellarValue.
+        let stellar_value = stellar_xdr::curr::StellarValue {
+            tx_set_hash: tx_set_hash.clone(),
+            close_time: stellar_xdr::curr::TimePoint(0),
+            upgrades: vec![].try_into().unwrap(),
+            ext: stellar_xdr::curr::StellarValueExt::Basic,
+        };
+        let value_xdr = stellar_value.to_xdr(Limits::none()).unwrap();
+        let envelope = ScpEnvelope {
+            statement: stellar_xdr::curr::ScpStatement {
+                node_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
+                slot_index: 100,
+                pledges: stellar_xdr::curr::ScpStatementPledges::Nominate(
+                    stellar_xdr::curr::ScpNomination {
+                        quorum_set_hash: Hash([0u8; 32]),
+                        votes: vec![stellar_xdr::curr::Value(value_xdr.try_into().unwrap())]
+                            .try_into()
+                            .unwrap(),
+                        accepted: vec![].try_into().unwrap(),
+                    },
+                ),
+            },
+            signature: stellar_xdr::curr::Signature::default(),
+        };
+        let env_xdr: Vec<u8> = envelope.to_xdr(Limits::none()).unwrap();
+        // Match the herder's PersistedSlotState JSON shape: serde_json renders
+        // `Vec<u8>` as a JSON array of numbers. Build that shape manually so
+        // we don't need a serde_json dev-dep on the db crate.
+        let env_array = env_xdr
+            .iter()
+            .map(|b| b.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(
+            r#"{{"version":1,"envelopes":[[{}]],"quorum_sets":[]}}"#,
+            env_array
+        )
+    }
+
+    #[test]
+    fn test_purge_unreferenced_tx_sets_atomic_basic() {
+        let conn = setup_db();
+
+        let referenced = Hash([0xAA; 32]);
+        let orphan = Hash([0xBB; 32]);
+
+        // Two tx sets persisted: one referenced, one orphan.
+        conn.save_tx_set_data(&referenced, &[1, 2, 3]).unwrap();
+        conn.save_tx_set_data(&orphan, &[4, 5, 6]).unwrap();
+
+        // One SCP state references `referenced`.
+        let state_json = persisted_state_json_referencing(&referenced);
+        conn.save_scp_slot_state(100, &state_json).unwrap();
+
+        // Atomic purge.
+        conn.purge_unreferenced_tx_sets_atomic().unwrap();
+
+        assert!(conn.has_tx_set_data(&referenced).unwrap());
+        assert!(!conn.has_tx_set_data(&orphan).unwrap());
+    }
+
+    #[test]
+    fn test_purge_unreferenced_tx_sets_atomic_empty_is_noop() {
+        let conn = setup_db();
+        // Empty DB — should be a no-op (and not error).
+        conn.purge_unreferenced_tx_sets_atomic().unwrap();
+    }
+
+    #[test]
+    fn test_purge_unreferenced_tx_sets_atomic_all_referenced() {
+        let conn = setup_db();
+
+        let hash = Hash([0xCC; 32]);
+        conn.save_tx_set_data(&hash, &[1]).unwrap();
+        let state_json = persisted_state_json_referencing(&hash);
+        conn.save_scp_slot_state(100, &state_json).unwrap();
+
+        conn.purge_unreferenced_tx_sets_atomic().unwrap();
+        assert!(conn.has_tx_set_data(&hash).unwrap());
+    }
+
+    #[test]
+    fn test_purge_unreferenced_tx_sets_atomic_skips_corrupt_state() {
+        let conn = setup_db();
+
+        let valid_hash = Hash([0xAA; 32]);
+        let orphan_from_corrupt = Hash([0xBB; 32]);
+        conn.save_tx_set_data(&valid_hash, &[1]).unwrap();
+        conn.save_tx_set_data(&orphan_from_corrupt, &[2]).unwrap();
+
+        // Valid state references valid_hash.
+        let valid_state = persisted_state_json_referencing(&valid_hash);
+        conn.save_scp_slot_state(100, &valid_state).unwrap();
+
+        // Corrupt JSON for slot 101 — invalid bytes that won't deserialize.
+        conn.save_scp_slot_state(101, "{not valid json").unwrap();
+
+        // Should NOT panic; corrupt state is logged + skipped. valid_hash
+        // survives; orphan_from_corrupt is deleted (can't prove it's
+        // referenced).
+        conn.purge_unreferenced_tx_sets_atomic().unwrap();
+        assert!(conn.has_tx_set_data(&valid_hash).unwrap());
+        assert!(!conn.has_tx_set_data(&orphan_from_corrupt).unwrap());
+    }
+
     #[test]
     fn test_copy_scp_history_to_stream_basic() {
         let conn = setup_db();

--- a/crates/db/src/queries/scp.rs
+++ b/crates/db/src/queries/scp.rs
@@ -347,6 +347,26 @@ pub trait ScpStatePersistenceQueries {
 
     /// Delete persisted transaction sets by their hashes.
     fn delete_tx_sets_by_hashes(&self, hashes: &[Hash]) -> Result<(), DbError>;
+
+    /// Atomic purge of unreferenced persisted transaction sets.
+    ///
+    /// Reads all persisted tx-set hashes, all persisted SCP slot states,
+    /// computes the set of orphan hashes (those not referenced by any
+    /// stored envelope), and deletes the orphans — all on the same
+    /// connection. The caller is expected to wrap the call in a transaction
+    /// (e.g. via [`Database::transaction`]) so the read-then-delete sequence
+    /// is observed atomically with respect to concurrent writers.
+    ///
+    /// SCP envelopes are stored as JSON-encoded `PersistedSlotState`. The
+    /// JSON shape (`{"envelopes": [[byte, byte, ...], ...], ...}`) is
+    /// defined by the herder's `PersistedSlotState` Serde representation;
+    /// this method parses it without depending on the herder crate.
+    ///
+    /// Per-state error handling: if a stored SCP state fails to parse, the
+    /// state is logged and skipped (its tx-set references can't be proven,
+    /// so its tx-sets may be deleted as orphans). Matches stellar-core
+    /// `HerderImpl::purgeOldPersistedTxSets()` (HerderImpl.cpp:2456-2478).
+    fn purge_unreferenced_tx_sets_atomic(&self) -> Result<(), DbError>;
 }
 
 impl ScpStatePersistenceQueries for Connection {
@@ -496,6 +516,139 @@ impl ScpStatePersistenceQueries for Connection {
         self.execute(&sql, params.as_slice())?;
         Ok(())
     }
+
+    fn purge_unreferenced_tx_sets_atomic(&self) -> Result<(), DbError> {
+        // Step 1: read all stored tx-set hashes.
+        let all_hashes_vec = self.get_all_tx_set_hashes()?;
+        if all_hashes_vec.is_empty() {
+            // Nothing to do; avoid a needless write lock when caller wraps
+            // this in a transaction.
+            return Ok(());
+        }
+        let all_hashes: std::collections::HashSet<Hash> = all_hashes_vec.into_iter().collect();
+
+        // Step 2: read all stored SCP slot states and compute the set of
+        // referenced tx-set hashes. Per-state error handling matches
+        // stellar-core (HerderImpl.cpp:2456-2478) and the in-memory path
+        // (`ScpPersistenceManager::purge_unreferenced_tx_sets`).
+        let mut referenced: std::collections::HashSet<Hash> = std::collections::HashSet::new();
+        for (slot, state_json) in self.load_all_scp_slot_states()? {
+            match referenced_tx_set_hashes_from_state_json(&state_json) {
+                Ok(hashes) => referenced.extend(hashes),
+                Err(e) => tracing::warn!(
+                    slot,
+                    error = %e,
+                    "Error extracting tx set hashes from persisted state, skipping"
+                ),
+            }
+        }
+
+        // Step 3: delete orphans (stored but not referenced).
+        let unreferenced: Vec<Hash> = all_hashes.difference(&referenced).cloned().collect();
+        if !unreferenced.is_empty() {
+            tracing::debug!(
+                count = unreferenced.len(),
+                "Purging unreferenced persisted tx sets (atomic)"
+            );
+            self.delete_tx_sets_by_hashes(&unreferenced)?;
+        }
+        Ok(())
+    }
+}
+
+/// Parse a JSON-encoded `PersistedSlotState` and return all tx-set hashes
+/// referenced by its envelopes.
+///
+/// Mirrors the herder's `PersistedSlotState` Serde shape:
+/// `{ "version": u32, "envelopes": [[u8, ...], ...], "quorum_sets": [...] }`.
+/// Each envelope is the raw XDR bytes of an `ScpEnvelope`. We decode the
+/// XDR and extract the tx-set hash from the embedded `StellarValue` in
+/// the pledges. This duplicates `henyey_herder::persistence::get_tx_set_hashes`
+/// — kept in sync by the regression tests in this module.
+fn referenced_tx_set_hashes_from_state_json(state_json: &str) -> Result<Vec<Hash>, DbError> {
+    let value: serde_json::Value = serde_json::from_str(state_json)
+        .map_err(|e| DbError::Integrity(format!("invalid persisted state JSON: {}", e)))?;
+    let envelopes_json = value
+        .get("envelopes")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            DbError::Integrity("persisted state JSON missing 'envelopes' array".to_string())
+        })?;
+
+    let mut hashes = Vec::new();
+    for env_json in envelopes_json {
+        let bytes: Vec<u8> = env_json
+            .as_array()
+            .ok_or_else(|| {
+                DbError::Integrity("persisted envelope JSON is not a byte array".to_string())
+            })?
+            .iter()
+            .map(|n| {
+                n.as_u64()
+                    .and_then(|x| u8::try_from(x).ok())
+                    .ok_or_else(|| {
+                        DbError::Integrity("invalid byte in persisted envelope".to_string())
+                    })
+            })
+            .collect::<Result<Vec<u8>, _>>()?;
+        let envelope = ScpEnvelope::from_xdr(bytes.as_slice(), Limits::none())?;
+        for hash in extract_tx_set_hashes_from_envelope(&envelope) {
+            hashes.push(hash);
+        }
+    }
+    Ok(hashes)
+}
+
+/// Extract the tx-set hashes referenced by an SCP envelope.
+///
+/// Mirrors `henyey_herder::persistence::get_tx_set_hashes`. The envelope's
+/// pledges carry an `ScpBallot` (in Prepare/Confirm/Externalize) or
+/// `Vec<Value>` (in Nominate); each `Value` decodes into a `StellarValue`
+/// whose `tx_set_hash` is the referenced hash.
+fn extract_tx_set_hashes_from_envelope(envelope: &ScpEnvelope) -> Vec<Hash> {
+    use stellar_xdr::curr::{ScpStatementPledges, StellarValue, Value as XdrValue};
+
+    fn from_value(value: &XdrValue) -> Option<Hash> {
+        let sv = StellarValue::from_xdr(value.as_slice(), Limits::none()).ok()?;
+        Some(sv.tx_set_hash)
+    }
+
+    let mut hashes = Vec::new();
+    match &envelope.statement.pledges {
+        ScpStatementPledges::Nominate(nom) => {
+            for value in nom.votes.iter().chain(nom.accepted.iter()) {
+                if let Some(h) = from_value(value) {
+                    hashes.push(h);
+                }
+            }
+        }
+        ScpStatementPledges::Prepare(prep) => {
+            if let Some(h) = from_value(&prep.ballot.value) {
+                hashes.push(h);
+            }
+            if let Some(p) = &prep.prepared {
+                if let Some(h) = from_value(&p.value) {
+                    hashes.push(h);
+                }
+            }
+            if let Some(pp) = &prep.prepared_prime {
+                if let Some(h) = from_value(&pp.value) {
+                    hashes.push(h);
+                }
+            }
+        }
+        ScpStatementPledges::Confirm(conf) => {
+            if let Some(h) = from_value(&conf.ballot.value) {
+                hashes.push(h);
+            }
+        }
+        ScpStatementPledges::Externalize(ext) => {
+            if let Some(h) = from_value(&ext.commit.value) {
+                hashes.push(h);
+            }
+        }
+    }
+    hashes
 }
 
 #[cfg(test)]

--- a/crates/db/src/scp_persistence.rs
+++ b/crates/db/src/scp_persistence.rs
@@ -106,6 +106,22 @@ impl SqliteScpPersistence {
     pub fn delete_tx_sets_by_hashes(&self, hashes: &[Hash]) -> Result<(), String> {
         self.with_connection(|conn| conn.delete_tx_sets_by_hashes(hashes))
     }
+
+    /// Atomic purge of unreferenced persisted transaction sets.
+    ///
+    /// Wraps the three-step purge (read hashes, read SCP states, delete
+    /// orphans) in a single SQLite transaction so a concurrent writer
+    /// (e.g. `persist_scp_state`) cannot have its freshly-inserted tx-set
+    /// deleted as an orphan between steps. See `#2770` for context.
+    pub fn purge_unreferenced_tx_sets_atomic(&self) -> Result<(), String> {
+        // BEGIN IMMEDIATE so the purge holds a RESERVED write lock for the
+        // entire read-then-delete sequence — blocks concurrent `save_tx_set`
+        // / `save_scp_state` on other pool connections so we cannot delete a
+        // tx-set that a writer is in the middle of registering. See #2770.
+        self.db
+            .transaction_immediate(|tx| tx.purge_unreferenced_tx_sets_atomic())
+            .map_err(Self::map_error)
+    }
 }
 
 #[cfg(test)]

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -870,12 +870,12 @@ impl Herder {
     /// `HerderImpl::startTxSetGCTimer()` (`HerderImpl.cpp:2440-2444`) /
     /// `purgeOldPersistedTxSets()` (`HerderImpl.cpp:2448-2487`) cadence.
     ///
-    /// TODO(#2770): the underlying `purge_unreferenced_tx_sets()` performs
-    /// three serial connection checkouts — `get_all_tx_set_hashes`,
-    /// `load_all_scp_states`, `delete_tx_sets_by_hashes` — without a single
-    /// SQLite transaction. With `persist_scp_state` now wired (#2768), a
-    /// concurrent persist between steps 2 and 3 could mark a fresh tx-set
-    /// as orphan. Tracked in #2770; make transactional there.
+    /// The underlying `purge_unreferenced_tx_sets()` routes through the
+    /// `ScpStatePersistence::purge_unreferenced_tx_sets_atomic` trait
+    /// method, which the SQLite backend overrides to run the three-step
+    /// purge inside a single transaction so a concurrent `persist_scp_state`
+    /// cannot have its tx-set deleted as an orphan between the read and the
+    /// delete (#2770).
     pub fn purge_persisted_tx_sets(&self) {
         let Some(manager) = self.scp_persistence.get() else {
             return;

--- a/crates/herder/src/persistence.rs
+++ b/crates/herder/src/persistence.rs
@@ -187,6 +187,63 @@ pub trait ScpStatePersistence: Send + Sync {
 
     /// Delete persisted transaction sets by their hashes.
     fn delete_tx_sets_by_hashes(&self, hashes: &[Hash]) -> Result<()>;
+
+    /// Atomic purge of unreferenced persisted transaction sets.
+    ///
+    /// Implementations that have transactional storage (e.g. SQLite) should
+    /// override this to wrap the read-then-delete sequence in a single
+    /// transaction, so a concurrent `save_tx_set` cannot have its tx-set
+    /// deleted as an orphan between the read and the delete.
+    ///
+    /// The default implementation is the historical three-call sequence
+    /// (read hashes, read SCP states, delete orphans). It is safe for
+    /// in-process backends whose individual calls already serialize on a
+    /// single lock (e.g. `InMemoryScpPersistence`); it is **not** safe for
+    /// backends that check out a fresh connection per call.
+    ///
+    /// Mirrors stellar-core `HerderImpl::purgeOldPersistedTxSets()`
+    /// (HerderImpl.cpp:2448-2487).
+    fn purge_unreferenced_tx_sets_atomic(&self) -> Result<()> {
+        let all_hashes: std::collections::HashSet<Hash> =
+            self.get_all_tx_set_hashes()?.into_iter().collect();
+        if all_hashes.is_empty() {
+            return Ok(());
+        }
+
+        let mut referenced = std::collections::HashSet::new();
+        for (slot, state) in self.load_all_scp_states()? {
+            match extract_tx_set_hashes_from_state(&state) {
+                Ok(hashes) => referenced.extend(hashes),
+                Err(e) => warn!(
+                    slot,
+                    "Error extracting tx set hashes from persisted state, skipping: {}", e
+                ),
+            }
+        }
+
+        let unreferenced: Vec<Hash> = all_hashes.difference(&referenced).cloned().collect();
+        if !unreferenced.is_empty() {
+            debug!(
+                count = unreferenced.len(),
+                "Purging unreferenced persisted tx sets"
+            );
+            self.delete_tx_sets_by_hashes(&unreferenced)?;
+        }
+        Ok(())
+    }
+}
+
+/// Extract all tx set hashes from a persisted slot state.
+///
+/// Returns an error if any envelope in the state cannot be decoded,
+/// allowing the caller to skip the entire state (per-state error granularity).
+fn extract_tx_set_hashes_from_state(state: &PersistedSlotState) -> Result<Vec<Hash>> {
+    let mut hashes = Vec::new();
+    for env_result in state.get_envelopes() {
+        let envelope = env_result?;
+        hashes.extend(get_tx_set_hashes(&envelope));
+    }
+    Ok(hashes)
 }
 
 /// In-memory implementation of SCP state persistence for testing.
@@ -559,57 +616,31 @@ impl ScpPersistenceManager {
 
     /// Purge persisted tx sets not referenced by any persisted SCP state.
     ///
-    /// Mirrors stellar-core's `purgeOldPersistedTxSets()` (`HerderImpl.cpp:2448-2487`).
-    /// Error handling is per-state: if a state fails to decode, we skip it
-    /// (preserving its tx set hashes as potentially referenced) and continue.
-    pub fn purge_unreferenced_tx_sets(&self) -> Result<()> {
-        let all_hashes: std::collections::HashSet<Hash> =
-            self.storage.get_all_tx_set_hashes()?.into_iter().collect();
-        if all_hashes.is_empty() {
-            return Ok(());
-        }
-
-        let mut referenced = std::collections::HashSet::new();
-
-        // Per-state error handling: skip entire state on error.
-        // Matches stellar-core HerderImpl.cpp:2456-2478 per-state try/catch.
-        for (slot, state) in self.storage.load_all_scp_states()? {
-            match Self::extract_tx_set_hashes_from_state(&state) {
-                Ok(hashes) => {
-                    referenced.extend(hashes);
-                }
-                Err(e) => {
-                    warn!(
-                        slot,
-                        "Error extracting tx set hashes from persisted state, skipping: {}", e
-                    );
-                }
-            }
-        }
-
-        let unreferenced: Vec<Hash> = all_hashes.difference(&referenced).cloned().collect();
-        if !unreferenced.is_empty() {
-            debug!(
-                count = unreferenced.len(),
-                "Purging unreferenced persisted tx sets"
-            );
-            self.storage.delete_tx_sets_by_hashes(&unreferenced)?;
-        }
-
-        Ok(())
-    }
-
-    /// Extract all tx set hashes from a persisted slot state.
+    /// Delegates to `ScpStatePersistence::purge_unreferenced_tx_sets_atomic`,
+    /// which the SQLite backend overrides to wrap the read-then-delete
+    /// sequence in a single transaction (preventing a concurrent
+    /// `persist_scp_state` from having its freshly-inserted tx-set deleted
+    /// as an orphan between the read and the delete). See #2770.
     ///
-    /// Returns an error if any envelope in the state cannot be decoded,
-    /// allowing the caller to skip the entire state (per-state error granularity).
-    fn extract_tx_set_hashes_from_state(state: &PersistedSlotState) -> Result<Vec<Hash>> {
-        let mut hashes = Vec::new();
-        for env_result in state.get_envelopes() {
-            let envelope = env_result?;
-            hashes.extend(get_tx_set_hashes(&envelope));
-        }
-        Ok(hashes)
+    /// Acquires the same in-process `last_slot_saved` lock that
+    /// `persist_scp_state` holds, serializing purge w.r.t. all persists at
+    /// the manager level. This is needed because `persist_scp_state` itself
+    /// performs two separate storage calls (`save_tx_set` then
+    /// `save_scp_state`), so a purge that interleaved between them would
+    /// still observe a tx-set without its referencing state. Matches
+    /// stellar-core (`HerderImpl.cpp`), which serializes persist and purge
+    /// on the main thread.
+    ///
+    /// Mirrors stellar-core's `purgeOldPersistedTxSets()` (`HerderImpl.cpp:2448-2487`).
+    /// Error handling is per-state: if a state fails to decode, the state is
+    /// skipped (its tx-set references can't be proven, so its tx-sets may be
+    /// deleted as orphans).
+    pub fn purge_unreferenced_tx_sets(&self) -> Result<()> {
+        // Hold the same lock `persist_scp_state` takes so the two operations
+        // serialize at the manager level (in addition to the SQLite-level
+        // BEGIN IMMEDIATE inside the SQLite backend's atomic implementation).
+        let _guard = self.last_slot_saved.write();
+        self.storage.purge_unreferenced_tx_sets_atomic()
     }
 }
 
@@ -1103,6 +1134,16 @@ impl ScpStatePersistence for SqliteScpPersistence {
     fn delete_tx_sets_by_hashes(&self, hashes: &[Hash]) -> Result<()> {
         self.inner
             .delete_tx_sets_by_hashes(hashes)
+            .map_err(HerderError::Internal)
+    }
+
+    /// Override the trait default with a SQLite-transactional implementation
+    /// so the read-then-delete sequence is atomic w.r.t. concurrent writers.
+    /// See `henyey_db::SqliteScpPersistence::purge_unreferenced_tx_sets_atomic`
+    /// (#2770).
+    fn purge_unreferenced_tx_sets_atomic(&self) -> Result<()> {
+        self.inner
+            .purge_unreferenced_tx_sets_atomic()
             .map_err(HerderError::Internal)
     }
 }

--- a/crates/herder/src/persistence.rs
+++ b/crates/herder/src/persistence.rs
@@ -800,7 +800,7 @@ mod tests {
     }
 
     /// Create an envelope whose NOMINATE ballot references a known tx set hash.
-    fn make_envelope_with_tx_set_hash(slot: u64, tx_set_hash: Hash) -> ScpEnvelope {
+    pub(super) fn make_envelope_with_tx_set_hash(slot: u64, tx_set_hash: Hash) -> ScpEnvelope {
         let stellar_value = StellarValue {
             tx_set_hash: tx_set_hash.clone(),
             close_time: TimePoint(0),
@@ -1166,5 +1166,39 @@ mod sqlite_tests {
         // Load all
         let all = persistence.load_all_tx_sets().unwrap();
         assert_eq!(all.len(), 1);
+    }
+
+    /// Exercise the atomic purge through `ScpPersistenceManager` backed by
+    /// `SqliteScpPersistence`. This is the path used in production once the
+    /// persist timer is wired (#2768).
+    #[test]
+    fn test_purge_atomic_via_manager_sqlite() {
+        use super::tests::make_envelope_with_tx_set_hash;
+
+        let db = henyey_db::Database::open_in_memory().unwrap();
+        let manager = ScpPersistenceManager::new(Box::new(SqliteScpPersistence::new(db)));
+
+        let referenced = Hash([0xAA; 32]);
+        let orphan = Hash([0xBB; 32]);
+
+        // Slot 100 references `referenced`; slot 50 references `orphan` then
+        // gets cleaned up so `orphan` becomes unreferenced.
+        let env_r = make_envelope_with_tx_set_hash(100, referenced.clone());
+        manager
+            .persist_scp_state(100, &[env_r], &[(referenced.clone(), vec![1])], &[])
+            .unwrap();
+        let env_o = make_envelope_with_tx_set_hash(50, orphan.clone());
+        manager
+            .persist_scp_state(50, &[env_o], &[(orphan.clone(), vec![2])], &[])
+            .unwrap();
+
+        // Drop slot 50's state -> orphan is now unreferenced.
+        // Cleanup itself calls purge — but we then call purge again to
+        // confirm the atomic path is idempotent.
+        manager.cleanup(100).unwrap();
+        manager.purge_unreferenced_tx_sets().unwrap();
+
+        assert!(manager.has_tx_set(&referenced).unwrap());
+        assert!(!manager.has_tx_set(&orphan).unwrap());
     }
 }

--- a/crates/herder/tests/persistence_race.rs
+++ b/crates/herder/tests/persistence_race.rs
@@ -1,0 +1,175 @@
+//! Regression tests for the persist/purge race in `ScpPersistenceManager`.
+//!
+//! `purge_unreferenced_tx_sets()` historically performed three separate
+//! connection checkouts against `SqliteScpPersistence`:
+//!   1. `get_all_tx_set_hashes()`
+//!   2. `load_all_scp_states()` (to compute referenced hashes)
+//!   3. `delete_tx_sets_by_hashes(orphans)`
+//!
+//! With those steps unsynchronized, a concurrent `persist_scp_state` between
+//! steps 2 and 3 could see its freshly-inserted tx-set deleted as an orphan.
+//! Stellar-core has no equivalent race because all herder work runs on the
+//! main thread (`HerderImpl.cpp` serializes persist and purge naturally).
+//!
+//! These tests exercise the atomic path added in #2770. See plan in the
+//! converged-plan comment on #2770.
+//!
+//! Parity reference:
+//! - `HerderImpl::purgeOldPersistedTxSets()` (HerderImpl.cpp:2448-2487)
+//! - `HerderImpl::startTxSetGCTimer()` (HerderImpl.cpp:2440-2444)
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use henyey_db::Database;
+use henyey_herder::{
+    get_tx_set_hashes, PersistedSlotState, ScpPersistenceManager, ScpStatePersistence,
+    SqliteScpPersistence,
+};
+use stellar_xdr::curr::{
+    Hash, Limits, NodeId, PublicKey, ScpEnvelope, ScpNomination, ScpStatement, ScpStatementPledges,
+    Signature, StellarValue, StellarValueExt, TimePoint, Uint256, Value, WriteXdr,
+};
+
+/// Build an SCP NOMINATE envelope whose value references the given tx-set hash.
+fn make_envelope_with_tx_set_hash(slot: u64, tx_set_hash: Hash) -> ScpEnvelope {
+    let stellar_value = StellarValue {
+        tx_set_hash,
+        close_time: TimePoint(0),
+        upgrades: vec![].try_into().unwrap(),
+        ext: StellarValueExt::Basic,
+    };
+    let value = stellar_value.to_xdr(Limits::none()).unwrap();
+    ScpEnvelope {
+        statement: ScpStatement {
+            node_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
+            slot_index: slot,
+            pledges: ScpStatementPledges::Nominate(ScpNomination {
+                quorum_set_hash: Hash([0u8; 32]),
+                votes: vec![Value(value.try_into().unwrap())].try_into().unwrap(),
+                accepted: vec![].try_into().unwrap(),
+            }),
+        },
+        signature: Signature::default(),
+    }
+}
+
+/// Direct SQLite-backend test of the new atomic trait method.
+///
+/// Structurally fails on `origin/main` because
+/// `ScpStatePersistence::purge_unreferenced_tx_sets_atomic` does not exist
+/// yet — the test fails to compile. Passes once the trait method is added.
+#[test]
+fn test_purge_atomic_on_sqlite_backend() {
+    let db = Database::open_in_memory().unwrap();
+    let persistence = SqliteScpPersistence::new(db);
+
+    let referenced_hash = Hash([0xAA; 32]);
+    let orphan_hash = Hash([0xBB; 32]);
+
+    // Seed via the trait so we exercise the SQLite path end-to-end.
+    let env = make_envelope_with_tx_set_hash(100, referenced_hash.clone());
+    let mut state = PersistedSlotState::new();
+    state.add_envelope(&env).unwrap();
+    persistence.save_scp_state(100, &state).unwrap();
+    persistence.save_tx_set(&referenced_hash, &[10u8]).unwrap();
+    persistence.save_tx_set(&orphan_hash, &[20u8]).unwrap();
+
+    // New atomic API — must exist as a trait method on ScpStatePersistence.
+    persistence.purge_unreferenced_tx_sets_atomic().unwrap();
+
+    assert!(
+        persistence.has_tx_set(&referenced_hash).unwrap(),
+        "Referenced tx-set should survive atomic purge"
+    );
+    assert!(
+        !persistence.has_tx_set(&orphan_hash).unwrap(),
+        "Orphan tx-set should be deleted by atomic purge"
+    );
+}
+
+/// Race test: spawn a background thread that continuously persists new SCP
+/// states (each with a fresh tx-set), while the main thread invokes
+/// `purge_unreferenced_tx_sets()` repeatedly. The persisted tx-sets are all
+/// referenced by their own envelopes, so the post-condition is: every
+/// tx-set the persister claimed to have written must still be present at
+/// the end.
+///
+/// Under the old non-atomic code, a tx-set inserted between
+/// `load_all_scp_states` and `delete_tx_sets_by_hashes` would be visible
+/// as a "stored hash" but not yet as a "referenced hash", and would be
+/// deleted as an orphan. The race is non-deterministic — documented here
+/// as a regression guard. The hard structural test for the new API is
+/// `test_purge_atomic_on_sqlite_backend` above.
+#[test]
+fn test_purge_atomic_survives_concurrent_persist() {
+    let db = Database::open_in_memory().unwrap();
+    let persistence = SqliteScpPersistence::new(db);
+    let manager = Arc::new(ScpPersistenceManager::new(Box::new(persistence)));
+
+    // Pre-populate: slot 100 references `referenced_hash`.
+    let referenced_hash = Hash([0x01; 32]);
+    let env = make_envelope_with_tx_set_hash(100, referenced_hash.clone());
+    manager
+        .persist_scp_state(100, &[env], &[(referenced_hash.clone(), vec![10])], &[])
+        .unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop.clone();
+    let manager_clone = manager.clone();
+    let persisted = Arc::new(parking_lot::Mutex::new(Vec::<Hash>::new()));
+    let persisted_clone = persisted.clone();
+
+    let persister = thread::spawn(move || {
+        let mut next_slot: u64 = 200;
+        while !stop_clone.load(Ordering::Relaxed) {
+            let mut hash_bytes = [0u8; 32];
+            hash_bytes[..8].copy_from_slice(&next_slot.to_le_bytes());
+            let tx_hash = Hash(hash_bytes);
+            let envelope = make_envelope_with_tx_set_hash(next_slot, tx_hash.clone());
+            // Sanity: envelope must reference tx_hash.
+            assert!(
+                get_tx_set_hashes(&envelope).contains(&tx_hash),
+                "envelope must reference tx_hash"
+            );
+            if manager_clone
+                .persist_scp_state(
+                    next_slot,
+                    &[envelope],
+                    &[(tx_hash.clone(), vec![next_slot as u8])],
+                    &[],
+                )
+                .is_ok()
+            {
+                persisted_clone.lock().push(tx_hash);
+            }
+            next_slot += 1;
+            thread::sleep(Duration::from_micros(50));
+        }
+    });
+
+    for _ in 0..50 {
+        manager.purge_unreferenced_tx_sets().unwrap();
+        thread::sleep(Duration::from_millis(2));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    persister.join().unwrap();
+
+    // Final assertion: pre-populated tx-set + every claimed-persisted tx-set
+    // must survive. All are referenced by their own envelopes.
+    assert!(
+        manager.has_tx_set(&referenced_hash).unwrap(),
+        "pre-populated referenced tx-set must survive"
+    );
+    let persisted_hashes = persisted.lock().clone();
+    for h in &persisted_hashes {
+        assert!(
+            manager.has_tx_set(h).unwrap(),
+            "concurrently-persisted tx-set {:?} must survive purge",
+            h
+        );
+    }
+}


### PR DESCRIPTION
Closes #2770

## Summary

`ScpPersistenceManager::purge_unreferenced_tx_sets()` historically performed three separate `with_connection` checkouts against `SqliteScpPersistence` (`get_all_tx_set_hashes`, `load_all_scp_states`, `delete_tx_sets_by_hashes`) without a single SQLite transaction. Once `persist_scp_state()` is wired in production (#2768), a concurrent persist between the read-states and delete-orphans steps could have its freshly-inserted tx-set deleted as an orphan.

This change makes the purge atomic at two levels:
1. **SQLite level** — a new `Database::transaction_immediate` helper wraps the three-step purge in a `BEGIN IMMEDIATE` transaction, holding a RESERVED write lock that blocks concurrent writers on other pool connections for the purge's full duration.
2. **Manager level** — `ScpPersistenceManager::purge_unreferenced_tx_sets` now also acquires the same `last_slot_saved` write lock as `persist_scp_state`. This is needed because `persist_scp_state` itself performs two separate storage calls (`save_tx_set` then `save_scp_state`), so a purge interleaved between them would still be able to delete a tx-set whose referencing state has not yet landed. Matches stellar-core, which serializes persist and purge on the main thread (`HerderImpl.cpp`).

The in-memory backend uses the default trait implementation (sequential calls), which is safe because its per-method `parking_lot::RwLock` already serializes.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2770#issuecomment-4474384283)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --all` passes (all crates, including new tests)
- [x] `cargo test -p henyey-db` (109 passed) — includes 4 new `test_purge_unreferenced_tx_sets_atomic_*` tests against the `Connection` impl
- [x] `cargo test -p henyey-herder` (1116 passed) — includes new `sqlite_tests::test_purge_atomic_via_manager_sqlite`
- [x] `cargo test -p henyey-herder --test persistence_race` (2 passed) — new integration test file with structural + race-regression tests

## Deviations from plan

- The plan called for a single SQLite transaction (`BEGIN ... COMMIT`) without specifying the lock mode. Implementation uses `BEGIN IMMEDIATE` (via a new `Database::transaction_immediate` helper) so the purge holds a RESERVED write lock immediately — necessary to block concurrent `save_tx_set` writes on other pool connections.
- The plan focused on purge-side atomicity only. Implementation additionally takes the manager-level `last_slot_saved` write lock inside `purge_unreferenced_tx_sets` to serialize purge with the non-atomic two-step `persist_scp_state`. Without this, the race regression test in the issue is non-deterministic; with it, the test passes consistently. This is a Minor deviation that keeps the plan's intent (matching stellar-core's serialization) while satisfying the issue's explicit "assert the persisted tx-set survives" requirement.
- Added `serde_json` as a `henyey-db` dependency so the db-layer atomic implementation can parse JSON-encoded `PersistedSlotState` without depending on the herder crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)