### PR TITLE
Implement XDR depth limit check for transaction validation

### DIFF
--- a/crates/ledger/tests/transaction_execution/preconditions.rs
+++ b/crates/ledger/tests/transaction_execution/preconditions.rs
@@ -2644,3 +2644,92 @@ fn test_audit_238_fee_bump_outer_auth_same_source() {
     );
     assert_eq!(result.fee_charged, 0, "No fee charged on pre-seq failure");
 }
+
+// ============================================================================
+// #2805 — XDR depth limit check at executor level
+// Mirrors: stellar-core TransactionFrame.cpp:1973 — over-depth envelope → txMALFORMED
+// ============================================================================
+
+#[test]
+fn test_execute_transaction_rejects_over_depth_envelope() {
+    // Build a deeply nested ScVal to exceed XDR depth limit of 500
+    let mut val = ScVal::U32(42);
+    for _ in 0..501 {
+        val = ScVal::Vec(Some(stellar_xdr::curr::ScVec(
+            vec![val].try_into().unwrap(),
+        )));
+    }
+
+    let secret = SecretKey::from_seed(&[7u8; 32]);
+    let account_id: AccountId = (&secret.public_key()).into();
+    let source = MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes()));
+
+    let (key, entry) = create_account_entry(account_id.clone(), 0, 10_000_000);
+    let snapshot = SnapshotBuilder::new(1)
+        .add_entry(key, entry)
+        .build_with_default_header();
+    let snapshot = SnapshotHandle::new(snapshot);
+
+    let op = Operation {
+        source_account: None,
+        body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+            host_function: HostFunction::InvokeContract(InvokeContractArgs {
+                contract_address: ScAddress::Contract(ContractId(Hash([9u8; 32]))),
+                function_name: ScSymbol(StringM::<32>::try_from("deep".to_string()).unwrap()),
+                args: vec![val].try_into().unwrap(),
+            }),
+            auth: VecM::default(),
+        }),
+    };
+
+    let tx = Transaction {
+        source_account: source,
+        fee: 10_000,
+        seq_num: SequenceNumber(1),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![op].try_into().unwrap(),
+        ext: TransactionExt::V1(SorobanTransactionData {
+            ext: SorobanTransactionDataExt::V0,
+            resources: SorobanResources {
+                footprint: LedgerFootprint {
+                    read_only: VecM::default(),
+                    read_write: VecM::default(),
+                },
+                instructions: 100,
+                disk_read_bytes: 0,
+                write_bytes: 0,
+            },
+            resource_fee: 5000,
+        }),
+    };
+
+    let mut envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: VecM::default(),
+    });
+
+    // Sign the envelope
+    let sig = sign_envelope(&envelope, &secret, &NetworkId::testnet());
+    if let TransactionEnvelope::Tx(ref mut env) = envelope {
+        env.signatures = vec![sig].try_into().unwrap();
+    }
+
+    let context = henyey_tx::LedgerContext::new(1, 1000, 100, 5_000_000, 25, NetworkId::testnet());
+    let mut executor = TransactionExecutor::new(
+        &context,
+        0,
+        SorobanConfig::default(),
+        ClassicEventConfig::default(),
+    );
+
+    let result = executor
+        .execute_transaction(&snapshot, &envelope, 100, None)
+        .expect("execute");
+    assert!(!result.success);
+    assert_eq!(
+        result.failure,
+        Some(ExecutionFailure::TxMalformed),
+        "over-depth envelope must be rejected as TxMalformed"
+    );
+}

--- a/crates/tx/PARITY_STATUS.md
+++ b/crates/tx/PARITY_STATUS.md
@@ -3,7 +3,7 @@
 **Crate**: `henyey-tx`
 **Upstream**: `stellar-core/src/transactions/` (v26.0.1)
 **Overall Parity**: 97%
-**Last Updated**: 2026-05-10
+**Last Updated**: 2026-05-19
 
 ## Summary
 
@@ -687,6 +687,8 @@ Both approaches ensure WASM compilation costs are NOT charged against transactio
 
 9. **Balance Refund Overflow (Fixed March 2026)**: Fee refund arithmetic could overflow on i64 boundaries. Fixed with saturating arithmetic.
 
+10. **XDR Depth Check (Fixed May 2026)**: Missing `check_xdr_depth(envelope, 500)` validation at the top of shared validation entry points (`check_valid_pre_seq_num_with_config`, `validate_basic`, `validate_full`). Over-depth envelopes could pass structural validation and leak as non-parity first failures. Fixed by adding depth-limited XDR write as the first check in all shared paths. Spec anchor references §4.2.3 and §4.2.6 corrected to §5.2 step 8 and §5.2 step 7 respectively.
+
 #### Remaining Work
 
 1. **Bucket list parity**: The primary blocker for higher match rates at high ledger numbers is bucket list state divergence, being addressed in `henyey-bucket`.
@@ -699,14 +701,14 @@ Both approaches ensure WASM compilation costs are NOT charged against transactio
 
 | Category | Count |
 |----------|-------|
-| Implemented (Full) | 201 |
+| Implemented (Full) | 202 |
 | Gaps (None + Partial) | 6 |
 | Intentional Omissions | 31 |
-| **Parity** | **201 / (201 + 6) = 97%** |
+| **Parity** | **202 / (202 + 6) = 97%** |
 
-Breakdown of the 201 implemented items:
+Breakdown of the 202 implemented items:
 - TransactionFrame accessors/methods: 29
-- Validation functions: 13
+- Validation functions: 14
 - SignatureChecker functions: 10
 - MutableTransactionResult functions: 16
 - FeeBumpTransactionFrame functions: 11

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -41,14 +41,42 @@
 use henyey_common::{asset::is_asset_valid, Hash256, NetworkId};
 use henyey_crypto::{PublicKey, Signature};
 use stellar_xdr::curr::{
-    AccountEntry, DecoratedSignature, OperationBody, Preconditions, SignerKey, TransactionEnvelope,
+    AccountEntry, DecoratedSignature, Limits, OperationBody, Preconditions, SignerKey,
+    TransactionEnvelope, WriteXdr,
 };
 
 use crate::fee_bump::{validate_fee_bump, FeeBumpError, FeeBumpFrame};
 use crate::frame::TransactionFrame;
 
+/// Maximum XDR recursion depth for envelope validation.
+/// Parity: stellar-core TransactionFrame.cpp:1973 / FeeBumpTransactionFrame.cpp:278
+const XDR_DEPTH_LIMIT: u32 = 500;
+
 /// stellar-core: TransactionFrame.cpp:65 — MAX_RESOURCE_FEE = 2^50
 pub(crate) const MAX_RESOURCE_FEE: i64 = 1i64 << 50;
+
+/// Check that the transaction envelope does not exceed the XDR recursion depth limit.
+///
+/// Parity: stellar-core `TransactionFrame::checkValid` (TransactionFrame.cpp:1973) and
+/// `FeeBumpTransactionFrame::checkValidImpl` (FeeBumpTransactionFrame.cpp:278):
+/// ```text
+/// if (!xdr::check_xdr_depth(mEnvelope, 500)) { return txMALFORMED; }
+/// ```
+///
+/// This validates the full outer envelope by attempting a depth-limited XDR write.
+/// If the envelope's recursive structure exceeds 500 levels, it is rejected as malformed.
+fn check_xdr_depth(frame: &TransactionFrame) -> std::result::Result<(), PreSeqNumError> {
+    if frame
+        .envelope()
+        .to_xdr(Limits::depth(XDR_DEPTH_LIMIT))
+        .is_err()
+    {
+        return Err(PreSeqNumError::Malformed(
+            "XDR depth limit exceeded".to_string(),
+        ));
+    }
+    Ok(())
+}
 
 /// Per-transaction Soroban resource limits from the network configuration.
 ///
@@ -550,7 +578,7 @@ pub fn is_too_late(
     }
 
     // Check ledger max bound
-    // Spec: TX_SPEC §4.2.3 — ledger sequence MUST be strictly less than maxLedger.
+    // Spec: TX_SPEC §5.2 step 8 — ledger sequence MUST be strictly less than maxLedger.
     let ledger_bounds = match frame.preconditions() {
         Preconditions::None | Preconditions::Time(_) => None,
         Preconditions::V2(cond) => cond.ledger_bounds,
@@ -584,7 +612,7 @@ fn validate_soroban_resources(
     context: &LedgerContext,
 ) -> std::result::Result<(), ValidationError> {
     if !frame.is_soroban() {
-        // Spec: TX_SPEC §4.2.6 — a non-Soroban transaction MUST NOT carry
+        // Spec: TX_SPEC §5.2 step 7 — a non-Soroban transaction MUST NOT carry
         // SorobanTransactionData. Result: txMALFORMED.
         if frame.soroban_data().is_some() {
             return Err(ValidationError::InvalidStructure(
@@ -728,6 +756,11 @@ pub fn validate_basic(
     frame: &TransactionFrame,
     context: &LedgerContext,
 ) -> std::result::Result<(), Vec<ValidationError>> {
+    // Spec: TX_SPEC §5.1-1 — XDR depth check (first, before any other validation).
+    if let Err(e) = check_xdr_depth(frame) {
+        return Err(vec![ValidationError::InvalidStructure(e.to_string())]);
+    }
+
     let mut errors = Vec::new();
 
     if let Err(e) = validate_structure(frame) {
@@ -772,6 +805,11 @@ pub fn validate_full(
     context: &LedgerContext,
     source_account: &AccountEntry,
 ) -> std::result::Result<(), Vec<ValidationError>> {
+    // Spec: TX_SPEC §5.1-1 — XDR depth check (first, before any other validation).
+    if let Err(e) = check_xdr_depth(frame) {
+        return Err(vec![ValidationError::InvalidStructure(e.to_string())]);
+    }
+
     let mut errors = Vec::new();
 
     if let Err(e) = validate_structure(frame) {
@@ -1010,6 +1048,12 @@ pub fn check_valid_pre_seq_num_with_config(
     _ledger_flags: u32,
     soroban_limits: Option<&SorobanResourceLimits>,
 ) -> std::result::Result<(), PreSeqNumError> {
+    // Spec: TX_SPEC §5.1-1 — XDR depth check on the full outer envelope.
+    // Parity: stellar-core TransactionFrame.cpp:1973
+    //   `if (!xdr::check_xdr_depth(mEnvelope, 500))`
+    // This MUST be first: over-depth envelopes must not leak as InvalidSignature/TooLate/etc.
+    check_xdr_depth(frame)?;
+
     // 1. Structure: op count, fee > 0, soroban single-op consistency
     if frame.operations().is_empty() {
         return Err(PreSeqNumError::MissingOperation);

--- a/crates/tx/tests/validation_parity.rs
+++ b/crates/tx/tests/validation_parity.rs
@@ -481,3 +481,105 @@ fn test_validate_basic_rejects_resource_fee_overflow() {
         errors
     );
 }
+
+// ============================================================================
+// #2805 — XDR depth limit check (§5.1-1)
+// Mirrors: stellar-core TransactionFrame.cpp:1969-1976 — xdr::check_xdr_depth(mEnvelope, 500)
+// ============================================================================
+
+/// Build an otherwise-valid Soroban envelope whose XDR nesting depth exceeds 500.
+/// Uses recursive ScVal::Vec nesting to achieve the required depth.
+fn make_over_depth_soroban_envelope() -> TransactionEnvelope {
+    // Build a deeply nested ScVal: Vec([Vec([Vec([...])])])
+    // Each ScVal::Vec layer adds XDR depth. We need >500 layers.
+    let mut val = ScVal::U32(42);
+    for _ in 0..501 {
+        val = ScVal::Vec(Some(stellar_xdr::curr::ScVec(
+            vec![val].try_into().unwrap(),
+        )));
+    }
+
+    let source = MuxedAccount::Ed25519(Uint256([1u8; 32]));
+    let op = Operation {
+        source_account: None,
+        body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+            host_function: HostFunction::InvokeContract(stellar_xdr::curr::InvokeContractArgs {
+                contract_address: ScAddress::Contract(ContractId(Hash([9u8; 32]))),
+                function_name: stellar_xdr::curr::ScSymbol(
+                    stellar_xdr::curr::StringM::<32>::try_from("deep".to_string()).unwrap(),
+                ),
+                args: vec![val].try_into().unwrap(),
+            }),
+            auth: VecM::default(),
+        }),
+    };
+
+    let tx = Transaction {
+        source_account: source,
+        fee: 10_000,
+        seq_num: SequenceNumber(1),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![op].try_into().unwrap(),
+        ext: TransactionExt::V1(SorobanTransactionData {
+            ext: SorobanTransactionDataExt::V0,
+            resources: SorobanResources {
+                footprint: empty_footprint(),
+                instructions: 100,
+                disk_read_bytes: 0,
+                write_bytes: 0,
+            },
+            resource_fee: 5000,
+        }),
+    };
+
+    TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: vec![].try_into().unwrap(),
+    })
+}
+
+/// §5.1-1: check_valid_pre_seq_num must reject envelopes exceeding XDR depth limit of 500.
+/// Parity: stellar-core TransactionFrame.cpp:1973 — `if (!xdr::check_xdr_depth(mEnvelope, 500))`
+#[test]
+fn test_reject_transaction_exceeding_xdr_depth_limit() {
+    let envelope = make_over_depth_soroban_envelope();
+    let frame = TransactionFrame::from_owned(envelope);
+
+    let result = check_valid_pre_seq_num(&frame, PROTOCOL_VERSION, 0);
+    assert_eq!(
+        result,
+        Err(PreSeqNumError::Malformed(
+            "XDR depth limit exceeded".to_string()
+        )),
+        "check_valid_pre_seq_num should reject over-depth envelope as Malformed"
+    );
+}
+
+/// §5.1-1: validate_basic must also reject envelopes exceeding XDR depth limit.
+#[test]
+fn test_validate_basic_rejects_transaction_exceeding_xdr_depth_limit() {
+    use henyey_tx::validation::{validate_basic, LedgerContext, ValidationError};
+
+    let envelope = make_over_depth_soroban_envelope();
+    let frame = TransactionFrame::from_owned(envelope);
+
+    let ctx = LedgerContext::new(
+        100,
+        1000,
+        100,
+        5_000_000,
+        PROTOCOL_VERSION,
+        NetworkId::testnet(),
+    );
+    let result = validate_basic(&frame, &ctx);
+    let errors = result.expect_err("validate_basic should reject over-depth envelope");
+    let has_depth_error = errors
+        .iter()
+        .any(|e| matches!(e, ValidationError::InvalidStructure(msg) if msg.contains("depth")));
+    assert!(
+        has_depth_error,
+        "expected InvalidStructure error about XDR depth, got: {:?}",
+        errors
+    );
+}


### PR DESCRIPTION
Closes #2805

## Summary

Adds the missing XDR depth guard (§5.1-1) as the first validation check in all shared transaction validation entry points. Over-depth envelopes (>500 XDR recursion levels) are now rejected as `Malformed` before any fee/time/signature processing, matching stellar-core's `xdr::check_xdr_depth(mEnvelope, 500)` behavior.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2805#issuecomment-4485739627)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-tx -p henyey-ledger passes (all 566 tests)

## Regression test

- **Tests:** `validation_parity::test_reject_transaction_exceeding_xdr_depth_limit`, `validation_parity::test_validate_basic_rejects_transaction_exceeding_xdr_depth_limit`, `preconditions::test_execute_transaction_rejects_over_depth_envelope`
- **Pre-fix:** committed as `c7ba251d` — verified FAILED with: `assertion left == right: Ok(()) != Err(Malformed(...))`
- **Post-fix:** verified PASSES after `767d74a0`

## Deviations from plan

- INV-T11/T13/T15 evidence audit found existing coverage adequate — no new tests needed, no reclassification.
- Anchor backfill limited to the two broken references plus the new depth-gate anchor; broader coverage stays follow-up per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
