### PR TITLE
Remove dead let _ = run_mode statements in catchup

### DIFF
--- a/crates/history/src/catchup/mod.rs
+++ b/crates/history/src/catchup/mod.rs
@@ -818,10 +818,6 @@ impl CatchupManager {
             "Starting catchup to ledger {} with mode {:?}, run_mode={}, lcl={}",
             target, mode, run_mode, lcl
         );
-        // run_mode is threaded through for observability and future behavioral
-        // differences (OFFLINE_COMPLETE tx-result verification, #2831). Currently
-        // only logged; replay-depth drives all range/download decisions.
-        let _ = run_mode;
         self.progress.target_ledger = target;
 
         // Calculate the catchup range based on mode
@@ -993,10 +989,6 @@ impl CatchupManager {
             "Starting catchup to ledger {} with checkpoint data (run_mode={})",
             target, config.run_mode
         );
-        // run_mode is threaded through for observability and future behavioral
-        // differences (OFFLINE_COMPLETE tx-result verification, #2831). Currently
-        // only logged; replay-depth drives all range/download decisions.
-        let _ = config.run_mode;
         self.progress.target_ledger = target;
 
         let checkpoint_seq =


### PR DESCRIPTION
Closes #2863

## Summary


## Plan reference

[Triage Report](https://github.com/stellar-experimental/henyey/issues/2863#issuecomment-4503502133)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-history -- -D warnings

## Deviations from plan

Also removed the second instance at line 999 (`let _ = config.run_mode;`) which follows the same dead-code pattern in the checkpoint-based catchup path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
