### PR TITLE
Clarify fee-bump op-count comment in ledger manager

### DIFF
--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -4243,9 +4243,10 @@ impl LedgerCloseContext<'_> {
         // Update stats
         let tx_count = tx_set_result.results.len();
         let success_count = tx_set_result.results.iter().filter(|r| r.success).count();
-        // Count ops from envelope operation lists (not execution results), mirroring
-        // stellar-core's `txSet.sizeOpTotal()`. Pre-execution-rejected txs (TxBadSeq,
-        // TxBadAuth, etc.) have zero operation_results but still contribute ops.
+        // Count ops mirroring stellar-core's `txSet.sizeOpTotal()` which sums
+        // `getNumOperations()` per tx. For fee-bump txs this is `inner_ops + 1`;
+        // for regular txs it is `operations.len()`. Uses the envelope (not
+        // execution results) so pre-execution-rejected txs still contribute.
         let op_count: usize = prepared
             .all_txs
             .iter()


### PR DESCRIPTION
Closes #2848

## Summary

Updates the op-count comment in `crates/ledger/src/manager.rs` to explicitly state that fee-bump transactions are counted as `inner_ops + 1` (matching stellar-core's `getNumOperations()`), clarifying that `envelope_operation_count()` does not simply count the operations in the inner transaction's operation list.

## Plan reference

[Triage Report comment](https://github.com/stellar-experimental/henyey/issues/2848#issuecomment-4497329061)

## Test plan

- [x] cargo clippy -p henyey-ledger -- -D warnings passes
- No functional changes; comment-only update

## Deviations from plan

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)