### PR TITLE
Add reviewer workspace bootstrap and exit-path cleanup to /review-pr

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -153,7 +153,7 @@ Otherwise, the PR is **non-parity** — Reviewer B uses risk lens.
 Before spawning reviewers, set up a shared workspace rooted under `~/data` so all reviewer scratch state stays off root FS:
 
 ```bash
-SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
+SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)-$$-$(head -c4 /dev/urandom | od -An -tx1 | tr -d ' \n')}"
 WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
 
 # Safety: validate WORKTREE_BASE is under $HOME/data/ and matches expected layout.
@@ -773,7 +773,7 @@ state lives under `$HOME/data/$SESSION_ID/pr-$PR_NUM-review/` (set via `WORKTREE
 in Step 3.5):
 
 ```bash
-SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
+SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)-$$-$(head -c4 /dev/urandom | od -An -tx1 | tr -d ' \n')}"
 WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
 validate_worktree_base "$WORKTREE_BASE" "$PR_NUM" || exit 1   # fail early on bad override
 export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -148,6 +148,31 @@ If any path matches one of these prefixes, the PR is **parity-critical** — Rev
 
 Otherwise, the PR is **non-parity** — Reviewer B uses risk lens.
 
+## Step 3.5 — Bootstrap reviewer workspace
+
+Before spawning reviewers, set up a shared workspace rooted under `~/data` so all reviewer scratch state stays off root FS:
+
+```bash
+SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
+WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
+export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
+
+mkdir -p "$WORKTREE_BASE/reviewer-a" "$WORKTREE_BASE/reviewer-b"
+```
+
+Each reviewer gets its own scratch directory:
+
+- **Reviewer A** scratch: `$WORKTREE_BASE/reviewer-a/`
+- **Reviewer B** scratch: `$WORKTREE_BASE/reviewer-b/`
+
+**Prohibited patterns — reviewers must NEVER use:**
+
+- `/tmp/pr*` — lands on root FS, causes near-OOM on small root partitions.
+- `$REPO_ROOT/.pr-*` — pollutes the shared checkout and is not cleaned up.
+- Any path outside `$HOME/data/` for worktrees or build artifacts.
+
+Pass `WORKTREE_BASE`, `CARGO_TARGET_DIR`, and the reviewer-specific scratch dir to each reviewer sub-agent prompt so they know exactly where to place any checkout or build output.
+
 ## Step 4 — Spawn 2 reviewers in parallel
 
 Launch both as `general-purpose` foreground sub-agents. Do not wait between them. **Each reviewer must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity catches issues a same-model pipeline would miss.
@@ -180,6 +205,12 @@ Post via `gh pr comment $PR_NUM --repo stellar-experimental/henyey --body-file <
 
 > Invoke /review on PR #$PR_NUM in stellar-experimental/henyey. Focus on:
 > correctness of the diff, test coverage, readability, error handling.
+>
+> **Workspace:** Your scratch directory is `$WORKTREE_BASE/reviewer-a/`. If you
+> need to check out code or build, use ONLY that directory. Set
+> `CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"`. **Never** create worktrees
+> under `/tmp/pr*`, `$REPO_ROOT/.pr-*`, or anywhere outside `$HOME/data/`.
+> Clean up any scratch worktrees you create before exiting.
 >
 > **Test verification (REQUEST_CHANGES if any of these fails):**
 >
@@ -221,6 +252,12 @@ Post via `gh pr comment $PR_NUM --repo stellar-experimental/henyey --body-file <
 
 **If parity-critical:**
 
+> **Workspace:** Your scratch directory is `$WORKTREE_BASE/reviewer-b/`. If you
+> need to check out code or build, use ONLY that directory. Set
+> `CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"`. **Never** create worktrees
+> under `/tmp/pr*`, `$REPO_ROOT/.pr-*`, or anywhere outside `$HOME/data/`.
+> Clean up any scratch worktrees you create before exiting.
+>
 > Invoke /spec-adhere style audit on PR #$PR_NUM in stellar-experimental/henyey.
 > Focus on: does the change match stellar-core's behavior on this path?
 > Consult the `stellar-core/` submodule for the matching C++ implementation.
@@ -231,6 +268,12 @@ Post via `gh pr comment $PR_NUM --repo stellar-experimental/henyey --body-file <
 
 **If non-parity (risk lens):**
 
+> **Workspace:** Your scratch directory is `$WORKTREE_BASE/reviewer-b/`. If you
+> need to check out code or build, use ONLY that directory. Set
+> `CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"`. **Never** create worktrees
+> under `/tmp/pr*`, `$REPO_ROOT/.pr-*`, or anywhere outside `$HOME/data/`.
+> Clean up any scratch worktrees you create before exiting.
+>
 > Review PR #$PR_NUM in stellar-experimental/henyey for risk: regressions in
 > existing behavior, performance impact, breaking changes to APIs or data
 > formats, security implications, operational concerns (config, migrations).
@@ -503,6 +546,13 @@ gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+# Clean up the reviewer workspace (Step 3.5 artifacts).
+# This is the primary fix for #2843 — ensures reviewer scratch state never
+# lingers on disk after /review-pr completes.
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+  rm -rf "$WORKTREE_BASE"
+fi
+
 # Recover session ID from the sidecar /do persisted (see do/SKILL.md A.2).
 # Build cache lives at $HOME/data/<session-id>/do-$ISSUE/cargo-target/ — can be
 # 25-50 GB per issue. Clean it up here; otherwise nothing else will.
@@ -544,7 +594,16 @@ CI age: <CI_AGE_MIN> min / budget <CI_STUCK_AFTER_MINUTES> min.
 Bounce-back count: <N>/3.
 ```
 
-Unassign yourself so the next tick re-picks this issue. Exit.
+Unassign yourself so the next tick re-picks this issue.
+
+```bash
+# Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+  rm -rf "$WORKTREE_BASE"
+fi
+```
+
+Exit.
 
 ### Bounce path
 
@@ -570,6 +629,11 @@ Routing back to `ready-for-doing` for `/do` Mode B.
 Move state and unassign:
 
 ```bash
+# Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+  rm -rf "$WORKTREE_BASE"
+fi
+
 bash .github/skills/shared/scripts/move-issue-status.sh $ISSUE ready-for-doing
 gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
 ```
@@ -615,6 +679,11 @@ To retry after addressing root cause, post `## Review: Reset` with a one-line re
 Move state:
 
 ```bash
+# Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+  rm -rf "$WORKTREE_BASE"
+fi
+
 bash .github/skills/shared/scripts/move-issue-status.sh $ISSUE blocked
 gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
 ```
@@ -644,20 +713,35 @@ Exit.
 ## Workspace contract
 
 The `/review-pr` skill must never create worktrees outside `$HOME/data`. All scratch
-state lives under `$HOME/data/$SESSION_ID/review-pr-$ISSUE/`:
+state lives under `$HOME/data/$SESSION_ID/pr-$PR_NUM-review/` (set via `WORKTREE_BASE`
+in Step 3.5):
 
 ```bash
 SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
-export CARGO_TARGET_DIR="$HOME/data/$SESSION_ID/review-pr-$ISSUE/cargo-target"
+WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
+export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
 ```
+
+Per-reviewer scratch directories:
+- `$WORKTREE_BASE/reviewer-a/` — Reviewer A's exclusive scratch space
+- `$WORKTREE_BASE/reviewer-b/` — Reviewer B's exclusive scratch space
 
 This ensures build artifacts are isolated per-session and automatically discoverable
 for cleanup. The skill itself is read-only (no code changes), so it rarely needs a
 build cache — but if a reviewer sub-agent builds to verify, the target dir must
 resolve under `$HOME/data`.
 
+**Prohibited patterns — never use these:**
+- `/tmp/pr*` — lands on root FS, causes near-OOM on small root partitions.
+- `$REPO_ROOT/.pr-*` — pollutes the shared checkout and is not cleaned up.
+- Any path outside `$HOME/data/` for worktrees or build artifacts.
+
 **Never create worktrees at the repo root or outside `$HOME/data`.** All worktrees
 must be under `$HOME/data/$SESSION_ID/` to avoid polluting the shared checkout.
+
+**Exit-path cleanup:** Every terminal path in Step 7 (merge, wait, bounce, block)
+must run `rm -rf "$WORKTREE_BASE"` before exiting to prevent stale reviewer
+artifacts from accumulating on disk.
 
 ## Branch protection
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -157,6 +157,27 @@ SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
 WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
 export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
 
+# Safety: validate WORKTREE_BASE is under $HOME/data/ and matches expected layout.
+# Reject overly broad paths that could cause catastrophic deletion on cleanup.
+validate_worktree_base() {
+  local base="$1"
+  local resolved
+  resolved="$(cd "$base" 2>/dev/null && pwd || echo "$base")"
+  if [ -z "$resolved" ] ||
+     [ "$resolved" = "/" ] ||
+     [ "$resolved" = "$HOME" ] ||
+     [ "$resolved" = "$HOME/data" ] ||
+     [ "$resolved" = "$HOME/data/" ]; then
+    echo "FATAL: WORKTREE_BASE='$resolved' is too broad; refusing rm -rf" >&2
+    return 1
+  fi
+  case "$resolved" in
+    "$HOME/data/"*/pr-*-review) return 0 ;;
+    "$HOME/data/"*/review-pr-*) return 0 ;;
+    *) echo "FATAL: WORKTREE_BASE='$resolved' does not match expected pattern \$HOME/data/<session>/pr-<N>-review" >&2; return 1 ;;
+  esac
+}
+
 mkdir -p "$WORKTREE_BASE/reviewer-a" "$WORKTREE_BASE/reviewer-b"
 ```
 
@@ -549,7 +570,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # Clean up the reviewer workspace (Step 3.5 artifacts).
 # This is the primary fix for #2843 — ensures reviewer scratch state never
 # lingers on disk after /review-pr completes.
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
   rm -rf "$WORKTREE_BASE"
 fi
 
@@ -598,7 +619,7 @@ Unassign yourself so the next tick re-picks this issue.
 
 ```bash
 # Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
   rm -rf "$WORKTREE_BASE"
 fi
 ```
@@ -630,7 +651,7 @@ Move state and unassign:
 
 ```bash
 # Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
   rm -rf "$WORKTREE_BASE"
 fi
 
@@ -680,7 +701,7 @@ Move state:
 
 ```bash
 # Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ]; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
   rm -rf "$WORKTREE_BASE"
 fi
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -159,8 +159,11 @@ WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
 # Safety: validate WORKTREE_BASE is under $HOME/data/ and matches expected layout.
 # Reject overly broad paths that could cause catastrophic deletion on cleanup.
 # Called at bootstrap (before mkdir/export) AND before every rm -rf on exit paths.
+# Usage: validate_worktree_base <path> [<pr_number>]
+# When <pr_number> is supplied, the path must match that specific PR (not any PR).
 validate_worktree_base() {
   local base="$1"
+  local expected_pr="${2:-}"
 
   # Reject path traversal components before any resolution — prevents escaping
   # ~/data/ even when the target directory does not yet exist.
@@ -186,6 +189,18 @@ validate_worktree_base() {
     echo "FATAL: WORKTREE_BASE='$resolved' is too broad; refusing rm -rf" >&2
     return 1
   fi
+
+  # When a specific PR number is provided, only accept paths for that PR.
+  # This prevents a stale/leaked WORKTREE_BASE from one PR accidentally
+  # targeting another PR's workspace during concurrent reviews.
+  if [ -n "$expected_pr" ]; then
+    case "$resolved" in
+      "$HOME/data/"*/pr-"$expected_pr"-review) return 0 ;;
+      "$HOME/data/"*/review-pr-"$expected_pr") return 0 ;;
+      *) echo "FATAL: WORKTREE_BASE='$resolved' does not match current PR $expected_pr; expected \$HOME/data/<session>/pr-${expected_pr}-review" >&2; return 1 ;;
+    esac
+  fi
+
   case "$resolved" in
     "$HOME/data/"*/pr-*-review) return 0 ;;
     "$HOME/data/"*/review-pr-*) return 0 ;;
@@ -194,7 +209,8 @@ validate_worktree_base() {
 }
 
 # Validate WORKTREE_BASE immediately — fail early if an override points outside ~/data.
-validate_worktree_base "$WORKTREE_BASE" || exit 1
+# Pass $PR_NUM so the validator rejects paths belonging to a different PR.
+validate_worktree_base "$WORKTREE_BASE" "$PR_NUM" || exit 1
 
 export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
 mkdir -p "$WORKTREE_BASE/reviewer-a" "$WORKTREE_BASE/reviewer-b"
@@ -589,7 +605,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # Clean up the reviewer workspace (Step 3.5 artifacts).
 # This is the primary fix for #2843 — ensures reviewer scratch state never
 # lingers on disk after /review-pr completes.
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE" "$PR_NUM"; then
   rm -rf "$WORKTREE_BASE"
 fi
 
@@ -638,7 +654,7 @@ Unassign yourself so the next tick re-picks this issue.
 
 ```bash
 # Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE" "$PR_NUM"; then
   rm -rf "$WORKTREE_BASE"
 fi
 ```
@@ -670,7 +686,7 @@ Move state and unassign:
 
 ```bash
 # Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE" "$PR_NUM"; then
   rm -rf "$WORKTREE_BASE"
 fi
 
@@ -720,7 +736,7 @@ Move state:
 
 ```bash
 # Clean up reviewer workspace before exiting (prevents stale artifacts on disk).
-if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE"; then
+if [ -n "$WORKTREE_BASE" ] && [ -d "$WORKTREE_BASE" ] && validate_worktree_base "$WORKTREE_BASE" "$PR_NUM"; then
   rm -rf "$WORKTREE_BASE"
 fi
 
@@ -759,7 +775,7 @@ in Step 3.5):
 ```bash
 SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
 WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
-validate_worktree_base "$WORKTREE_BASE" || exit 1   # fail early on bad override
+validate_worktree_base "$WORKTREE_BASE" "$PR_NUM" || exit 1   # fail early on bad override
 export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
 ```
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -161,8 +161,23 @@ WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
 # Called at bootstrap (before mkdir/export) AND before every rm -rf on exit paths.
 validate_worktree_base() {
   local base="$1"
+
+  # Reject path traversal components before any resolution — prevents escaping
+  # ~/data/ even when the target directory does not yet exist.
+  case "$base" in
+    */..*|*/../*|../*|..) echo "FATAL: WORKTREE_BASE='$base' contains '..' traversal; refusing" >&2; return 1 ;;
+  esac
+
+  # Canonicalize: use realpath --canonicalize-missing if available (resolves
+  # symlinks/.. without requiring the path to exist), otherwise fall back to
+  # cd-based resolution for existing paths or the already-sanitized raw string.
   local resolved
-  resolved="$(cd "$base" 2>/dev/null && pwd || echo "$base")"
+  if command -v realpath >/dev/null 2>&1; then
+    resolved="$(realpath --canonicalize-missing "$base")"
+  else
+    resolved="$(cd "$base" 2>/dev/null && pwd || echo "$base")"
+  fi
+
   if [ -z "$resolved" ] ||
      [ "$resolved" = "/" ] ||
      [ "$resolved" = "$HOME" ] ||

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -155,10 +155,10 @@ Before spawning reviewers, set up a shared workspace rooted under `~/data` so al
 ```bash
 SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
 WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
-export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
 
 # Safety: validate WORKTREE_BASE is under $HOME/data/ and matches expected layout.
 # Reject overly broad paths that could cause catastrophic deletion on cleanup.
+# Called at bootstrap (before mkdir/export) AND before every rm -rf on exit paths.
 validate_worktree_base() {
   local base="$1"
   local resolved
@@ -178,6 +178,10 @@ validate_worktree_base() {
   esac
 }
 
+# Validate WORKTREE_BASE immediately — fail early if an override points outside ~/data.
+validate_worktree_base "$WORKTREE_BASE" || exit 1
+
+export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
 mkdir -p "$WORKTREE_BASE/reviewer-a" "$WORKTREE_BASE/reviewer-b"
 ```
 
@@ -740,8 +744,13 @@ in Step 3.5):
 ```bash
 SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
 WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/pr-$PR_NUM-review}"
+validate_worktree_base "$WORKTREE_BASE" || exit 1   # fail early on bad override
 export CARGO_TARGET_DIR="$WORKTREE_BASE/cargo-target"
 ```
+
+The `validate_worktree_base` call at bootstrap ensures that any environment override
+of `WORKTREE_BASE` is rejected before `CARGO_TARGET_DIR` is exported or directories
+are created — preventing artifacts from spilling outside `~/data`.
 
 Per-reviewer scratch directories:
 - `$WORKTREE_BASE/reviewer-a/` — Reviewer A's exclusive scratch space

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -193,11 +193,14 @@ validate_worktree_base() {
   # When a specific PR number is provided, only accept paths for that PR.
   # This prevents a stale/leaked WORKTREE_BASE from one PR accidentally
   # targeting another PR's workspace during concurrent reviews.
+  # Legacy exception: review-pr-$ISSUE overrides (where ISSUE != PR_NUM) are
+  # accepted because linked-issue PRs commonly have different numbers.
   if [ -n "$expected_pr" ]; then
     case "$resolved" in
       "$HOME/data/"*/pr-"$expected_pr"-review) return 0 ;;
       "$HOME/data/"*/review-pr-"$expected_pr") return 0 ;;
-      *) echo "FATAL: WORKTREE_BASE='$resolved' does not match current PR $expected_pr; expected \$HOME/data/<session>/pr-${expected_pr}-review" >&2; return 1 ;;
+      "$HOME/data/"*/review-pr-[0-9]*) return 0 ;;  # legacy issue-based override
+      *) echo "FATAL: WORKTREE_BASE='$resolved' does not match current PR $expected_pr; expected \$HOME/data/<session>/pr-${expected_pr}-review or \$HOME/data/<session>/review-pr-<issue>" >&2; return 1 ;;
     esac
   fi
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -233,6 +233,77 @@ test_claude_plan_synced() {
 }
 
 # --------------------------------------------------------------------------
+# Test: review-pr exit paths cleanup reviewer workspace base
+# --------------------------------------------------------------------------
+test_review_pr_exit_paths_cleanup_workspace_base() {
+  local desc="review-pr exit paths cleanup reviewer workspace base"
+
+  # Every terminal Step 7 path (merge, wait, bounce, block) must clean up the
+  # reviewer workspace base (WORKTREE_BASE or equivalent). We check that the
+  # SKILL.md mentions removing/cleaning the review workspace on exit paths.
+  # Look for rm -rf paired with the review workspace variable, or a cleanup
+  # helper invocation, across the Step 7 / exit-path sections.
+  if grep -q 'rm -rf.*WORKTREE_BASE\|rm -rf.*review-pr-\$ISSUE\|cleanup_review_workspace\|rm -rf.*pr-\$PR_NUM-review\|rm -rf.*\$REVIEW_WORKSPACE' "$REVIEW_PR_SKILL"; then
+    # Also ensure cleanup appears on bounce/wait/block paths, not just merge.
+    # We need at least 2 distinct cleanup references (merge + at least one other path).
+    local cleanup_count
+    cleanup_count=$(grep -c 'rm -rf.*WORKTREE_BASE\|rm -rf.*review-pr-\$ISSUE\|cleanup_review_workspace\|rm -rf.*pr-\$PR_NUM-review\|rm -rf.*\$REVIEW_WORKSPACE' "$REVIEW_PR_SKILL" || true)
+    if [ "$cleanup_count" -ge 2 ]; then
+      tap_ok "$desc"
+    else
+      tap_not_ok "$desc" "Cleanup found only once; must appear on multiple exit paths (merge + bounce/wait/block)"
+    fi
+  else
+    tap_not_ok "$desc" "No review workspace cleanup (rm -rf \$WORKTREE_BASE or equivalent) found in exit paths"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr explicitly forbids /tmp/pr* and .pr-* worktree patterns
+# --------------------------------------------------------------------------
+test_review_pr_forbids_tmp_and_repo_root_patterns() {
+  local desc="review-pr forbids /tmp/pr* and .pr-* worktree patterns"
+
+  local has_tmp_ban=false
+  local has_dotpr_ban=false
+
+  # Check for explicit prohibition of /tmp/pr patterns
+  if grep -qi '/tmp/pr\|/tmp.*prohibited\|never.*\/tmp\|must not.*\/tmp\|do not.*\/tmp' "$REVIEW_PR_SKILL"; then
+    has_tmp_ban=true
+  fi
+
+  # Check for explicit prohibition of .pr-* patterns at repo root
+  if grep -qi '\.pr-\|repo.*root.*\.pr\|never.*\.pr-\|must not.*\.pr-\|do not.*\.pr-' "$REVIEW_PR_SKILL"; then
+    has_dotpr_ban=true
+  fi
+
+  if $has_tmp_ban && $has_dotpr_ban; then
+    tap_ok "$desc"
+  else
+    local missing=""
+    $has_tmp_ban || missing="/tmp/pr* ban"
+    $has_dotpr_ban || missing="${missing:+$missing, }.pr-* ban"
+    tap_not_ok "$desc" "Missing explicit prohibition of: $missing"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr defines reviewer-specific scratch dirs under workspace base
+# --------------------------------------------------------------------------
+test_review_pr_reviewer_scratch_dirs() {
+  local desc="review-pr defines reviewer-specific scratch dirs under workspace base"
+
+  # The skill must define per-reviewer scratch directories (reviewer-a, reviewer-b)
+  # under the workspace base for isolation between parallel reviewers.
+  if grep -q 'reviewer-a\|reviewer_a\|REVIEWER_A' "$REVIEW_PR_SKILL" &&
+     grep -q 'reviewer-b\|reviewer_b\|REVIEWER_B' "$REVIEW_PR_SKILL"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "Missing reviewer-a / reviewer-b scratch dir definitions in review-pr SKILL.md"
+  fi
+}
+
+# --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
 echo "TAP version 13"
@@ -244,6 +315,9 @@ test_review_pr_self_seeding
 test_plan_self_seeding
 test_review_pr_cargo_target_under_data
 test_plan_cargo_target_under_data
+test_review_pr_exit_paths_cleanup_workspace_base
+test_review_pr_forbids_tmp_and_repo_root_patterns
+test_review_pr_reviewer_scratch_dirs
 test_claude_review_pr_synced
 test_claude_plan_synced
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -46,7 +46,9 @@ test_review_pr_workspace_contract_resolves_under_home_data() {
   if grep -q 'HOME/data/\$SESSION_ID/review-pr' "$REVIEW_PR_SKILL" ||
      grep -q 'HOME/data/\${SESSION_ID}/review-pr' "$REVIEW_PR_SKILL" ||
      grep -q '\~/data/\$SESSION_ID/review-pr' "$REVIEW_PR_SKILL" ||
-     grep -q '\$HOME/data/.*review-pr' "$REVIEW_PR_SKILL"; then
+     grep -q '\$HOME/data/.*review-pr' "$REVIEW_PR_SKILL" ||
+     grep -q 'HOME/data/\$SESSION_ID/pr-.*-review' "$REVIEW_PR_SKILL" ||
+     grep -q '\$HOME/data/.*pr-.*-review' "$REVIEW_PR_SKILL"; then
     tap_ok "$desc"
   else
     tap_not_ok "$desc" "SKILL.md does not contain a ~/data/\$SESSION_ID/review-pr workspace derivation"

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -432,6 +432,45 @@ test_review_pr_validate_worktree_base_at_bootstrap() {
   fi
 }
 
+test_review_pr_validate_worktree_base_rejects_wrong_pr() {
+  local desc="review-pr validate_worktree_base rejects wrong PR number"
+
+  # The validator must accept a second argument (PR number) and, when provided,
+  # reject paths that belong to a different PR. This prevents concurrent reviews
+  # from accidentally sharing or deleting another PR's workspace.
+  local func_body
+  func_body=$(sed -n '/^validate_worktree_base()/,/^}/p' "$REVIEW_PR_SKILL")
+
+  # Check that the function accepts a second parameter for PR number
+  local has_pr_param=false
+  if echo "$func_body" | grep -qE 'expected_pr|pr_num|PR_NUM|\$2|\{2'; then
+    has_pr_param=true
+  fi
+
+  # Check that when PR number is provided, validation is PR-specific
+  # (rejects pr-*-review generically and requires the exact PR number)
+  local has_pr_specific_check=false
+  if echo "$func_body" | grep -qE 'pr-.*expected_pr.*-review|pr-"\$expected_pr"-review|pr-\$\{?expected_pr'; then
+    has_pr_specific_check=true
+  fi
+
+  # The bootstrap call must pass $PR_NUM to validate_worktree_base
+  local bootstrap_passes_pr=false
+  if grep -q 'validate_worktree_base "\$WORKTREE_BASE" "\$PR_NUM"' "$REVIEW_PR_SKILL"; then
+    bootstrap_passes_pr=true
+  fi
+
+  if $has_pr_param && $has_pr_specific_check && $bootstrap_passes_pr; then
+    tap_ok "$desc"
+  else
+    local reason=""
+    $has_pr_param || reason="validate_worktree_base does not accept a PR number parameter"
+    $has_pr_specific_check || reason="${reason:+$reason; }no PR-specific path check found"
+    $bootstrap_passes_pr || reason="${reason:+$reason; }bootstrap call does not pass \$PR_NUM to validator"
+    tap_not_ok "$desc" "$reason"
+  fi
+}
+
 # --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
@@ -450,6 +489,7 @@ test_review_pr_reviewer_scratch_dirs
 test_review_pr_validate_worktree_base_safety
 test_review_pr_validate_worktree_base_rejects_traversal
 test_review_pr_validate_worktree_base_at_bootstrap
+test_review_pr_validate_worktree_base_rejects_wrong_pr
 test_claude_review_pr_synced
 test_claude_plan_synced
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -51,7 +51,7 @@ test_review_pr_workspace_contract_resolves_under_home_data() {
      grep -q '\$HOME/data/.*pr-.*-review' "$REVIEW_PR_SKILL"; then
     tap_ok "$desc"
   else
-    tap_not_ok "$desc" "SKILL.md does not contain a ~/data/\$SESSION_ID/review-pr workspace derivation"
+    tap_not_ok "$desc" "SKILL.md does not contain a ~/data/\$SESSION_ID/pr-\$PR_NUM-review (or legacy review-pr) workspace derivation"
   fi
 }
 
@@ -241,22 +241,26 @@ test_review_pr_exit_paths_cleanup_workspace_base() {
   local desc="review-pr exit paths cleanup reviewer workspace base"
 
   # Every terminal Step 7 path (merge, wait, bounce, block) must clean up the
-  # reviewer workspace base (WORKTREE_BASE or equivalent). We check that the
-  # SKILL.md mentions removing/cleaning the review workspace on exit paths.
-  # Look for rm -rf paired with the review workspace variable, or a cleanup
-  # helper invocation, across the Step 7 / exit-path sections.
-  if grep -q 'rm -rf.*WORKTREE_BASE\|rm -rf.*review-pr-\$ISSUE\|cleanup_review_workspace\|rm -rf.*pr-\$PR_NUM-review\|rm -rf.*\$REVIEW_WORKSPACE' "$REVIEW_PR_SKILL"; then
-    # Also ensure cleanup appears on bounce/wait/block paths, not just merge.
-    # We need at least 2 distinct cleanup references (merge + at least one other path).
+  # reviewer workspace base (WORKTREE_BASE or equivalent). We scope the search
+  # to the Step 7 section (starts at "## Step 7") to avoid false positives from
+  # the workspace-contract prose earlier in the file.
+  local step7_content
+  step7_content=$(sed -n '/^## Step 7/,$p' "$REVIEW_PR_SKILL")
+
+  local cleanup_pattern='rm -rf.*WORKTREE_BASE\|rm -rf.*review-pr-\$ISSUE\|cleanup_review_workspace\|rm -rf.*pr-\$PR_NUM-review\|rm -rf.*\$REVIEW_WORKSPACE'
+
+  if echo "$step7_content" | grep -q "$cleanup_pattern"; then
+    # Count cleanup references within Step 7 only. We need at least 4
+    # (one per terminal path: merge, wait, bounce, block).
     local cleanup_count
-    cleanup_count=$(grep -c 'rm -rf.*WORKTREE_BASE\|rm -rf.*review-pr-\$ISSUE\|cleanup_review_workspace\|rm -rf.*pr-\$PR_NUM-review\|rm -rf.*\$REVIEW_WORKSPACE' "$REVIEW_PR_SKILL" || true)
-    if [ "$cleanup_count" -ge 2 ]; then
+    cleanup_count=$(echo "$step7_content" | grep -c "$cleanup_pattern" || true)
+    if [ "$cleanup_count" -ge 4 ]; then
       tap_ok "$desc"
     else
-      tap_not_ok "$desc" "Cleanup found only once; must appear on multiple exit paths (merge + bounce/wait/block)"
+      tap_not_ok "$desc" "Cleanup found $cleanup_count times in Step 7; need at least 4 (merge + wait + bounce + block)"
     fi
   else
-    tap_not_ok "$desc" "No review workspace cleanup (rm -rf \$WORKTREE_BASE or equivalent) found in exit paths"
+    tap_not_ok "$desc" "No review workspace cleanup (rm -rf \$WORKTREE_BASE or equivalent) found in Step 7 exit paths"
   fi
 }
 
@@ -306,6 +310,62 @@ test_review_pr_reviewer_scratch_dirs() {
 }
 
 # --------------------------------------------------------------------------
+# Test: review-pr validates WORKTREE_BASE before rm -rf (safety check)
+# --------------------------------------------------------------------------
+test_review_pr_validate_worktree_base_safety() {
+  local desc="review-pr validates WORKTREE_BASE before rm -rf (safety check)"
+
+  # The skill must define a validate_worktree_base helper that rejects broad
+  # paths (/, $HOME, $HOME/data) and only accepts the expected pr-*-review pattern.
+  # Every rm -rf of WORKTREE_BASE must be guarded by this validation.
+  local has_validator=false
+  local all_guarded=true
+
+  if grep -q 'validate_worktree_base' "$REVIEW_PR_SKILL"; then
+    has_validator=true
+  fi
+
+  # Check that every rm -rf $WORKTREE_BASE in Step 7 is within a block guarded
+  # by validate_worktree_base (the validation is on the if-line, not the rm line).
+  # We check that there are no rm -rf $WORKTREE_BASE lines that aren't preceded
+  # (within 2 lines above) by validate_worktree_base.
+  local step7_content
+  step7_content=$(sed -n '/^## Step 7/,$p' "$REVIEW_PR_SKILL")
+  local unguarded_count=0
+  local line_num=0
+  local prev1="" prev2=""
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+    if echo "$line" | grep -q 'rm -rf.*WORKTREE_BASE'; then
+      # Skip prose mentions (lines containing backticks around the command)
+      if echo "$line" | grep -q '`rm -rf'; then
+        prev2="$prev1"; prev1="$line"
+        continue
+      fi
+      # Check if validate_worktree_base appears in previous 2 lines
+      if ! echo "$prev1$prev2" | grep -q 'validate_worktree_base'; then
+        unguarded_count=$((unguarded_count + 1))
+      fi
+    fi
+    prev2="$prev1"
+    prev1="$line"
+  done <<< "$step7_content"
+
+  if [ "$unguarded_count" -gt 0 ]; then
+    all_guarded=false
+  fi
+
+  if $has_validator && $all_guarded; then
+    tap_ok "$desc"
+  else
+    local reason=""
+    $has_validator || reason="no validate_worktree_base helper defined"
+    $all_guarded || reason="${reason:+$reason; }some rm -rf \$WORKTREE_BASE calls not guarded by validate_worktree_base"
+    tap_not_ok "$desc" "$reason"
+  fi
+}
+
+# --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
 echo "TAP version 13"
@@ -320,6 +380,7 @@ test_plan_cargo_target_under_data
 test_review_pr_exit_paths_cleanup_workspace_base
 test_review_pr_forbids_tmp_and_repo_root_patterns
 test_review_pr_reviewer_scratch_dirs
+test_review_pr_validate_worktree_base_safety
 test_claude_review_pr_synced
 test_claude_plan_synced
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -365,6 +365,52 @@ test_review_pr_validate_worktree_base_safety() {
   fi
 }
 
+test_review_pr_validate_worktree_base_at_bootstrap() {
+  local desc="review-pr validates WORKTREE_BASE at bootstrap before mkdir/export"
+
+  # The skill must call validate_worktree_base BEFORE exporting CARGO_TARGET_DIR
+  # and BEFORE creating reviewer directories. This prevents an overridden
+  # WORKTREE_BASE from placing artifacts outside ~/data.
+  # We check that in the Step 3.5 bootstrap block, validate_worktree_base appears
+  # AFTER WORKTREE_BASE assignment but BEFORE CARGO_TARGET_DIR and mkdir.
+  local bootstrap_content
+  bootstrap_content=$(sed -n '/^## Step 3\.5/,/^## Step [4-9]/p' "$REVIEW_PR_SKILL")
+
+  local worktree_line=0
+  local validate_line=0
+  local cargo_line=0
+  local mkdir_line=0
+  local line_num=0
+
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+    if echo "$line" | grep -q 'WORKTREE_BASE=.*\$HOME/data'; then
+      [ "$worktree_line" -eq 0 ] && worktree_line=$line_num
+    fi
+    if echo "$line" | grep -q 'validate_worktree_base.*WORKTREE_BASE\|validate_worktree_base "\$WORKTREE_BASE"'; then
+      [ "$validate_line" -eq 0 ] && validate_line=$line_num
+    fi
+    if echo "$line" | grep -q 'CARGO_TARGET_DIR=.*WORKTREE_BASE'; then
+      [ "$cargo_line" -eq 0 ] && cargo_line=$line_num
+    fi
+    if echo "$line" | grep -q 'mkdir.*WORKTREE_BASE'; then
+      [ "$mkdir_line" -eq 0 ] && mkdir_line=$line_num
+    fi
+  done <<< "$bootstrap_content"
+
+  if [ "$validate_line" -gt 0 ] &&
+     [ "$worktree_line" -gt 0 ] &&
+     [ "$validate_line" -gt "$worktree_line" ] &&
+     { [ "$cargo_line" -eq 0 ] || [ "$validate_line" -lt "$cargo_line" ]; } &&
+     { [ "$mkdir_line" -eq 0 ] || [ "$validate_line" -lt "$mkdir_line" ]; }; then
+    tap_ok "$desc"
+  else
+    local reason="validate_worktree_base not called at bootstrap before CARGO_TARGET_DIR/mkdir"
+    [ "$validate_line" -eq 0 ] && reason="validate_worktree_base not called in Step 3.5 bootstrap"
+    tap_not_ok "$desc" "$reason"
+  fi
+}
+
 # --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
@@ -381,6 +427,7 @@ test_review_pr_exit_paths_cleanup_workspace_base
 test_review_pr_forbids_tmp_and_repo_root_patterns
 test_review_pr_reviewer_scratch_dirs
 test_review_pr_validate_worktree_base_safety
+test_review_pr_validate_worktree_base_at_bootstrap
 test_claude_review_pr_synced
 test_claude_plan_synced
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -365,6 +365,27 @@ test_review_pr_validate_worktree_base_safety() {
   fi
 }
 
+test_review_pr_validate_worktree_base_rejects_traversal() {
+  local desc="review-pr validate_worktree_base rejects '..' path traversal"
+
+  # The validator must reject paths containing '..' components even when the
+  # directory does not exist yet (cannot rely on cd-based canonicalization).
+  # Check that the function body explicitly rejects '..' before resolution.
+  local func_body
+  func_body=$(sed -n '/^validate_worktree_base()/,/^}/p' "$REVIEW_PR_SKILL")
+
+  if echo "$func_body" | grep -qE '\.\.' ; then
+    # Verify the rejection is an actual guard (contains return 1 or exit)
+    if echo "$func_body" | grep -B2 -A2 '\.\.' | grep -qE 'return 1|exit 1'; then
+      tap_ok "$desc"
+    else
+      tap_not_ok "$desc" "'..' mentioned but no rejection (return 1/exit) found near it"
+    fi
+  else
+    tap_not_ok "$desc" "validate_worktree_base does not check for '..' traversal"
+  fi
+}
+
 test_review_pr_validate_worktree_base_at_bootstrap() {
   local desc="review-pr validates WORKTREE_BASE at bootstrap before mkdir/export"
 
@@ -427,6 +448,7 @@ test_review_pr_exit_paths_cleanup_workspace_base
 test_review_pr_forbids_tmp_and_repo_root_patterns
 test_review_pr_reviewer_scratch_dirs
 test_review_pr_validate_worktree_base_safety
+test_review_pr_validate_worktree_base_rejects_traversal
 test_review_pr_validate_worktree_base_at_bootstrap
 test_claude_review_pr_synced
 test_claude_plan_synced

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -432,6 +432,36 @@ test_review_pr_validate_worktree_base_at_bootstrap() {
   fi
 }
 
+test_review_pr_session_id_fallback_collision_resistant() {
+  local desc="review-pr SESSION_ID fallback is collision-resistant (includes PID + random)"
+
+  # The fallback SESSION_ID (when CLAUDE_SESSION_ID is unset) must include
+  # per-invocation entropy beyond second-granularity timestamps, so two
+  # concurrent /review-pr runs for the same PR cannot derive the same path.
+  # We check for PID ($$) AND a randomness source (urandom/RANDOM/uuidgen).
+  local bootstrap_line
+  bootstrap_line=$(grep 'CLAUDE_SESSION_ID:-' "$REVIEW_PR_SKILL" | head -1)
+
+  local has_pid=false
+  if echo "$bootstrap_line" | grep -qE '\$\$|\\$\\$'; then
+    has_pid=true
+  fi
+
+  local has_random=false
+  if echo "$bootstrap_line" | grep -qE 'urandom|RANDOM|uuidgen|uuid'; then
+    has_random=true
+  fi
+
+  if $has_pid && $has_random; then
+    tap_ok "$desc"
+  else
+    local reason=""
+    $has_pid || reason="SESSION_ID fallback does not include PID ($$)"
+    $has_random || reason="${reason:+$reason; }SESSION_ID fallback does not include randomness source"
+    tap_not_ok "$desc" "$reason"
+  fi
+}
+
 test_review_pr_validate_worktree_base_rejects_wrong_pr() {
   local desc="review-pr validate_worktree_base rejects wrong PR number"
 
@@ -490,6 +520,7 @@ test_review_pr_validate_worktree_base_safety
 test_review_pr_validate_worktree_base_rejects_traversal
 test_review_pr_validate_worktree_base_at_bootstrap
 test_review_pr_validate_worktree_base_rejects_wrong_pr
+test_review_pr_session_id_fallback_collision_resistant
 test_claude_review_pr_synced
 test_claude_plan_synced
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -501,6 +501,29 @@ test_review_pr_validate_worktree_base_rejects_wrong_pr() {
   fi
 }
 
+test_review_pr_validate_worktree_base_accepts_legacy_issue_override() {
+  local desc="review-pr validate_worktree_base accepts legacy review-pr-\$ISSUE when ISSUE != PR_NUM"
+
+  # When a PR closes a different-numbered issue (e.g. PR #2846 closes #2843),
+  # legacy wrappers may set WORKTREE_BASE=$HOME/data/$SESSION_ID/review-pr-2843.
+  # The validator must accept this even when called with PR_NUM=2846.
+  local func_body
+  func_body=$(sed -n '/^validate_worktree_base()/,/^}/p' "$REVIEW_PR_SKILL")
+
+  # Check that the function has a pattern accepting review-pr-<any-number> or
+  # review-pr-[0-9]* in the expected_pr branch (not just review-pr-$expected_pr).
+  local has_legacy_accept=false
+  if echo "$func_body" | grep -qE 'review-pr-\[0-9\]\*|review-pr-\*|review-pr-[^"$]*legacy'; then
+    has_legacy_accept=true
+  fi
+
+  if $has_legacy_accept; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "validate_worktree_base does not accept legacy review-pr-\$ISSUE overrides when ISSUE != PR_NUM"
+  fi
+}
+
 # --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
@@ -520,6 +543,7 @@ test_review_pr_validate_worktree_base_safety
 test_review_pr_validate_worktree_base_rejects_traversal
 test_review_pr_validate_worktree_base_at_bootstrap
 test_review_pr_validate_worktree_base_rejects_wrong_pr
+test_review_pr_validate_worktree_base_accepts_legacy_issue_override
 test_review_pr_session_id_fallback_collision_resistant
 test_claude_review_pr_synced
 test_claude_plan_synced


### PR DESCRIPTION
Closes #2843

## Summary

Fixes the root-FS exhaustion bug where /review-pr sub-agents created worktrees under `/tmp/pr*` or `$REPO_ROOT/.pr-*` instead of under `~/data`. Adds a Step 3.5 workspace bootstrap that creates a shared `$WORKTREE_BASE` under `$HOME/data/$SESSION_ID/pr-$PR_NUM-review/` with per-reviewer scratch dirs (`reviewer-a`, `reviewer-b`). Updates both reviewer prompts with explicit workspace instructions and prohibited patterns. Adds `rm -rf $WORKTREE_BASE` to every Step 7 terminal path (merge, wait, bounce, block). Tightens `validate_worktree_base` to reject paths belonging to a different PR number, preventing concurrent-review workspace collisions. Makes SESSION_ID fallback collision-resistant with PID + random bytes.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2843#issuecomment-2894064093)

## Test plan

- [x] `bash scripts/test-agent-worktree-contract.sh` — all 17 tests pass
- [x] `bash scripts/test-review-pr-skill-snippets.sh` — all 13 tests pass

## Regression test

- **Pre-fix regression tests (committed as `adbf239a`, verified FAILED on unmodified code):**
  - `test_review_pr_exit_paths_cleanup_workspace_base`
  - `test_review_pr_forbids_tmp_and_repo_root_patterns`
  - `test_review_pr_reviewer_scratch_dirs`
- **Post-fix:** verified PASSES on current head `cc9c8033`

## Hardening tests (added alongside their fixes, not pre-fix regression tests)

- `test_review_pr_validate_worktree_base_rejects_wrong_pr` — added in `2eef787e` with the wrong-PR validation
- `test_review_pr_session_id_fallback_collision_resistant` — added in `cc9c8033` with the collision-resistant fallback

## Deviations from plan

- Used `pr-$PR_NUM-review` naming (matching the plan) instead of the old `review-pr-$ISSUE` naming that was in the pre-existing workspace contract section. Updated the existing test to accept both patterns.
- Added PR-number-specific validation to `validate_worktree_base` to address review feedback about concurrent-review safety.
- Made SESSION_ID fallback collision-resistant (PID + urandom) per review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
