### PR TITLE
Implement future-slot timer reschedule (§5.4-2)

### DIFF
--- a/crates/app/src/app/close.rs
+++ b/crates/app/src/app/close.rs
@@ -112,6 +112,11 @@ impl SyncRecoveryCallback for App {
         self.lost_sync_count.fetch_add(1, Ordering::Relaxed);
         // Update herder state to syncing
         self.herder.set_state(henyey_herder::HerderState::Syncing);
+        // Cancel all outstanding SCP timers — they belong to the previous
+        // tracking epoch and must not fire after sync loss. Without this,
+        // stale ballot/nomination timers would execute their timeout handlers
+        // (e.g. bump_ballot) against an outdated consensus state.
+        self.timer_manager_handle.cancel_all_timers_nonblocking();
         // Tell the overlay we're no longer tracking so it can rotate peers.
         if let Some(flag) = self.overlay_tracking.lock().unwrap().as_ref() {
             flag.store(false, Ordering::Relaxed);

--- a/crates/app/src/app/close.rs
+++ b/crates/app/src/app/close.rs
@@ -112,6 +112,11 @@ impl SyncRecoveryCallback for App {
         self.lost_sync_count.fetch_add(1, Ordering::Relaxed);
         // Update herder state to syncing
         self.herder.set_state(henyey_herder::HerderState::Syncing);
+        // Advance the timer epoch so that any ScpTimerEvents already queued in
+        // scp_timer_rx (from the prior tracking epoch) will be discarded by
+        // handle_scp_timer_event(). This closes the race window where
+        // cancel_all_timers_nonblocking() cannot retract already-sent events.
+        self.scp_timer_epoch.fetch_add(1, Ordering::Release);
         // Cancel all outstanding SCP timers — they belong to the previous
         // tracking epoch and must not fire after sync loss. Without this,
         // stale ballot/nomination timers would execute their timeout handlers

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -111,6 +111,40 @@ pub(super) fn should_delay_checkpoint(checkpoint: u64, first_sequential_ledger: 
     checkpoint < first_sequential_ledger
 }
 
+/// The action to take when an SCP timer event fires.
+///
+/// Pure classification of the three-way split from stellar-core's
+/// `HerderSCPDriver::timerCallbackWrapper`: old-slot timers are dropped,
+/// future-slot timers are re-armed at 1 second while tracking, and
+/// current-slot timers fire immediately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TimerEventAction {
+    /// Old-slot timer — discard without re-arming.
+    Drop,
+    /// Future-slot timer while tracking — re-arm with 1-second delay.
+    Rearm,
+    /// Current slot or non-tracking — execute the timeout handler.
+    Fire,
+}
+
+/// Classify a timer event into an action based on the event's slot, the next
+/// consensus slot, and whether the herder is currently tracking.
+///
+/// Spec: HERDER_SPEC §5.4-2 (future-slot timer reschedule).
+pub(super) fn classify_timer_event(
+    event_slot: u64,
+    next_consensus_slot: u64,
+    is_tracking: bool,
+) -> TimerEventAction {
+    if event_slot < next_consensus_slot {
+        TimerEventAction::Drop
+    } else if event_slot > next_consensus_slot && is_tracking {
+        TimerEventAction::Rearm
+    } else {
+        TimerEventAction::Fire
+    }
+}
+
 impl App {
     /// Try to trigger consensus for the next ledger.
     ///
@@ -1349,33 +1383,53 @@ impl App {
             return;
         }
 
-        // Staleness guard: compute the active slot exactly as the old
-        // check_scp_timeouts did (consensus.rs:1157-1158).
-        let current_ledger = self.current_ledger_seq() as u64;
-        let active_slot = self.herder.tracking_slot().get().max(current_ledger + 1);
-        if event.slot != active_slot {
-            // Stale event — slot advanced past this timer
-            return;
-        }
+        let next_slot = self.herder.next_consensus_ledger_index().get();
+        let action = classify_timer_event(event.slot, next_slot, self.herder.is_tracking());
 
-        // Fire the timeout handler, preserving counters and spawn_blocking
-        // for nomination (parity with the removed check_scp_timeouts).
-        match event.timer_type {
-            henyey_herder::TimerType::Nomination => {
-                self.nomination_timeout_fires
-                    .fetch_add(1, Ordering::Relaxed);
-                let outcome = self
-                    .herder
-                    .handle_nomination_timeout_blocking(event.slot)
-                    .await;
-                if matches!(outcome, henyey_herder::TimeoutOutcome::SkippedStale) {
-                    self.nomination_timeout_skipped_stale
-                        .fetch_add(1, Ordering::Relaxed);
+        match action {
+            TimerEventAction::Drop => {
+                // Stale old-slot timer — drop without re-arming.
+                // Spec: HERDER_SPEC §5.4-2: old-slot timers are discarded.
+            }
+            TimerEventAction::Rearm => {
+                // Future-slot timer while tracking — re-arm for 1 second.
+                // Spec: HERDER_SPEC §5.4-2: stellar-core's timerCallbackWrapper
+                // defers future-slot timer callbacks by re-scheduling them at a
+                // 1-second interval until the slot becomes current.
+                let one_second = std::time::Duration::from_secs(1);
+                match event.timer_type {
+                    henyey_herder::TimerType::Nomination => {
+                        self.timer_manager_handle
+                            .schedule_nomination_timeout(event.slot, one_second)
+                            .await;
+                    }
+                    henyey_herder::TimerType::Ballot => {
+                        self.timer_manager_handle
+                            .schedule_ballot_timeout(event.slot, one_second)
+                            .await;
+                    }
                 }
             }
-            henyey_herder::TimerType::Ballot => {
-                self.ballot_timeout_fires.fetch_add(1, Ordering::Relaxed);
-                self.herder.handle_ballot_timeout(event.slot);
+            TimerEventAction::Fire => {
+                // Current slot or non-tracking — execute the timeout handler.
+                match event.timer_type {
+                    henyey_herder::TimerType::Nomination => {
+                        self.nomination_timeout_fires
+                            .fetch_add(1, Ordering::Relaxed);
+                        let outcome = self
+                            .herder
+                            .handle_nomination_timeout_blocking(event.slot)
+                            .await;
+                        if matches!(outcome, henyey_herder::TimeoutOutcome::SkippedStale) {
+                            self.nomination_timeout_skipped_stale
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                    henyey_herder::TimerType::Ballot => {
+                        self.ballot_timeout_fires.fetch_add(1, Ordering::Relaxed);
+                        self.herder.handle_ballot_timeout(event.slot);
+                    }
+                }
             }
         }
     }
@@ -2016,5 +2070,67 @@ mod tests {
     #[test]
     fn test_should_delay_checkpoint_first_checkpoint_behind() {
         assert!(should_delay_checkpoint(1, 5));
+    }
+
+    // ── TimerEventAction / classify_timer_event tests ────────────────────
+
+    use super::{classify_timer_event, TimerEventAction};
+
+    /// Future-slot nomination timer while tracking → Rearm (1-second defer).
+    /// Spec: HERDER_SPEC §5.4-2.
+    #[test]
+    fn test_handle_scp_timer_event_reschedules_future_nomination_by_one_second() {
+        // next_slot = 100, event_slot = 105, tracking = true → Rearm
+        assert_eq!(
+            classify_timer_event(105, 100, true),
+            TimerEventAction::Rearm
+        );
+    }
+
+    /// Future-slot ballot timer while tracking → Rearm (1-second defer).
+    /// Spec: HERDER_SPEC §5.4-2.
+    #[test]
+    fn test_handle_scp_timer_event_reschedules_future_ballot_by_one_second() {
+        // next_slot = 50, event_slot = 51, tracking = true → Rearm
+        assert_eq!(classify_timer_event(51, 50, true), TimerEventAction::Rearm);
+    }
+
+    /// Old-slot timer → Drop without re-arming.
+    #[test]
+    fn test_handle_scp_timer_event_drops_old_slot_without_rearm() {
+        // next_slot = 100, event_slot = 99 → Drop
+        assert_eq!(classify_timer_event(99, 100, true), TimerEventAction::Drop);
+        assert_eq!(classify_timer_event(99, 100, false), TimerEventAction::Drop);
+        // Far behind
+        assert_eq!(classify_timer_event(1, 100, true), TimerEventAction::Drop);
+    }
+
+    /// Current-slot timer → Fire immediately regardless of tracking state.
+    #[test]
+    fn test_classify_timer_event_current_slot_fires() {
+        assert_eq!(classify_timer_event(100, 100, true), TimerEventAction::Fire);
+        assert_eq!(
+            classify_timer_event(100, 100, false),
+            TimerEventAction::Fire
+        );
+    }
+
+    /// Future-slot timer while NOT tracking → Fire (don't enter defer loop).
+    #[test]
+    fn test_classify_timer_event_future_slot_not_tracking_fires() {
+        // Not tracking: even future-slot events should fire, not rearm.
+        assert_eq!(
+            classify_timer_event(105, 100, false),
+            TimerEventAction::Fire
+        );
+    }
+
+    /// Edge case: event_slot == next_slot + 1 while tracking → Rearm (just barely future).
+    #[test]
+    fn test_classify_timer_event_one_ahead_tracking_rearms() {
+        assert_eq!(
+            classify_timer_event(101, 100, true),
+            TimerEventAction::Rearm
+        );
     }
 }

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -1397,8 +1397,15 @@ impl App {
 
         match action {
             TimerEventAction::Drop => {
-                // Stale old-slot timer — drop without re-arming.
-                // Spec: HERDER_SPEC §5.4-2: old-slot timers are discarded.
+                // Stale old-slot timer — cancel all timers for this slot.
+                // Parity: stellar-core's timerCallbackWrapper routes mismatched
+                // slots through setupTimer(), which erases the entire slot's
+                // timer set when slotIndex <= trackingConsensusLedgerIndex().
+                // This ensures sibling timers for the same stale slot are also
+                // cleaned up rather than firing later.
+                self.timer_manager_handle
+                    .cancel_slot_timers(event.slot)
+                    .await;
             }
             TimerEventAction::Rearm => {
                 // Future-slot timer while tracking — re-arm for 1 second.
@@ -2329,6 +2336,66 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "no timer event should be re-delivered for a dropped old-slot timer"
+        );
+    }
+
+    /// End-to-end: old-slot timer cancels sibling timers for the same slot.
+    ///
+    /// Parity: stellar-core's setupTimer() erases the entire slot's timer set
+    /// when slotIndex <= trackingConsensusLedgerIndex(). This test verifies
+    /// that when an old-slot timer fires through the Drop path, any
+    /// previously-scheduled sibling timer for the same slot is also cancelled.
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_e2e_old_slot_cancels_sibling_timers() {
+        let (_dir, app) = mk_validator_app().await;
+
+        // Bootstrap at ledger 1 → next_slot = 2, tracking
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+        assert_eq!(app.herder.next_consensus_ledger_index().get(), 2);
+
+        // Schedule a ballot timer for slot 3 (currently a future slot) via the
+        // Rearm path. This simulates a ballot timer that was deferred.
+        let slot = 3u64;
+        app.timer_manager_handle
+            .schedule_ballot_timeout(slot, std::time::Duration::from_secs(2))
+            .await;
+
+        // Yield to let the timer manager process the schedule command
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Now advance herder so slot 3 becomes an old slot (bootstrap at 5 →
+        // next_slot = 6, so slot 3 < 6).
+        app.herder.bootstrap(5);
+        assert_eq!(app.herder.next_consensus_ledger_index().get(), 6);
+        assert!(app.herder.is_tracking());
+
+        // Fire a nomination timer event for the now-old slot 3.
+        // This should hit the Drop path AND cancel all timers for slot 3.
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot,
+            timer_type: henyey_herder::TimerType::Nomination,
+        };
+        app.handle_scp_timer_event(event).await;
+
+        // Yield to let cancel propagate
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Advance time well past the 2-second ballot timer and verify it was
+        // cancelled — no timer event should arrive from the sibling ballot.
+        let mut rx = app.scp_timer_rx.lock().await;
+        tokio::time::advance(std::time::Duration::from_secs(5)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            rx.try_recv().is_err(),
+            "sibling ballot timer for the old slot must be cancelled"
         );
     }
 }

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -2088,7 +2088,7 @@ mod tests {
     /// Future-slot nomination timer while tracking → Rearm (1-second defer).
     /// Spec: HERDER_SPEC §5.4-2.
     #[test]
-    fn test_handle_scp_timer_event_reschedules_future_nomination_by_one_second() {
+    fn test_classify_timer_event_future_nomination_tracking_rearms() {
         // next_slot = 100, event_slot = 105, tracking = true → Rearm
         assert_eq!(
             classify_timer_event(105, 100, true),
@@ -2099,14 +2099,14 @@ mod tests {
     /// Future-slot ballot timer while tracking → Rearm (1-second defer).
     /// Spec: HERDER_SPEC §5.4-2.
     #[test]
-    fn test_handle_scp_timer_event_reschedules_future_ballot_by_one_second() {
+    fn test_classify_timer_event_future_ballot_tracking_rearms() {
         // next_slot = 50, event_slot = 51, tracking = true → Rearm
         assert_eq!(classify_timer_event(51, 50, true), TimerEventAction::Rearm);
     }
 
     /// Old-slot timer while tracking → Drop without re-arming.
     #[test]
-    fn test_handle_scp_timer_event_drops_old_slot_without_rearm() {
+    fn test_classify_timer_event_old_slot_tracking_drops() {
         // next_slot = 100, event_slot = 99, tracking = true → Drop
         assert_eq!(classify_timer_event(99, 100, true), TimerEventAction::Drop);
         // Far behind, tracking
@@ -2149,6 +2149,186 @@ mod tests {
         assert_eq!(
             classify_timer_event(101, 100, true),
             TimerEventAction::Rearm
+        );
+    }
+
+    // ── End-to-end handle_scp_timer_event tests ─────────────────────────
+    //
+    // These exercise the full App::handle_scp_timer_event path including the
+    // timer_manager_handle scheduling and fire-counter side effects. Uses
+    // paused tokio time to verify exact 1-second rearm timing.
+
+    use super::super::App;
+    use std::sync::atomic::Ordering;
+
+    /// Helper: build a minimal validator App with paused-time-compatible config.
+    async fn mk_validator_app() -> (tempfile::TempDir, App) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("timer-event-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .validator(true)
+            .node_seed("SAFTEV5U6QDFE2DRMSD7HBE76XG7SQZJD6VIUTHIXTJGO77RUQYVURLA")
+            .build();
+        let app = App::new(config).await.unwrap();
+        (dir, app)
+    }
+
+    /// End-to-end: future-slot nomination timer while tracking is re-armed at
+    /// exactly 1 second and fires back through the timer bridge.
+    ///
+    /// Verifies:
+    /// - nomination_timeout_fires counter does NOT increment on the defer path
+    /// - the same timer type (nomination) is re-delivered after exactly 1 second
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_e2e_future_nomination_rearms_one_second() {
+        let (_dir, app) = mk_validator_app().await;
+
+        // Bootstrap herder at ledger 1 → tracking slot = 2, is_tracking = true
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+        let next_slot = app.herder.next_consensus_ledger_index().get();
+        assert_eq!(next_slot, 2);
+
+        // Inject a nomination timer event for a future slot (slot 5 > next_slot 2)
+        let future_slot = 5u64;
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: future_slot,
+            timer_type: henyey_herder::TimerType::Nomination,
+        };
+
+        let fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
+
+        app.handle_scp_timer_event(event).await;
+
+        // Fire counter must NOT have incremented (defer path, not fire path)
+        assert_eq!(
+            app.nomination_timeout_fires.load(Ordering::Relaxed),
+            fires_before,
+            "nomination_timeout_fires must not increment on the rearm path"
+        );
+
+        // Give the timer manager task a chance to receive and process the
+        // ScheduleNominationTimeout command before we advance time.
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // The timer manager should have scheduled a 1-second timeout.
+        // Advance time by just under 1 second — no event should arrive yet.
+        let mut rx = app.scp_timer_rx.lock().await;
+        tokio::time::advance(std::time::Duration::from_millis(999)).await;
+        // Yield multiple times to let the timer manager task process
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "timer must not fire before 1 second"
+        );
+
+        // Advance past the 1-second mark
+        tokio::time::advance(std::time::Duration::from_millis(2)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // The timer bridge should have delivered a new ScpTimerEvent
+        let redelivered = rx
+            .try_recv()
+            .expect("expected re-delivered nomination timer event");
+        assert_eq!(redelivered.slot, future_slot);
+        assert_eq!(redelivered.timer_type, henyey_herder::TimerType::Nomination);
+    }
+
+    /// End-to-end: future-slot ballot timer while tracking is re-armed at
+    /// exactly 1 second and fires back through the timer bridge.
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_e2e_future_ballot_rearms_one_second() {
+        let (_dir, app) = mk_validator_app().await;
+
+        app.herder.bootstrap(1);
+        let next_slot = app.herder.next_consensus_ledger_index().get();
+
+        // Future-slot ballot event
+        let future_slot = next_slot + 3;
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: future_slot,
+            timer_type: henyey_herder::TimerType::Ballot,
+        };
+
+        let fires_before = app.ballot_timeout_fires.load(Ordering::Relaxed);
+
+        app.handle_scp_timer_event(event).await;
+
+        // Fire counter must NOT have incremented
+        assert_eq!(
+            app.ballot_timeout_fires.load(Ordering::Relaxed),
+            fires_before,
+            "ballot_timeout_fires must not increment on the rearm path"
+        );
+
+        // Give the timer manager task a chance to process the schedule command
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Advance time past 1 second and verify the ballot timer re-fires
+        let mut rx = app.scp_timer_rx.lock().await;
+        tokio::time::advance(std::time::Duration::from_millis(1001)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        let redelivered = rx
+            .try_recv()
+            .expect("expected re-delivered ballot timer event");
+        assert_eq!(redelivered.slot, future_slot);
+        assert_eq!(redelivered.timer_type, henyey_herder::TimerType::Ballot);
+    }
+
+    /// End-to-end: old-slot timer while tracking is dropped — no re-arm occurs,
+    /// no fire counters advance, and no timer event is re-delivered.
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_e2e_old_slot_drops_without_rearm() {
+        let (_dir, app) = mk_validator_app().await;
+
+        app.herder.bootstrap(5);
+        let next_slot = app.herder.next_consensus_ledger_index().get();
+        assert_eq!(next_slot, 6);
+
+        // Old-slot nomination event (slot 3 < next_slot 6)
+        let old_slot = 3u64;
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: old_slot,
+            timer_type: henyey_herder::TimerType::Nomination,
+        };
+
+        let nom_fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
+        let ballot_fires_before = app.ballot_timeout_fires.load(Ordering::Relaxed);
+
+        app.handle_scp_timer_event(event).await;
+
+        // No fire counters should have incremented
+        assert_eq!(
+            app.nomination_timeout_fires.load(Ordering::Relaxed),
+            nom_fires_before,
+            "nomination_timeout_fires must not increment on the drop path"
+        );
+        assert_eq!(
+            app.ballot_timeout_fires.load(Ordering::Relaxed),
+            ballot_fires_before,
+            "ballot_timeout_fires must not increment on the drop path"
+        );
+
+        // Advance time well past any possible re-arm delay and verify nothing arrives
+        let mut rx = app.scp_timer_rx.lock().await;
+        tokio::time::advance(std::time::Duration::from_secs(5)).await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "no timer event should be re-delivered for a dropped old-slot timer"
         );
     }
 }

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -131,14 +131,23 @@ pub(super) enum TimerEventAction {
 /// consensus slot, and whether the herder is currently tracking.
 ///
 /// Spec: HERDER_SPEC §5.4-2 (future-slot timer reschedule).
+///
+/// Parity: stellar-core's `timerCallbackWrapper` only applies the slot-based
+/// defer/drop logic when `isTracking()` is true. When not tracking, all timer
+/// callbacks fire immediately regardless of slot relationship to
+/// `nextConsensusLedgerIndex()`.
 pub(super) fn classify_timer_event(
     event_slot: u64,
     next_consensus_slot: u64,
     is_tracking: bool,
 ) -> TimerEventAction {
-    if event_slot < next_consensus_slot {
+    if !is_tracking {
+        // Not tracking: fire immediately, matching stellar-core's
+        // timerCallbackWrapper fallthrough when !isTracking().
+        TimerEventAction::Fire
+    } else if event_slot < next_consensus_slot {
         TimerEventAction::Drop
-    } else if event_slot > next_consensus_slot && is_tracking {
+    } else if event_slot > next_consensus_slot {
         TimerEventAction::Rearm
     } else {
         TimerEventAction::Fire
@@ -2095,14 +2104,23 @@ mod tests {
         assert_eq!(classify_timer_event(51, 50, true), TimerEventAction::Rearm);
     }
 
-    /// Old-slot timer → Drop without re-arming.
+    /// Old-slot timer while tracking → Drop without re-arming.
     #[test]
     fn test_handle_scp_timer_event_drops_old_slot_without_rearm() {
-        // next_slot = 100, event_slot = 99 → Drop
+        // next_slot = 100, event_slot = 99, tracking = true → Drop
         assert_eq!(classify_timer_event(99, 100, true), TimerEventAction::Drop);
-        assert_eq!(classify_timer_event(99, 100, false), TimerEventAction::Drop);
-        // Far behind
+        // Far behind, tracking
         assert_eq!(classify_timer_event(1, 100, true), TimerEventAction::Drop);
+    }
+
+    /// Old-slot timer while NOT tracking → Fire immediately.
+    /// Parity: stellar-core's timerCallbackWrapper fires all callbacks when
+    /// !isTracking(), regardless of slot relationship to nextConsensusLedgerIndex().
+    #[test]
+    fn test_classify_timer_event_old_slot_not_tracking_fires() {
+        // Not tracking: old-slot timers fire immediately, not dropped.
+        assert_eq!(classify_timer_event(99, 100, false), TimerEventAction::Fire);
+        assert_eq!(classify_timer_event(1, 100, false), TimerEventAction::Fire);
     }
 
     /// Current-slot timer → Fire immediately regardless of tracking state.

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -135,26 +135,20 @@ pub(super) enum TimerEventAction {
 /// Parity: stellar-core's `timerCallbackWrapper` only applies the slot-based
 /// defer/drop logic when `isTracking()` is true. When not tracking, all timer
 /// callbacks fire immediately regardless of slot relationship to
-/// `nextConsensusLedgerIndex()`.
-///
-/// Safety: when not tracking, we still drop old-slot timers as defense-in-depth.
-/// Outstanding timers from a prior tracking epoch are cancelled by `on_lost_sync`,
-/// but this prevents any that slip through the cancellation race from executing
-/// stale timeout handlers (e.g. bump_ballot on an outdated slot).
+/// `nextConsensusLedgerIndex()`. We match this behavior exactly — stale events
+/// from prior tracking epochs are rejected by the epoch guard in
+/// `handle_scp_timer_event()` before reaching this classifier.
 pub(super) fn classify_timer_event(
     event_slot: u64,
     next_consensus_slot: u64,
     is_tracking: bool,
 ) -> TimerEventAction {
     if !is_tracking {
-        // Not tracking: fire only if the timer is for the current slot.
-        // Drop stale timers from a prior tracking epoch that survived the
-        // on_lost_sync cancellation window.
-        if event_slot < next_consensus_slot {
-            TimerEventAction::Drop
-        } else {
-            TimerEventAction::Fire
-        }
+        // Not tracking: fire unconditionally. Matches stellar-core's
+        // timerCallbackWrapper which only gates on slot when isTracking().
+        // Stale events from prior epochs are already rejected by the
+        // epoch guard before reaching this point.
+        TimerEventAction::Fire
     } else if event_slot < next_consensus_slot {
         TimerEventAction::Drop
     } else if event_slot > next_consensus_slot {
@@ -2150,13 +2144,14 @@ mod tests {
     }
 
     /// Old-slot timer while NOT tracking → Drop (defense-in-depth).
-    /// Even though on_lost_sync cancels outstanding timers, any that slip through
-    /// the cancellation race must not execute stale timeout handlers.
+    /// Parity: stellar-core fires timer callbacks unconditionally when !isTracking().
+    /// Old-slot timers from prior tracking epochs are rejected by the epoch guard
+    /// before reaching the classifier, so this path is safe.
     #[test]
-    fn test_classify_timer_event_old_slot_not_tracking_drops() {
-        // Not tracking: old-slot timers are dropped as defense-in-depth.
-        assert_eq!(classify_timer_event(99, 100, false), TimerEventAction::Drop);
-        assert_eq!(classify_timer_event(1, 100, false), TimerEventAction::Drop);
+    fn test_classify_timer_event_old_slot_not_tracking_fires() {
+        // Not tracking: all timers fire (parity with stellar-core timerCallbackWrapper).
+        assert_eq!(classify_timer_event(99, 100, false), TimerEventAction::Fire);
+        assert_eq!(classify_timer_event(1, 100, false), TimerEventAction::Fire);
     }
 
     /// Current-slot timer → Fire immediately regardless of tracking state.

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -136,15 +136,25 @@ pub(super) enum TimerEventAction {
 /// defer/drop logic when `isTracking()` is true. When not tracking, all timer
 /// callbacks fire immediately regardless of slot relationship to
 /// `nextConsensusLedgerIndex()`.
+///
+/// Safety: when not tracking, we still drop old-slot timers as defense-in-depth.
+/// Outstanding timers from a prior tracking epoch are cancelled by `on_lost_sync`,
+/// but this prevents any that slip through the cancellation race from executing
+/// stale timeout handlers (e.g. bump_ballot on an outdated slot).
 pub(super) fn classify_timer_event(
     event_slot: u64,
     next_consensus_slot: u64,
     is_tracking: bool,
 ) -> TimerEventAction {
     if !is_tracking {
-        // Not tracking: fire immediately, matching stellar-core's
-        // timerCallbackWrapper fallthrough when !isTracking().
-        TimerEventAction::Fire
+        // Not tracking: fire only if the timer is for the current slot.
+        // Drop stale timers from a prior tracking epoch that survived the
+        // on_lost_sync cancellation window.
+        if event_slot < next_consensus_slot {
+            TimerEventAction::Drop
+        } else {
+            TimerEventAction::Fire
+        }
     } else if event_slot < next_consensus_slot {
         TimerEventAction::Drop
     } else if event_slot > next_consensus_slot {
@@ -2126,14 +2136,14 @@ mod tests {
         assert_eq!(classify_timer_event(1, 100, true), TimerEventAction::Drop);
     }
 
-    /// Old-slot timer while NOT tracking → Fire immediately.
-    /// Parity: stellar-core's timerCallbackWrapper fires all callbacks when
-    /// !isTracking(), regardless of slot relationship to nextConsensusLedgerIndex().
+    /// Old-slot timer while NOT tracking → Drop (defense-in-depth).
+    /// Even though on_lost_sync cancels outstanding timers, any that slip through
+    /// the cancellation race must not execute stale timeout handlers.
     #[test]
-    fn test_classify_timer_event_old_slot_not_tracking_fires() {
-        // Not tracking: old-slot timers fire immediately, not dropped.
-        assert_eq!(classify_timer_event(99, 100, false), TimerEventAction::Fire);
-        assert_eq!(classify_timer_event(1, 100, false), TimerEventAction::Fire);
+    fn test_classify_timer_event_old_slot_not_tracking_drops() {
+        // Not tracking: old-slot timers are dropped as defense-in-depth.
+        assert_eq!(classify_timer_event(99, 100, false), TimerEventAction::Drop);
+        assert_eq!(classify_timer_event(1, 100, false), TimerEventAction::Drop);
     }
 
     /// Current-slot timer → Fire immediately regardless of tracking state.
@@ -2446,6 +2456,80 @@ mod tests {
             app.nomination_timeout_fires.load(Ordering::Relaxed),
             fires_before + 1,
             "timer for LCL+1 must fire immediately in the corrective window, not be rearmed"
+        );
+    }
+
+    /// Regression test: stale SCP timers must NOT fire after Tracking → Syncing.
+    ///
+    /// Scenario: the node was tracking at slot 2 and loses sync. While syncing,
+    /// the LCL advances (via catchup) to ledger 5. A stale ballot timer from the
+    /// old tracking epoch (slot 2) fires. The handler must drop it because
+    /// slot 2 < next_slot (6), not execute bump_ballot on outdated state.
+    ///
+    /// This regression was introduced when the non-tracking path unconditionally
+    /// returned `Fire` for all slots. The fix drops old-slot timers regardless
+    /// of tracking state.
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_e2e_stale_timer_after_sync_loss_drops() {
+        use henyey_herder::sync_recovery::SyncRecoveryCallback;
+
+        let (_dir, app) = mk_validator_app().await;
+
+        // Bootstrap herder at ledger 1 → tracking slot = 2, is_tracking = true
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+        assert_eq!(app.herder.next_consensus_ledger_index().get(), 2);
+
+        // Simulate losing sync — transitions herder to Syncing and cancels timers
+        app.on_lost_sync();
+        assert!(!app.herder.is_tracking());
+        assert_eq!(app.herder.state(), henyey_herder::HerderState::Syncing);
+
+        // Allow timer manager to process the cancel command
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Simulate LCL advancing via catchup while syncing (ledger 5 → next = 6)
+        {
+            let mut header = app.ledger_manager().current_header();
+            header.ledger_seq = 5;
+            app.ledger_manager()
+                .set_header_for_test(header, henyey_common::Hash256::default());
+        }
+        assert_eq!(app.current_ledger_seq(), 5);
+
+        // Now inject a stale ballot timer event from the old tracking epoch (slot 2).
+        // This simulates a timer that was already in-flight in the event channel
+        // when on_lost_sync cancelled timers.
+        let stale_event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: 2,
+            timer_type: henyey_herder::TimerType::Ballot,
+        };
+
+        let fires_before = app.ballot_timeout_fires.load(Ordering::Relaxed);
+        app.handle_scp_timer_event(stale_event).await;
+
+        // The stale timer must NOT have fired — slot 2 < next_slot 6, so it's dropped.
+        assert_eq!(
+            app.ballot_timeout_fires.load(Ordering::Relaxed),
+            fires_before,
+            "stale ballot timer from prior tracking epoch must not fire after sync loss"
+        );
+
+        // Also verify a stale nomination timer for the old tracking slot is dropped.
+        let stale_nom_event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: 2,
+            timer_type: henyey_herder::TimerType::Nomination,
+        };
+
+        let nom_fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
+        app.handle_scp_timer_event(stale_nom_event).await;
+
+        assert_eq!(
+            app.nomination_timeout_fires.load(Ordering::Relaxed),
+            nom_fires_before,
+            "stale nomination timer from prior tracking epoch must not fire after sync loss"
         );
     }
 }

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -1401,6 +1401,19 @@ impl App {
         if !self.herder.state().can_receive_scp() {
             return;
         }
+        // Gate: reject events from a prior tracking epoch. These were already
+        // queued in scp_timer_rx before on_lost_sync() incremented the epoch,
+        // so cancel_all_timers_nonblocking() could not retract them.
+        let current_epoch = self.scp_timer_epoch.load(Ordering::Acquire);
+        if event.epoch != current_epoch {
+            tracing::debug!(
+                slot = event.slot,
+                event_epoch = event.epoch,
+                current_epoch,
+                "Dropping stale timer event from prior tracking epoch"
+            );
+            return;
+        }
 
         // Use max(tracking_slot, current_ledger + 1) as the effective next slot.
         // In the INV-H2 corrective window where LCL + 1 > tracking_slot, a timer
@@ -2218,6 +2231,7 @@ mod tests {
         let event = super::super::scp_timer_bridge::ScpTimerEvent {
             slot: future_slot,
             timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0,
         };
 
         let fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
@@ -2278,6 +2292,7 @@ mod tests {
         let event = super::super::scp_timer_bridge::ScpTimerEvent {
             slot: future_slot,
             timer_type: henyey_herder::TimerType::Ballot,
+            epoch: 0,
         };
 
         let fires_before = app.ballot_timeout_fires.load(Ordering::Relaxed);
@@ -2325,6 +2340,7 @@ mod tests {
         let event = super::super::scp_timer_bridge::ScpTimerEvent {
             slot: old_slot,
             timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0,
         };
 
         let nom_fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
@@ -2393,6 +2409,7 @@ mod tests {
         let event = super::super::scp_timer_bridge::ScpTimerEvent {
             slot,
             timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0,
         };
         app.handle_scp_timer_event(event).await;
 
@@ -2446,6 +2463,7 @@ mod tests {
         let event = super::super::scp_timer_bridge::ScpTimerEvent {
             slot: 6,
             timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0,
         };
 
         let fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
@@ -2505,6 +2523,7 @@ mod tests {
         let stale_event = super::super::scp_timer_bridge::ScpTimerEvent {
             slot: 2,
             timer_type: henyey_herder::TimerType::Ballot,
+            epoch: 0,
         };
 
         let fires_before = app.ballot_timeout_fires.load(Ordering::Relaxed);
@@ -2521,6 +2540,7 @@ mod tests {
         let stale_nom_event = super::super::scp_timer_bridge::ScpTimerEvent {
             slot: 2,
             timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0,
         };
 
         let nom_fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
@@ -2530,6 +2550,106 @@ mod tests {
             app.nomination_timeout_fires.load(Ordering::Relaxed),
             nom_fires_before,
             "stale nomination timer from prior tracking epoch must not fire after sync loss"
+        );
+    }
+
+    /// Regression test: future-slot timers queued before sync loss must be
+    /// dropped after the epoch advances, even when their slot >= next_slot.
+    ///
+    /// Scenario: the node is tracking at slot 2. A future-slot ballot timer
+    /// for slot 5 fires and gets queued in scp_timer_rx (the channel). Before
+    /// the main loop processes it, on_lost_sync() is called, incrementing the
+    /// tracking epoch. When the event is finally dequeued, its epoch (0) does
+    /// not match the current epoch (1), so it must be dropped — even though
+    /// slot 5 >= next_slot and would otherwise hit the Fire branch.
+    ///
+    /// Without the epoch guard, this would call handle_ballot_timeout() /
+    /// handle_nomination_timeout() against stale consensus state.
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_future_slot_stale_epoch_drops() {
+        use henyey_herder::sync_recovery::SyncRecoveryCallback;
+
+        let (_dir, app) = mk_validator_app().await;
+
+        // Bootstrap herder at ledger 1 → tracking slot = 2, is_tracking = true
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+        assert_eq!(app.herder.next_consensus_ledger_index().get(), 2);
+
+        // The timer epoch starts at 0
+        assert_eq!(
+            app.scp_timer_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            0
+        );
+
+        // Simulate losing sync — this increments the epoch to 1
+        app.on_lost_sync();
+        assert!(!app.herder.is_tracking());
+        assert_eq!(
+            app.scp_timer_epoch
+                .load(std::sync::atomic::Ordering::Acquire),
+            1
+        );
+
+        // Allow timer manager to process the cancel command
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Inject a FUTURE-slot ballot timer event from the OLD epoch (epoch 0).
+        // This simulates a timer that was already queued in scp_timer_rx before
+        // on_lost_sync() was called. Slot 5 >= next_slot (2), so without the
+        // epoch guard it would hit the Fire branch.
+        let stale_future_ballot = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: 5,
+            timer_type: henyey_herder::TimerType::Ballot,
+            epoch: 0, // old epoch — before sync loss
+        };
+
+        let fires_before = app.ballot_timeout_fires.load(Ordering::Relaxed);
+        app.handle_scp_timer_event(stale_future_ballot).await;
+
+        assert_eq!(
+            app.ballot_timeout_fires.load(Ordering::Relaxed),
+            fires_before,
+            "future-slot ballot timer from prior epoch must not fire after sync loss"
+        );
+
+        // Same for nomination timers — verify uniform rejection
+        let stale_future_nom = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: 5,
+            timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0, // old epoch
+        };
+
+        let nom_fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
+        app.handle_scp_timer_event(stale_future_nom).await;
+
+        assert_eq!(
+            app.nomination_timeout_fires.load(Ordering::Relaxed),
+            nom_fires_before,
+            "future-slot nomination timer from prior epoch must not fire after sync loss"
+        );
+
+        // Verify that a timer with the CURRENT epoch (1) IS processed normally.
+        // This confirms the epoch guard is checking the right thing and not
+        // blanket-rejecting all post-sync-loss timers.
+        let current_epoch_event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: 5,
+            timer_type: henyey_herder::TimerType::Ballot,
+            epoch: 1, // current epoch — after sync loss
+        };
+
+        // This event passes the epoch check, passes can_receive_scp (Syncing allows it),
+        // and hits the Fire branch (non-tracking, slot >= next_slot). It will actually
+        // call handle_ballot_timeout — confirming the epoch guard is selective.
+        let fires_before_current = app.ballot_timeout_fires.load(Ordering::Relaxed);
+        app.handle_scp_timer_event(current_epoch_event).await;
+        assert_eq!(
+            app.ballot_timeout_fires.load(Ordering::Relaxed),
+            fires_before_current + 1,
+            "event with current epoch must pass the epoch guard and fire"
         );
     }
 }

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -1435,16 +1435,36 @@ impl App {
                 // Spec: HERDER_SPEC §5.4-2: stellar-core's timerCallbackWrapper
                 // defers future-slot timer callbacks by re-scheduling them at a
                 // 1-second interval until the slot becomes current.
+                //
+                // Preserve the *originating* epoch (`event.epoch`) across the
+                // defer loop rather than letting the timer manager re-sample the
+                // current global epoch. Otherwise, if on_lost_sync() bumps the
+                // epoch between this event firing and the re-arm command being
+                // processed, the re-armed timer would be stamped with the new
+                // epoch and survive into Syncing — a "rebirth" that stellar-core
+                // cannot do, since its timerCallbackWrapper/setupTimer defer loop
+                // operates on the same in-process timer state. The event already
+                // passed the epoch guard above (event.epoch == current_epoch), so
+                // carrying event.epoch keeps the re-armed timer rejectable once
+                // the epoch advances.
                 let one_second = std::time::Duration::from_secs(1);
                 match event.timer_type {
                     henyey_herder::TimerType::Nomination => {
                         self.timer_manager_handle
-                            .schedule_nomination_timeout(event.slot, one_second)
+                            .reschedule_nomination_timeout_with_epoch(
+                                event.slot,
+                                one_second,
+                                event.epoch,
+                            )
                             .await;
                     }
                     henyey_herder::TimerType::Ballot => {
                         self.timer_manager_handle
-                            .schedule_ballot_timeout(event.slot, one_second)
+                            .reschedule_ballot_timeout_with_epoch(
+                                event.slot,
+                                one_second,
+                                event.epoch,
+                            )
                             .await;
                     }
                 }
@@ -2645,6 +2665,108 @@ mod tests {
             app.ballot_timeout_fires.load(Ordering::Relaxed),
             fires_before_current + 1,
             "event with current epoch must pass the epoch guard and fire"
+        );
+    }
+
+    /// Regression test for #2803 (PR #2821 final bounce, Parity comment 30):
+    /// the future-slot 1-second defer loop must NOT "rebirth" a pre-sync-loss
+    /// timer into the new epoch.
+    ///
+    /// Scenario: tracking at slot 2. A future-slot nomination timer (slot 5,
+    /// epoch 0) fires and is classified `Rearm`, re-scheduling for 1 second.
+    /// Before the re-armed timer fires, `on_lost_sync()` bumps the tracking
+    /// epoch to 1. When the re-armed timer finally fires and is re-delivered
+    /// through the production TimerManager → ScpTimerBridge path, it must carry
+    /// the ORIGINATING epoch (0), not the bumped epoch (1) — so the epoch guard
+    /// in `handle_scp_timer_event()` rejects it instead of firing it into the
+    /// timeout handler while the node is Syncing.
+    ///
+    /// stellar-core's in-process `timerCallbackWrapper`/`setupTimer` defer loop
+    /// cannot rebirth a pre-sync-loss timer this way; this test pins henyey's
+    /// split-architecture equivalent.
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_e2e_rearm_preserves_epoch_across_sync_loss() {
+        use henyey_herder::sync_recovery::SyncRecoveryCallback;
+
+        let (_dir, app) = mk_validator_app().await;
+
+        // Bootstrap at ledger 1 → tracking slot = 2, is_tracking = true.
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+        assert_eq!(app.herder.next_consensus_ledger_index().get(), 2);
+        assert_eq!(app.scp_timer_epoch.load(Ordering::Acquire), 0);
+
+        // Future-slot nomination event from the current (epoch 0) tracking
+        // epoch — classified Rearm and re-scheduled for 1 second carrying
+        // epoch 0.
+        let future_slot = 5u64;
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: future_slot,
+            timer_type: henyey_herder::TimerType::Nomination,
+            epoch: 0,
+        };
+        app.handle_scp_timer_event(event).await;
+
+        // Let the timer manager process the re-arm command.
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Lose sync mid-defer: bump the global epoch to 1 (and cancel timers).
+        // The re-arm command was already processed above, so the re-armed timer
+        // is in flight with its originating epoch 0.
+        app.on_lost_sync();
+        assert!(!app.herder.is_tracking());
+        assert_eq!(app.scp_timer_epoch.load(Ordering::Acquire), 1);
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Note: on_lost_sync() also cancels all timers, but to prove the
+        // epoch-preservation property independently of cancellation ordering we
+        // re-arm explicitly with the originating epoch (this is exactly what the
+        // Rearm branch does) and then advance time. Whichever wins the race, the
+        // re-delivered event must carry epoch 0.
+        app.timer_manager_handle
+            .reschedule_nomination_timeout_with_epoch(
+                future_slot,
+                std::time::Duration::from_secs(1),
+                0,
+            )
+            .await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Advance past the 1-second defer; the re-armed timer fires and is
+        // re-delivered through the production bridge.
+        let redelivered = {
+            let mut rx = app.scp_timer_rx.lock().await;
+            tokio::time::advance(std::time::Duration::from_millis(1001)).await;
+            for _ in 0..10 {
+                tokio::task::yield_now().await;
+            }
+            rx.try_recv()
+                .expect("expected re-delivered nomination timer event")
+        };
+
+        // The re-delivered event MUST carry the originating epoch (0), not the
+        // bumped global epoch (1). This is the core of the fix.
+        assert_eq!(
+            redelivered.epoch, 0,
+            "re-armed timer must carry the originating epoch across sync loss, not be reborn into the new epoch"
+        );
+        assert_eq!(redelivered.slot, future_slot);
+
+        // Feeding the re-delivered event back into the handler must DROP it via
+        // the epoch guard (event.epoch 0 != current_epoch 1) — no fire, no SCP
+        // state mutation while Syncing.
+        let nom_fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
+        app.handle_scp_timer_event(redelivered).await;
+        assert_eq!(
+            app.nomination_timeout_fires.load(Ordering::Relaxed),
+            nom_fires_before,
+            "re-delivered timer from the prior epoch must be dropped after sync loss, not fired"
         );
     }
 }

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -1392,7 +1392,13 @@ impl App {
             return;
         }
 
-        let next_slot = self.herder.next_consensus_ledger_index().get();
+        // Use max(tracking_slot, current_ledger + 1) as the effective next slot.
+        // In the INV-H2 corrective window where LCL + 1 > tracking_slot, a timer
+        // for LCL + 1 is current from the app's perspective and must fire immediately
+        // rather than being deferred as a "future" slot.
+        let tracking_next = self.herder.next_consensus_ledger_index().get();
+        let lcl_next = self.current_ledger_seq() as u64 + 1;
+        let next_slot = tracking_next.max(lcl_next);
         let action = classify_timer_event(event.slot, next_slot, self.herder.is_tracking());
 
         match action {
@@ -2396,6 +2402,50 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "sibling ballot timer for the old slot must be cancelled"
+        );
+    }
+
+    /// Regression test for INV-H2 corrective window: when LCL + 1 > tracking_slot,
+    /// a timer for LCL + 1 must fire immediately (not be deferred as a "future" slot).
+    ///
+    /// This exercises the max(tracking_slot, current_ledger + 1) floor that prevents
+    /// an unintended 1-second delay in the corrective recovery path.
+    #[tokio::test(start_paused = true)]
+    async fn test_handle_scp_timer_event_e2e_lcl_ahead_of_tracking_fires_immediately() {
+        let (_dir, app) = mk_validator_app().await;
+
+        // Bootstrap herder at ledger 1 → tracking slot = 2, is_tracking = true
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+        assert_eq!(app.herder.next_consensus_ledger_index().get(), 2);
+
+        // Advance the LCL to ledger 5 without advancing herder tracking.
+        // This creates the INV-H2 corrective window: LCL=5, tracking_slot=2,
+        // so current_ledger + 1 = 6 > tracking_slot = 2.
+        {
+            let mut header = app.ledger_manager().current_header();
+            header.ledger_seq = 5;
+            app.ledger_manager()
+                .set_header_for_test(header, henyey_common::Hash256::default());
+        }
+        assert_eq!(app.current_ledger_seq(), 5);
+
+        // A nomination timer for slot 6 (= current_ledger + 1) should fire
+        // immediately — it is "current" from the app's perspective even though
+        // it's ahead of the tracking slot.
+        let event = super::super::scp_timer_bridge::ScpTimerEvent {
+            slot: 6,
+            timer_type: henyey_herder::TimerType::Nomination,
+        };
+
+        let fires_before = app.nomination_timeout_fires.load(Ordering::Relaxed);
+        app.handle_scp_timer_event(event).await;
+
+        // The fire counter must increment — this timer should NOT be rearmed.
+        assert_eq!(
+            app.nomination_timeout_fires.load(Ordering::Relaxed),
+            fires_before + 1,
+            "timer for LCL+1 must fire immediately in the corrective window, not be rearmed"
         );
     }
 }

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -1224,11 +1224,9 @@ impl App {
         // matching stellar-core's VirtualTimer pattern.
         let (scp_timer_tx, scp_timer_rx) = tokio::sync::mpsc::unbounded_channel();
         let scp_timer_epoch = Arc::new(AtomicU64::new(0));
-        let timer_bridge = std::sync::Arc::new(scp_timer_bridge::ScpTimerBridge::new(
-            scp_timer_tx,
-            Arc::clone(&scp_timer_epoch),
-        ));
-        let (timer_manager_handle, timer_manager) = henyey_herder::TimerManager::new(timer_bridge);
+        let timer_bridge = std::sync::Arc::new(scp_timer_bridge::ScpTimerBridge::new(scp_timer_tx));
+        let (timer_manager_handle, timer_manager) =
+            henyey_herder::TimerManager::new(timer_bridge, Arc::clone(&scp_timer_epoch));
         let timer_manager_join = tokio::spawn(timer_manager.run());
 
         let herder_config = Self::build_herder_config(&config, &keypair, local_quorum_set);

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -763,6 +763,9 @@ pub struct App {
     survey_reporting: RwLock<SurveyReportingState>,
     /// SCP timer manager handle for scheduling/cancelling timers.
     timer_manager_handle: henyey_herder::TimerManagerHandle,
+    /// Tracking epoch counter — incremented on sync loss to invalidate
+    /// in-flight timer events that were queued during the previous epoch.
+    scp_timer_epoch: Arc<AtomicU64>,
     /// SCP timer event receiver for the main loop.
     scp_timer_rx: TokioMutex<tokio::sync::mpsc::UnboundedReceiver<scp_timer_bridge::ScpTimerEvent>>,
     /// JoinHandle for the timer manager background task.
@@ -1220,7 +1223,11 @@ impl App {
         // Replaces the 500ms polling interval with exact-expiry timers
         // matching stellar-core's VirtualTimer pattern.
         let (scp_timer_tx, scp_timer_rx) = tokio::sync::mpsc::unbounded_channel();
-        let timer_bridge = std::sync::Arc::new(scp_timer_bridge::ScpTimerBridge::new(scp_timer_tx));
+        let scp_timer_epoch = Arc::new(AtomicU64::new(0));
+        let timer_bridge = std::sync::Arc::new(scp_timer_bridge::ScpTimerBridge::new(
+            scp_timer_tx,
+            Arc::clone(&scp_timer_epoch),
+        ));
         let (timer_manager_handle, timer_manager) = henyey_herder::TimerManager::new(timer_bridge);
         let timer_manager_join = tokio::spawn(timer_manager.run());
 
@@ -1385,6 +1392,7 @@ impl App {
             survey_throttle,
             survey_reporting: RwLock::new(SurveyReportingState::new(now)),
             timer_manager_handle,
+            scp_timer_epoch,
             scp_timer_rx: TokioMutex::new(scp_timer_rx),
             timer_manager_join: TokioMutex::new(Some(timer_manager_join)),
             meta_stream: std::sync::Mutex::new(meta_stream_for_mutex),

--- a/crates/app/src/app/scp_timer_bridge.rs
+++ b/crates/app/src/app/scp_timer_bridge.rs
@@ -5,12 +5,10 @@
 //! adapter that sends timer events to the main event loop for processing,
 //! matching stellar-core's single-shot `VirtualTimer` delivery pattern.
 //!
-//! Each event is stamped with a tracking epoch so the receiver can discard
-//! stale events that were queued before a sync-loss transition. The epoch is
-//! incremented by `on_lost_sync()` and checked by `handle_scp_timer_event()`.
-
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+//! Each event is stamped with the tracking epoch that was current when the
+//! timer was scheduled (captured by [`TimerManager`] at schedule-time). This
+//! allows `handle_scp_timer_event()` to discard stale events from prior epochs
+//! even if they expire after `on_lost_sync()` increments the epoch.
 
 use henyey_herder::{TimerCallback, TimerType};
 use henyey_scp::SlotIndex;
@@ -20,40 +18,35 @@ use henyey_scp::SlotIndex;
 pub(super) struct ScpTimerEvent {
     pub slot: SlotIndex,
     pub timer_type: TimerType,
-    /// The tracking epoch at which this event was enqueued.
+    /// The tracking epoch at which this timer was originally scheduled.
     pub epoch: u64,
 }
 
 /// Adapter implementing [`TimerCallback`] that forwards timer fires over a channel.
 pub(super) struct ScpTimerBridge {
     sender: tokio::sync::mpsc::UnboundedSender<ScpTimerEvent>,
-    /// Shared tracking epoch — incremented on sync loss.
-    epoch: Arc<AtomicU64>,
 }
 
 impl ScpTimerBridge {
-    pub fn new(
-        sender: tokio::sync::mpsc::UnboundedSender<ScpTimerEvent>,
-        epoch: Arc<AtomicU64>,
-    ) -> Self {
-        Self { sender, epoch }
+    pub fn new(sender: tokio::sync::mpsc::UnboundedSender<ScpTimerEvent>) -> Self {
+        Self { sender }
     }
 }
 
 impl TimerCallback for ScpTimerBridge {
-    fn on_nomination_timeout(&self, slot: SlotIndex) {
+    fn on_nomination_timeout(&self, slot: SlotIndex, epoch: u64) {
         let _ = self.sender.send(ScpTimerEvent {
             slot,
             timer_type: TimerType::Nomination,
-            epoch: self.epoch.load(Ordering::Acquire),
+            epoch,
         });
     }
 
-    fn on_ballot_timeout(&self, slot: SlotIndex) {
+    fn on_ballot_timeout(&self, slot: SlotIndex, epoch: u64) {
         let _ = self.sender.send(ScpTimerEvent {
             slot,
             timer_type: TimerType::Ballot,
-            epoch: self.epoch.load(Ordering::Acquire),
+            epoch,
         });
     }
 }

--- a/crates/app/src/app/scp_timer_bridge.rs
+++ b/crates/app/src/app/scp_timer_bridge.rs
@@ -4,6 +4,13 @@
 //! SCP nomination/ballot timers expire. This module provides a channel-based
 //! adapter that sends timer events to the main event loop for processing,
 //! matching stellar-core's single-shot `VirtualTimer` delivery pattern.
+//!
+//! Each event is stamped with a tracking epoch so the receiver can discard
+//! stale events that were queued before a sync-loss transition. The epoch is
+//! incremented by `on_lost_sync()` and checked by `handle_scp_timer_event()`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use henyey_herder::{TimerCallback, TimerType};
 use henyey_scp::SlotIndex;
@@ -13,16 +20,23 @@ use henyey_scp::SlotIndex;
 pub(super) struct ScpTimerEvent {
     pub slot: SlotIndex,
     pub timer_type: TimerType,
+    /// The tracking epoch at which this event was enqueued.
+    pub epoch: u64,
 }
 
 /// Adapter implementing [`TimerCallback`] that forwards timer fires over a channel.
 pub(super) struct ScpTimerBridge {
     sender: tokio::sync::mpsc::UnboundedSender<ScpTimerEvent>,
+    /// Shared tracking epoch — incremented on sync loss.
+    epoch: Arc<AtomicU64>,
 }
 
 impl ScpTimerBridge {
-    pub fn new(sender: tokio::sync::mpsc::UnboundedSender<ScpTimerEvent>) -> Self {
-        Self { sender }
+    pub fn new(
+        sender: tokio::sync::mpsc::UnboundedSender<ScpTimerEvent>,
+        epoch: Arc<AtomicU64>,
+    ) -> Self {
+        Self { sender, epoch }
     }
 }
 
@@ -31,6 +45,7 @@ impl TimerCallback for ScpTimerBridge {
         let _ = self.sender.send(ScpTimerEvent {
             slot,
             timer_type: TimerType::Nomination,
+            epoch: self.epoch.load(Ordering::Acquire),
         });
     }
 
@@ -38,6 +53,7 @@ impl TimerCallback for ScpTimerBridge {
         let _ = self.sender.send(ScpTimerEvent {
             slot,
             timer_type: TimerType::Ballot,
+            epoch: self.epoch.load(Ordering::Acquire),
         });
     }
 }

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -168,7 +168,7 @@ Corresponds to: `HerderSCPDriver.h`
 | `getValueString()` | `get_value_string()` | Full |
 | `setupTimer()` | `TimerManager` | Full |
 | `stopTimer()` | `TimerManager` | Full |
-| `timerCallbackWrapper()` future-slot defer | `App::handle_scp_timer_event` 3-way split | Full |
+| `timerCallbackWrapper()` future-slot defer + old-slot cleanup | `App::handle_scp_timer_event` 3-way split | Full |
 | `computeTimeout()` | `compute_timeout()` | Full |
 | `getHashOf()` | `compute_hash_node()` | Full |
 | `combineCandidates()` | `combine_candidates()` | Full |

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -168,6 +168,7 @@ Corresponds to: `HerderSCPDriver.h`
 | `getValueString()` | `get_value_string()` | Full |
 | `setupTimer()` | `TimerManager` | Full |
 | `stopTimer()` | `TimerManager` | Full |
+| `timerCallbackWrapper()` future-slot defer | `App::handle_scp_timer_event` 3-way split | Full |
 | `computeTimeout()` | `compute_timeout()` | Full |
 | `getHashOf()` | `compute_hash_node()` | Full |
 | `combineCandidates()` | `combine_candidates()` | Full |

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -168,7 +168,7 @@ Corresponds to: `HerderSCPDriver.h`
 | `getValueString()` | `get_value_string()` | Full |
 | `setupTimer()` | `TimerManager` | Full |
 | `stopTimer()` | `TimerManager` | Full |
-| `timerCallbackWrapper()` future-slot defer + old-slot cleanup | `App::handle_scp_timer_event` 3-way split | Full |
+| `timerCallbackWrapper()` future-slot defer + old-slot cleanup | `App::handle_scp_timer_event` 3-way split; epoch-preserving re-arm across sync loss | Full |
 | `computeTimeout()` | `compute_timeout()` | Full |
 | `getHashOf()` | `compute_hash_node()` | Full |
 | `combineCandidates()` | `combine_candidates()` | Full |

--- a/crates/herder/src/timer_manager.rs
+++ b/crates/herder/src/timer_manager.rs
@@ -39,6 +39,7 @@
 //! ```
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -204,12 +205,16 @@ impl TimerManagerHandle {
 /// Callback trait for timer expiration events.
 ///
 /// Implement this trait to receive timer expiration callbacks.
+/// The `epoch` parameter is the tracking epoch captured at timer-schedule time,
+/// allowing receivers to discard stale events from prior epochs.
 pub trait TimerCallback: Send + Sync + 'static {
     /// Called when a nomination timeout expires.
-    fn on_nomination_timeout(&self, slot: SlotIndex);
+    /// `epoch` is the tracking epoch that was current when this timer was scheduled.
+    fn on_nomination_timeout(&self, slot: SlotIndex, epoch: u64);
 
     /// Called when a ballot timeout expires.
-    fn on_ballot_timeout(&self, slot: SlotIndex);
+    /// `epoch` is the tracking epoch that was current when this timer was scheduled.
+    fn on_ballot_timeout(&self, slot: SlotIndex, epoch: u64);
 }
 
 /// Timer type for a slot.
@@ -227,6 +232,9 @@ struct ActiveTimer {
     expires_at: Instant,
     /// Unique ID to detect if timer was rescheduled (stored for future use)
     _generation: u64,
+    /// The tracking epoch at which this timer was scheduled. Passed to the
+    /// callback on fire so the receiver can discard events from prior epochs.
+    epoch: u64,
 }
 
 /// The timer manager that runs as a background task.
@@ -237,14 +245,20 @@ pub struct TimerManager<C: TimerCallback> {
     timers: HashMap<(SlotIndex, TimerType), ActiveTimer>,
     /// Generation counter for timer identification
     generation: u64,
+    /// Shared tracking epoch — read at schedule-time and stored in each timer.
+    epoch: Arc<AtomicU64>,
 }
 
 impl<C: TimerCallback> TimerManager<C> {
-    /// Create a new timer manager with the given callback.
+    /// Create a new timer manager with the given callback and shared epoch.
+    ///
+    /// The `epoch` is read at timer-schedule time and stored in each active timer.
+    /// When a timer fires, the stored epoch is passed to the callback, allowing
+    /// the receiver to detect and discard stale events from prior tracking epochs.
     ///
     /// Returns a handle for sending commands and the manager itself which should
     /// be spawned as a tokio task.
-    pub fn new(callback: Arc<C>) -> (TimerManagerHandle, Self) {
+    pub fn new(callback: Arc<C>, epoch: Arc<AtomicU64>) -> (TimerManagerHandle, Self) {
         let (sender, receiver) = mpsc::unbounded_channel();
         let handle = TimerManagerHandle { sender };
         let manager = Self {
@@ -252,6 +266,7 @@ impl<C: TimerCallback> TimerManager<C> {
             receiver,
             timers: HashMap::new(),
             generation: 0,
+            epoch,
         };
         (handle, manager)
     }
@@ -327,12 +342,14 @@ impl<C: TimerCallback> TimerManager<C> {
     fn schedule_timer(&mut self, slot: SlotIndex, timer_type: TimerType, duration: Duration) {
         self.generation = self.generation.wrapping_add(1);
         let expires_at = Instant::now() + duration;
+        let epoch = self.epoch.load(Ordering::Acquire);
 
         let timer = ActiveTimer {
             timer_type,
             slot,
             expires_at,
             _generation: self.generation,
+            epoch,
         };
 
         debug!(
@@ -387,21 +404,21 @@ impl<C: TimerCallback> TimerManager<C> {
             .timers
             .iter()
             .filter(|(_, t)| t.expires_at <= now)
-            .map(|(k, t)| (*k, t.timer_type, t.slot))
+            .map(|(k, t)| (*k, t.timer_type, t.slot, t.epoch))
             .collect();
 
         // Remove and fire
-        for (key, timer_type, slot) in expired {
+        for (key, timer_type, slot, epoch) in expired {
             self.timers.remove(&key);
 
-            trace!(slot, timer_type = ?timer_type, "Firing timer");
+            trace!(slot, timer_type = ?timer_type, epoch, "Firing timer");
 
             match timer_type {
                 TimerType::Nomination => {
-                    self.callback.on_nomination_timeout(slot);
+                    self.callback.on_nomination_timeout(slot, epoch);
                 }
                 TimerType::Ballot => {
-                    self.callback.on_ballot_timeout(slot);
+                    self.callback.on_ballot_timeout(slot, epoch);
                 }
             }
         }
@@ -429,8 +446,11 @@ pub struct TimerManagerWithStats<C: TimerCallback> {
 
 impl<C: TimerCallback> TimerManagerWithStats<C> {
     /// Create a new timer manager with stats tracking.
-    pub fn new(callback: Arc<C>) -> (TimerManagerHandle, Arc<RwLock<TimerStats>>, Self) {
-        let (handle, inner) = TimerManager::new(callback);
+    pub fn new(
+        callback: Arc<C>,
+        epoch: Arc<AtomicU64>,
+    ) -> (TimerManagerHandle, Arc<RwLock<TimerStats>>, Self) {
+        let (handle, inner) = TimerManager::new(callback, epoch);
         let stats = Arc::new(RwLock::new(TimerStats::default()));
         let manager = Self {
             inner,
@@ -512,11 +532,11 @@ mod tests {
     }
 
     impl TimerCallback for TestCallback {
-        fn on_nomination_timeout(&self, slot: SlotIndex) {
+        fn on_nomination_timeout(&self, slot: SlotIndex, _epoch: u64) {
             self.nomination_fired.store(slot, Ordering::SeqCst);
         }
 
-        fn on_ballot_timeout(&self, slot: SlotIndex) {
+        fn on_ballot_timeout(&self, slot: SlotIndex, _epoch: u64) {
             self.ballot_fired.store(slot, Ordering::SeqCst);
         }
     }
@@ -524,7 +544,7 @@ mod tests {
     #[tokio::test]
     async fn test_nomination_timeout_fires() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
 
         let manager_task = tokio::spawn(manager.run());
 
@@ -547,7 +567,7 @@ mod tests {
     #[tokio::test]
     async fn test_ballot_timeout_fires() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
 
         let manager_task = tokio::spawn(manager.run());
 
@@ -570,7 +590,7 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_prevents_firing() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
 
         let manager_task = tokio::spawn(manager.run());
 
@@ -597,7 +617,7 @@ mod tests {
     #[tokio::test]
     async fn test_reschedule_timer() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
 
         let manager_task = tokio::spawn(manager.run());
 
@@ -632,7 +652,7 @@ mod tests {
     #[tokio::test]
     async fn test_purge_old_slots() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
 
         let manager_task = tokio::spawn(manager.run());
 
@@ -665,7 +685,7 @@ mod tests {
     #[tokio::test]
     async fn test_nonblocking_schedule_nomination() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
         let manager_task = tokio::spawn(manager.run());
 
         handle.schedule_nomination_timeout_nonblocking(55, Duration::from_millis(50));
@@ -680,7 +700,7 @@ mod tests {
     #[tokio::test]
     async fn test_nonblocking_schedule_ballot() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
         let manager_task = tokio::spawn(manager.run());
 
         handle.schedule_ballot_timeout_nonblocking(77, Duration::from_millis(50));
@@ -695,7 +715,7 @@ mod tests {
     #[tokio::test]
     async fn test_nonblocking_cancel_nomination() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
         let manager_task = tokio::spawn(manager.run());
 
         handle.schedule_nomination_timeout_nonblocking(42, Duration::from_millis(100));
@@ -712,7 +732,7 @@ mod tests {
     #[tokio::test]
     async fn test_nonblocking_cancel_ballot() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
         let manager_task = tokio::spawn(manager.run());
 
         handle.schedule_ballot_timeout_nonblocking(42, Duration::from_millis(100));
@@ -729,7 +749,7 @@ mod tests {
     #[tokio::test]
     async fn test_nonblocking_cancel_slot_timers() {
         let callback = Arc::new(TestCallback::new());
-        let (handle, manager) = TimerManager::new(callback.clone());
+        let (handle, manager) = TimerManager::new(callback.clone(), Arc::new(AtomicU64::new(0)));
         let manager_task = tokio::spawn(manager.run());
 
         handle.schedule_nomination_timeout_nonblocking(42, Duration::from_millis(100));

--- a/crates/herder/src/timer_manager.rs
+++ b/crates/herder/src/timer_manager.rs
@@ -190,6 +190,15 @@ impl TimerManagerHandle {
             tracing::warn!(slot, "timer channel closed: cancel ballot dropped");
         }
     }
+
+    /// Cancel all active timers (non-blocking).
+    /// Used from synchronous contexts like `on_lost_sync` where outstanding
+    /// SCP timers must be invalidated immediately on state transition.
+    pub fn cancel_all_timers_nonblocking(&self) {
+        if self.sender.send(TimerCommand::CancelAllTimers).is_err() {
+            tracing::warn!("timer channel closed: cancel all timers dropped");
+        }
+    }
 }
 
 /// Callback trait for timer expiration events.

--- a/crates/herder/src/timer_manager.rs
+++ b/crates/herder/src/timer_manager.rs
@@ -54,9 +54,29 @@ use henyey_scp::SlotIndex;
 #[derive(Debug)]
 pub enum TimerCommand {
     /// Schedule a nomination timeout for a slot (overwrites existing timer).
-    ScheduleNominationTimeout { slot: SlotIndex, duration: Duration },
+    ///
+    /// `epoch` is `None` for normal scheduling (the timer manager stamps the
+    /// timer with the current global tracking epoch). It is `Some(e)` when an
+    /// already-fired timer is being re-armed (the future-slot 1-second defer
+    /// loop), so the re-armed timer inherits the *originating* epoch instead of
+    /// re-sampling the current one. This prevents a pre-sync-loss timer from
+    /// being "reborn" into a newer epoch and surviving into Syncing — a race
+    /// that has no analog in stellar-core, where `timerCallbackWrapper` and
+    /// `setupTimer` operate on the same in-process timer state.
+    ScheduleNominationTimeout {
+        slot: SlotIndex,
+        duration: Duration,
+        epoch: Option<u64>,
+    },
     /// Schedule a ballot timeout for a slot (overwrites existing timer).
-    ScheduleBallotTimeout { slot: SlotIndex, duration: Duration },
+    ///
+    /// See [`TimerCommand::ScheduleNominationTimeout`] for the meaning of
+    /// `epoch`.
+    ScheduleBallotTimeout {
+        slot: SlotIndex,
+        duration: Duration,
+        epoch: Option<u64>,
+    },
     /// Cancel all timers for a slot.
     CancelSlotTimers { slot: SlotIndex },
     /// Cancel the nomination timer for a slot (but keep ballot timer).
@@ -90,17 +110,67 @@ impl TimerManagerHandle {
     }
 
     /// Schedule a nomination timeout for a slot.
+    ///
+    /// The timer is stamped with the current global tracking epoch at
+    /// schedule-time. To re-arm an already-fired timer while preserving its
+    /// originating epoch (the future-slot defer loop), use
+    /// [`Self::reschedule_nomination_timeout_with_epoch`] instead.
     pub async fn schedule_nomination_timeout(&self, slot: SlotIndex, duration: Duration) {
-        let _ = self
-            .sender
-            .send(TimerCommand::ScheduleNominationTimeout { slot, duration });
+        let _ = self.sender.send(TimerCommand::ScheduleNominationTimeout {
+            slot,
+            duration,
+            epoch: None,
+        });
     }
 
     /// Schedule a ballot timeout for a slot.
+    ///
+    /// See [`Self::schedule_nomination_timeout`] for epoch semantics.
     pub async fn schedule_ballot_timeout(&self, slot: SlotIndex, duration: Duration) {
-        let _ = self
-            .sender
-            .send(TimerCommand::ScheduleBallotTimeout { slot, duration });
+        let _ = self.sender.send(TimerCommand::ScheduleBallotTimeout {
+            slot,
+            duration,
+            epoch: None,
+        });
+    }
+
+    /// Re-arm a nomination timeout for a slot, preserving the originating
+    /// tracking `epoch` rather than re-sampling the current global epoch.
+    ///
+    /// Used by the future-slot 1-second defer loop: when a future-slot timer
+    /// fires while tracking, it is re-scheduled for 1 second. If the node loses
+    /// sync between the fire and the re-arm, sampling the *current* epoch would
+    /// let the re-armed timer survive into Syncing. Carrying the firing event's
+    /// epoch keeps the re-armed timer attributable to the epoch in which it was
+    /// originally created, so the epoch guard rejects it after sync loss —
+    /// matching stellar-core's in-process defer loop, which cannot rebirth a
+    /// pre-sync-loss timer.
+    pub async fn reschedule_nomination_timeout_with_epoch(
+        &self,
+        slot: SlotIndex,
+        duration: Duration,
+        epoch: u64,
+    ) {
+        let _ = self.sender.send(TimerCommand::ScheduleNominationTimeout {
+            slot,
+            duration,
+            epoch: Some(epoch),
+        });
+    }
+
+    /// Re-arm a ballot timeout for a slot, preserving the originating tracking
+    /// `epoch`. See [`Self::reschedule_nomination_timeout_with_epoch`].
+    pub async fn reschedule_ballot_timeout_with_epoch(
+        &self,
+        slot: SlotIndex,
+        duration: Duration,
+        epoch: u64,
+    ) {
+        let _ = self.sender.send(TimerCommand::ScheduleBallotTimeout {
+            slot,
+            duration,
+            epoch: Some(epoch),
+        });
     }
 
     /// Cancel all timers for a slot (both nomination and ballot).
@@ -141,7 +211,11 @@ impl TimerManagerHandle {
     pub fn schedule_nomination_timeout_nonblocking(&self, slot: SlotIndex, duration: Duration) {
         if self
             .sender
-            .send(TimerCommand::ScheduleNominationTimeout { slot, duration })
+            .send(TimerCommand::ScheduleNominationTimeout {
+                slot,
+                duration,
+                epoch: None,
+            })
             .is_err()
         {
             tracing::warn!(slot, "timer channel closed: schedule nomination dropped");
@@ -152,7 +226,11 @@ impl TimerManagerHandle {
     pub fn schedule_ballot_timeout_nonblocking(&self, slot: SlotIndex, duration: Duration) {
         if self
             .sender
-            .send(TimerCommand::ScheduleBallotTimeout { slot, duration })
+            .send(TimerCommand::ScheduleBallotTimeout {
+                slot,
+                duration,
+                epoch: None,
+            })
             .is_err()
         {
             tracing::warn!(slot, "timer channel closed: schedule ballot dropped");
@@ -306,11 +384,19 @@ impl<C: TimerCallback> TimerManager<C> {
     /// Handle a single timer command. Returns `false` on Shutdown.
     pub(crate) fn handle_command(&mut self, cmd: TimerCommand) -> bool {
         match cmd {
-            TimerCommand::ScheduleNominationTimeout { slot, duration } => {
-                self.schedule_timer(slot, TimerType::Nomination, duration);
+            TimerCommand::ScheduleNominationTimeout {
+                slot,
+                duration,
+                epoch,
+            } => {
+                self.schedule_timer(slot, TimerType::Nomination, duration, epoch);
             }
-            TimerCommand::ScheduleBallotTimeout { slot, duration } => {
-                self.schedule_timer(slot, TimerType::Ballot, duration);
+            TimerCommand::ScheduleBallotTimeout {
+                slot,
+                duration,
+                epoch,
+            } => {
+                self.schedule_timer(slot, TimerType::Ballot, duration, epoch);
             }
             TimerCommand::CancelSlotTimers { slot } => {
                 self.cancel_slot_timers(slot);
@@ -339,10 +425,22 @@ impl<C: TimerCallback> TimerManager<C> {
     }
 
     /// Schedule a timer for a slot (overwrites any existing timer).
-    fn schedule_timer(&mut self, slot: SlotIndex, timer_type: TimerType, duration: Duration) {
+    ///
+    /// `epoch_override` is `None` for normal scheduling (the timer is stamped
+    /// with the current global tracking epoch). It is `Some(e)` when re-arming
+    /// an already-fired timer (the future-slot defer loop), in which case the
+    /// timer inherits the originating epoch `e` rather than re-sampling the
+    /// current one — see [`TimerCommand::ScheduleNominationTimeout`].
+    fn schedule_timer(
+        &mut self,
+        slot: SlotIndex,
+        timer_type: TimerType,
+        duration: Duration,
+        epoch_override: Option<u64>,
+    ) {
         self.generation = self.generation.wrapping_add(1);
         let expires_at = Instant::now() + duration;
-        let epoch = self.epoch.load(Ordering::Acquire);
+        let epoch = epoch_override.unwrap_or_else(|| self.epoch.load(Ordering::Acquire));
 
         let timer = ActiveTimer {
             timer_type,
@@ -520,6 +618,12 @@ mod tests {
     struct TestCallback {
         nomination_fired: AtomicU64,
         ballot_fired: AtomicU64,
+        /// Epoch carried by the most recent nomination callback. Sentinel
+        /// `u64::MAX` means "no nomination has fired yet".
+        last_nomination_epoch: AtomicU64,
+        /// Epoch carried by the most recent ballot callback. Sentinel
+        /// `u64::MAX` means "no ballot has fired yet".
+        last_ballot_epoch: AtomicU64,
     }
 
     impl TestCallback {
@@ -527,17 +631,21 @@ mod tests {
             Self {
                 nomination_fired: AtomicU64::new(0),
                 ballot_fired: AtomicU64::new(0),
+                last_nomination_epoch: AtomicU64::new(u64::MAX),
+                last_ballot_epoch: AtomicU64::new(u64::MAX),
             }
         }
     }
 
     impl TimerCallback for TestCallback {
-        fn on_nomination_timeout(&self, slot: SlotIndex, _epoch: u64) {
+        fn on_nomination_timeout(&self, slot: SlotIndex, epoch: u64) {
             self.nomination_fired.store(slot, Ordering::SeqCst);
+            self.last_nomination_epoch.store(epoch, Ordering::SeqCst);
         }
 
-        fn on_ballot_timeout(&self, slot: SlotIndex, _epoch: u64) {
+        fn on_ballot_timeout(&self, slot: SlotIndex, epoch: u64) {
             self.ballot_fired.store(slot, Ordering::SeqCst);
+            self.last_ballot_epoch.store(epoch, Ordering::SeqCst);
         }
     }
 
@@ -645,6 +753,94 @@ mod tests {
         assert_eq!(callback.nomination_fired.load(Ordering::SeqCst), 42);
 
         // Shutdown
+        handle.shutdown().await;
+        let _ = timeout(Duration::from_millis(100), manager_task).await;
+    }
+
+    /// Regression for #2803 (PR #2821 final bounce): the future-slot 1-second
+    /// defer loop must preserve the *originating* tracking epoch across a
+    /// re-arm, even if the global epoch is bumped (as on_lost_sync() does)
+    /// between the timer firing and the re-arm command being processed.
+    ///
+    /// Without epoch preservation, `schedule_timer` re-samples the current
+    /// global epoch, so a pre-sync-loss future-slot timer would be re-stamped
+    /// with the new epoch and survive into Syncing — the app-layer epoch guard
+    /// (which rejects events whose epoch != current) could no longer reject it.
+    /// stellar-core's in-process `timerCallbackWrapper`/`setupTimer` defer loop
+    /// cannot rebirth a pre-sync-loss timer this way.
+    #[tokio::test]
+    async fn test_reschedule_with_epoch_preserves_originating_epoch() {
+        let callback = Arc::new(TestCallback::new());
+        let shared_epoch = Arc::new(AtomicU64::new(0));
+        let (handle, manager) = TimerManager::new(callback.clone(), shared_epoch.clone());
+
+        let manager_task = tokio::spawn(manager.run());
+
+        // Re-arm a nomination timer carrying the originating epoch (0) — this is
+        // exactly what the Rearm branch of handle_scp_timer_event() does, using
+        // the firing event's epoch rather than the current global epoch.
+        handle
+            .reschedule_nomination_timeout_with_epoch(42, Duration::from_millis(80), 0)
+            .await;
+
+        // Simulate on_lost_sync(): bump the global tracking epoch *after* the
+        // re-arm command was sent but *before* the timer fires. A re-sampling
+        // implementation would stamp the timer with epoch 1.
+        shared_epoch.store(1, Ordering::Release);
+
+        // Same race for the ballot path.
+        handle
+            .reschedule_ballot_timeout_with_epoch(43, Duration::from_millis(80), 0)
+            .await;
+
+        // Wait for both timers to fire.
+        tokio::time::sleep(Duration::from_millis(160)).await;
+
+        assert_eq!(callback.nomination_fired.load(Ordering::SeqCst), 42);
+        assert_eq!(callback.ballot_fired.load(Ordering::SeqCst), 43);
+
+        // The fired callbacks must carry the ORIGINATING epoch (0), not the
+        // bumped global epoch (1). This is what keeps the re-armed timer
+        // rejectable by the app-layer epoch guard after sync loss.
+        assert_eq!(
+            callback.last_nomination_epoch.load(Ordering::SeqCst),
+            0,
+            "re-armed nomination timer must carry the originating epoch, not the bumped global epoch"
+        );
+        assert_eq!(
+            callback.last_ballot_epoch.load(Ordering::SeqCst),
+            0,
+            "re-armed ballot timer must carry the originating epoch, not the bumped global epoch"
+        );
+
+        handle.shutdown().await;
+        let _ = timeout(Duration::from_millis(100), manager_task).await;
+    }
+
+    /// Sanity counterpart: a *normal* schedule (epoch = None) samples the
+    /// current global epoch at schedule-time, confirming the override is the
+    /// only path that preserves a stale epoch.
+    #[tokio::test]
+    async fn test_normal_schedule_samples_current_epoch() {
+        let callback = Arc::new(TestCallback::new());
+        let shared_epoch = Arc::new(AtomicU64::new(7));
+        let (handle, manager) = TimerManager::new(callback.clone(), shared_epoch.clone());
+
+        let manager_task = tokio::spawn(manager.run());
+
+        handle
+            .schedule_nomination_timeout(42, Duration::from_millis(50))
+            .await;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(callback.nomination_fired.load(Ordering::SeqCst), 42);
+        assert_eq!(
+            callback.last_nomination_epoch.load(Ordering::SeqCst),
+            7,
+            "normal schedule must stamp the timer with the current global epoch"
+        );
+
         handle.shutdown().await;
         let _ = timeout(Duration::from_millis(100), manager_task).await;
     }


### PR DESCRIPTION
Closes #2803

## Summary

Restores stellar-core's 1-second future-slot SCP timer defer loop in henyey's split app/herder architecture. When a timer fires for a slot ahead of `next_consensus_ledger_index()` while tracking, it is now re-armed via `timer_manager_handle` for exactly one second instead of being silently dropped. This matches `HerderSCPDriver::timerCallbackWrapper`'s behavior.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2803#issuecomment-4484774826)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-app -- -D warnings
- [x] `cargo test -p henyey-app -- timer_event` — 10 tests pass (7 classification + 3 end-to-end)
- [x] `cargo test -p henyey-herder -- timeout` — 13 existing tests pass

## Deviations from plan

- Extracted `classify_timer_event()` as a pure function with `TimerEventAction` enum to enable unit testing without constructing a full `App`. The async handler delegates to this classifier.
- Added 3 end-to-end tests (`test_handle_scp_timer_event_e2e_*`) that call `App::handle_scp_timer_event()` with paused tokio time to verify the full async timer chain, in addition to the 7 unit tests that verify the classification logic directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)