### PR TITLE
Enforce ~/data workspace contract for reviewer/critic sub-agents

### DIFF
--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -84,6 +84,22 @@ must be preserved. If not parity-critical: write "n/a — non-parity path".>
 
 ## Step 3 — Round 1: Spawn 3 critics in parallel
 
+### Critic workspace contract
+
+**All critic scratch work must live only under `$HOME/data`.** Critics should prefer the existing checkout for read-only inspection. If a critic needs a scratch checkout (e.g. to run a test or verify a claim), it must live under `$HOME/data`, never in the repo root, the repo parent, or anywhere outside `$HOME/data`. Each critic derives its workspace as follows:
+
+```bash
+SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
+WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/plan-$ISSUE}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
+
+# Critic-specific scratch dir (only if needed for checkout/build):
+CRITIC_WORKTREE="$WORKTREE_BASE/critic-a"  # or critic-b, critic-c
+mkdir -p "$CRITIC_WORKTREE"
+```
+
+Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those; otherwise it falls back to `$HOME/data/$SESSION_ID/plan-$ISSUE/...`.
+
 Launch three `general-purpose` agents in parallel — do not wait between them. **Each critic must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity is the whole point of the critic step. Each gets the issue number, the plan-draft comment ID, and a focused brief:
 
 ### Critic A — Correctness

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -144,6 +144,22 @@ Otherwise, the PR is **non-parity** — Reviewer B uses risk lens.
 
 ## Step 4 — Spawn 2 reviewers in parallel
 
+### Reviewer workspace contract
+
+**All reviewer scratch work must live only under `$HOME/data`.** Reviewers must never create worktrees, checkouts, or build artifacts in the repo root, the repo parent, or anywhere outside `$HOME/data`. Each reviewer derives its workspace as follows:
+
+```bash
+SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
+WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/review-pr-$PR_NUM}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
+
+# Reviewer-specific worktree (e.g. for regression-test verification):
+REVIEWER_WORKTREE="$WORKTREE_BASE/reviewer-a"
+mkdir -p "$REVIEWER_WORKTREE"
+```
+
+Include this bootstrap verbatim in each reviewer's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the reviewer respects those; otherwise it falls back to `$HOME/data/$SESSION_ID/review-pr-$PR_NUM/...`.
+
 Launch both as `general-purpose` foreground sub-agents. Do not wait between them. **Each reviewer must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity catches issues a same-model pipeline would miss.
 
 **Why structured comments, not `gh pr review --approve`:** the authenticated GH user is the PR author (the same user opened the PR via `/do` and now reviews it). GitHub disallows author self-approval, so `gh pr review --approve` is silently downgraded to a comment by `gh`. Instead, each reviewer posts a structured comment with a verdict marker that `/review-pr` parses in Step 6.
@@ -184,11 +200,14 @@ Post via `gh pr comment $PR_NUM --repo stellar-experimental/henyey --body-file <
 >    - **Verify the regression test would have caught the bug.** Walk the PR
 >      commit list (\`gh pr view $PR_NUM --json commits\`). The test should
 >      have been committed BEFORE the fix. Check out the parent of the fix
->      commit and run the test:
+>      commit IN YOUR REVIEWER WORKSPACE and run the test:
 >      \`\`\`bash
+>      # Use the reviewer workspace — never checkout in the repo root
+>      cd "$REVIEWER_WORKTREE"
+>      git clone --shared "$REPO_ROOT" . 2>/dev/null || true
 >      git fetch origin pull/$PR_NUM/head:pr-$PR_NUM
 >      git checkout <test-commit-sha>
->      cargo test -p henyey-<crate> <test_fn> 2>&1 | tail -10
+>      CARGO_TARGET_DIR="$CARGO_TARGET_DIR" cargo test -p henyey-<crate> <test_fn> 2>&1 | tail -10
 >      \`\`\`
 >      Confirm the test FAILS at that point. If the test passes at the test-
 >      commit, the regression test doesn't actually capture the bug → bounce.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,12 @@ jobs:
         run: git submodule update --init stellar-core
       - name: Check spec-eval freshness
         run: bash scripts/check-spec-eval-freshness.sh
+
+  agent-worktree-contract:
+    name: Agent Worktree Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify agent workspace contract
+        run: bash scripts/test-agent-worktree-contract.sh

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# test-agent-worktree-contract.sh — TAP contract test for agent workspace placement.
+#
+# Verifies that /review-pr and /plan skill files enforce the ~/data workspace
+# contract: all worktrees, cargo targets, and scratch dirs resolve under
+# $HOME/data/$SESSION_ID/..., and both skills explicitly forbid repo-root or
+# repo-parent worktree creation.
+#
+# Usage: bash scripts/test-agent-worktree-contract.sh
+# Exit: 0 if all tests pass, 1 otherwise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REVIEW_PR_SKILL="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+PLAN_SKILL="$REPO_ROOT/.github/skills/plan/SKILL.md"
+
+PASS=0
+FAIL=0
+TEST_NUM=0
+
+tap_ok() {
+  TEST_NUM=$((TEST_NUM + 1))
+  PASS=$((PASS + 1))
+  echo "ok $TEST_NUM - $1"
+}
+
+tap_not_ok() {
+  TEST_NUM=$((TEST_NUM + 1))
+  FAIL=$((FAIL + 1))
+  echo "not ok $TEST_NUM - $1"
+  echo "#   $2"
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr workspace contract resolves under ~/data
+# --------------------------------------------------------------------------
+test_review_pr_workspace_contract_resolves_under_home_data() {
+  local desc="review-pr workspace contract resolves under ~/data"
+
+  # The skill must contain a reviewer workspace bootstrap that derives paths
+  # under $HOME/data. We look for the documented pattern.
+  if grep -q 'HOME/data/\$SESSION_ID/review-pr' "$REVIEW_PR_SKILL" ||
+     grep -q 'HOME/data/\${SESSION_ID}/review-pr' "$REVIEW_PR_SKILL" ||
+     grep -q '\~/data/\$SESSION_ID/review-pr' "$REVIEW_PR_SKILL" ||
+     grep -q '\$HOME/data/.*review-pr' "$REVIEW_PR_SKILL"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "SKILL.md does not contain a ~/data/\$SESSION_ID/review-pr workspace derivation"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: plan workspace contract resolves under ~/data
+# --------------------------------------------------------------------------
+test_plan_workspace_contract_resolves_under_home_data() {
+  local desc="plan workspace contract resolves under ~/data"
+
+  if grep -q 'HOME/data/\$SESSION_ID/plan' "$PLAN_SKILL" ||
+     grep -q 'HOME/data/\${SESSION_ID}/plan' "$PLAN_SKILL" ||
+     grep -q '\~/data/\$SESSION_ID/plan' "$PLAN_SKILL" ||
+     grep -q '\$HOME/data/.*plan-\$ISSUE' "$PLAN_SKILL"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "SKILL.md does not contain a ~/data/\$SESSION_ID/plan workspace derivation"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: skill prompts forbid repo-root worktrees
+# --------------------------------------------------------------------------
+test_skill_prompts_forbid_repo_root_worktrees() {
+  local desc="skill prompts forbid repo-root worktrees"
+  local review_has_guard=false
+  local plan_has_guard=false
+
+  # Check review-pr skill for explicit prohibition
+  if grep -qi 'never.*worktree.*repo.*root\|never.*repo.*root.*worktree\|never.*create.*worktree.*outside.*~/data\|must not.*worktree.*outside.*\~/data\|do not.*create.*worktree.*outside\|never.*outside.*\$HOME/data\|must.*under.*\$HOME/data\|only.*under.*\$HOME/data' "$REVIEW_PR_SKILL"; then
+    review_has_guard=true
+  fi
+
+  # Check plan skill for explicit prohibition
+  if grep -qi 'never.*worktree.*repo.*root\|never.*repo.*root.*worktree\|never.*create.*worktree.*outside.*~/data\|must not.*worktree.*outside.*\~/data\|do not.*create.*worktree.*outside\|never.*outside.*\$HOME/data\|must.*under.*\$HOME/data\|only.*under.*\$HOME/data' "$PLAN_SKILL"; then
+    plan_has_guard=true
+  fi
+
+  if $review_has_guard && $plan_has_guard; then
+    tap_ok "$desc"
+  else
+    local missing=""
+    $review_has_guard || missing="review-pr"
+    $plan_has_guard || missing="${missing:+$missing, }plan"
+    tap_not_ok "$desc" "Missing repo-root worktree prohibition in: $missing"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr bootstrap is self-seeding (works with or without env vars)
+# --------------------------------------------------------------------------
+test_review_pr_self_seeding() {
+  local desc="review-pr bootstrap is self-seeding (WORKTREE_BASE fallback)"
+
+  # The skill should show a ${WORKTREE_BASE:-...} or SESSION_ID fallback pattern
+  if grep -q 'WORKTREE_BASE:-\|SESSION_ID:-\|CLAUDE_SESSION_ID:-' "$REVIEW_PR_SKILL" ||
+     grep -q 'WORKTREE_BASE:=' "$REVIEW_PR_SKILL"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "No self-seeding fallback (e.g. \${WORKTREE_BASE:-...}) found in review-pr SKILL.md"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: plan bootstrap is self-seeding (works with or without env vars)
+# --------------------------------------------------------------------------
+test_plan_self_seeding() {
+  local desc="plan bootstrap is self-seeding (WORKTREE_BASE fallback)"
+
+  if grep -q 'WORKTREE_BASE:-\|SESSION_ID:-\|CLAUDE_SESSION_ID:-' "$PLAN_SKILL" ||
+     grep -q 'WORKTREE_BASE:=' "$PLAN_SKILL"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "No self-seeding fallback (e.g. \${WORKTREE_BASE:-...}) found in plan SKILL.md"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr CARGO_TARGET_DIR resolves under ~/data
+# --------------------------------------------------------------------------
+test_review_pr_cargo_target_under_data() {
+  local desc="review-pr CARGO_TARGET_DIR resolves under ~/data"
+
+  if grep -q 'CARGO_TARGET_DIR.*HOME/data\|CARGO_TARGET_DIR.*~/data' "$REVIEW_PR_SKILL" ||
+     grep -q 'CARGO_TARGET_DIR.*\$WORKTREE_BASE' "$REVIEW_PR_SKILL"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "CARGO_TARGET_DIR not directed to ~/data in review-pr SKILL.md"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: plan CARGO_TARGET_DIR resolves under ~/data
+# --------------------------------------------------------------------------
+test_plan_cargo_target_under_data() {
+  local desc="plan CARGO_TARGET_DIR resolves under ~/data"
+
+  if grep -q 'CARGO_TARGET_DIR.*HOME/data\|CARGO_TARGET_DIR.*~/data' "$PLAN_SKILL" ||
+     grep -q 'CARGO_TARGET_DIR.*\$WORKTREE_BASE' "$PLAN_SKILL"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "CARGO_TARGET_DIR not directed to ~/data in plan SKILL.md"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Run all tests
+# --------------------------------------------------------------------------
+echo "TAP version 13"
+
+test_review_pr_workspace_contract_resolves_under_home_data
+test_plan_workspace_contract_resolves_under_home_data
+test_skill_prompts_forbid_repo_root_worktrees
+test_review_pr_self_seeding
+test_plan_self_seeding
+test_review_pr_cargo_target_under_data
+test_plan_cargo_target_under_data
+
+echo "1..$TEST_NUM"
+echo "# pass: $PASS"
+echo "# fail: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Closes #2814

## Summary

Adds mandatory workspace bootstrap sections to `/review-pr` (Step 4) and `/plan` (Step 3) skill files so reviewer/critic sub-agents derive worktrees and cargo targets under `$HOME/data/$SESSION_ID/...` instead of spilling ~8-10G directories into the repo root or parent.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2814#issuecomment-4487132730)

## Test plan

- [x] `scripts/test-agent-worktree-contract.sh` — 7 TAP assertions all pass
- [x] CI job `Agent Worktree Contract` added to `.github/workflows/ci.yml`

## Regression test

- **Test:** `scripts/test-agent-worktree-contract.sh` (all 7 assertions)
- **Pre-fix:** committed as `a66e429a` — verified FAILED with: all 7 TAP assertions fail (no workspace contract in either skill file)
- **Post-fix:** verified PASSES after `14b86ed3`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)