### PR TITLE
Plumb TrustSource::Scp through online catchup callers

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -843,7 +843,8 @@ impl App {
         if let Some((seq, hash)) = self.resolve_scp_trust_anchor(target_ledger) {
             tracing::info!(
                 target_ledger,
-                anchor_seq = seq,
+                adjacent_slot = target_ledger + 1,
+                trusted_seq = seq,
                 anchor_hash = %hash.to_hex(),
                 "Resolved SCP trust anchor from externalized slot target+1"
             );
@@ -6218,7 +6219,7 @@ mod tests {
     async fn test_resolve_scp_trust_anchor_uses_herder_target_plus_one_prev_hash() {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
-        let config = crate::config::ConfigBuilder::new()
+        let config = crate::config::ConfigBuilder::simulation()
             .database_path(db_path)
             .build();
         let app = App::new(config).await.unwrap();
@@ -6238,7 +6239,7 @@ mod tests {
     async fn test_resolve_scp_trust_anchor_returns_none_without_adjacent_tx_set() {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
-        let config = crate::config::ConfigBuilder::new()
+        let config = crate::config::ConfigBuilder::simulation()
             .database_path(db_path)
             .build();
         let app = App::new(config).await.unwrap();
@@ -6273,45 +6274,5 @@ mod tests {
         // because the tx-set is not cached. resolve_scp_trust_anchor should return None.
         let result = app.resolve_scp_trust_anchor(target_ledger);
         assert_eq!(result, None);
-    }
-
-    #[tokio::test]
-    async fn test_run_catchup_work_applies_resolved_scp_anchor_to_manager() {
-        // This test verifies the wiring: when resolve_scp_trust_anchor returns
-        // Some, the CatchupManager receives the anchor. We test this indirectly
-        // by verifying that resolve_scp_trust_anchor is called with target_ledger
-        // and produces the expected result, since the integration of the anchor
-        // into catchup_manager is exercised by the code path in run_catchup_work.
-        //
-        // A full integration test would require a running archive, which is out
-        // of scope for unit tests. The history-side test
-        // (test_set_trusted_scp_anchor_updates_reverse_walk_config) verifies that
-        // the anchor, once set, is used correctly in verification.
-        let dir = tempfile::tempdir().expect("temp dir");
-        let db_path = dir.path().join("rs-stellar-test.db");
-        let config = crate::config::ConfigBuilder::new()
-            .database_path(db_path)
-            .build();
-        let app = App::new(config).await.unwrap();
-
-        let target_ledger: u32 = 500;
-        let expected_prev_hash = henyey_common::types::Hash256([7u8; 32]);
-        seed_externalized_with_tx_set(&app, (target_ledger + 1) as u64, expected_prev_hash);
-
-        // Verify the anchor is correctly resolved (this is what run_catchup_work calls).
-        let anchor = app.resolve_scp_trust_anchor(target_ledger);
-        assert_eq!(anchor, Some((target_ledger, expected_prev_hash)));
-
-        // Verify that CatchupManager correctly receives and stores the anchor.
-        use henyey_bucket::BucketManager;
-        let tmp = tempfile::tempdir().unwrap();
-        let bucket_manager = BucketManager::new(tmp.path().to_path_buf()).unwrap();
-        let db = henyey_db::Database::open_in_memory().unwrap();
-        let mut manager = henyey_history::CatchupManager::new(vec![], bucket_manager, db);
-        if let Some((seq, hash)) = anchor {
-            manager.set_trusted_scp_anchor(seq, hash);
-        }
-        // The anchor is pub(super) so we can't directly inspect it here,
-        // but the history-side test confirms it flows through to ReverseWalkConfig.
     }
 }

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -851,6 +851,10 @@ impl App {
                     "Resolved SCP trust anchor from externalized slot target+1"
                 );
                 catchup_manager.set_trusted_scp_anchor(seq, hash);
+                #[cfg(test)]
+                {
+                    *self.last_installed_scp_anchor.lock().unwrap() = Some((seq, hash));
+                }
             }
         }
 
@@ -6283,64 +6287,19 @@ mod tests {
     // Production-path wiring tests: verify that run_catchup_work() installs
     // (or does not install) the SCP trust anchor based on CatchupRunMode.
     //
-    // These tests drive the real catchup_with_run_mode() entry point and use
-    // tracing capture to observe the anchor-installation decision. The
-    // "Resolved SCP trust anchor" log fires inside run_catchup_work() at the
-    // exact production branch under test, BEFORE any archive I/O. If the
-    // `if run_mode == CatchupRunMode::Online` gate were removed, both tests
-    // would see the log (causing the offline test to fail).
+    // These tests drive the real catchup_with_run_mode() entry point and
+    // assert on `App::last_installed_scp_anchor` (a #[cfg(test)] field that
+    // records the actual `set_trusted_scp_anchor()` call). This catches the
+    // case where the surrounding log is preserved but the setter is removed.
     // ================================================================
-
-    /// Minimal tracing layer that records whether a specific message was logged.
-    mod anchor_tracing {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
-        use tracing::subscriber::Subscriber;
-        use tracing_subscriber::layer::Context;
-        use tracing_subscriber::Layer;
-
-        /// Layer that sets a flag when "Resolved SCP trust anchor" is logged.
-        pub struct AnchorDetector {
-            pub detected: Arc<AtomicBool>,
-        }
-
-        impl<S: Subscriber> Layer<S> for AnchorDetector {
-            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-                // Check the message field for our target log line.
-                let mut visitor = MessageVisitor(String::new());
-                event.record(&mut visitor);
-                if visitor.0.contains("Resolved SCP trust anchor") {
-                    self.detected.store(true, Ordering::SeqCst);
-                }
-            }
-        }
-
-        struct MessageVisitor(String);
-
-        impl tracing::field::Visit for MessageVisitor {
-            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-                if field.name() == "message" {
-                    self.0 = format!("{:?}", value);
-                }
-            }
-
-            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-                if field.name() == "message" {
-                    self.0 = value.to_string();
-                }
-            }
-        }
-    }
 
     /// Online catchup with herder data MUST install the SCP trust anchor.
     /// This test exercises the real `catchup_with_run_mode(Online)` production
-    /// path and would fail if the anchor-installation block were removed.
+    /// path and would fail if the `set_trusted_scp_anchor()` call were removed
+    /// (even if the surrounding log line is preserved).
     #[tokio::test]
     async fn test_online_catchup_installs_scp_trust_anchor_production_path() {
         use henyey_history::CatchupRunMode;
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
-        use tracing_subscriber::layer::SubscriberExt;
 
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
@@ -6370,13 +6329,12 @@ mod tests {
             "precondition: herder data must be available"
         );
 
-        // Set up tracing capture to detect anchor installation.
-        let detected = Arc::new(AtomicBool::new(false));
-        let layer = anchor_tracing::AnchorDetector {
-            detected: Arc::clone(&detected),
-        };
-        let subscriber = tracing_subscriber::registry().with(layer);
-        let _guard = tracing::subscriber::set_default(subscriber);
+        // Precondition: no anchor installed yet.
+        assert_eq!(
+            *app.last_installed_scp_anchor.lock().unwrap(),
+            None,
+            "precondition: anchor must not be installed before catchup"
+        );
 
         // Run online catchup — the anchor decision fires before archive download.
         let (persist_tx, _persist_rx) = tokio::sync::oneshot::channel();
@@ -6394,12 +6352,14 @@ mod tests {
             )
             .await;
 
-        // The anchor-installation log MUST have fired for Online mode.
-        assert!(
-            detected.load(Ordering::SeqCst),
-            "Online catchup with herder data must install SCP trust anchor \
-             (log 'Resolved SCP trust anchor' was not emitted — \
-             the run_catchup_work() online wiring is broken)"
+        // Assert that set_trusted_scp_anchor was actually called with expected values.
+        let installed = app.last_installed_scp_anchor.lock().unwrap().clone();
+        assert_eq!(
+            installed,
+            Some((target_ledger, expected_prev_hash)),
+            "Online catchup with herder data must call set_trusted_scp_anchor() \
+             on CatchupManager — removing the setter while keeping the log \
+             would cause this assertion to fail"
         );
     }
 
@@ -6410,9 +6370,6 @@ mod tests {
     #[tokio::test]
     async fn test_offline_catchup_does_not_install_scp_trust_anchor_production_path() {
         use henyey_history::CatchupRunMode;
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
-        use tracing_subscriber::layer::SubscriberExt;
 
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
@@ -6443,14 +6400,6 @@ mod tests {
             "precondition: herder data must be available"
         );
 
-        // Set up tracing capture to detect anchor installation.
-        let detected = Arc::new(AtomicBool::new(false));
-        let layer = anchor_tracing::AnchorDetector {
-            detected: Arc::clone(&detected),
-        };
-        let subscriber = tracing_subscriber::registry().with(layer);
-        let _guard = tracing::subscriber::set_default(subscriber);
-
         // Run offline catchup — the anchor decision must NOT fire.
         let (persist_tx, _persist_rx) = tokio::sync::oneshot::channel();
         let finalize = super::persist::CatchupFinalizer::deferred(
@@ -6467,12 +6416,12 @@ mod tests {
             )
             .await;
 
-        // The anchor-installation log must NOT have fired for OfflineBasic.
-        assert!(
-            !detected.load(Ordering::SeqCst),
-            "Offline catchup must NOT install SCP trust anchor even when \
-             herder has externalized target+1 (log 'Resolved SCP trust anchor' \
-             was emitted — the run_mode gate is broken)"
+        // The anchor must NOT have been installed for OfflineBasic.
+        let installed = app.last_installed_scp_anchor.lock().unwrap().clone();
+        assert_eq!(
+            installed, None,
+            "Offline catchup must NOT call set_trusted_scp_anchor() even when \
+             herder has externalized target+1 — the run_mode gate is broken"
         );
     }
 }

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -840,15 +840,18 @@ impl App {
         // If target + 1 has been externalized and its tx-set is available, use
         // tx_set.previous_ledger_hash() as the trusted anchor for reverse-walk
         // verification. This matches stellar-core's startOnlineCatchup() behavior.
-        if let Some((seq, hash)) = self.resolve_scp_trust_anchor(target_ledger) {
-            tracing::info!(
-                target_ledger,
-                adjacent_slot = target_ledger + 1,
-                trusted_seq = seq,
-                anchor_hash = %hash.to_hex(),
-                "Resolved SCP trust anchor from externalized slot target+1"
-            );
-            catchup_manager.set_trusted_scp_anchor(seq, hash);
+        // Only applies to Online mode — offline/synthetic paths have no SCP context.
+        if run_mode == CatchupRunMode::Online {
+            if let Some((seq, hash)) = self.resolve_scp_trust_anchor(target_ledger) {
+                tracing::info!(
+                    target_ledger,
+                    adjacent_slot = target_ledger + 1,
+                    trusted_seq = seq,
+                    anchor_hash = %hash.to_hex(),
+                    "Resolved SCP trust anchor from externalized slot target+1"
+                );
+                catchup_manager.set_trusted_scp_anchor(seq, hash);
+            }
         }
 
         // Run catchup
@@ -6274,5 +6277,74 @@ mod tests {
         // because the tx-set is not cached. resolve_scp_trust_anchor should return None.
         let result = app.resolve_scp_trust_anchor(target_ledger);
         assert_eq!(result, None);
+    }
+
+    /// Regression test: offline catchup must NOT install an SCP trust anchor even
+    /// when herder has externalized target+1. This verifies the run_mode gate
+    /// added in response to the review finding that offline paths must remain
+    /// TrustSource::None regardless of incidental herder cache state.
+    #[tokio::test]
+    async fn test_offline_catchup_does_not_install_scp_trust_anchor() {
+        use henyey_history::CatchupRunMode;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let mut config = crate::config::ConfigBuilder::simulation()
+            .database_path(db_path)
+            .build();
+        // Point to an unreachable archive — catchup will fail at download,
+        // but that's after the SCP anchor decision point.
+        config.history.archives = vec![crate::config::HistoryArchiveEntry {
+            name: "unreachable".to_string(),
+            url: "http://127.0.0.1:1/.well-known/stellar-history.json".to_string(),
+            get_enabled: true,
+            put_enabled: false,
+            put: None,
+            mkdir: None,
+        }];
+        let app = App::new(config).await.unwrap();
+
+        let target_ledger: u32 = 100;
+        let expected_prev_hash = henyey_common::types::Hash256([42u8; 32]);
+
+        // Seed herder with externalized target+1. This means
+        // resolve_scp_trust_anchor() WOULD return Some if called.
+        seed_externalized_with_tx_set(&app, (target_ledger + 1) as u64, expected_prev_hash);
+
+        // Verify the herder data is available.
+        assert_eq!(
+            app.resolve_scp_trust_anchor(target_ledger),
+            Some((target_ledger, expected_prev_hash)),
+            "precondition: herder data must be available"
+        );
+
+        // Run offline catchup — this should NOT install the SCP anchor.
+        let (persist_tx, _persist_rx) = tokio::sync::oneshot::channel();
+        let finalize = super::persist::CatchupFinalizer::deferred(
+            app.db.clone(),
+            app.ledger_manager.clone(),
+            persist_tx,
+        );
+        let result = app
+            .catchup_with_run_mode(
+                CatchupTarget::Ledger(target_ledger),
+                CatchupMode::Minimal,
+                CatchupRunMode::OfflineBasic,
+                finalize,
+            )
+            .await;
+
+        // Catchup fails (archive unreachable) — that's expected and fine.
+        // The important thing is that it did NOT fail with FatalChainDisagreement,
+        // which would indicate the SCP anchor was incorrectly installed.
+        assert!(
+            result.is_err(),
+            "expected catchup to fail (unreachable archive)"
+        );
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            !err_msg.contains("FatalChainDisagreement"),
+            "offline catchup must not produce FatalChainDisagreement; got: {err_msg}"
+        );
     }
 }

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -6279,21 +6279,74 @@ mod tests {
         assert_eq!(result, None);
     }
 
-    /// Regression test: offline catchup must NOT install an SCP trust anchor even
-    /// when herder has externalized target+1. This verifies the run_mode gate
-    /// added in response to the review finding that offline paths must remain
-    /// TrustSource::None regardless of incidental herder cache state.
+    // ================================================================
+    // Production-path wiring tests: verify that run_catchup_work() installs
+    // (or does not install) the SCP trust anchor based on CatchupRunMode.
+    //
+    // These tests drive the real catchup_with_run_mode() entry point and use
+    // tracing capture to observe the anchor-installation decision. The
+    // "Resolved SCP trust anchor" log fires inside run_catchup_work() at the
+    // exact production branch under test, BEFORE any archive I/O. If the
+    // `if run_mode == CatchupRunMode::Online` gate were removed, both tests
+    // would see the log (causing the offline test to fail).
+    // ================================================================
+
+    /// Minimal tracing layer that records whether a specific message was logged.
+    mod anchor_tracing {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use tracing::subscriber::Subscriber;
+        use tracing_subscriber::layer::Context;
+        use tracing_subscriber::Layer;
+
+        /// Layer that sets a flag when "Resolved SCP trust anchor" is logged.
+        pub struct AnchorDetector {
+            pub detected: Arc<AtomicBool>,
+        }
+
+        impl<S: Subscriber> Layer<S> for AnchorDetector {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                // Check the message field for our target log line.
+                let mut visitor = MessageVisitor(String::new());
+                event.record(&mut visitor);
+                if visitor.0.contains("Resolved SCP trust anchor") {
+                    self.detected.store(true, Ordering::SeqCst);
+                }
+            }
+        }
+
+        struct MessageVisitor(String);
+
+        impl tracing::field::Visit for MessageVisitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    self.0 = format!("{:?}", value);
+                }
+            }
+
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                if field.name() == "message" {
+                    self.0 = value.to_string();
+                }
+            }
+        }
+    }
+
+    /// Online catchup with herder data MUST install the SCP trust anchor.
+    /// This test exercises the real `catchup_with_run_mode(Online)` production
+    /// path and would fail if the anchor-installation block were removed.
     #[tokio::test]
-    async fn test_offline_catchup_does_not_install_scp_trust_anchor() {
+    async fn test_online_catchup_installs_scp_trust_anchor_production_path() {
         use henyey_history::CatchupRunMode;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use tracing_subscriber::layer::SubscriberExt;
 
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
         let mut config = crate::config::ConfigBuilder::simulation()
             .database_path(db_path)
             .build();
-        // Point to an unreachable archive — catchup will fail at download,
-        // but that's after the SCP anchor decision point.
         config.history.archives = vec![crate::config::HistoryArchiveEntry {
             name: "unreachable".to_string(),
             url: "http://127.0.0.1:1/.well-known/stellar-history.json".to_string(),
@@ -6307,25 +6360,105 @@ mod tests {
         let target_ledger: u32 = 100;
         let expected_prev_hash = henyey_common::types::Hash256([42u8; 32]);
 
-        // Seed herder with externalized target+1. This means
-        // resolve_scp_trust_anchor() WOULD return Some if called.
+        // Seed herder with externalized target+1.
         seed_externalized_with_tx_set(&app, (target_ledger + 1) as u64, expected_prev_hash);
 
-        // Verify the herder data is available.
+        // Precondition: herder data is available.
         assert_eq!(
             app.resolve_scp_trust_anchor(target_ledger),
             Some((target_ledger, expected_prev_hash)),
             "precondition: herder data must be available"
         );
 
-        // Run offline catchup — this should NOT install the SCP anchor.
+        // Set up tracing capture to detect anchor installation.
+        let detected = Arc::new(AtomicBool::new(false));
+        let layer = anchor_tracing::AnchorDetector {
+            detected: Arc::clone(&detected),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // Run online catchup — the anchor decision fires before archive download.
         let (persist_tx, _persist_rx) = tokio::sync::oneshot::channel();
         let finalize = super::persist::CatchupFinalizer::deferred(
             app.db.clone(),
             app.ledger_manager.clone(),
             persist_tx,
         );
-        let result = app
+        let _result = app
+            .catchup_with_run_mode(
+                CatchupTarget::Ledger(target_ledger),
+                CatchupMode::Minimal,
+                CatchupRunMode::Online,
+                finalize,
+            )
+            .await;
+
+        // The anchor-installation log MUST have fired for Online mode.
+        assert!(
+            detected.load(Ordering::SeqCst),
+            "Online catchup with herder data must install SCP trust anchor \
+             (log 'Resolved SCP trust anchor' was not emitted — \
+             the run_catchup_work() online wiring is broken)"
+        );
+    }
+
+    /// Offline catchup must NOT install an SCP trust anchor even when herder
+    /// has externalized target+1. This exercises the real
+    /// `catchup_with_run_mode(OfflineBasic)` production path and would fail
+    /// if the `run_mode == Online` gate were removed.
+    #[tokio::test]
+    async fn test_offline_catchup_does_not_install_scp_trust_anchor_production_path() {
+        use henyey_history::CatchupRunMode;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let mut config = crate::config::ConfigBuilder::simulation()
+            .database_path(db_path)
+            .build();
+        config.history.archives = vec![crate::config::HistoryArchiveEntry {
+            name: "unreachable".to_string(),
+            url: "http://127.0.0.1:1/.well-known/stellar-history.json".to_string(),
+            get_enabled: true,
+            put_enabled: false,
+            put: None,
+            mkdir: None,
+        }];
+        let app = App::new(config).await.unwrap();
+
+        let target_ledger: u32 = 100;
+        let expected_prev_hash = henyey_common::types::Hash256([42u8; 32]);
+
+        // Seed herder with externalized target+1. resolve_scp_trust_anchor()
+        // WOULD return Some if called — but OfflineBasic must skip it.
+        seed_externalized_with_tx_set(&app, (target_ledger + 1) as u64, expected_prev_hash);
+
+        // Precondition: herder data is available.
+        assert_eq!(
+            app.resolve_scp_trust_anchor(target_ledger),
+            Some((target_ledger, expected_prev_hash)),
+            "precondition: herder data must be available"
+        );
+
+        // Set up tracing capture to detect anchor installation.
+        let detected = Arc::new(AtomicBool::new(false));
+        let layer = anchor_tracing::AnchorDetector {
+            detected: Arc::clone(&detected),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // Run offline catchup — the anchor decision must NOT fire.
+        let (persist_tx, _persist_rx) = tokio::sync::oneshot::channel();
+        let finalize = super::persist::CatchupFinalizer::deferred(
+            app.db.clone(),
+            app.ledger_manager.clone(),
+            persist_tx,
+        );
+        let _result = app
             .catchup_with_run_mode(
                 CatchupTarget::Ledger(target_ledger),
                 CatchupMode::Minimal,
@@ -6334,17 +6467,12 @@ mod tests {
             )
             .await;
 
-        // Catchup fails (archive unreachable) — that's expected and fine.
-        // The important thing is that it did NOT fail with FatalChainDisagreement,
-        // which would indicate the SCP anchor was incorrectly installed.
+        // The anchor-installation log must NOT have fired for OfflineBasic.
         assert!(
-            result.is_err(),
-            "expected catchup to fail (unreachable archive)"
-        );
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(
-            !err_msg.contains("FatalChainDisagreement"),
-            "offline catchup must not produce FatalChainDisagreement; got: {err_msg}"
+            !detected.load(Ordering::SeqCst),
+            "Offline catchup must NOT install SCP trust anchor even when \
+             herder has externalized target+1 (log 'Resolved SCP trust anchor' \
+             was emitted — the run_mode gate is broken)"
         );
     }
 }

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -836,6 +836,20 @@ impl App {
         // frames match the live-mode LedgerCloseMetaExt version.
         catchup_manager.set_emit_meta_ext_v1(self.config.metadata.emit_ledger_close_meta_ext_v1);
 
+        // §9.1 + INV-C5: Resolve an SCP-derived trust anchor for online catchup.
+        // If target + 1 has been externalized and its tx-set is available, use
+        // tx_set.previous_ledger_hash() as the trusted anchor for reverse-walk
+        // verification. This matches stellar-core's startOnlineCatchup() behavior.
+        if let Some((seq, hash)) = self.resolve_scp_trust_anchor(target_ledger) {
+            tracing::info!(
+                target_ledger,
+                anchor_seq = seq,
+                anchor_hash = %hash.to_hex(),
+                "Resolved SCP trust anchor from externalized slot target+1"
+            );
+            catchup_manager.set_trusted_scp_anchor(seq, hash);
+        }
+
         // Run catchup
         progress.set_phase(CatchupPhase::DownloadingBuckets);
 
@@ -918,6 +932,24 @@ impl App {
         tracing::info!("Verifying catchup state");
 
         Ok(output)
+    }
+
+    /// Resolve an SCP-derived trust anchor for reverse-walk verification.
+    ///
+    /// Checks `Herder::check_ledger_close(target_ledger + 1)` for a concrete
+    /// tx-set. If available, returns `(target_ledger, tx_set.previous_ledger_hash())`
+    /// which is the hash of `target_ledger` as attested by SCP consensus.
+    /// Returns `None` if the adjacent slot is not externalized or its tx-set
+    /// is not yet cached (preserving the existing untrusted fallback behavior).
+    ///
+    /// This mirrors stellar-core's `LedgerApplyManagerImpl::startOnlineCatchup()`
+    /// which anchors verification at `firstBufferedLedger.txSet.previousLedgerHash()`.
+    pub(crate) fn resolve_scp_trust_anchor(&self, target_ledger: u32) -> Option<(u32, Hash256)> {
+        let adjacent_slot = (target_ledger as u64) + 1;
+        let info = self.herder.check_ledger_close(adjacent_slot)?;
+        let tx_set = info.tx_set?;
+        let prev_hash = tx_set.previous_ledger_hash();
+        Some((target_ledger, prev_hash))
     }
 
     async fn download_checkpoint_with_historywork(
@@ -6145,5 +6177,141 @@ mod tests {
              #2789: suppression on every tick prevents any state-changing recovery.",
             app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
         );
+    }
+
+    // ================================================================
+    // §9.1 + INV-C5: SCP trust anchor resolution tests (#2830)
+    // ================================================================
+
+    /// Helper: seed herder with an externalized slot carrying a tx-set whose
+    /// `previous_ledger_hash` is `expected_prev_hash`.
+    fn seed_externalized_with_tx_set(
+        app: &App,
+        slot: u64,
+        previous_ledger_hash: henyey_common::types::Hash256,
+    ) {
+        use stellar_xdr::curr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
+
+        let tx_set = henyey_herder::TransactionSet::new(previous_ledger_hash, vec![]);
+        let tx_set_hash = *tx_set.hash();
+
+        // Cache the tx-set in the SCP driver so check_ledger_close can find it.
+        app.herder.scp_driver().cache_tx_set(tx_set);
+
+        // Build a StellarValue with the matching tx_set_hash.
+        let sv = StellarValue {
+            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            close_time: TimePoint(1000),
+            upgrades: vec![].try_into().unwrap(),
+            ext: StellarValueExt::Basic,
+        };
+        let value =
+            stellar_xdr::curr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap());
+
+        // Record the slot as externalized.
+        app.herder
+            .scp_driver()
+            .record_externalized(slot, value, None);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_scp_trust_anchor_uses_herder_target_plus_one_prev_hash() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        let target_ledger: u32 = 100;
+        let expected_prev_hash = henyey_common::types::Hash256([42u8; 32]);
+
+        // Seed slot target+1 with a tx-set whose previous_ledger_hash is expected_prev_hash.
+        seed_externalized_with_tx_set(&app, (target_ledger + 1) as u64, expected_prev_hash);
+
+        // resolve_scp_trust_anchor should return (target_ledger, expected_prev_hash).
+        let result = app.resolve_scp_trust_anchor(target_ledger);
+        assert_eq!(result, Some((target_ledger, expected_prev_hash)));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_scp_trust_anchor_returns_none_without_adjacent_tx_set() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        let target_ledger: u32 = 200;
+
+        // Case 1: slot target+1 is not externalized at all.
+        let result = app.resolve_scp_trust_anchor(target_ledger);
+        assert_eq!(result, None);
+
+        // Case 2: slot target+1 is externalized but WITHOUT a cached tx-set.
+        // Build a StellarValue with a tx_set_hash that has no cached tx-set.
+        {
+            use stellar_xdr::curr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
+
+            let fake_hash = henyey_common::types::Hash256([99u8; 32]);
+            let sv = StellarValue {
+                tx_set_hash: stellar_xdr::curr::Hash(fake_hash.0),
+                close_time: TimePoint(2000),
+                upgrades: vec![].try_into().unwrap(),
+                ext: StellarValueExt::Basic,
+            };
+            let value =
+                stellar_xdr::curr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap());
+
+            app.herder
+                .scp_driver()
+                .record_externalized((target_ledger + 1) as u64, value, None);
+        }
+
+        // check_ledger_close will return Some(LedgerCloseInfo { tx_set: None, ... })
+        // because the tx-set is not cached. resolve_scp_trust_anchor should return None.
+        let result = app.resolve_scp_trust_anchor(target_ledger);
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_run_catchup_work_applies_resolved_scp_anchor_to_manager() {
+        // This test verifies the wiring: when resolve_scp_trust_anchor returns
+        // Some, the CatchupManager receives the anchor. We test this indirectly
+        // by verifying that resolve_scp_trust_anchor is called with target_ledger
+        // and produces the expected result, since the integration of the anchor
+        // into catchup_manager is exercised by the code path in run_catchup_work.
+        //
+        // A full integration test would require a running archive, which is out
+        // of scope for unit tests. The history-side test
+        // (test_set_trusted_scp_anchor_updates_reverse_walk_config) verifies that
+        // the anchor, once set, is used correctly in verification.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        let target_ledger: u32 = 500;
+        let expected_prev_hash = henyey_common::types::Hash256([7u8; 32]);
+        seed_externalized_with_tx_set(&app, (target_ledger + 1) as u64, expected_prev_hash);
+
+        // Verify the anchor is correctly resolved (this is what run_catchup_work calls).
+        let anchor = app.resolve_scp_trust_anchor(target_ledger);
+        assert_eq!(anchor, Some((target_ledger, expected_prev_hash)));
+
+        // Verify that CatchupManager correctly receives and stores the anchor.
+        use henyey_bucket::BucketManager;
+        let tmp = tempfile::tempdir().unwrap();
+        let bucket_manager = BucketManager::new(tmp.path().to_path_buf()).unwrap();
+        let db = henyey_db::Database::open_in_memory().unwrap();
+        let mut manager = henyey_history::CatchupManager::new(vec![], bucket_manager, db);
+        if let Some((seq, hash)) = anchor {
+            manager.set_trusted_scp_anchor(seq, hash);
+        }
+        // The anchor is pub(super) so we can't directly inspect it here,
+        // but the history-side test confirms it flows through to ReverseWalkConfig.
     }
 }

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -566,6 +566,12 @@ pub struct App {
     /// to `publish_single_checkpoint` will swap it to `false` and panic.
     #[cfg(test)]
     pub(crate) publish_panic_inject: AtomicBool,
+    /// Records the last SCP trust anchor installed during `run_catchup_work`.
+    /// Used by tests to verify that `set_trusted_scp_anchor` was actually called
+    /// on the `CatchupManager` (not just that the surrounding log was emitted).
+    #[cfg(test)]
+    pub(crate) last_installed_scp_anchor:
+        std::sync::Mutex<Option<(u32, henyey_common::types::Hash256)>>,
     /// Buffered externalized ledgers waiting to apply.
     ///
     /// # Invariant (event-loop freeze guard rail)
@@ -1297,6 +1303,8 @@ impl App {
             publish_in_progress: AtomicBool::new(false),
             #[cfg(test)]
             publish_panic_inject: AtomicBool::new(false),
+            #[cfg(test)]
+            last_installed_scp_anchor: std::sync::Mutex::new(None),
             syncing_ledgers: RwLock::new(BTreeMap::new()),
             last_externalized_slot: AtomicU64::new(0),
             scp_messages_sent: AtomicU64::new(0),

--- a/crates/history/PARITY_STATUS.md
+++ b/crates/history/PARITY_STATUS.md
@@ -18,7 +18,7 @@
 | Publish queue persistence | Full | SQLite-backed queue replaces filesystem queue |
 | Publish orchestration | Partial | Missing some callbacks, metrics, cleanup helpers |
 | State snapshot publishing | Partial | No differential HAS upload; upload ordering now matches stellar-core (data-before-HAS) |
-| Verification | Full | Header entry hash, header chain, bucket, tx-set, tx-result checks implemented |
+| Verification | Full | Header entry hash, header chain, bucket, tx-set, tx-result checks implemented; SCP trust anchor plumbed from online catchup (§9.1 + INV-C5) |
 | Catchup and replay | Full | Rust-native orchestration covers core flow; §11.2 5-case knit-to-LCL decision matrix matches stellar-core |
 | Metrics and status plumbing | None | No Medida/StatusManager equivalent yet |
 

--- a/crates/history/SPEC_ADHERENCE.md
+++ b/crates/history/SPEC_ADHERENCE.md
@@ -41,7 +41,7 @@ invariants. INV-C9 (bucket-apply newest-wins) lives in
 | §8.2 | Phase 2: Download + verify chain | Full | `catchup/mod.rs:540-545`, `verify.rs:253-441` |
 | §8.4 | Apply buffered ledgers | N/A | lives in `crates/app/src/app/ledger_close.rs:1758-1792` (`try_apply_buffered_ledgers`) |
 | §8.5 | Post-bucket asserts (HAS/header/LCL) | Full | `catchup/mod.rs:463-486` |
-| §9.1 | Trust establishment | Partial | `verify.rs:303-306` — only TrustSource::None used at call site (`catchup/replay.rs:235`) |
+| §9.1 | Trust establishment | Full | `verify.rs:303-306` — `TrustSource::Scp` plumbed from `App::resolve_scp_trust_anchor()` through `CatchupManager::set_trusted_scp_anchor()` to `catchup/replay.rs` |
 | §9.2 | Reverse-walk verification | Full | `verify.rs:253-441` |
 | §9.3 | Outcome → fatal mapping | Full | `verify.rs:422-436` |
 | §10.1 | Bucket size limit + per-bucket SHA-256 | Full | `catchup/download.rs:230-240`, bucket hash verify in `apply_buckets` (`catchup/buckets.rs:381-405`) |
@@ -123,7 +123,7 @@ invariants. INV-C9 (bucket-apply newest-wins) lives in
 - **§8.5 post-apply asserts**: `catchup/mod.rs:463-486`. **Full**. Both (a) HAS/header seq agreement and (b) INV-C15 (`checkpoint_header.ledger_seq >= lcl_seq`).
 
 ### §9 — Ledger Chain Verification
-- **§9.1 trust anchors**: `verify.rs:53-67` defines `TrustSource::{Scp{seq,hash}, None}` and `ChainTrustAnchors`. Call site at `catchup/replay.rs:235` always uses `TrustSource::None` because SCP-side hash plumbing is not wired through. **Partial**. The pure verification code path correctly implements the trusted-hash check (verify.rs:354-384); only the caller side does not yet provide a trusted hash.
+- **§9.1 trust anchors**: `verify.rs:53-67` defines `TrustSource::{Scp{seq,hash}, None}` and `ChainTrustAnchors`. Online catchup now derives the trust anchor from `Herder::check_ledger_close(target+1)` via `App::resolve_scp_trust_anchor()` and passes it through `CatchupManager::set_trusted_scp_anchor()` to the reverse-walk config in `catchup/replay.rs`. **Full**. Matches stellar-core's `LedgerApplyManagerImpl::startOnlineCatchup()` → `VerifyLedgerChainWork` path. Offline/synthetic callers without an adjacent externalized slot still get `TrustSource::None`.
 - **§9.2 reverse-walk algorithm**: `verify.rs:253-441`. **Full**. Partitions into checkpoint groups, walks reverse, threads cross-checkpoint link, checks `previous_ledger_hash` continuity, LCL+1 link check (verify.rs:393-405).
 - **§9.3 outcome → fatal**: `verify.rs:422-436`. **Full**. When `local_state_disagrees && TrustSource::Scp`, returns `FatalChainDisagreement`; with `TrustSource::None`, returns `InvalidPreviousHash` (retryable). Matches §9.3 table.
 
@@ -179,7 +179,7 @@ All constants present with correct values:
 | INV-C2 (Checkpoint alignment) | Full | `verify.rs:282-292` (group partition by checkpoint); checkpoint ledger range enforced via `verify_tx_result_ordering` (`verify.rs:808-842`). |
 | INV-C3 (HAS integrity) | Full | `verify.rs:709-761` + `archive_state.rs:404-473`. |
 | INV-C4 (BucketList hash agreement) | Full | `verify.rs:480-494` (`verify_ledger_hash`) + `archive_state.rs:600-654` (`compute_bucket_list_hash`). |
-| INV-C5 (Trust anchor authentication) | Partial | Verification function supports `TrustSource::Scp` (`verify.rs:355-384`), but call site uses `TrustSource::None` (`catchup/replay.rs:235`). Internal-only verification still flags LCL disagreement as fatal-via-`InvalidPreviousHash` retry, but no SCP-side trusted hash is plumbed. |
+| INV-C5 (Trust anchor authentication) | Full | Verification function supports `TrustSource::Scp` (`verify.rs:355-384`) and online catchup now plumbs the SCP-derived anchor from `App::resolve_scp_trust_anchor()` → `CatchupManager::set_trusted_scp_anchor()` → `catchup/replay.rs`. LCL disagreement is fatal when trusted hash exists. |
 | INV-C6 (Tx result hash check) | Partial | `verify_tx_result_set` correct (`verify.rs:542-563`) but no `OFFLINE_COMPLETE`-mode caller that loops over every replay-range ledger. See §12. |
 | INV-C7 (Knit-to-LCL exclusivity) | Full | `catchup/replay.rs:58-117` — five mutually-exclusive cases; case 5 returns `KnitOvershot` error (fatal). |
 | INV-C8 (Buffered drain ordering) | N/A | Lives in `crates/app/src/app/ledger_close.rs:1758-1792` (`try_apply_buffered_ledgers` only advances `next_seq = current + 1`; gap stops the chain). |
@@ -220,7 +220,7 @@ No dangling anchors were detected — all cited sections exist in the regenerate
 ## Recommendations
 
 1. **~~Add OFFLINE_BASIC / OFFLINE_COMPLETE / ONLINE mode discriminator~~** ✅ Done (#2829). Wire OFFLINE_COMPLETE to a `verify_results_for_range` work that loops over `results-*.xdr.gz` files for every checkpoint in the replay range, invoking `verify_tx_result_set` per ledger. Closes the §12 / INV-C6 gap (#2831).
-2. **Plumb SCP-side trusted hash through** to `catchup/replay.rs:235` so `TrustSource::Scp` is actually exercised in ONLINE mode. Closes the INV-C5 gap (currently relies on internal-only chain consistency).
+2. ~~**Plumb SCP-side trusted hash through** to `catchup/replay.rs:235` so `TrustSource::Scp` is actually exercised in ONLINE mode. Closes the INV-C5 gap (currently relies on internal-only chain consistency).~~ *(Done — #2830. `App::resolve_scp_trust_anchor()` derives the anchor from `Herder::check_ledger_close(target+1)` and passes it to `CatchupManager::set_trusted_scp_anchor()`.)*
 3. ~~**Add a `REBUILD_FOR_OFFER_TABLE`-equivalent persistent-state flag**~~ *(Partially resolved — §14.5 two-window design covers the startup/catchup recovery path. Remaining gap: CLI readers (`publish_history`, `self_check`) anchor on `MAX(ledgerseq)` instead of durable LCL/HAS and may observe ahead-of-LCL state after a Window-1 crash. Needs hardening.)*
 4. ~~**Update spec §5.3** to acknowledge SQLite-backed publish queue as a conforming alternative storage shape (or vice versa, if filesystem-backed is required for stellar-core interoperability).~~ *(No spec update needed — documented in-repo as intentional implementation difference; queue is node-local. Tracked as Drift 1 above.)*
 5. **Update spec §6.3** to make the post-#2677 collapsed factoring of Case 1 / Case 2 / Case 4b explicit, eliminating the apparent drift.

--- a/crates/history/src/catchup/mod.rs
+++ b/crates/history/src/catchup/mod.rs
@@ -283,6 +283,14 @@ pub struct CatchupManager {
     /// When true, synthetic bucket-apply meta uses `LedgerCloseMetaExtV1`
     /// (matching the live mode setting `EMIT_LEDGER_CLOSE_META_EXT_V1`).
     pub(super) emit_meta_ext_v1: bool,
+
+    /// Optional SCP-derived trusted anchor for reverse-walk verification (§9.1 + INV-C5).
+    ///
+    /// When set, the reverse-walk verifier uses `TrustSource::Scp` instead of
+    /// `TrustSource::None`, making local-state disagreement fatal (non-retriable).
+    /// Derived from `Herder::check_ledger_close(target + 1)` during online catchup:
+    /// `(target_ledger, tx_set.previous_ledger_hash())`.
+    pub(super) trusted_scp_anchor: Option<(u32, Hash256)>,
 }
 
 impl CatchupManager {
@@ -303,6 +311,7 @@ impl CatchupManager {
             network_passphrase: None,
             meta_callback: None,
             emit_meta_ext_v1: false,
+            trusted_scp_anchor: None,
         }
     }
 
@@ -321,6 +330,7 @@ impl CatchupManager {
             network_passphrase: None,
             meta_callback: None,
             emit_meta_ext_v1: false,
+            trusted_scp_anchor: None,
         }
     }
 
@@ -359,6 +369,20 @@ impl CatchupManager {
     /// meta extension version.
     pub fn set_emit_meta_ext_v1(&mut self, enabled: bool) {
         self.emit_meta_ext_v1 = enabled;
+    }
+
+    /// Set an SCP-derived trusted anchor for reverse-walk verification (§9.1 + INV-C5).
+    ///
+    /// When set, `verify_downloaded_data` builds `ReverseWalkConfig` with
+    /// `TrustSource::Scp { seq, hash }` instead of the default `TrustSource::None`.
+    /// This makes local-state disagreement during header-chain verification a
+    /// fatal (non-retriable) error, matching stellar-core's online catchup behavior
+    /// (`LedgerApplyManagerImpl::startOnlineCatchup` → `VerifyLedgerChainWork`).
+    ///
+    /// The anchor is derived from `Herder::check_ledger_close(target + 1)`:
+    /// `(target_ledger, tx_set.previous_ledger_hash())`.
+    pub fn set_trusted_scp_anchor(&mut self, seq: u32, hash: Hash256) {
+        self.trusted_scp_anchor = Some((seq, hash));
     }
 
     /// Select an archive for a download attempt, rotating through available archives.

--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -1167,13 +1167,107 @@ mod tests {
     // §9.1 + INV-C5: Trusted SCP anchor configuration tests (#2830)
     // ================================================================
 
-    #[test]
-    fn test_set_trusted_scp_anchor_updates_reverse_walk_config() {
-        use crate::verify;
+    /// Build a valid header chain and matching `LedgerData` entries.
+    /// Returns (ledger_data_vec, hash_of_header_before_chain) where the
+    /// hash before the chain is the `previous_ledger_hash` of the first header.
+    fn make_test_ledger_data_chain(
+        start_seq: u32,
+        count: u32,
+    ) -> (Vec<super::LedgerData>, Hash256) {
+        use crate::verify::compute_header_hash;
+        use henyey_common::protocol::LclContext;
+        use stellar_xdr::curr::{Hash, StellarValue, TimePoint, VecM};
 
-        // Construct a CatchupManager with a trusted SCP anchor.
+        let mut entries = Vec::with_capacity(count as usize);
+        let mut prev_hash = Hash256::ZERO;
+        let genesis_hash = prev_hash;
+
+        for i in 0..count {
+            let seq = start_seq + i;
+            let header = LedgerHeader {
+                ledger_version: 25,
+                previous_ledger_hash: prev_hash.into(),
+                scp_value: StellarValue {
+                    tx_set_hash: Hash([0u8; 32]),
+                    close_time: TimePoint(0),
+                    upgrades: VecM::default(),
+                    ext: stellar_xdr::curr::StellarValueExt::Basic,
+                },
+                tx_set_result_hash: Hash([0u8; 32]),
+                bucket_list_hash: Hash([0u8; 32]),
+                ledger_seq: seq,
+                total_coins: 0,
+                fee_pool: 0,
+                inflation_seq: 0,
+                id_pool: 0,
+                base_fee: 100,
+                base_reserve: 5000000,
+                max_tx_set_size: 100,
+                skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
+                ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            };
+
+            let lcl_context = LclContext::new(25, prev_hash);
+            let ledger_data =
+                super::LedgerData::new(header.clone(), None, None, &lcl_context).unwrap();
+            prev_hash = compute_header_hash(&header).unwrap();
+            entries.push(ledger_data);
+        }
+
+        (entries, genesis_hash)
+    }
+
+    /// With TrustSource::Scp (anchor set), LCL disagreement produces
+    /// FatalChainDisagreement through the production `verify_downloaded_data` path.
+    #[test]
+    fn test_verify_downloaded_data_scp_anchor_makes_lcl_disagreement_fatal() {
+        use crate::verify::compute_header_hash;
+
+        let tmpdir = tempfile::tempdir().unwrap();
         let bucket_manager =
-            henyey_bucket::BucketManager::new(tempfile::tempdir().unwrap().keep()).unwrap();
+            henyey_bucket::BucketManager::new(tmpdir.path().to_path_buf()).unwrap();
+        let db = henyey_db::Database::open_in_memory().unwrap();
+        let archive =
+            crate::archive::HistoryArchive::with_name("http://localhost:1234", "test").unwrap();
+        let mut manager = super::CatchupManager::new(vec![archive], bucket_manager, db);
+
+        // Enable header chain verification (production default for catchup).
+        manager.replay_config.verify_header_chain = true;
+
+        // Build a valid chain of 5 headers starting at seq 10.
+        let (ledger_data, _genesis_hash) = make_test_ledger_data_chain(10, 5);
+
+        // Compute the hash of the last header for the SCP trust anchor.
+        let last_header = ledger_data.last().unwrap().header();
+        let last_hash = compute_header_hash(last_header).unwrap();
+
+        // Set SCP trust anchor at the last header in the chain.
+        manager.set_trusted_scp_anchor(last_header.ledger_seq, last_hash);
+
+        // Build a DISAGREEING LCL: seq = 9 (right before chain start), but
+        // hash is wrong (doesn't match first header's previous_ledger_hash).
+        let wrong_lcl_hash = Hash256::from_bytes([0xBB; 32]);
+        let lcl_snapshot = make_test_lcl(9, wrong_lcl_hash, Hash256::ZERO);
+
+        // Call the production path: verify_downloaded_data.
+        let err = manager
+            .verify_downloaded_data(&ledger_data, &lcl_snapshot)
+            .unwrap_err();
+
+        // With TrustSource::Scp, LCL disagreement must be fatal.
+        assert!(
+            matches!(err, crate::HistoryError::FatalChainDisagreement),
+            "expected FatalChainDisagreement with SCP anchor, got: {err}"
+        );
+    }
+
+    /// Without SCP anchor (TrustSource::None), LCL disagreement produces
+    /// InvalidPreviousHash through the production `verify_downloaded_data` path.
+    #[test]
+    fn test_verify_downloaded_data_no_anchor_makes_lcl_disagreement_non_fatal() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let bucket_manager =
+            henyey_bucket::BucketManager::new(tmpdir.path().to_path_buf()).unwrap();
         let db = henyey_db::Database::open_in_memory().unwrap();
         let archive =
             crate::archive::HistoryArchive::with_name("http://localhost:1234", "test").unwrap();
@@ -1182,60 +1276,25 @@ mod tests {
         // Enable header chain verification.
         manager.replay_config.verify_header_chain = true;
 
-        // Set the SCP trust anchor.
-        let anchor_seq = 128u32;
-        let anchor_hash = Hash256::from_bytes([0xAB; 32]);
-        manager.set_trusted_scp_anchor(anchor_seq, anchor_hash);
+        // Build a valid chain of 5 headers starting at seq 10.
+        let (ledger_data, _genesis_hash) = make_test_ledger_data_chain(10, 5);
 
-        // Verify the anchor is stored.
-        assert_eq!(manager.trusted_scp_anchor, Some((anchor_seq, anchor_hash)));
+        // Do NOT set any SCP trust anchor (TrustSource::None by default).
 
-        // The verify_downloaded_data method uses self.trusted_scp_anchor
-        // to build TrustSource::Scp. We verify the field is correctly set
-        // which the replay code reads as:
-        //   match &self.trusted_scp_anchor {
-        //       Some((seq, hash)) => TrustSource::Scp { seq: *seq, hash: *hash },
-        //       None => TrustSource::None,
-        //   }
-        let trust_source = match &manager.trusted_scp_anchor {
-            Some((seq, hash)) => verify::TrustSource::Scp {
-                seq: *seq,
-                hash: *hash,
-            },
-            None => verify::TrustSource::None,
-        };
-        match trust_source {
-            verify::TrustSource::Scp { seq, hash } => {
-                assert_eq!(seq, anchor_seq);
-                assert_eq!(hash, anchor_hash);
-            }
-            verify::TrustSource::None => panic!("Expected TrustSource::Scp"),
-        }
-    }
+        // Build a DISAGREEING LCL.
+        let wrong_lcl_hash = Hash256::from_bytes([0xBB; 32]);
+        let lcl_snapshot = make_test_lcl(9, wrong_lcl_hash, Hash256::ZERO);
 
-    #[test]
-    fn test_reverse_walk_config_defaults_to_trust_source_none() {
-        use crate::verify;
+        // Call the production path: verify_downloaded_data.
+        let err = manager
+            .verify_downloaded_data(&ledger_data, &lcl_snapshot)
+            .unwrap_err();
 
-        // Construct a CatchupManager WITHOUT a trusted SCP anchor.
-        let bucket_manager =
-            henyey_bucket::BucketManager::new(tempfile::tempdir().unwrap().keep()).unwrap();
-        let db = henyey_db::Database::open_in_memory().unwrap();
-        let archive =
-            crate::archive::HistoryArchive::with_name("http://localhost:1234", "test").unwrap();
-        let manager = super::CatchupManager::new(vec![archive], bucket_manager, db);
-
-        // No anchor set — trusted_scp_anchor should be None.
-        assert_eq!(manager.trusted_scp_anchor, None);
-
-        // The replay code should produce TrustSource::None.
-        let trust_source = match &manager.trusted_scp_anchor {
-            Some((seq, hash)) => verify::TrustSource::Scp {
-                seq: *seq,
-                hash: *hash,
-            },
-            None => verify::TrustSource::None,
-        };
-        assert!(matches!(trust_source, verify::TrustSource::None));
+        // Without SCP anchor, LCL disagreement is treated as a broken chain
+        // (InvalidPreviousHash) — retriable, not fatal.
+        assert!(
+            matches!(err, crate::HistoryError::InvalidPreviousHash { .. }),
+            "expected InvalidPreviousHash without SCP anchor, got: {err}"
+        );
     }
 }

--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -229,10 +229,15 @@ impl CatchupManager {
             // from highest to lowest, threading trust from the top anchor.
             // Individual header integrity was already verified during download
             // (per-checkpoint verify_header_chain_from_entries).
+            let trust_source = match &self.trusted_scp_anchor {
+                Some((seq, hash)) => verify::TrustSource::Scp {
+                    seq: *seq,
+                    hash: *hash,
+                },
+                None => verify::TrustSource::None,
+            };
             let config = verify::ReverseWalkConfig {
-                // TrustSource::None until SCP consensus hash plumbing is added.
-                // Internal consistency and LCL comparison are still verified.
-                trust_source: verify::TrustSource::None,
+                trust_source,
                 lcl: Some((lcl_snapshot.header.ledger_seq, lcl_snapshot.hash)),
                 max_supported_version: henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION,
                 min_supported_version: henyey_common::protocol::MIN_LEDGER_PROTOCOL_VERSION,
@@ -1156,5 +1161,81 @@ mod tests {
             }
             assert!(found_any, "metric {metric} not found in catchup/replay.rs",);
         }
+    }
+
+    // ================================================================
+    // §9.1 + INV-C5: Trusted SCP anchor configuration tests (#2830)
+    // ================================================================
+
+    #[test]
+    fn test_set_trusted_scp_anchor_updates_reverse_walk_config() {
+        use crate::verify;
+
+        // Construct a CatchupManager with a trusted SCP anchor.
+        let bucket_manager =
+            henyey_bucket::BucketManager::new(tempfile::tempdir().unwrap().keep()).unwrap();
+        let db = henyey_db::Database::open_in_memory().unwrap();
+        let archive =
+            crate::archive::HistoryArchive::with_name("http://localhost:1234", "test").unwrap();
+        let mut manager = super::CatchupManager::new(vec![archive], bucket_manager, db);
+
+        // Enable header chain verification.
+        manager.replay_config.verify_header_chain = true;
+
+        // Set the SCP trust anchor.
+        let anchor_seq = 128u32;
+        let anchor_hash = Hash256::from_bytes([0xAB; 32]);
+        manager.set_trusted_scp_anchor(anchor_seq, anchor_hash);
+
+        // Verify the anchor is stored.
+        assert_eq!(manager.trusted_scp_anchor, Some((anchor_seq, anchor_hash)));
+
+        // The verify_downloaded_data method uses self.trusted_scp_anchor
+        // to build TrustSource::Scp. We verify the field is correctly set
+        // which the replay code reads as:
+        //   match &self.trusted_scp_anchor {
+        //       Some((seq, hash)) => TrustSource::Scp { seq: *seq, hash: *hash },
+        //       None => TrustSource::None,
+        //   }
+        let trust_source = match &manager.trusted_scp_anchor {
+            Some((seq, hash)) => verify::TrustSource::Scp {
+                seq: *seq,
+                hash: *hash,
+            },
+            None => verify::TrustSource::None,
+        };
+        match trust_source {
+            verify::TrustSource::Scp { seq, hash } => {
+                assert_eq!(seq, anchor_seq);
+                assert_eq!(hash, anchor_hash);
+            }
+            verify::TrustSource::None => panic!("Expected TrustSource::Scp"),
+        }
+    }
+
+    #[test]
+    fn test_reverse_walk_config_defaults_to_trust_source_none() {
+        use crate::verify;
+
+        // Construct a CatchupManager WITHOUT a trusted SCP anchor.
+        let bucket_manager =
+            henyey_bucket::BucketManager::new(tempfile::tempdir().unwrap().keep()).unwrap();
+        let db = henyey_db::Database::open_in_memory().unwrap();
+        let archive =
+            crate::archive::HistoryArchive::with_name("http://localhost:1234", "test").unwrap();
+        let manager = super::CatchupManager::new(vec![archive], bucket_manager, db);
+
+        // No anchor set — trusted_scp_anchor should be None.
+        assert_eq!(manager.trusted_scp_anchor, None);
+
+        // The replay code should produce TrustSource::None.
+        let trust_source = match &manager.trusted_scp_anchor {
+            Some((seq, hash)) => verify::TrustSource::Scp {
+                seq: *seq,
+                hash: *hash,
+            },
+            None => verify::TrustSource::None,
+        };
+        assert!(matches!(trust_source, verify::TrustSource::None));
     }
 }


### PR DESCRIPTION
Closes #2830

## Summary

Implements the missing caller-side plumbing for §9.1 + INV-C5 TrustSource::Scp. During online catchup, after the concrete target ledger is resolved, the new `App::resolve_scp_trust_anchor()` helper checks `Herder::check_ledger_close(target+1)` for a concrete tx-set. If available, it derives `(target_ledger, tx_set.previous_ledger_hash())` as the trusted SCP anchor and passes it through `CatchupManager::set_trusted_scp_anchor()` into the reverse-walk verification config. This matches stellar-core's `LedgerApplyManagerImpl::startOnlineCatchup()` behavior.

When target+1 is not externalized or its tx-set is not cached, the existing `TrustSource::None` fallback is preserved (offline/synthetic paths unaffected).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2830#issuecomment-4503092407)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-history -p henyey-app -- -D warnings
- [x] All 5 new tests pass (3 app-side, 2 history-side)
- [x] Existing tests preserved (verify, catchup, app target selection)

## Deviations from plan

- Tests directly exercise the trust anchor resolution and storage rather than running a full end-to-end catchup (which requires a running archive server). The wiring is verified by combining the app-side anchor tests with the history-side config tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)