### PR TITLE
Fix SCP spec adherence: INV-S9 assertion, §8.2 iteration cap, anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ henyey/
 
 | Crate | Purpose | Parity |
 |-------|---------|--------|
-| [`henyey-scp`](crates/scp/README.md) | Stellar Consensus Protocol: nomination, balloting, quorum logic | [95%](crates/scp/PARITY_STATUS.md) |
+| [`henyey-scp`](crates/scp/README.md) | Stellar Consensus Protocol: nomination, balloting, quorum logic | [96%](crates/scp/PARITY_STATUS.md) |
 | [`henyey-herder`](crates/herder/README.md) | Consensus coordination, transaction queue, ledger close triggers | [79%](crates/herder/PARITY_STATUS.md) |
 | [`henyey-overlay`](crates/overlay/README.md) | P2P overlay network, peer management, message flooding | [92%](crates/overlay/PARITY_STATUS.md) |
 

--- a/crates/scp/PARITY_STATUS.md
+++ b/crates/scp/PARITY_STATUS.md
@@ -2,8 +2,8 @@
 
 **Crate**: `henyey-scp`
 **Upstream**: `stellar-core/src/scp/`
-**Overall Parity**: 95%
-**Last Updated**: 2026-04-26
+**Overall Parity**: 96%
+**Last Updated**: 2026-05-19
 
 ## Summary
 
@@ -216,7 +216,7 @@ Corresponds to: `NominationProtocol.h`
 | `emitNomination()` | `emit_nomination()` | Full |
 | `acceptPredicate()` | Inline in `should_accept_value()` | Full |
 | `applyAll()` | Inline iteration | Full |
-| `updateRoundLeaders()` | `update_round_leaders()` | Full |
+| `updateRoundLeaders()` | `update_round_leaders()` | Full | Zero-weight exclusion + 1000-iteration cap |
 | `hashNode()` | `compute_hash_node()` via driver | Full |
 | `hashValue()` | `hash_value()` via driver | Full |
 | `getNodePriority()` | `get_node_priority()` | Full |

--- a/crates/scp/SPEC_ADHERENCE.md
+++ b/crates/scp/SPEC_ADHERENCE.md
@@ -3,17 +3,17 @@
 **Spec version:** 26 (stellar-core v26.0.1 / Protocol 26)
 **Spec path:** `stellar-specs/SCP_SPEC.md` (1689 lines)
 **Crate:** `crates/scp`
-**Last updated:** 2026-05-13
-**Overall adherence:** 96%
+**Last updated:** 2026-05-19
+**Overall adherence:** 100%
 
 Counts (production code only, tests excluded):
-- Full: 47
-- Partial: 2
+- Full: 49
+- Partial: 0
 - Absent: 0
 - Drift: 0
 - N/A: 3
 
-`adherence_pct = 47 / (47 + 2 + 0) = 95.9%`
+`adherence_pct = 49 / (49 + 0 + 0) = 100%`
 
 ## Summary
 
@@ -73,7 +73,7 @@ Counts (production code only, tests excluded):
 | INV-S6 `c ≲ h ≲ b` chain | Full | `check_invariants` verifies both edges (ballot/mod.rs:443-458). |
 | INV-S7 Commit-only-with-high | Full | `check_invariants` enforces (`commit.is_some()` requires `high_ballot.is_some()`, ballot/mod.rs:443-451); `bump_to_ballot` clears commit when it clears high (state_machine.rs:559-566). |
 | INV-S8 CONFIRM/EXTERNALIZE require complete state | Full | `check_invariants` rejects missing core fields in Confirm/Externalize (ballot/mod.rs:395-411). |
-| INV-S9 Commit voiding correctness | Partial | Voiding happens correctly in `set_accept_prepared` when `mHighBallot ≨ mPrepared / mPreparedPrime` (state_machine.rs:106-124). **However**, the spec's "MUST happen only in `SCP_PHASE_PREPARE`; voiding in CONFIRM or EXTERNALIZE is forbidden" assertion is **not** explicitly enforced. The implementation relies on the upstream conditions (commit + new accept-prepared) being structurally impossible outside PREPARE rather than an explicit phase check. Stellar-core enforces this with a `releaseAssert(mPhase == SCP_PHASE_PREPARE)` at the same site. |
+| INV-S9 Commit voiding correctness | Full | Voiding happens in `set_accept_prepared` when `mHighBallot ≨ mPrepared / mPreparedPrime` (state_machine.rs:120-135). Explicit `assert_eq!(self.phase, BallotPhase::Prepare)` matches stellar-core's `dbgAssert(mPhase == SCP_PHASE_PREPARE)`. |
 | INV-S10 `mValueOverride` locking | Full | `bump_state` uses `value_override` when set (ballot/mod.rs:946-952); `set_confirm_prepared` and `set_accept_commit` set it (state_machine.rs:234, 328). |
 | INV-S11 Singleton qset for EXTERNALIZE | Full | `statement_quorum_set` returns `simple_quorum_set(1, vec![nodeid])` for Externalize statements (ballot/statements.rs:122-124). `commitQuorumSetHash` is not consulted for quorum/v-blocking gating. |
 | INV-S12 Nomination set monotonicity | Full | `is_newer_nomination` checks `old_votes ⊆ new_votes` AND `old_accepted ⊆ new_accepted` AND at least one strictly grew (nomination.rs:777-789); same logic in `compare.rs:97-108`. |
@@ -126,9 +126,9 @@ Counts (production code only, tests excluded):
 - **Status**: Full.
 
 ### §8.2 — Round-leader election
-- **Spec**: Normalize qset with `idToRemove = localNodeID`; iterate priority computation; if `topPriority == 0` for all candidates, increment `mRoundNumber` and retry; cap at 1000 iterations.
-- **Rust**: `nomination.rs::update_round_leaders` (lines 947-988). The 1000-iteration cap from the spec is **not present** — the loop is bounded only by `round_leaders.len() < max_leader_count` plus the `top_priority == 0` reset. In practice, the absence of the cap is benign on sane qsets (which the spec elsewhere requires); on a degenerate qset the loop could in principle spin longer than upstream. Treat as **Partial** for completeness.
-- **Status**: Partial (missing the defensive 1000-iteration ceiling).
+- **Spec**: Normalize qset with `idToRemove = localNodeID`; iterate priority computation; if `topPriority == 0` for all candidates, increment `mRoundNumber` and retry; cap at 1000 iterations. Only count nodes with non-zero weight toward `maxLeaderCount`.
+- **Rust**: `nomination.rs::update_round_leaders`. Computes `max_leader_count` by counting only nodes with non-zero weight (matching stellar-core's approach). Includes the 1000-iteration defensive cap that panics on exhaustion, matching stellar-core's `throw std::runtime_error`.
+- **Status**: Full.
 
 ### §9.5.1 — attemptAcceptPrepared step ordering
 - **Spec**: For each candidate (highest→lowest), apply 5 filters in order: CONFIRM-phase prepared-extension, CONFIRM-phase commit compatibility, ≤ p' skip, ≲ p skip, `federatedAccept`.
@@ -155,9 +155,9 @@ None identified. The two Partial items above are completeness gaps (missing defe
 
 ## Recommendations
 
-1. **Add the missing phase assertion for INV-S9 commit voiding.** In `ballot/state_machine.rs::set_accept_prepared` around line 121 (where `self.commit = None`), add a debug-assert that `self.phase == BallotPhase::Prepare`. Stellar-core has this assert; it's defense-in-depth against future refactors.
-2. **Cap the round-leader election loop at 1000 iterations (§8.2 step 4).** In `nomination.rs::update_round_leaders` (around line 959), add a counter and panic at 1000 to match the spec's defensive cap.
-3. **Fix the dangling spec anchor** in `crates/scp/src/ballot/mod.rs:914` (currently cites `§9.13`, should be `§10.4`).
+1. ~~**Add the missing phase assertion for INV-S9 commit voiding.**~~ ✅ Done (2026-05-19).
+2. ~~**Cap the round-leader election loop at 1000 iterations (§8.2 step 4).**~~ ✅ Done (2026-05-19).
+3. ~~**Fix the dangling spec anchor** in `crates/scp/src/ballot/mod.rs:914` (§9.13 → §10.4).~~ ✅ Done (2026-05-19).
 4. **Optional: rename `MAX_PROTOCOL_TRANSITIONS` → `MAX_ADVANCE_SLOT_RECURSION`** (ballot/mod.rs:48) to match the spec name verbatim; the semantics are identical.
 5. **Optional: add an explicit re-exported constant** `pub const MAX_ADVANCE_SLOT_RECURSION: u32 = 50;` at crate level so external integrators (or tests in adjacent crates) can reference it without hardcoding `50`.
-6. **Consider adding `// Spec: SCP_SPEC §N.M` anchors** at the major entry points (e.g., `nominate`, `process_envelope` paths, `attempt_*` functions, `set_state_from_envelope`). The crate currently has only 1 anchor; richer anchoring would let future `/spec-adhere` audits operate by anchor-first lookup and would help reviewers cross-reference against the regenerated spec.
+6. ~~**Consider adding `// Spec: SCP_SPEC §N.M` anchors** at the major entry points.~~ ✅ Done (2026-05-19): anchors added at `advance_slot`, `nominate`, `federated_accept`, `federated_ratify`, `set_accept_prepared`, and `update_round_leaders`.

--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -911,7 +911,7 @@ impl BallotProtocol {
         self.latest_envelopes
             .insert(envelope.statement.node_id.clone(), envelope.clone());
         self.last_envelope = Some(envelope.clone());
-        // Spec: SCP_SPEC §9.13 — set last_envelope_emit to prevent re-emission
+        // Spec: SCP_SPEC §10.4 — set last_envelope_emit to prevent re-emission
         // after crash recovery.
         self.last_envelope_emit = Some(envelope.clone());
 
@@ -997,6 +997,40 @@ impl BallotProtocol {
         ctx: &SlotContext<'_, D>,
     ) -> bool {
         self.attempt_confirm_commit(hint, ctx)
+    }
+
+    /// Test helper: set the ballot phase.
+    pub(crate) fn set_phase_for_test(&mut self, phase: BallotPhase) {
+        self.phase = phase;
+    }
+
+    /// Test helper: set commit ballot.
+    pub(crate) fn set_commit_for_test(&mut self, commit: Option<ScpBallot>) {
+        self.commit = commit;
+    }
+
+    /// Test helper: set high_ballot.
+    pub(crate) fn set_high_ballot_for_test(&mut self, high: Option<ScpBallot>) {
+        self.high_ballot = high;
+    }
+
+    /// Test helper: set prepared ballot.
+    pub(crate) fn set_prepared_ballot_for_test(&mut self, prepared: Option<ScpBallot>) {
+        self.prepared = prepared;
+    }
+
+    /// Test helper: set current_ballot.
+    pub(crate) fn set_current_ballot_for_test(&mut self, ballot: Option<ScpBallot>) {
+        self.current_ballot = ballot;
+    }
+
+    /// Test helper: expose set_accept_prepared for direct testing.
+    pub(crate) fn set_accept_prepared_for_test<D: SCPDriver>(
+        &mut self,
+        ballot: ScpBallot,
+        ctx: &SlotContext<'_, D>,
+    ) -> bool {
+        self.set_accept_prepared(ballot, ctx)
     }
 }
 
@@ -4936,5 +4970,127 @@ mod tests {
             !driver.get_externalized_values().is_empty(),
             "externalization should occur with CONFIRM hint"
         );
+    }
+
+    /// INV-S9: In PREPARE phase, accepting a prepared ballot that is incompatible
+    /// with high_ballot should clear commit. This tests the positive case.
+    #[test]
+    fn test_advance_slot_clears_commit_when_prepare_accepts_incompatible_prepared() {
+        let node_self = make_node_id(0);
+        let node_b = make_node_id(1);
+        let node_c = make_node_id(2);
+        let value_a: Value = vec![1u8, 0].try_into().unwrap();
+        let value_b: Value = vec![2u8, 0].try_into().unwrap();
+        // Use a 3-of-3 quorum so the self-envelope alone can't form a quorum
+        // in the recursive advance_slot call.
+        let quorum_set =
+            make_quorum_set(vec![node_self.clone(), node_b.clone(), node_c.clone()], 3);
+        let driver = Arc::new(
+            MockDriverBuilder::new()
+                .quorum_set(quorum_set.clone())
+                .build(),
+        );
+        let ctx = ctx!(&node_self, &quorum_set, &driver, 1);
+
+        let mut bp = BallotProtocol::new();
+        // Set up PREPARE phase with commit and high_ballot
+        bp.set_phase_for_test(BallotPhase::Prepare);
+        bp.set_current_ballot_for_test(Some(ScpBallot {
+            counter: 2,
+            value: value_a.clone(),
+        }));
+        bp.set_commit_for_test(Some(ScpBallot {
+            counter: 1,
+            value: value_a.clone(),
+        }));
+        bp.set_high_ballot_for_test(Some(ScpBallot {
+            counter: 1,
+            value: value_a.clone(),
+        }));
+
+        // Accept a prepared ballot with an incompatible value that is > high_ballot
+        // This should trigger the commit-voiding path
+        let incompatible_prepared = ScpBallot {
+            counter: 2,
+            value: value_b.clone(),
+        };
+
+        let did_work = bp.set_accept_prepared_for_test(incompatible_prepared, &ctx);
+        assert!(did_work, "set_accept_prepared should have done work");
+        // commit should be cleared because prepared (value_b counter=2) is
+        // incompatible with high_ballot (value_a counter=1) and high < prepared
+        assert!(
+            bp.commit().is_none(),
+            "commit must be cleared when incompatible prepared is accepted in PREPARE phase"
+        );
+    }
+
+    /// INV-S9 complementary: In CONFIRM phase, attempt_accept_prepared filters out
+    /// incompatible candidates so the commit-voiding assertion is never reached.
+    #[test]
+    fn test_attempt_accept_prepared_confirm_phase_rejects_incompatible_candidate() {
+        let node_self = make_node_id(0);
+        let node_b = make_node_id(1);
+        let value_a: Value = vec![1u8, 0].try_into().unwrap();
+        let value_b: Value = vec![2u8, 0].try_into().unwrap();
+        let quorum_set = make_quorum_set(vec![node_self.clone(), node_b.clone()], 1);
+        let driver = Arc::new(
+            MockDriverBuilder::new()
+                .quorum_set(quorum_set.clone())
+                .build(),
+        );
+        let ctx = ctx!(&node_self, &quorum_set, &driver, 1);
+
+        let mut bp = BallotProtocol::new();
+        // Set up CONFIRM phase with commit and high_ballot on value_a
+        bp.set_phase_for_test(BallotPhase::Confirm);
+        bp.set_current_ballot_for_test(Some(ScpBallot {
+            counter: 2,
+            value: value_a.clone(),
+        }));
+        bp.set_commit_for_test(Some(ScpBallot {
+            counter: 1,
+            value: value_a.clone(),
+        }));
+        bp.set_high_ballot_for_test(Some(ScpBallot {
+            counter: 2,
+            value: value_a.clone(),
+        }));
+        bp.set_prepared_ballot_for_test(Some(ScpBallot {
+            counter: 2,
+            value: value_a.clone(),
+        }));
+
+        // Create a hint that would suggest accepting prepared for value_b (incompatible)
+        let qs_hash = crate::quorum::hash_quorum_set(&quorum_set);
+        let hint = ScpStatement {
+            node_id: node_b.clone(),
+            slot_index: 1,
+            pledges: ScpStatementPledges::Prepare(ScpStatementPrepare {
+                ballot: ScpBallot {
+                    counter: 3,
+                    value: value_b.clone(),
+                },
+                prepared: Some(ScpBallot {
+                    counter: 3,
+                    value: value_b.clone(),
+                }),
+                prepared_prime: None,
+                n_c: 0,
+                n_h: 0,
+                quorum_set_hash: qs_hash.into(),
+            }),
+        };
+
+        // In CONFIRM phase, attempt_accept_prepared should filter out the
+        // incompatible candidate because it's not compatible with commit
+        let _result = bp.advance_slot_for_test(&hint, &ctx);
+        // The incompatible ballot should have been filtered — commit stays intact
+        assert!(
+            bp.commit().is_some(),
+            "commit must remain unchanged in CONFIRM phase — incompatible candidates are filtered"
+        );
+        // Phase should still be CONFIRM
+        assert_eq!(bp.phase(), BallotPhase::Confirm);
     }
 }

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -7,6 +7,9 @@ use super::*;
 
 impl BallotProtocol {
     /// Try to advance the slot state based on received messages.
+    ///
+    // Spec: SCP_SPEC §10 — ballot protocol progression: attempt accept-prepared,
+    // confirm-prepared, accept-commit, confirm-commit in order, then bump.
     pub(super) fn advance_slot<D: SCPDriver>(
         &mut self,
         hint: &ScpStatement,
@@ -96,13 +99,16 @@ impl BallotProtocol {
         false
     }
 
-    fn set_accept_prepared<D: SCPDriver>(
+    pub(super) fn set_accept_prepared<D: SCPDriver>(
         &mut self,
         ballot: ScpBallot,
         ctx: &SlotContext<'_, D>,
     ) -> bool {
         let mut did_work = self.set_prepared(ballot.clone(), ctx.driver, ctx.slot_index);
 
+        // Spec: SCP_SPEC §10.4 — clear commit when high_ballot is incompatible
+        // with newly accepted prepared ballot. This can only happen in PREPARE phase;
+        // in CONFIRM phase, attempt_accept_prepared filters out incompatible candidates.
         if self.commit.is_some() {
             let Some(high) = self.high_ballot.as_ref() else {
                 return did_work;
@@ -118,6 +124,12 @@ impl BallotProtocol {
                     .map(|p| are_ballots_less_and_incompatible(high, p))
                     .unwrap_or(false);
             if incompatible {
+                // stellar-core: dbgAssert(mPhase == SCP_PHASE_PREPARE)
+                assert_eq!(
+                    self.phase,
+                    BallotPhase::Prepare,
+                    "commit voiding can only occur in PREPARE phase"
+                );
                 self.commit = None;
                 did_work = true;
             }

--- a/crates/scp/src/ballot/statements.rs
+++ b/crates/scp/src/ballot/statements.rs
@@ -301,6 +301,8 @@ impl BallotProtocol {
         map
     }
 
+    // Spec: SCP_SPEC §5.3 — federated accept: a statement is accepted if
+    // either a v-blocking set accepts it, or a quorum votes-or-accepts it.
     pub(super) fn federated_accept<D: SCPDriver, V, A>(
         &self,
         voted: V,
@@ -332,6 +334,8 @@ impl BallotProtocol {
         is_quorum(ctx.local_quorum_set, &supporters, get_qs)
     }
 
+    // Spec: SCP_SPEC §5.4 — federated ratify (confirm): a statement is ratified
+    // when a quorum of nodes accept it.
     pub(super) fn federated_ratify<D: SCPDriver, V>(
         &self,
         voted: V,

--- a/crates/scp/src/nomination.rs
+++ b/crates/scp/src/nomination.rs
@@ -206,6 +206,28 @@ impl NominationProtocol {
         self.latest_composite = value;
     }
 
+    /// Test helper: directly call update_round_leaders.
+    #[cfg(test)]
+    pub(crate) fn update_round_leaders_for_test<D: SCPDriver>(
+        &mut self,
+        ctx: &SlotContext<'_, D>,
+        prev_value: &Value,
+    ) {
+        self.update_round_leaders(ctx, prev_value);
+    }
+
+    /// Test helper: pre-seed round_leaders to test no-progress scenarios.
+    #[cfg(test)]
+    pub(crate) fn set_round_leaders_for_test(&mut self, leaders: BTreeSet<NodeId>) {
+        self.round_leaders = leaders;
+    }
+
+    /// Test helper: set the previous_value (required for hash computations).
+    #[cfg(test)]
+    pub(crate) fn set_previous_value_for_test(&mut self, value: Option<Value>) {
+        self.previous_value = value;
+    }
+
     /// Get the last envelope constructed by this node.
     pub fn get_last_envelope(&self) -> Option<&ScpEnvelope> {
         self.last_envelope.as_ref()
@@ -357,6 +379,8 @@ impl NominationProtocol {
     ///
     /// # Returns
     /// True if nomination was updated.
+    // Spec: SCP_SPEC §8 — nomination protocol entry point: propose values,
+    // update round leaders, and emit nomination envelope.
     pub(crate) fn nominate<D: SCPDriver>(
         &mut self,
         ctx: &SlotContext<'_, D>,
@@ -944,6 +968,8 @@ impl NominationProtocol {
             .compute_value_hash(ctx.slot_index, prev, self.round, value)
     }
 
+    // Spec: SCP_SPEC §8.2 — round-leader election: compute leaders per round,
+    // only counting nodes with non-zero weight, with a 1000-iteration defensive cap.
     fn update_round_leaders<D: SCPDriver>(&mut self, ctx: &SlotContext<'_, D>, prev_value: &Value) {
         // stellar-core normalizes the quorum set, removing self and adjusting thresholds.
         // This ensures weight calculations and leader selection match stellar-core.
@@ -953,8 +979,26 @@ impl NominationProtocol {
             Some(ctx.local_node_id),
         );
 
-        // maxLeaderCount = 1 (self) + all nodes in the normalized set
-        let max_leader_count = 1 + Self::count_all_nodes(&normalized_qs);
+        // Count potential leaders: only include nodes with non-zero weight,
+        // as nodes with weight 0 can never be elected as round leaders.
+        // stellar-core: counts local + forAllNodes with getNodeWeight > 0
+        let mut max_leader_count: usize = 0;
+        if ctx
+            .driver
+            .get_node_weight(ctx.local_node_id, &normalized_qs, true)
+            > 0
+        {
+            max_leader_count += 1;
+        }
+        Self::for_all_nodes(&normalized_qs, &mut |node| {
+            if ctx.driver.get_node_weight(node, &normalized_qs, false) > 0 {
+                max_leader_count += 1;
+            }
+        });
+
+        // Cap the number of iterations to prevent infinite loops if something has
+        // gone wrong (stellar-core: iterationsRemaining = 1000)
+        let mut iterations_remaining: u32 = 1000;
 
         while self.round_leaders.len() < max_leader_count {
             let mut new_leaders = HashSet::new();
@@ -984,6 +1028,11 @@ impl NominationProtocol {
             }
 
             self.round = self.round.saturating_add(1);
+
+            iterations_remaining -= 1;
+            if iterations_remaining == 0 {
+                panic!("updateRoundLeaders appears to be stuck in an infinite loop");
+            }
         }
     }
 
@@ -1025,18 +1074,6 @@ impl NominationProtocol {
         for inner in quorum_set.inner_sets.iter() {
             Self::for_all_nodes(inner, f);
         }
-    }
-
-    /// Count all nodes in a quorum set (stellar-core `forAllNodes` with counter).
-    ///
-    /// Since the quorum set is already normalized with self removed,
-    /// this counts all validators without exclusions.
-    fn count_all_nodes(quorum_set: &ScpQuorumSet) -> usize {
-        let mut count = quorum_set.validators.len();
-        for inner in quorum_set.inner_sets.iter() {
-            count += Self::count_all_nodes(inner);
-        }
-        count
     }
 
     /// Restore state from a saved envelope (for crash recovery).
@@ -2782,5 +2819,265 @@ mod tests {
             priority_zero, priority_max,
             "different custom weights must produce different priorities"
         );
+    }
+
+    /// A driver that gives zero weight to specific nodes, to test zero-weight exclusion.
+    struct ZeroWeightDriver {
+        quorum_set: ScpQuorumSet,
+        zero_weight_nodes: HashSet<NodeId>,
+    }
+
+    impl SCPDriver for ZeroWeightDriver {
+        fn validate_value(
+            &self,
+            _slot_index: u64,
+            _value: &Value,
+            _nomination: bool,
+        ) -> ValidationLevel {
+            ValidationLevel::FullyValidated
+        }
+
+        fn combine_candidates(&self, _slot_index: u64, candidates: &[Value]) -> Option<Value> {
+            candidates.first().cloned()
+        }
+
+        fn extract_valid_value(&self, _slot_index: u64, value: &Value) -> Option<Value> {
+            Some(value.clone())
+        }
+
+        fn emit_envelope(&self, _envelope: &ScpEnvelope) {}
+
+        fn get_quorum_set(&self, _node_id: &NodeId) -> Option<ScpQuorumSet> {
+            Some(self.quorum_set.clone())
+        }
+
+        fn nominating_value(&self, _slot_index: u64, _value: &Value) {}
+        fn value_externalized(&self, _slot_index: u64, _value: &Value) {}
+        fn ballot_did_prepare(&self, _slot_index: u64, _ballot: &ScpBallot) {}
+        fn ballot_did_confirm(&self, _slot_index: u64, _ballot: &ScpBallot) {}
+
+        fn get_node_weight(
+            &self,
+            node_id: &NodeId,
+            quorum_set: &ScpQuorumSet,
+            is_local: bool,
+        ) -> u64 {
+            if self.zero_weight_nodes.contains(node_id) {
+                return 0;
+            }
+            crate::driver::base_get_node_weight(node_id, quorum_set, is_local)
+        }
+
+        fn compute_hash_node(
+            &self,
+            _slot_index: u64,
+            _prev_value: &Value,
+            is_priority: bool,
+            round: u32,
+            node_id: &NodeId,
+        ) -> u64 {
+            let seed = match &node_id.0 {
+                PublicKey::PublicKeyTypeEd25519(Uint256(bytes)) => bytes[0] as u64,
+            };
+            if is_priority {
+                let h = (seed
+                    .wrapping_mul(7919)
+                    .wrapping_add((round as u64).wrapping_mul(104729)))
+                    % 100_000;
+                h + 1
+            } else {
+                1
+            }
+        }
+
+        fn compute_value_hash(
+            &self,
+            _slot_index: u64,
+            _prev_value: &Value,
+            _round: u32,
+            value: &Value,
+        ) -> u64 {
+            value.iter().map(|b| *b as u64).sum()
+        }
+
+        fn compute_timeout(&self, _round: u32, _is_nomination: bool) -> Duration {
+            Duration::from_millis(1)
+        }
+
+        fn sign_envelope(&self, _envelope: &mut ScpEnvelope) {}
+        fn verify_envelope(&self, _envelope: &ScpEnvelope) -> bool {
+            true
+        }
+        fn stop_timer(&self, _slot_index: u64, _timer_type: crate::driver::SCPTimerType) {}
+        fn has_upgrades(&self, _value: &Value) -> bool {
+            false
+        }
+        fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
+            None
+        }
+        fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+            u32::MAX
+        }
+    }
+
+    #[test]
+    fn test_round_leaders_exclude_zero_weight_validators() {
+        // Create a quorum set with 4 nodes: node0 (local), node1, node2, node3
+        // node2 and node3 have zero weight — they should never become leaders.
+        let node0 = make_node_id(0);
+        let node1 = make_node_id(1);
+        let node2 = make_node_id(2);
+        let node3 = make_node_id(3);
+
+        let quorum_set = make_quorum_set(
+            vec![node0.clone(), node1.clone(), node2.clone(), node3.clone()],
+            2,
+        );
+
+        let mut zero_weight_nodes = HashSet::new();
+        zero_weight_nodes.insert(node2.clone());
+        zero_weight_nodes.insert(node3.clone());
+
+        let driver = Arc::new(ZeroWeightDriver {
+            quorum_set: quorum_set.clone(),
+            zero_weight_nodes,
+        });
+
+        let mut nom = NominationProtocol::new();
+        nom.set_previous_value_for_test(Some(make_value(&[0])));
+
+        let prev = make_value(&[0]);
+        let ctx = ctx!(&node0, &quorum_set, &driver, 1);
+
+        nom.update_round_leaders_for_test(&ctx, &prev);
+
+        let leaders = nom.get_round_leaders();
+        // Zero-weight nodes must not appear as leaders
+        assert!(
+            !leaders.contains(&node2),
+            "zero-weight node2 must not be a leader"
+        );
+        assert!(
+            !leaders.contains(&node3),
+            "zero-weight node3 must not be a leader"
+        );
+        // At least one non-zero-weight node should be a leader
+        assert!(
+            leaders.contains(&node0) || leaders.contains(&node1),
+            "at least one non-zero-weight node should be a leader"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "updateRoundLeaders appears to be stuck in an infinite loop")]
+    fn test_round_leaders_abort_after_1000_no_progress_iterations() {
+        // Setup: a driver that always returns the same leader (node1) regardless of round.
+        // Pre-seed round_leaders with node1 so no progress is ever made.
+        // max_leader_count > 1, so the loop tries to find more leaders but can't.
+        let node0 = make_node_id(0);
+        let node1 = make_node_id(1);
+        let node2 = make_node_id(2);
+
+        let quorum_set = make_quorum_set(vec![node0.clone(), node1.clone(), node2.clone()], 2);
+
+        // Give node2 zero weight so max_leader_count = 2 (node0 + node1).
+        // Pre-seed leaders with both, except we need to make the loop think there's
+        // one more to find. Actually let's give all nodes non-zero weight (max=3)
+        // but make the priority function always return the same winner.
+        // We'll use a driver where compute_hash_node always returns the same value
+        // for all nodes so they always tie, but then use a special driver that
+        // makes only node1 ever win by always inserting only node1.
+        //
+        // Simpler approach: give all 3 nodes non-zero weight (max_leader_count=3),
+        // pre-seed round_leaders with {node1} (size=1 < 3), and use a driver
+        // where only node1 ever gets priority. This ensures the loop never
+        // adds new leaders.
+
+        // A driver where only node1 gets non-zero priority
+        struct StuckDriver {
+            quorum_set: ScpQuorumSet,
+            stuck_leader: NodeId,
+        }
+
+        impl SCPDriver for StuckDriver {
+            fn validate_value(&self, _: u64, _: &Value, _: bool) -> ValidationLevel {
+                ValidationLevel::FullyValidated
+            }
+            fn combine_candidates(&self, _: u64, c: &[Value]) -> Option<Value> {
+                c.first().cloned()
+            }
+            fn extract_valid_value(&self, _: u64, v: &Value) -> Option<Value> {
+                Some(v.clone())
+            }
+            fn emit_envelope(&self, _: &ScpEnvelope) {}
+            fn get_quorum_set(&self, _: &NodeId) -> Option<ScpQuorumSet> {
+                Some(self.quorum_set.clone())
+            }
+            fn nominating_value(&self, _: u64, _: &Value) {}
+            fn value_externalized(&self, _: u64, _: &Value) {}
+            fn ballot_did_prepare(&self, _: u64, _: &ScpBallot) {}
+            fn ballot_did_confirm(&self, _: u64, _: &ScpBallot) {}
+            fn get_node_weight(&self, _: &NodeId, _: &ScpQuorumSet, _: bool) -> u64 {
+                // All nodes have non-zero weight (so max_leader_count = all nodes)
+                u64::MAX / 2
+            }
+            fn compute_hash_node(
+                &self,
+                _: u64,
+                _: &Value,
+                is_priority: bool,
+                _round: u32,
+                node_id: &NodeId,
+            ) -> u64 {
+                if !is_priority {
+                    // Weight check: return 1, always <= u64::MAX/2
+                    return 1;
+                }
+                // Only the stuck_leader gets high priority
+                if node_id == &self.stuck_leader {
+                    1000
+                } else {
+                    500
+                }
+            }
+            fn compute_value_hash(&self, _: u64, _: &Value, _: u32, v: &Value) -> u64 {
+                v.iter().map(|b| *b as u64).sum()
+            }
+            fn compute_timeout(&self, _: u32, _: bool) -> Duration {
+                Duration::from_millis(1)
+            }
+            fn sign_envelope(&self, _: &mut ScpEnvelope) {}
+            fn verify_envelope(&self, _: &ScpEnvelope) -> bool {
+                true
+            }
+            fn stop_timer(&self, _: u64, _: crate::driver::SCPTimerType) {}
+            fn has_upgrades(&self, _: &Value) -> bool {
+                false
+            }
+            fn strip_all_upgrades(&self, _: &Value) -> Option<Value> {
+                None
+            }
+            fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+                u32::MAX
+            }
+        }
+
+        let driver = Arc::new(StuckDriver {
+            quorum_set: quorum_set.clone(),
+            stuck_leader: node1.clone(),
+        });
+
+        let mut nom = NominationProtocol::new();
+        nom.set_previous_value_for_test(Some(make_value(&[0])));
+        // Pre-seed with node1 so the loop makes no progress (node1 always wins again)
+        let mut initial_leaders = BTreeSet::new();
+        initial_leaders.insert(node1.clone());
+        nom.set_round_leaders_for_test(initial_leaders);
+
+        let prev = make_value(&[0]);
+        let ctx = ctx!(&node0, &quorum_set, &driver, 1);
+
+        // This should panic after 1000 iterations
+        nom.update_round_leaders_for_test(&ctx, &prev);
     }
 }


### PR DESCRIPTION
Closes #2801

## Summary

Resolves the 4 SCP spec adherence findings reported in #2801:

2. **§8.2 round-leader election** — ports upstream `updateRoundLeaders()` logic: only counts non-zero-weight nodes toward `max_leader_count`, adds 1000-iteration defensive cap (panic on exhaustion).
3. **Dangling spec anchor** — corrects `§9.13` → `§10.4` in `set_state_from_envelope`.
4. **Spec anchor backfill** — adds `// Spec:` breadcrumbs at `advance_slot`, `nominate`, `federated_accept`, `federated_ratify`, `update_round_leaders`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2801)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-scp -- -D warnings
- [x] cargo test -p henyey-scp (547 tests pass, including 4 new)

## New test coverage

- `ballot::tests::test_advance_slot_clears_commit_when_prepare_accepts_incompatible_prepared`
- `ballot::tests::test_attempt_accept_prepared_confirm_phase_rejects_incompatible_candidate`
- `nomination::tests::test_round_leaders_exclude_zero_weight_validators`
- `nomination::tests::test_round_leaders_abort_after_1000_no_progress_iterations`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)