### PR TITLE
Clarify XDR depth guard doc comment

### DIFF
--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -48,7 +48,13 @@ use stellar_xdr::curr::{
 use crate::fee_bump::{validate_fee_bump, FeeBumpError, FeeBumpFrame};
 use crate::frame::TransactionFrame;
 
-/// Maximum XDR recursion depth for envelope validation.
+/// Maximum XDR recursion depth (500 levels) for envelope validation.
+///
+/// stellar-core's `xdr::check_xdr_depth(envelope, 500)` rejects envelopes whose
+/// recursive XDR structure exceeds 500 nesting levels (returning `txMALFORMED`).
+/// This is a recursion-depth limit, not a byte-size limit — it prevents stack
+/// overflow from deeply nested XDR unions/sequences.
+///
 /// Parity: stellar-core TransactionFrame.cpp:1973 / FeeBumpTransactionFrame.cpp:278
 const XDR_DEPTH_LIMIT: u32 = 500;
 


### PR DESCRIPTION
Closes #2844

## Summary

Expands the doc comment on `XDR_DEPTH_LIMIT` in `crates/tx/src/validation.rs` to explicitly describe the 500-level recursion-depth limit, distinguish it from a byte-size limit, and explain its purpose (preventing stack overflow from deeply nested XDR structures).

## Plan reference

[Triage Report](https://github.com/stellar-experimental/henyey/issues/2844#issuecomment-4496627116)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-tx (clean)
- No test changes (docs only)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)