### PR TITLE
Make false→true tx-set validity cache flips fatal (INV-H8)

### DIFF
--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -195,7 +195,7 @@ Corresponds to: `HerderSCPDriver.h`
 | `getMaybeDeadNodes()` | `DeadNodeTracker` | Full |
 | `startCheckForDeadNodesInterval()` | `DeadNodeTracker` | Full |
 | `getNodeWeight()` | _(not implemented)_ | None |
-| `cacheValidTxSet()` | `TxSetTracker::store_valid` | Full (fatal on false→true flip per INV-H8) |
+| `cacheValidTxSet()` | `TxSetTracker::store_valid` | Partial (fatal on false→true flip per INV-H8; nomination-side write path not yet wired) |
 | `checkAndCacheTxSetValid()` | `ScpDriver::check_and_cache_tx_set_valid` | Full |
 
 ### Persistence (`persistence.rs`)
@@ -507,7 +507,7 @@ Features not yet implemented. These ARE counted against parity %.
 | `recordSCPEvent()` / `recordSCPExternalizeEvent()` | Low | SCP event tracking |
 | `getExternalizeLag()` / `getQsetLagInfo()` | Low | Externalize timing metrics |
 | `getNodeWeight()` | Medium | Application-specific leader election (P22+) |
-| ~~`cacheValidTxSet()` / `checkAndCacheTxSetValid()`~~ | ~~Low~~ | ~~TxSet validity caching~~ — **Implemented** (#2818) |
+| ~~`cacheValidTxSet()` / `checkAndCacheTxSetValid()`~~ | ~~Low~~ | ~~TxSet validity caching~~ — **Partially implemented** (#2818): fatal flip guard done, nomination-side write path pending |
 | `wrapEnvelope()` / `wrapStellarValue()` / `wrapValue()` | Low | Value wrapper pattern |
 | Ballot phase callbacks (7 methods) | Low | Logging/metrics callbacks |
 | `getPrepareStart()` / SCPTiming | Partial | `SlotTimingState::ballot_start` tracks prepare start; `nomination_duration` matches `mNominateToPrepare`. Missing: `mPrepareToExternalize` metric. |

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -195,8 +195,8 @@ Corresponds to: `HerderSCPDriver.h`
 | `getMaybeDeadNodes()` | `DeadNodeTracker` | Full |
 | `startCheckForDeadNodesInterval()` | `DeadNodeTracker` | Full |
 | `getNodeWeight()` | _(not implemented)_ | None |
-| `cacheValidTxSet()` | _(not implemented)_ | None |
-| `checkAndCacheTxSetValid()` | _(not implemented)_ | None |
+| `cacheValidTxSet()` | `TxSetTracker::store_valid` | Full (fatal on false→true flip per INV-H8) |
+| `checkAndCacheTxSetValid()` | `ScpDriver::check_and_cache_tx_set_valid` | Full |
 
 ### Persistence (`persistence.rs`)
 
@@ -507,7 +507,7 @@ Features not yet implemented. These ARE counted against parity %.
 | `recordSCPEvent()` / `recordSCPExternalizeEvent()` | Low | SCP event tracking |
 | `getExternalizeLag()` / `getQsetLagInfo()` | Low | Externalize timing metrics |
 | `getNodeWeight()` | Medium | Application-specific leader election (P22+) |
-| `cacheValidTxSet()` / `checkAndCacheTxSetValid()` | Low | TxSet validity caching |
+| ~~`cacheValidTxSet()` / `checkAndCacheTxSetValid()`~~ | ~~Low~~ | ~~TxSet validity caching~~ — **Implemented** (#2818) |
 | `wrapEnvelope()` / `wrapStellarValue()` / `wrapValue()` | Low | Value wrapper pattern |
 | Ballot phase callbacks (7 methods) | Low | Logging/metrics callbacks |
 | `getPrepareStart()` / SCPTiming | Partial | `SlotTimingState::ballot_start` tracks prepare start; `nomination_duration` matches `mNominateToPrepare`. Missing: `mPrepareToExternalize` metric. |

--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -3,9 +3,9 @@
 **Spec version:** 26 (stellar-core v26.0.1 / Protocol 26)
 **Crate:** crates/herder
 **Last updated:** 2026-05-13
-**Overall adherence:** 83%
+**Overall adherence:** 86%
 
-**Tally:** Full 49 | Partial 9 | Absent 1 | Drift 2 | N/A 4
+**Tally:** Full 51 | Partial 7 | Absent 1 | Drift 2 | N/A 4
 
 Adherence percentage is computed as `Full / (Full + Partial + Absent) × 100` over
 normative-strong claims (MUST/SHALL/MUST NOT/SHALL NOT). Drift and N/A items

--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -3,9 +3,9 @@
 **Spec version:** 26 (stellar-core v26.0.1 / Protocol 26)
 **Crate:** crates/herder
 **Last updated:** 2026-05-13
-**Overall adherence:** 86%
+**Overall adherence:** 83%
 
-**Tally:** Full 51 | Partial 7 | Absent 1 | Drift 2 | N/A 4
+**Tally:** Full 49 | Partial 9 | Absent 1 | Drift 2 | N/A 4
 
 Adherence percentage is computed as `Full / (Full + Partial + Absent) × 100` over
 normative-strong claims (MUST/SHALL/MUST NOT/SHALL NOT). Drift and N/A items
@@ -59,7 +59,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §9.4 | Cluster footprint disjointness (TX_ORDERING_INVALID) | Full | tx_set_utils.rs |
 | §9.5 | Per-tx validation + accountFeeMap | Full | tx_set_utils.rs::get_invalid_tx_list_with_fee_map |
 | §9.6 | XDR structural decoding | Full | tx_queue/tx_set.rs:646-734 |
-| §9.7 | Validity cache + fatal on flip | Full | tx_set_tracker.rs (fatal panic on false→true flip, #2818) |
+| §9.7 | Validity cache + fatal on flip | Partial | tx_set_tracker.rs (fatal panic on false→true flip, #2818); nomination-side write path not yet wired |
 | §10 | Apply ordering (sequential + parallel) | N/A | implemented in `crates/ledger/src/close.rs` (cross-crate by spec mapping) |
 | §11 | combineCandidates: tx-set selection + tiebreaks | Full | scp_driver.rs:1849-2017 + 2037-2105 |
 | §11 | combineCandidates: upgrade merge by type | Full | scp_driver.rs:1918-1939, 2021-2034 |
@@ -108,7 +108,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §17 | INV-H5 StellarValue close-time monotonicity | Full | scp_driver.rs:1198-1226 (check_close_time) |
 | §17 | INV-H6 Upgrade ordering | Full | scp_driver.rs:1563-1584 |
 | §17 | INV-H7 Tx set hash stability roundtrip | Full | herder.rs:3054 (validate_and_cache_built_tx_set) |
-| §17 | INV-H8 Validity cache consistency | Full | tx_set_tracker.rs panics on false→true flip (#2818) |
+| §17 | INV-H8 Validity cache consistency | Partial | tx_set_tracker.rs panics on false→true flip (#2818); nomination-side write path pending |
 | §17 | INV-H9 Single nominate per slot | Full | herder.rs:2415 (early-return on is_nominating) |
 | §18 | Constants table | Full (most) | see Constants section below |
 
@@ -385,7 +385,9 @@ excluded. SHOULD claims and operational defaults excluded.
     `cacheValidTxSet` which throws `std::runtime_error`.
     Search: `grep -rn "Inconsistent txSet validity" crates/herder/src/`
     → `tx_set_tracker.rs` panic message.
-  - **Status:** Full (#2818).
+  - **Gap:** The nomination-side path (`HerderImpl::cacheValidTxSet` equivalent)
+    does not yet write `true` into the validity cache after self-validation.
+  - **Status:** Partial (#2818).
 
 ### §10 — Apply Ordering
 
@@ -679,7 +681,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | INV-H5 (StellarValue close-time monotonicity) | Full | `scp_driver.rs:1198-1226 check_close_time` |
 | INV-H6 (Upgrade ordering) | Full | `scp_driver.rs:1563-1584 check_upgrade_ordering` + `herder.rs:3142-3150` sort-on-build |
 | INV-H7 (Tx set hash stability roundtrip) | Full | `herder.rs:3054` `validate_and_cache_built_tx_set` + roundtrip in `self_validate_nomination_tx_set` |
-| INV-H8 (Validity cache consistency) | Full | `tx_set_tracker.rs::store_valid` panics on false→true flip (#2818) |
+| INV-H8 (Validity cache consistency) | Partial | `tx_set_tracker.rs::store_valid` panics on false→true flip (#2818); nomination-side write path pending |
 | INV-H9 (Single nominate per slot) | Full | `herder.rs:2415-2423` early-return on `is_nominating` |
 
 ### Drift notes
@@ -692,8 +694,10 @@ excluded. SHOULD claims and operational defaults excluded.
   invariant is restored, not violated; classify as drift if strict spec
   conformance is required.
 
-- **INV-H8**: Now Full (#2818). `store_valid` panics on false→true flips
-  matching stellar-core's `cacheValidTxSet` fatal error.
+- **INV-H8**: Now Partial (#2818). `store_valid` panics on false→true flips
+  matching stellar-core's `cacheValidTxSet` fatal error. The nomination-side
+  write path (equivalent to upstream `HerderImpl::cacheValidTxSet` call) is
+  not yet wired to populate the validity cache after self-validation.
 
 ---
 
@@ -741,7 +745,9 @@ sections present in the current spec:
    work. Low priority but spec-mandated.
 
 2. ~~**Implement the runtime "validity cache false→true" abort** (§9.7 /
-   INV-H8).~~ Done in #2818.
+   INV-H8).~~ Fatal flip guard done in #2818. Remaining: wire the
+   nomination-side write path to populate the validity cache after
+   self-validation (equivalent to upstream `HerderImpl::cacheValidTxSet`).
 
 3. **Document the INV-H2 deviation** more visibly in `PARITY_STATUS.md`
    so reviewers understand the spec calls it fatal but henyey treats it

--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -59,7 +59,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §9.4 | Cluster footprint disjointness (TX_ORDERING_INVALID) | Full | tx_set_utils.rs |
 | §9.5 | Per-tx validation + accountFeeMap | Full | tx_set_utils.rs::get_invalid_tx_list_with_fee_map |
 | §9.6 | XDR structural decoding | Full | tx_queue/tx_set.rs:646-734 |
-| §9.7 | Validity cache + fatal on flip | Partial | tx_set_tracker.rs (cached, no flip-abort) |
+| §9.7 | Validity cache + fatal on flip | Full | tx_set_tracker.rs (fatal panic on false→true flip, #2818) |
 | §10 | Apply ordering (sequential + parallel) | N/A | implemented in `crates/ledger/src/close.rs` (cross-crate by spec mapping) |
 | §11 | combineCandidates: tx-set selection + tiebreaks | Full | scp_driver.rs:1849-2017 + 2037-2105 |
 | §11 | combineCandidates: upgrade merge by type | Full | scp_driver.rs:1918-1939, 2021-2034 |
@@ -108,7 +108,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §17 | INV-H5 StellarValue close-time monotonicity | Full | scp_driver.rs:1198-1226 (check_close_time) |
 | §17 | INV-H6 Upgrade ordering | Full | scp_driver.rs:1563-1584 |
 | §17 | INV-H7 Tx set hash stability roundtrip | Full | herder.rs:3054 (validate_and_cache_built_tx_set) |
-| §17 | INV-H8 Validity cache consistency | Partial | tx_set_tracker.rs caches but does not abort on false→true flip |
+| §17 | INV-H8 Validity cache consistency | Full | tx_set_tracker.rs panics on false→true flip (#2818) |
 | §17 | INV-H9 Single nominate per slot | Full | herder.rs:2415 (early-return on is_nominating) |
 | §18 | Constants table | Full (most) | see Constants section below |
 
@@ -380,12 +380,12 @@ excluded. SHOULD claims and operational defaults excluded.
 - **§9.7 (MUST + SHOULD)** Validity cache + fatal on cached-false →
   observed-true.
   - **Rust:** `tx_set_tracker.rs:21 TXSET_VALID_CACHE_SIZE = 1000`. The
-    cache stores both true and false outcomes. **No** runtime
-    "false-then-true" abort assertion is found.
-    Search: `grep -rn "Inconsistent txSet validity\|cached.*false.*true" crates/herder/src/`
-    → nothing.
-  - **Status:** Partial (cache present; spec's MAY-grade abort omitted).
-    See INV-H8.
+    cache stores both true and false outcomes. `store_valid` panics on
+    false→true flip before overwriting, matching stellar-core's
+    `cacheValidTxSet` which throws `std::runtime_error`.
+    Search: `grep -rn "Inconsistent txSet validity" crates/herder/src/`
+    → `tx_set_tracker.rs` panic message.
+  - **Status:** Full (#2818).
 
 ### §10 — Apply Ordering
 
@@ -679,7 +679,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | INV-H5 (StellarValue close-time monotonicity) | Full | `scp_driver.rs:1198-1226 check_close_time` |
 | INV-H6 (Upgrade ordering) | Full | `scp_driver.rs:1563-1584 check_upgrade_ordering` + `herder.rs:3142-3150` sort-on-build |
 | INV-H7 (Tx set hash stability roundtrip) | Full | `herder.rs:3054` `validate_and_cache_built_tx_set` + roundtrip in `self_validate_nomination_tx_set` |
-| INV-H8 (Validity cache consistency) | Partial | `tx_set_tracker.rs::valid_cache` stores results; no abort on false→true flip |
+| INV-H8 (Validity cache consistency) | Full | `tx_set_tracker.rs::store_valid` panics on false→true flip (#2818) |
 | INV-H9 (Single nominate per slot) | Full | `herder.rs:2415-2423` early-return on `is_nominating` |
 
 ### Drift notes
@@ -692,8 +692,8 @@ excluded. SHOULD claims and operational defaults excluded.
   invariant is restored, not violated; classify as drift if strict spec
   conformance is required.
 
-- **INV-H8 partial**: A SHOULD-grade defensive abort. Cache size matches
-  (`TXSET_VALID_CACHE_SIZE = 1000`).
+- **INV-H8**: Now Full (#2818). `store_valid` panics on false→true flips
+  matching stellar-core's `cacheValidTxSet` fatal error.
 
 ---
 
@@ -740,9 +740,8 @@ sections present in the current spec:
    callback may fire before tracking advances, producing spurious timer
    work. Low priority but spec-mandated.
 
-2. **Implement the runtime "validity cache false→true" abort** (§9.7 /
-   INV-H8). MAY-grade but useful for catching builder/validator
-   divergence in production.
+2. ~~**Implement the runtime "validity cache false→true" abort** (§9.7 /
+   INV-H8).~~ Done in #2818.
 
 3. **Document the INV-H2 deviation** more visibly in `PARITY_STATUS.md`
    so reviewers understand the spec calls it fatal but henyey treats it

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -7036,6 +7036,57 @@ mod tests {
         assert!(result, "Pre-v20 LedgerManager should be permissive");
     }
 
+    /// Regression test for #2818: check_and_cache_tx_set_valid must reuse a
+    /// pre-seeded cached `false` without revalidation. This locks down the
+    /// cached-invalid short-circuit path and proves it does not trigger the
+    /// fatal false→true panic in store_valid.
+    #[test]
+    fn test_check_and_cache_tx_set_valid_reuses_cached_false_without_revalidation() {
+        use stellar_xdr::curr::{
+            GeneralizedTransactionSet, Hash, ParallelTxsComponent, TransactionPhase,
+            TransactionSetV1,
+        };
+
+        let driver = make_test_driver();
+        let lcl_hash = Hash256::ZERO;
+
+        // Build a minimal generalized TX set that would otherwise validate
+        // successfully (empty phases, valid structure, protocol < 20 is permissive).
+        let gen = GeneralizedTransactionSet::V1(TransactionSetV1 {
+            previous_ledger_hash: Hash(lcl_hash.0),
+            phases: vec![
+                TransactionPhase::V0(vec![].try_into().unwrap()),
+                TransactionPhase::V1(ParallelTxsComponent {
+                    base_fee: Some(100),
+                    execution_stages: vec![].try_into().unwrap(),
+                }),
+            ]
+            .try_into()
+            .unwrap(),
+        });
+        let tx_set = TransactionSet::new_generalized(gen);
+
+        // Pre-seed the validity cache with `false` for this tx set's key.
+        let cache_key = (lcl_hash, *tx_set.hash(), 0u64);
+        driver.tx_tracker.store_valid(cache_key, false);
+
+        // Call check_and_cache_tx_set_valid — must return cached `false`
+        // without running validation (which would produce `true` and trigger
+        // the fatal false→true flip panic).
+        let result = driver.check_and_cache_tx_set_valid(&tx_set, lcl_hash, 0);
+        assert!(
+            !result,
+            "check_and_cache_tx_set_valid must return cached false without revalidation"
+        );
+
+        // Verify the cache entry remains `false` (not overwritten).
+        assert_eq!(
+            driver.tx_tracker.check_valid(&cache_key),
+            Some(false),
+            "cached false must not be overwritten"
+        );
+    }
+
     #[test]
     fn test_combine_candidates_merges_6_upgrade_types() {
         // Verify that 6 distinct upgrade types from multiple candidates merge correctly

--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -620,8 +620,8 @@ mod tests {
         // Overwrite true→false: previous is true
         assert_eq!(tracker.store_valid(key, false), Some(true));
 
-        // Overwrite false→true (INV-H8 flip): previous is false
-        assert_eq!(tracker.store_valid(key, true), Some(false));
+        // NOTE: false→true flip is now fatal (INV-H8, #2818) — tested
+        // separately in test_store_valid_false_to_true_flip_panics_before_overwrite.
     }
 
     /// Regression test for AUDIT-080: unsolicited tx sets must not be cached.
@@ -1107,6 +1107,69 @@ mod tests {
         assert!(
             tracker.cache_count() >= 1,
             "cache should not be empty after stores"
+        );
+    }
+
+    /// Regression test for #2818: A false→true validity-cache flip must panic
+    /// (fatal per HERDER_SPEC §9.7 / INV-H8) and must NOT overwrite the cached
+    /// `false` entry.
+    #[test]
+    fn test_store_valid_false_to_true_flip_panics_before_overwrite() {
+        let tracker = TxSetTracker::new(256);
+        let lcl = Hash256::from_bytes([0; 32]);
+        let key_hash = Hash256::from_bytes([1; 32]);
+        let key = (lcl, key_hash, 0u64);
+
+        // Seed the cache with false.
+        tracker.store_valid(key, false);
+        assert_eq!(tracker.check_valid(&key), Some(false));
+
+        // Attempt false→true: must panic.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tracker.store_valid(key, true);
+        }));
+        assert!(result.is_err(), "false→true flip must panic (INV-H8)");
+
+        // The cached value must still be `false` — the panic fires BEFORE the
+        // overwrite so the invariant-violating `true` is never persisted.
+        assert_eq!(
+            tracker.check_valid(&key),
+            Some(false),
+            "cached value must remain false after panic"
+        );
+    }
+
+    /// Regression test for #2818: The panic message for a false→true flip must
+    /// contain the upstream-style prefix and the tx-set hash so operators can
+    /// correlate it with the offending tx set.
+    #[test]
+    fn test_store_valid_false_to_true_flip_panic_mentions_tx_set_hash() {
+        let tracker = TxSetTracker::new(256);
+        let lcl = Hash256::from_bytes([0; 32]);
+        let key_hash = Hash256::from_bytes([0xab; 32]);
+        let key = (lcl, key_hash, 0u64);
+
+        tracker.store_valid(key, false);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tracker.store_valid(key, true);
+        }));
+        let err = result.expect_err("false→true flip must panic");
+        let msg = err
+            .downcast_ref::<String>()
+            .map(|s| s.as_str())
+            .or_else(|| err.downcast_ref::<&str>().copied())
+            .unwrap_or("");
+
+        assert!(
+            msg.contains("Inconsistent txSet validity for tx set"),
+            "panic message must contain upstream prefix, got: {msg}"
+        );
+        // The tx-set hash component of the key should appear in the message.
+        let hash_hex = key_hash.to_hex();
+        assert!(
+            msg.contains(&hash_hex),
+            "panic message must contain tx-set hash {hash_hex}, got: {msg}"
         );
     }
 }

--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -289,18 +289,25 @@ impl TxSetTracker {
     /// Store a validity result. Uses random-two-choice eviction at capacity.
     ///
     /// Returns the previous cached value for this key, if any.
-    /// Emits a warning when a previously-invalid entry is overwritten with valid
-    /// (false→true flip), per HERDER_SPEC INV-H8 detection.
+    ///
+    /// # Panics
+    ///
+    /// Panics when a previously-invalid entry would be overwritten with `true`
+    /// (false→true flip). This is fatal per HERDER_SPEC §9.7 / INV-H8 and
+    /// mirrors stellar-core's `cacheValidTxSet` which throws
+    /// `std::runtime_error("Inconsistent txSet validity for tx set ...")`.
+    /// The panic fires BEFORE the overwrite so the cached `false` remains intact.
     pub fn store_valid(&self, key: (Hash256, Hash256, u64), valid: bool) -> Option<bool> {
         let mut cache = self.valid_cache.lock();
         let previous = cache.get(&key).copied();
-        if let Some(false) = previous {
-            if valid {
-                warn!(
-                    ?key,
-                    "tx set valid cache flip: false→true (INV-H8 detection)"
-                );
-            }
+        if previous == Some(false) && valid {
+            // Fatal: the tx-set hash is the second tuple element.
+            let tx_set_hash = key.1;
+            panic!(
+                "Inconsistent txSet validity for tx set {} (INV-H8): \
+                 cached as invalid, now revalidated as valid",
+                tx_set_hash.to_hex()
+            );
         }
         cache.put(key, valid);
         previous


### PR DESCRIPTION
Closes #2818

## Summary

Makes `TxSetTracker::store_valid` panic on false→true validity-cache flips, matching stellar-core's `cacheValidTxSet` which throws `std::runtime_error("Inconsistent txSet validity for tx set ...")`. The panic fires before the `cache.put` so the original `false` entry remains intact. Updates PARITY_STATUS.md and SPEC_ADHERENCE.md to mark INV-H8 / §9.7 as Partial (fatal flip guard done; nomination-side write path pending).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2818#issuecomment-4498455702)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-herder -- -D warnings
- [x] cargo test -p henyey-herder passes

## Regression test

- **Pre-fix tests (committed as `3631a01d` — verified FAILED on current main):**
  - `tx_set_tracker::tests::test_store_valid_false_to_true_flip_panics_before_overwrite` — failed with: `assertion failed: false→true flip must panic (INV-H8)`
  - `tx_set_tracker::tests::test_store_valid_false_to_true_flip_panic_mentions_tx_set_hash` — failed because no panic is raised
- **Post-fix verification:** both tracker tests PASS after `37dac48d` (fix commit)
- **Additional coverage (added in `03f341f4`, post-fix only):**
  - `scp_driver::tests::test_check_and_cache_tx_set_valid_reuses_cached_false_without_revalidation` — locks down the cached-`false` short-circuit path so revalidation cannot accidentally trip the new fatal flip guard. This test was added alongside the parity doc updates and was only verified post-fix.

## Deviations from plan

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)