### PR TITLE
Improve XDR depth guard error details

### DIFF
--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -72,16 +72,24 @@ pub(crate) const MAX_RESOURCE_FEE: i64 = 1i64 << 50;
 /// This validates the full outer envelope by attempting a depth-limited XDR write.
 /// If the envelope's recursive structure exceeds 500 levels, it is rejected as malformed.
 fn check_xdr_depth(frame: &TransactionFrame) -> std::result::Result<(), PreSeqNumError> {
-    if frame
-        .envelope()
-        .to_xdr(Limits::depth(XDR_DEPTH_LIMIT))
-        .is_err()
-    {
-        return Err(PreSeqNumError::Malformed(
-            "XDR depth limit exceeded".to_string(),
-        ));
+    if let Err(err) = frame.envelope().to_xdr(Limits::depth(XDR_DEPTH_LIMIT)) {
+        return Err(format_xdr_depth_error(err));
     }
     Ok(())
+}
+
+/// Convert a `stellar_xdr` error from a depth-limited XDR write into a
+/// [`PreSeqNumError::Malformed`] with an actionable message.
+///
+/// - `DepthLimitExceeded` → includes the configured limit value.
+/// - Any other XDR error → preserves the underlying error text.
+fn format_xdr_depth_error(err: stellar_xdr::curr::Error) -> PreSeqNumError {
+    match err {
+        stellar_xdr::curr::Error::DepthLimitExceeded => PreSeqNumError::Malformed(format!(
+            "XDR depth limit exceeded (limit: {XDR_DEPTH_LIMIT})"
+        )),
+        other => PreSeqNumError::Malformed(format!("XDR depth check failed: {other}")),
+    }
 }
 
 /// Per-transaction Soroban resource limits from the network configuration.

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -3845,8 +3845,8 @@ mod tests {
             _ => panic!("expected Malformed"),
         };
         assert!(
-            msg.contains("500"),
-            "message should mention the limit value 500, got: {msg}"
+            msg.contains(&XDR_DEPTH_LIMIT.to_string()),
+            "message should mention the configured limit value, got: {msg}"
         );
     }
 

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -1927,6 +1927,87 @@ mod tests {
         assert!(validate_full(&TransactionFrame::from_owned(envelope), &context, &account).is_ok());
     }
 
+    /// validate_full must reject envelopes exceeding XDR depth limit as InvalidStructure.
+    /// This exercises the `check_xdr_depth` guard at the top of `validate_full` (line 823),
+    /// which is a separate call site from `validate_basic`.
+    #[test]
+    fn test_validate_full_rejects_over_depth_envelope() {
+        // Build a deeply nested ScVal to exceed the 500-depth XDR limit.
+        let mut val = ScVal::U32(42);
+        for _ in 0..501 {
+            val = ScVal::Vec(Some(stellar_xdr::curr::ScVec(
+                vec![val].try_into().unwrap(),
+            )));
+        }
+
+        let source = MuxedAccount::Ed25519(Uint256([1u8; 32]));
+        let account_id = AccountId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
+        let op = Operation {
+            source_account: None,
+            body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+                host_function: HostFunction::InvokeContract(InvokeContractArgs {
+                    contract_address: ScAddress::Contract(ContractId(Hash([9u8; 32]))),
+                    function_name: ScSymbol(StringM::<32>::try_from("deep".to_string()).unwrap()),
+                    args: vec![val].try_into().unwrap(),
+                }),
+                auth: VecM::default(),
+            }),
+        };
+
+        let tx = Transaction {
+            source_account: source,
+            fee: 10_000,
+            seq_num: SequenceNumber(2),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![op].try_into().unwrap(),
+            ext: TransactionExt::V1(SorobanTransactionData {
+                ext: SorobanTransactionDataExt::V0,
+                resources: SorobanResources {
+                    footprint: LedgerFootprint {
+                        read_only: VecM::default(),
+                        read_write: VecM::default(),
+                    },
+                    instructions: 100,
+                    disk_read_bytes: 0,
+                    write_bytes: 0,
+                },
+                resource_fee: 5000,
+            }),
+        };
+
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+
+        let context = LedgerContext::testnet(1, 1000);
+        let account = create_account_entry(account_id, 1);
+        let frame = TransactionFrame::from_owned(envelope);
+
+        let result = validate_full(&frame, &context, &account);
+        let errors = result.expect_err("validate_full should reject over-depth envelope");
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::InvalidStructure(_))),
+            "expected InvalidStructure for over-depth envelope, got: {:?}",
+            errors
+        );
+
+        // Verify the error message includes the depth limit value.
+        let msg = match &errors[0] {
+            ValidationError::InvalidStructure(m) => m.clone(),
+            other => panic!("expected InvalidStructure, got: {:?}", other),
+        };
+        assert!(
+            msg.contains(&XDR_DEPTH_LIMIT.to_string()),
+            "error message should include limit value {}, got: {}",
+            XDR_DEPTH_LIMIT,
+            msg
+        );
+    }
+
     /// Test validate_time_bounds with min_time in the future.
     #[test]
     fn test_validate_time_bounds_too_early() {

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -3815,4 +3815,49 @@ mod tests {
         // Account key = 1 classic disk read, ContractData = 0 (Soroban, in-memory)
         assert_eq!(count, 1);
     }
+
+    // ========================================================================
+    // #2845 — XDR depth guard error detail tests
+    // ========================================================================
+
+    #[test]
+    fn test_xdr_depth_error_message_includes_limit() {
+        let err = stellar_xdr::curr::Error::DepthLimitExceeded;
+        let result = format_xdr_depth_error(err);
+        assert_eq!(
+            result,
+            PreSeqNumError::Malformed(format!(
+                "XDR depth limit exceeded (limit: {})",
+                XDR_DEPTH_LIMIT
+            )),
+            "depth error message should include the configured limit"
+        );
+        let msg = match &result {
+            PreSeqNumError::Malformed(m) => m.clone(),
+            _ => panic!("expected Malformed"),
+        };
+        assert!(
+            msg.contains("500"),
+            "message should mention the limit value 500, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_xdr_depth_error_message_preserves_non_depth_xdr_error() {
+        let err = stellar_xdr::curr::Error::LengthLimitExceeded;
+        let expected_inner = format!("{err}");
+        let result = format_xdr_depth_error(err);
+        let msg = match &result {
+            PreSeqNumError::Malformed(m) => m.clone(),
+            _ => panic!("expected Malformed"),
+        };
+        assert!(
+            msg.contains(&expected_inner),
+            "message should contain the original XDR error text, got: {msg}"
+        );
+        assert!(
+            msg.contains("XDR depth check failed"),
+            "message should have 'XDR depth check failed' prefix, got: {msg}"
+        );
+    }
 }

--- a/crates/tx/tests/validation_parity.rs
+++ b/crates/tx/tests/validation_parity.rs
@@ -590,7 +590,7 @@ fn test_validate_basic_rejects_transaction_exceeding_xdr_depth_limit() {
 fn test_reject_fee_bump_transaction_exceeding_xdr_depth_limit() {
     use stellar_xdr::curr::{
         DecoratedSignature, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
-        FeeBumpTransactionInnerTx, Int64, Signature, SignatureHint,
+        FeeBumpTransactionInnerTx, Signature, SignatureHint,
     };
 
     // Build an over-depth inner envelope and wrap it in a fee-bump.
@@ -602,7 +602,7 @@ fn test_reject_fee_bump_transaction_exceeding_xdr_depth_limit() {
 
     let fee_bump_tx = FeeBumpTransaction {
         fee_source: MuxedAccount::Ed25519(Uint256([2u8; 32])),
-        fee: Int64(20_000),
+        fee: 20_000,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_tx_env),
         ext: FeeBumpTransactionExt::V0,
     };

--- a/crates/tx/tests/validation_parity.rs
+++ b/crates/tx/tests/validation_parity.rs
@@ -550,9 +550,9 @@ fn test_reject_transaction_exceeding_xdr_depth_limit() {
     assert_eq!(
         result,
         Err(PreSeqNumError::Malformed(
-            "XDR depth limit exceeded".to_string()
+            "XDR depth limit exceeded (limit: 500)".to_string()
         )),
-        "check_valid_pre_seq_num should reject over-depth envelope as Malformed"
+        "check_valid_pre_seq_num should reject over-depth envelope as Malformed with limit"
     );
 }
 
@@ -576,10 +576,54 @@ fn test_validate_basic_rejects_transaction_exceeding_xdr_depth_limit() {
     let errors = result.expect_err("validate_basic should reject over-depth envelope");
     let has_depth_error = errors
         .iter()
-        .any(|e| matches!(e, ValidationError::InvalidStructure(msg) if msg.contains("depth")));
+        .any(|e| matches!(e, ValidationError::InvalidStructure(msg) if msg.contains("depth") && msg.contains("500")));
     assert!(
         has_depth_error,
-        "expected InvalidStructure error about XDR depth, got: {:?}",
+        "expected InvalidStructure error about XDR depth with limit 500, got: {:?}",
         errors
+    );
+}
+
+/// §5.1-1: Fee-bump envelopes must also be rejected when the outer envelope exceeds
+/// the XDR depth limit. Parity: stellar-core FeeBumpTransactionFrame.cpp:278.
+#[test]
+fn test_reject_fee_bump_transaction_exceeding_xdr_depth_limit() {
+    use stellar_xdr::curr::{
+        DecoratedSignature, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
+        FeeBumpTransactionInnerTx, Int64, Signature, SignatureHint,
+    };
+
+    // Build an over-depth inner envelope and wrap it in a fee-bump.
+    let inner_envelope = make_over_depth_soroban_envelope();
+    let inner_tx_env = match inner_envelope {
+        TransactionEnvelope::Tx(env) => env,
+        _ => panic!("expected Tx variant"),
+    };
+
+    let fee_bump_tx = FeeBumpTransaction {
+        fee_source: MuxedAccount::Ed25519(Uint256([2u8; 32])),
+        fee: Int64(20_000),
+        inner_tx: FeeBumpTransactionInnerTx::Tx(inner_tx_env),
+        ext: FeeBumpTransactionExt::V0,
+    };
+
+    let fee_bump_envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
+        tx: fee_bump_tx,
+        signatures: vec![DecoratedSignature {
+            hint: SignatureHint([0u8; 4]),
+            signature: Signature(vec![0u8; 64].try_into().unwrap()),
+        }]
+        .try_into()
+        .unwrap(),
+    });
+
+    let frame = TransactionFrame::from_owned(fee_bump_envelope);
+    let result = check_valid_pre_seq_num(&frame, PROTOCOL_VERSION, 0);
+    assert_eq!(
+        result,
+        Err(PreSeqNumError::Malformed(
+            "XDR depth limit exceeded (limit: 500)".to_string()
+        )),
+        "check_valid_pre_seq_num should reject over-depth fee-bump envelope as Malformed"
     );
 }

--- a/crates/tx/tests/validation_parity.rs
+++ b/crates/tx/tests/validation_parity.rs
@@ -541,22 +541,23 @@ fn make_over_depth_soroban_envelope() -> TransactionEnvelope {
 
 /// §5.1-1: check_valid_pre_seq_num must reject envelopes exceeding XDR depth limit of 500.
 /// Parity: stellar-core TransactionFrame.cpp:1973 — `if (!xdr::check_xdr_depth(mEnvelope, 500))`
+/// Note: stellar-core only asserts txMALFORMED (result code), not the message text.
+/// We verify the Malformed classification here; message content is tested in unit tests.
 #[test]
 fn test_reject_transaction_exceeding_xdr_depth_limit() {
     let envelope = make_over_depth_soroban_envelope();
     let frame = TransactionFrame::from_owned(envelope);
 
     let result = check_valid_pre_seq_num(&frame, PROTOCOL_VERSION, 0);
-    assert_eq!(
-        result,
-        Err(PreSeqNumError::Malformed(
-            "XDR depth limit exceeded (limit: 500)".to_string()
-        )),
-        "check_valid_pre_seq_num should reject over-depth envelope as Malformed with limit"
+    assert!(
+        matches!(&result, Err(PreSeqNumError::Malformed(_))),
+        "check_valid_pre_seq_num should reject over-depth envelope as Malformed, got: {:?}",
+        result
     );
 }
 
 /// §5.1-1: validate_basic must also reject envelopes exceeding XDR depth limit.
+/// Parity: stellar-core only asserts txMALFORMED; we verify InvalidStructure classification.
 #[test]
 fn test_validate_basic_rejects_transaction_exceeding_xdr_depth_limit() {
     use henyey_tx::validation::{validate_basic, LedgerContext, ValidationError};
@@ -576,10 +577,10 @@ fn test_validate_basic_rejects_transaction_exceeding_xdr_depth_limit() {
     let errors = result.expect_err("validate_basic should reject over-depth envelope");
     let has_depth_error = errors
         .iter()
-        .any(|e| matches!(e, ValidationError::InvalidStructure(msg) if msg.contains("depth") && msg.contains("500")));
+        .any(|e| matches!(e, ValidationError::InvalidStructure(_)));
     assert!(
         has_depth_error,
-        "expected InvalidStructure error about XDR depth with limit 500, got: {:?}",
+        "expected InvalidStructure error for over-depth envelope, got: {:?}",
         errors
     );
 }
@@ -619,11 +620,9 @@ fn test_reject_fee_bump_transaction_exceeding_xdr_depth_limit() {
 
     let frame = TransactionFrame::from_owned(fee_bump_envelope);
     let result = check_valid_pre_seq_num(&frame, PROTOCOL_VERSION, 0);
-    assert_eq!(
-        result,
-        Err(PreSeqNumError::Malformed(
-            "XDR depth limit exceeded (limit: 500)".to_string()
-        )),
-        "check_valid_pre_seq_num should reject over-depth fee-bump envelope as Malformed"
+    assert!(
+        matches!(&result, Err(PreSeqNumError::Malformed(_))),
+        "check_valid_pre_seq_num should reject over-depth fee-bump envelope as Malformed, got: {:?}",
+        result
     );
 }


### PR DESCRIPTION
Closes #2845

## Summary

Replaces the boolean `is_err()` collapse in `check_xdr_depth` with explicit matching on `stellar_xdr::curr::Error`. `DepthLimitExceeded` now reports the configured limit (500) in the malformed message, and other XDR errors preserve the underlying error text instead of being silently dropped.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2845#issuecomment-4497412162)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-tx -- -D warnings
- [x] cargo test -p henyey-tx --lib --tests (1360 tests pass)

## New tests added

- `validation::tests::test_xdr_depth_error_message_includes_limit` — unit-tests the helper with `DepthLimitExceeded`
- `validation::tests::test_xdr_depth_error_message_preserves_non_depth_xdr_error` — unit-tests the helper with `LengthLimitExceeded`
- `validation::tests::test_validate_full_rejects_over_depth_envelope` — exercises `validate_full`'s own `check_xdr_depth` call site
- `test_reject_fee_bump_transaction_exceeding_xdr_depth_limit` — fee-bump parity coverage

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)