### PR TITLE
Instrument soroban_state Arc strong_count for diagnostic

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2188,6 +2188,10 @@ impl App {
                 .record(us_to_secs(perf.bucket_lock_wait_us));
             crate::metrics::CLOSE_EVICTION_SECONDS.record(us_to_secs(perf.eviction_us));
             crate::metrics::CLOSE_SOROBAN_STATE_SECONDS.record(us_to_secs(perf.soroban_state_us));
+            crate::metrics::CLOSE_SOROBAN_STATE_DATA_ARC_COUNT
+                .record(perf.soroban_state_data_arc_count as f64);
+            crate::metrics::CLOSE_SOROBAN_STATE_CODE_ARC_COUNT
+                .record(perf.soroban_state_code_arc_count as f64);
             crate::metrics::CLOSE_BUCKET_ADD_SECONDS.record(us_to_secs(perf.add_batch_us));
             crate::metrics::CLOSE_HOT_ARCHIVE_SECONDS.record(us_to_secs(perf.hot_archive_us));
             crate::metrics::CLOSE_HEADER_SECONDS.record(us_to_secs(perf.header_us));

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -802,6 +802,10 @@ metric_catalog! {
             => "Ledger close eviction phase (seconds)";
         CLOSE_SOROBAN_STATE_SECONDS = "henyey_ledger_close_soroban_state_seconds"
             => "Ledger close soroban_state phase (seconds)";
+        CLOSE_SOROBAN_STATE_DATA_ARC_COUNT = "henyey_ledger_close_soroban_state_data_arc_refs"
+            => "Arc strong_count for contract_data_entries at start of soroban_state phase";
+        CLOSE_SOROBAN_STATE_CODE_ARC_COUNT = "henyey_ledger_close_soroban_state_code_arc_refs"
+            => "Arc strong_count for contract_code_entries at start of soroban_state phase";
         CLOSE_BUCKET_ADD_SECONDS = "henyey_ledger_close_bucket_add_seconds"
             => "Ledger close bucket_add phase (seconds)";
         CLOSE_HOT_ARCHIVE_SECONDS = "henyey_ledger_close_hot_archive_seconds"
@@ -1339,6 +1343,9 @@ const SCP_RELAY_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0,
 ];
 
+/// Arc strong_count bucket boundaries for soroban_state diagnostics.
+const SOROBAN_ARC_COUNT_BUCKETS: &[f64] = &[1.0, 2.0, 3.0, 5.0, 10.0];
+
 /// Configure all histogram bucket overrides on a `PrometheusBuilder`.
 ///
 /// Shared between `install_recorder()` and `ensure_test_recorder()` so that
@@ -1427,6 +1434,17 @@ fn configure_histogram_buckets(builder: PrometheusBuilder) -> PrometheusBuilder 
             SCP_RELAY_BUCKETS,
         )
         .expect("valid scp relay histogram buckets")
+        // Soroban state Arc strong_count histograms (issue #2810).
+        .set_buckets_for_metric(
+            Matcher::Full(CLOSE_SOROBAN_STATE_DATA_ARC_COUNT.to_string()),
+            SOROBAN_ARC_COUNT_BUCKETS,
+        )
+        .expect("valid soroban state data arc count histogram buckets")
+        .set_buckets_for_metric(
+            Matcher::Full(CLOSE_SOROBAN_STATE_CODE_ARC_COUNT.to_string()),
+            SOROBAN_ARC_COUNT_BUCKETS,
+        )
+        .expect("valid soroban state code arc count histogram buckets")
 }
 
 // ── Test helper ────────────────────────────────────────────────────────
@@ -2579,6 +2597,47 @@ mod tests {
                 "dashboard JSON files reference unknown metrics:\n  {}",
                 unknown.join("\n  ")
             );
+        }
+    }
+
+    /// Verify soroban state Arc-count histograms render with custom [1, 2, 3, 5, 10] buckets.
+    #[test]
+    fn test_soroban_state_arc_count_histograms_custom_buckets_rendered() {
+        let recorder = configure_histogram_buckets(PrometheusBuilder::new()).build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            CLOSE_SOROBAN_STATE_DATA_ARC_COUNT.record(2.0);
+            CLOSE_SOROBAN_STATE_CODE_ARC_COUNT.record(1.0);
+        });
+
+        let output = handle.render();
+
+        for metric in &[
+            CLOSE_SOROBAN_STATE_DATA_ARC_COUNT,
+            CLOSE_SOROBAN_STATE_CODE_ARC_COUNT,
+        ] {
+            let name = metric.name();
+            for boundary in &["1", "2", "3", "5", "10"] {
+                let needle = format!("{}_bucket{{le=\"{}\"}}", name, boundary);
+                assert!(
+                    output.contains(&needle),
+                    "missing custom bucket boundary `{}` for metric `{}`.\nOutput:\n{}",
+                    needle,
+                    name,
+                    output,
+                );
+            }
+            // Default-only boundaries must be absent.
+            for absent in &["0.001", "0.005", "0.01", "0.05", "0.1", "0.5", "30"] {
+                let absent_needle = format!("{}_bucket{{le=\"{}\"}}", name, absent);
+                assert!(
+                    !output.contains(&absent_needle),
+                    "default-only boundary `{}` should NOT appear for metric `{}`",
+                    absent_needle,
+                    name,
+                );
+            }
         }
     }
 }

--- a/crates/ledger/src/close.rs
+++ b/crates/ledger/src/close.rs
@@ -1063,6 +1063,12 @@ pub struct LedgerClosePerf {
     pub soroban_stage_count: usize,
     /// Maximum number of clusters in any single stage (0 if no Soroban phase).
     pub soroban_max_cluster_count: usize,
+
+    /// Arc strong_count for the contract data map at the start of soroban_state phase.
+    /// A value >1 indicates make_mut will deep-clone.
+    pub soroban_state_data_arc_count: usize,
+    /// Arc strong_count for the contract code map at the start of soroban_state phase.
+    pub soroban_state_code_arc_count: usize,
 }
 
 impl std::ops::AddAssign<&LedgerClosePerf> for LedgerClosePerf {
@@ -1087,6 +1093,8 @@ impl std::ops::AddAssign<&LedgerClosePerf> for LedgerClosePerf {
         self.fee_pre_deduct_us += rhs.fee_pre_deduct_us;
         self.post_exec_us += rhs.post_exec_us;
         self.tx_count += rhs.tx_count;
+        self.soroban_state_data_arc_count += rhs.soroban_state_data_arc_count;
+        self.soroban_state_code_arc_count += rhs.soroban_state_code_arc_count;
         // soroban_stage_count and soroban_max_cluster_count are per-close
         // (not cumulative), so take the latest rather than summing.
     }
@@ -1991,5 +1999,30 @@ mod tests {
             std::cmp::Ordering::Greater,
             "Test requires that sorting would reverse cluster order"
         );
+    }
+
+    #[test]
+    fn test_ledger_close_perf_add_assign_accumulates_soroban_arc_counts() {
+        let mut agg = LedgerClosePerf::default();
+        assert_eq!(agg.soroban_state_data_arc_count, 0);
+        assert_eq!(agg.soroban_state_code_arc_count, 0);
+
+        let perf1 = LedgerClosePerf {
+            soroban_state_data_arc_count: 2,
+            soroban_state_code_arc_count: 1,
+            ..Default::default()
+        };
+        agg += &perf1;
+        assert_eq!(agg.soroban_state_data_arc_count, 2);
+        assert_eq!(agg.soroban_state_code_arc_count, 1);
+
+        let perf2 = LedgerClosePerf {
+            soroban_state_data_arc_count: 3,
+            soroban_state_code_arc_count: 5,
+            ..Default::default()
+        };
+        agg += &perf2;
+        assert_eq!(agg.soroban_state_data_arc_count, 5);
+        assert_eq!(agg.soroban_state_code_arc_count, 6);
     }
 }

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -4917,6 +4917,8 @@ impl LedgerCloseContext<'_> {
             hot_archive_us,
             bg_eviction_data,
             evicted_meta_keys,
+            soroban_state_data_arc_count,
+            soroban_state_code_arc_count,
         ) = {
             let lock_wait_start = std::time::Instant::now();
             let mut bucket_list = self.manager.bucket_list.write();
@@ -5216,6 +5218,24 @@ impl LedgerCloseContext<'_> {
             // Update in-memory Soroban state with changes from this ledger.
             // This happens AFTER computing state size window (see comment above).
             let soroban_state_start = std::time::Instant::now();
+
+            // Diagnostic: sample Arc strong_count BEFORE any make_mut call.
+            // A count >1 means make_mut will deep-clone the map.
+            let (soroban_state_data_arc_count, soroban_state_code_arc_count) = {
+                let soroban_state_read = self.manager.soroban_state.read();
+                soroban_state_read.arc_strong_counts()
+            };
+            let dirty_entry_count = init_entries.len() + live_entries.len() + dead_entries.len();
+            tracing::debug!(
+                ledger_seq = self.close_data.ledger_seq,
+                data_arc_count = soroban_state_data_arc_count,
+                code_arc_count = soroban_state_code_arc_count,
+                data_count = self.manager.soroban_state.read().contract_data_count(),
+                code_count = self.manager.soroban_state.read().contract_code_count(),
+                dirty_entry_count,
+                "soroban_state phase: pre-mutation Arc diagnostics"
+            );
+
             // Gate on prev_version (initialLedgerVers): on the upgrade ledger, the
             // in-memory Soroban state update via this path does NOT run.
             if prev_version >= henyey_common::MIN_SOROBAN_PROTOCOL_VERSION {
@@ -5502,6 +5522,8 @@ impl LedgerCloseContext<'_> {
                 hot_archive_us,
                 bg_eviction_data,
                 evicted_meta_keys,
+                soroban_state_data_arc_count,
+                soroban_state_code_arc_count,
             )
         };
 
@@ -5905,6 +5927,8 @@ impl LedgerCloseContext<'_> {
             rss_after_bytes: rss_after,
             soroban_stage_count: self.soroban_stage_count,
             soroban_max_cluster_count: self.soroban_max_cluster_count,
+            soroban_state_data_arc_count,
+            soroban_state_code_arc_count,
         };
 
         Ok(LedgerCloseResult::new(new_header, header_hash)

--- a/crates/ledger/src/soroban_state.rs
+++ b/crates/ledger/src/soroban_state.rs
@@ -420,6 +420,17 @@ impl InMemorySorobanState {
         self.contract_code_entries.len()
     }
 
+    /// Get the `Arc::strong_count` for the data and code maps.
+    ///
+    /// Returns `(data_arc_count, code_arc_count)`. A count of 1 means
+    /// `Arc::make_mut` can mutate in-place; >1 means a deep clone will occur.
+    pub fn arc_strong_counts(&self) -> (usize, usize) {
+        (
+            Arc::strong_count(&self.contract_data_entries),
+            Arc::strong_count(&self.contract_code_entries),
+        )
+    }
+
     /// Get the total contract data state size in bytes.
     pub fn contract_data_state_size(&self) -> i64 {
         self.contract_data_state_size
@@ -1960,5 +1971,51 @@ mod tests {
 
         // Snapshot still unchanged
         assert_eq!(snap.contract_data_state_size(), snap_data_size);
+    }
+
+    #[test]
+    fn test_arc_strong_counts_tracks_snapshot_sharing() {
+        let mut state = InMemorySorobanState::new();
+        state.set_last_closed_ledger_seq(100);
+
+        // Fresh state: sole owner of both Arcs.
+        let (data_count, code_count) = state.arc_strong_counts();
+        assert_eq!(data_count, 1, "fresh state data arc should have count 1");
+        assert_eq!(code_count, 1, "fresh state code arc should have count 1");
+
+        // Insert some data so the maps are non-trivial.
+        let data1 = make_contract_data_entry([10u8; 32]);
+        let code1 = make_contract_code_entry([20u8; 32]);
+        state.process_entry_create(&data1, 25, None).unwrap();
+        state.process_entry_create(&code1, 25, None).unwrap();
+
+        // Still sole owner.
+        let (data_count, code_count) = state.arc_strong_counts();
+        assert_eq!(data_count, 1);
+        assert_eq!(code_count, 1);
+
+        // Take a snapshot — now both Arcs are shared.
+        let _snap = state.snapshot();
+        let (data_count, code_count) = state.arc_strong_counts();
+        assert_eq!(data_count, 2, "snapshot should increment data arc count");
+        assert_eq!(code_count, 2, "snapshot should increment code arc count");
+
+        // Take another snapshot — triple sharing.
+        let _snap2 = state.snapshot();
+        let (data_count, code_count) = state.arc_strong_counts();
+        assert_eq!(data_count, 3);
+        assert_eq!(code_count, 3);
+
+        // Drop one snapshot — back to double.
+        drop(_snap);
+        let (data_count, code_count) = state.arc_strong_counts();
+        assert_eq!(data_count, 2);
+        assert_eq!(code_count, 2);
+
+        // Drop the last snapshot — sole owner again.
+        drop(_snap2);
+        let (data_count, code_count) = state.arc_strong_counts();
+        assert_eq!(data_count, 1);
+        assert_eq!(code_count, 1);
     }
 }


### PR DESCRIPTION
Closes #2810

## Summary

Adds diagnostic-only instrumentation to measure the Arc strong_count on the soroban_state contract_data and contract_code maps at the start of the soroban_state close phase. When strong_count > 1, `Arc::make_mut` will deep-clone the entire map — this instrumentation identifies which holder is responsible for the residual latency spikes observed post-#1912.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2810#issuecomment-4483462226)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-ledger -p henyey-app -- -D warnings
- [x] cargo test -p henyey-ledger -p henyey-app passes

## Changes

- `crates/ledger/src/soroban_state.rs` — new `arc_strong_counts()` accessor + unit test
- `crates/ledger/src/close.rs` — new `soroban_state_data_arc_count` / `code_arc_count` fields in `LedgerClosePerf`, updated `AddAssign` + unit test
- `crates/ledger/src/manager.rs` — sample arc counts before soroban_state mutations, `debug!` log with diagnostics, carry through perf struct
- `crates/app/src/metrics.rs` — register `henyey_ledger_close_soroban_state_data_arc_refs` and `…_code_arc_refs` histograms with custom [1, 2, 3, 5, 10] buckets + unit test
- `crates/app/src/app/ledger_close.rs` — record new histograms from `result.perf`

## Deviations from plan

- Metric names use `_arc_refs` suffix instead of `_arc_count` because Prometheus forbids histogram base names ending in `_count` (reserved suffix for histogram exposition format).
- Skipped the app-side `test_handle_close_complete_records_soroban_arc_count_histograms` test — the existing `test_all_histograms_described_and_recorded` already verifies all catalog histograms are properly rendered, providing equivalent coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)