### PR TITLE
Exercise hostile env overrides in agent-worktree contract tests

### DIFF
--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -86,19 +86,21 @@ must be preserved. If not parity-critical: write "n/a — non-parity path".>
 
 ### Critic workspace contract
 
-**All critic scratch work must live only under `$HOME/data`.** Critics should prefer the existing checkout for read-only inspection. If a critic needs a scratch checkout (e.g. to run a test or verify a claim), it must live under `$HOME/data`, never in the repo root, the repo parent, or anywhere outside `$HOME/data`. Each critic derives its workspace as follows:
+**All critic scratch work must live only under `$HOME/data`.** Critics should prefer the existing checkout for read-only inspection. If a critic needs a scratch checkout (e.g. to run a test or verify a claim), it must live under `$HOME/data`, never in the repo root, the repo parent, or anywhere outside `$HOME/data`. Each critic derives its workspace by sourcing the shared contract helper:
 
 ```bash
-SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
-WORKTREE_BASE="${WORKTREE_BASE:-$HOME/data/$SESSION_ID/plan-$ISSUE}"
-export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
 
-# Critic-specific scratch dir (only if needed for checkout/build):
-CRITIC_WORKTREE="$WORKTREE_BASE/critic-a"  # or critic-b, critic-c
+# plan_critic_bootstrap validates and exports WORKTREE_BASE, CARGO_TARGET_DIR,
+# and CRITIC_WORKTREE. Pre-seeded values are accepted only if they resolve under
+# $HOME/data; hostile values (outside $HOME/data or using ../ traversal) are
+# rejected with a non-zero exit.
+plan_critic_bootstrap "$ISSUE" "critic-a"  # or critic-b, critic-c
 mkdir -p "$CRITIC_WORKTREE"
 ```
 
-Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those; otherwise it falls back to `$HOME/data/$SESSION_ID/plan-$ISSUE/...`.
+Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those only if they resolve under `$HOME/data`; otherwise it falls back to `$HOME/data/$SESSION_ID/plan-$ISSUE/...`. Hostile overrides (paths outside `$HOME/data` or traversal like `$HOME/data/../escape`) are rejected before any `mkdir`, `git clone`, or cargo command runs.
 
 Launch three `general-purpose` agents in parallel — do not wait between them. **Each critic must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity is the whole point of the critic step. Each gets the issue number, the plan-draft comment ID, and a focused brief:
 

--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -96,11 +96,11 @@ source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
 # and CRITIC_WORKTREE. Pre-seeded values are accepted only if they resolve under
 # $HOME/data; hostile values (outside $HOME/data or using ../ traversal) are
 # rejected with a non-zero exit.
-plan_critic_bootstrap "$ISSUE" "critic-a"  # or critic-b, critic-c
+plan_critic_bootstrap "$ISSUE" "critic-a" || exit 1  # or critic-b, critic-c
 mkdir -p "$CRITIC_WORKTREE"
 ```
 
-Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those only if they resolve under `$HOME/data`; otherwise it falls back to `$HOME/data/$SESSION_ID/plan-$ISSUE/...`. Hostile overrides (paths outside `$HOME/data` or traversal like `$HOME/data/../escape`) are rejected before any `mkdir`, `git clone`, or cargo command runs.
+Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those only if they resolve under `$HOME/data`; otherwise the bootstrap rejects the hostile value and exits non-zero — the `|| exit 1` guard ensures no subsequent commands run with stale env vars. Hostile overrides (paths outside `$HOME/data` or traversal like `$HOME/data/../escape`) are rejected before any `mkdir`, `git clone`, or cargo command runs.
 
 Launch three `general-purpose` agents in parallel — do not wait between them. **Each critic must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity is the whole point of the critic step. Each gets the issue number, the plan-draft comment ID, and a focused brief:
 

--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -86,7 +86,7 @@ must be preserved. If not parity-critical: write "n/a — non-parity path".>
 
 ### Critic workspace contract
 
-**All critic scratch work must live only under `$HOME/data`.** Critics should prefer the existing checkout for read-only inspection. If a critic needs a scratch checkout (e.g. to run a test or verify a claim), it must live under `$HOME/data`, never in the repo root, the repo parent, or anywhere outside `$HOME/data`. Each critic derives its workspace by sourcing the shared contract helper:
+**All critic scratch work must live only under `~/data` (the real home directory's `data/` subdirectory, derived from the passwd entry — immune to `$HOME` poisoning).** Critics should prefer the existing checkout for read-only inspection. If a critic needs a scratch checkout (e.g. to run a test or verify a claim), it must live under `~/data`, never in the repo root, the repo parent, or anywhere outside `~/data`. Each critic derives its workspace by sourcing the shared contract helper:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -94,13 +94,15 @@ source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
 
 # plan_critic_bootstrap validates and exports WORKTREE_BASE, CARGO_TARGET_DIR,
 # and CRITIC_WORKTREE. Pre-seeded values are accepted only if they resolve under
-# $HOME/data; hostile values (outside $HOME/data or using ../ traversal) are
-# rejected with a non-zero exit.
+# the real ~/data AND match the expected session/issue prefix
+# ($HOME/data/$SESSION_ID/plan-$ISSUE/...). Hostile values (outside ~/data,
+# using ../ traversal, HOME poisoning, or cross-session paths) are rejected
+# with a non-zero exit.
 plan_critic_bootstrap "$ISSUE" "critic-a" || exit 1  # or critic-b, critic-c
 mkdir -p "$CRITIC_WORKTREE"
 ```
 
-Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those only if they resolve under `$HOME/data`; otherwise the bootstrap rejects the hostile value and exits non-zero — the `|| exit 1` guard ensures no subsequent commands run with stale env vars. Hostile overrides (paths outside `$HOME/data` or traversal like `$HOME/data/../escape`) are rejected before any `mkdir`, `git clone`, or cargo command runs.
+Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those only if they resolve under the real `~/data` AND under the expected session/issue prefix (`~/data/$SESSION_ID/plan-$ISSUE/...`); otherwise the bootstrap rejects the value and exits non-zero — the `|| exit 1` guard ensures no subsequent commands run with stale env vars. Hostile overrides (paths outside `~/data`, traversal like `~/data/../escape`, HOME-poisoned paths, or cross-session shared directories) are rejected before any `mkdir`, `git clone`, or cargo command runs.
 
 Launch three `general-purpose` agents in parallel — do not wait between them. **Each critic must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity is the whole point of the critic step. Each gets the issue number, the plan-draft comment ID, and a focused brief:
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -655,7 +655,7 @@ source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
 # and REVIEWER_WORKTREE. Pre-seeded values are accepted only if they resolve
 # under $HOME/data; hostile values (outside $HOME/data or using ../ traversal)
 # are rejected with a non-zero exit.
-review_pr_bootstrap "$ISSUE"
+review_pr_bootstrap "$ISSUE" || exit 1
 mkdir -p "$REVIEWER_WORKTREE"
 ```
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -643,9 +643,10 @@ Exit.
 
 ## Workspace contract
 
-The `/review-pr` skill must never create worktrees outside `$HOME/data`. All scratch
-state lives under `$HOME/data/$SESSION_ID/review-pr-$ISSUE/`. Reviewers derive their
-workspace by sourcing the shared contract helper:
+The `/review-pr` skill must never create worktrees outside `~/data` (the real home
+directory's `data/` subdirectory, derived from the passwd entry — immune to `$HOME`
+poisoning). All scratch state lives under `~/data/$SESSION_ID/review-pr-$ISSUE/`.
+Reviewers derive their workspace by sourcing the shared contract helper:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -653,8 +654,10 @@ source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
 
 # review_pr_bootstrap validates and exports WORKTREE_BASE, CARGO_TARGET_DIR,
 # and REVIEWER_WORKTREE. Pre-seeded values are accepted only if they resolve
-# under $HOME/data; hostile values (outside $HOME/data or using ../ traversal)
-# are rejected with a non-zero exit.
+# under the real ~/data AND match the expected session/issue prefix
+# (~/data/$SESSION_ID/review-pr-$ISSUE/...). Hostile values (outside ~/data,
+# ../ traversal, HOME poisoning, or cross-session shared directories) are
+# rejected with a non-zero exit.
 review_pr_bootstrap "$ISSUE" || exit 1
 mkdir -p "$REVIEWER_WORKTREE"
 ```
@@ -662,10 +665,10 @@ mkdir -p "$REVIEWER_WORKTREE"
 This ensures build artifacts are isolated per-session and automatically discoverable
 for cleanup. The skill itself is read-only (no code changes), so it rarely needs a
 build cache — but if a reviewer sub-agent builds to verify, the target dir must
-resolve under `$HOME/data`.
+resolve under `~/data` and within the session prefix.
 
-**Never create worktrees at the repo root or outside `$HOME/data`.** All worktrees
-must be under `$HOME/data/$SESSION_ID/` to avoid polluting the shared checkout.
+**Never create worktrees at the repo root or outside `~/data`.** All worktrees
+must be under `~/data/$SESSION_ID/` to avoid polluting the shared checkout.
 
 ## Branch protection
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -644,11 +644,19 @@ Exit.
 ## Workspace contract
 
 The `/review-pr` skill must never create worktrees outside `$HOME/data`. All scratch
-state lives under `$HOME/data/$SESSION_ID/review-pr-$ISSUE/`:
+state lives under `$HOME/data/$SESSION_ID/review-pr-$ISSUE/`. Reviewers derive their
+workspace by sourcing the shared contract helper:
 
 ```bash
-SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
-export CARGO_TARGET_DIR="$HOME/data/$SESSION_ID/review-pr-$ISSUE/cargo-target"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+
+# review_pr_bootstrap validates and exports WORKTREE_BASE, CARGO_TARGET_DIR,
+# and REVIEWER_WORKTREE. Pre-seeded values are accepted only if they resolve
+# under $HOME/data; hostile values (outside $HOME/data or using ../ traversal)
+# are rejected with a non-zero exit.
+review_pr_bootstrap "$ISSUE"
+mkdir -p "$REVIEWER_WORKTREE"
 ```
 
 This ensures build artifacts are isolated per-session and automatically discoverable

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -12,10 +12,10 @@
 #   plan_critic_bootstrap "$ISSUE" "critic-a"
 #   review_pr_bootstrap "$ISSUE"
 
-# NOTE: Do not use `set -e` here — this file is meant to be sourced by callers,
-# and errexit inside command substitutions can cause hard exits that bypass
-# caller error handling. Callers should check return codes explicitly.
-set -uo pipefail
+# NOTE: This file is meant to be sourced by callers. Do NOT set shell options
+# (set -e, set -u, set -o pipefail, etc.) here — doing so mutates the caller's
+# shell state, which is an operational regression risk. All functions below use
+# explicit guards and return codes instead of relying on global shell options.
 
 # canonicalize_contract_path <path>
 # Resolve symlinks and collapse .. traversals without requiring the path to exist.

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -2,8 +2,9 @@
 # agent-worktree-contract.sh — Shared helper for enforcing the ~/data workspace contract.
 #
 # All agent scratch work (worktrees, cargo targets, critic checkouts) must live
-# under $HOME/data. This library provides canonicalization and enforcement helpers
-# that skill bootstraps source before deriving workspace paths.
+# under <real-home>/data where <real-home> is derived from the passwd entry (not
+# the potentially-poisoned $HOME env var). This library provides canonicalization
+# and enforcement helpers that skill bootstraps source before deriving workspace paths.
 #
 # Usage:
 #   source scripts/lib/agent-worktree-contract.sh
@@ -17,6 +18,18 @@
 # shell state, which is an operational regression risk. All functions below use
 # explicit guards and return codes instead of relying on global shell options.
 
+# _contract_real_home — Returns the real home directory from the passwd database.
+# This is the trust anchor — immune to $HOME poisoning.
+_contract_real_home() {
+  local pw_home
+  pw_home="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6)"
+  if [[ -z "$pw_home" ]]; then
+    # Fallback: if getent is unavailable (unlikely on Linux), use ~user expansion
+    pw_home="$(eval echo "~$(id -un)")"
+  fi
+  echo "$pw_home"
+}
+
 # canonicalize_contract_path <path>
 # Resolve symlinks and collapse .. traversals without requiring the path to exist.
 # Uses realpath -m (GNU coreutils) for canonical resolution.
@@ -26,18 +39,21 @@ canonicalize_contract_path() {
 }
 
 # require_home_data_path <path> <var_name>
-# Validates that a resolved path lives under $HOME/data. Exits non-zero with an
-# error message if the path escapes the contract boundary.
+# Validates that a resolved path lives under <real-home>/data. Exits non-zero with
+# an error message if the path escapes the contract boundary. The trust anchor is
+# the passwd-derived home, not $HOME, to prevent HOME-poisoning attacks.
 require_home_data_path() {
   local path="$1"
   local var_name="$2"
   local canonical
   canonical="$(canonicalize_contract_path "$path")"
+  local real_home
+  real_home="$(_contract_real_home)"
   local home_data
-  home_data="$(canonicalize_contract_path "$HOME/data")"
+  home_data="$(canonicalize_contract_path "$real_home/data")"
 
-  # Directory-boundary check: accept exact $HOME/data or paths under $HOME/data/.
-  # A plain prefix check would incorrectly accept sibling paths like $HOME/data-evil.
+  # Directory-boundary check: accept exact <real-home>/data or paths under it.
+  # A plain prefix check would incorrectly accept sibling paths like ~/data-evil.
   if [[ "$canonical" != "$home_data" && "$canonical" != "$home_data/"* ]]; then
     echo "ERROR: $var_name='$path' resolves to '$canonical' which is outside '$home_data'" >&2
     return 1
@@ -45,31 +61,37 @@ require_home_data_path() {
   echo "$canonical"
 }
 
-# validate_and_set_worktree_base <candidate> <var_name>
-# If candidate is set, validate it stays under $HOME/data. Returns the canonical path.
-validate_and_set_worktree_base() {
-  local candidate="$1"
-  local var_name="$2"
-  require_home_data_path "$candidate" "$var_name"
-}
+# require_session_prefix <canonical_path> <expected_prefix> <var_name>
+# Validates that a canonical path lives under the expected session/issue prefix.
+# This enforces per-session isolation: pre-seeded overrides cannot redirect to a
+# shared or cross-session directory under ~/data.
+require_session_prefix() {
+  local canonical="$1"
+  local expected_prefix="$2"
+  local var_name="$3"
+  local canon_prefix
+  canon_prefix="$(canonicalize_contract_path "$expected_prefix")"
 
-# validate_and_set_cargo_target_dir <candidate> <var_name>
-# If candidate is set, validate it stays under $HOME/data. Returns the canonical path.
-validate_and_set_cargo_target_dir() {
-  local candidate="$1"
-  local var_name="$2"
-  require_home_data_path "$candidate" "$var_name"
+  if [[ "$canonical" != "$canon_prefix" && "$canonical" != "$canon_prefix/"* ]]; then
+    echo "ERROR: $var_name='$canonical' is not under expected session prefix '$canon_prefix'" >&2
+    return 1
+  fi
 }
 
 # plan_critic_bootstrap <issue> <critic_id>
 # Derives and validates the full workspace layout for a /plan critic.
 # Exports: WORKTREE_BASE, CARGO_TARGET_DIR, CRITIC_WORKTREE
-# Respects pre-seeded env vars but validates them; rejects hostile values.
+# Validates pre-seeded env vars against both ~/data boundary AND session prefix.
 # On failure, clears all derived vars to prevent stale-env escape.
 plan_critic_bootstrap() {
   local issue="$1"
   local critic_id="$2"
   local session_id="${CLAUDE_SESSION_ID:-${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}}"
+  local real_home
+  real_home="$(_contract_real_home)"
+
+  # The expected session prefix for plan operations
+  local expected_prefix="$real_home/data/$session_id/plan-$issue"
 
   # Capture incoming overrides before clearing, so we can validate them.
   local incoming_base="${WORKTREE_BASE:-}"
@@ -79,10 +101,17 @@ plan_critic_bootstrap() {
   unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
 
   # Derive or validate WORKTREE_BASE
-  local candidate_base="${incoming_base:-$HOME/data/$session_id/plan-$issue}"
+  local candidate_base="${incoming_base:-$real_home/data/$session_id/plan-$issue}"
   if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
     unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
     return 1
+  fi
+  # Enforce session-prefix isolation for pre-seeded overrides
+  if [[ -n "$incoming_base" ]]; then
+    if ! require_session_prefix "$WORKTREE_BASE" "$expected_prefix" "WORKTREE_BASE"; then
+      unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
+      return 1
+    fi
   fi
   export WORKTREE_BASE
 
@@ -91,6 +120,13 @@ plan_critic_bootstrap() {
   if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
     unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
     return 1
+  fi
+  # Enforce session-prefix isolation for pre-seeded overrides
+  if [[ -n "$incoming_cargo" ]]; then
+    if ! require_session_prefix "$CARGO_TARGET_DIR" "$expected_prefix" "CARGO_TARGET_DIR"; then
+      unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
+      return 1
+    fi
   fi
   export CARGO_TARGET_DIR
 
@@ -106,11 +142,16 @@ plan_critic_bootstrap() {
 # review_pr_bootstrap <issue>
 # Derives and validates the full workspace layout for a /review-pr reviewer.
 # Exports: WORKTREE_BASE, CARGO_TARGET_DIR, REVIEWER_WORKTREE
-# Respects pre-seeded env vars but validates them; rejects hostile values.
+# Validates pre-seeded env vars against both ~/data boundary AND session prefix.
 # On failure, clears all derived vars to prevent stale-env escape.
 review_pr_bootstrap() {
   local issue="$1"
   local session_id="${CLAUDE_SESSION_ID:-${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}}"
+  local real_home
+  real_home="$(_contract_real_home)"
+
+  # The expected session prefix for review-pr operations
+  local expected_prefix="$real_home/data/$session_id/review-pr-$issue"
 
   # Capture incoming overrides before clearing, so we can validate them.
   local incoming_base="${WORKTREE_BASE:-}"
@@ -120,10 +161,17 @@ review_pr_bootstrap() {
   unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
 
   # Derive or validate WORKTREE_BASE
-  local candidate_base="${incoming_base:-$HOME/data/$session_id/review-pr-$issue}"
+  local candidate_base="${incoming_base:-$real_home/data/$session_id/review-pr-$issue}"
   if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
     unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
     return 1
+  fi
+  # Enforce session-prefix isolation for pre-seeded overrides
+  if [[ -n "$incoming_base" ]]; then
+    if ! require_session_prefix "$WORKTREE_BASE" "$expected_prefix" "WORKTREE_BASE"; then
+      unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
+      return 1
+    fi
   fi
   export WORKTREE_BASE
 
@@ -132,6 +180,13 @@ review_pr_bootstrap() {
   if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
     unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
     return 1
+  fi
+  # Enforce session-prefix isolation for pre-seeded overrides
+  if [[ -n "$incoming_cargo" ]]; then
+    if ! require_session_prefix "$CARGO_TARGET_DIR" "$expected_prefix" "CARGO_TARGET_DIR"; then
+      unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
+      return 1
+    fi
   fi
   export CARGO_TARGET_DIR
 

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -12,7 +12,10 @@
 #   plan_critic_bootstrap "$ISSUE" "critic-a"
 #   review_pr_bootstrap "$ISSUE"
 
-set -euo pipefail
+# NOTE: Do not use `set -e` here — this file is meant to be sourced by callers,
+# and errexit inside command substitutions can cause hard exits that bypass
+# caller error handling. Callers should check return codes explicitly.
+set -uo pipefail
 
 # canonicalize_contract_path <path>
 # Resolve symlinks and collapse .. traversals without requiring the path to exist.
@@ -33,7 +36,9 @@ require_home_data_path() {
   local home_data
   home_data="$(canonicalize_contract_path "$HOME/data")"
 
-  if [[ "$canonical" != "$home_data"* ]]; then
+  # Directory-boundary check: accept exact $HOME/data or paths under $HOME/data/.
+  # A plain prefix check would incorrectly accept sibling paths like $HOME/data-evil.
+  if [[ "$canonical" != "$home_data" && "$canonical" != "$home_data/"* ]]; then
     echo "ERROR: $var_name='$path' resolves to '$canonical' which is outside '$home_data'" >&2
     return 1
   fi
@@ -67,17 +72,23 @@ plan_critic_bootstrap() {
 
   # Derive or validate WORKTREE_BASE
   local candidate_base="${WORKTREE_BASE:-$HOME/data/$session_id/plan-$issue}"
-  WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")" || return 1
+  if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
+    return 1
+  fi
   export WORKTREE_BASE
 
   # Derive or validate CARGO_TARGET_DIR
   local candidate_cargo="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
-  CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")" || return 1
+  if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
+    return 1
+  fi
   export CARGO_TARGET_DIR
 
   # Derive critic-specific worktree
   CRITIC_WORKTREE="$WORKTREE_BASE/$critic_id"
-  CRITIC_WORKTREE="$(require_home_data_path "$CRITIC_WORKTREE" "CRITIC_WORKTREE")" || return 1
+  if ! CRITIC_WORKTREE="$(require_home_data_path "$CRITIC_WORKTREE" "CRITIC_WORKTREE")"; then
+    return 1
+  fi
   export CRITIC_WORKTREE
 }
 
@@ -91,16 +102,22 @@ review_pr_bootstrap() {
 
   # Derive or validate WORKTREE_BASE
   local candidate_base="${WORKTREE_BASE:-$HOME/data/$session_id/review-pr-$issue}"
-  WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")" || return 1
+  if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
+    return 1
+  fi
   export WORKTREE_BASE
 
   # Derive or validate CARGO_TARGET_DIR
   local candidate_cargo="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
-  CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")" || return 1
+  if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
+    return 1
+  fi
   export CARGO_TARGET_DIR
 
   # Derive reviewer-specific worktree
   REVIEWER_WORKTREE="$WORKTREE_BASE/reviewer"
-  REVIEWER_WORKTREE="$(require_home_data_path "$REVIEWER_WORKTREE" "REVIEWER_WORKTREE")" || return 1
+  if ! REVIEWER_WORKTREE="$(require_home_data_path "$REVIEWER_WORKTREE" "REVIEWER_WORKTREE")"; then
+    return 1
+  fi
   export REVIEWER_WORKTREE
 }

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# agent-worktree-contract.sh — Shared helper for enforcing the ~/data workspace contract.
+#
+# All agent scratch work (worktrees, cargo targets, critic checkouts) must live
+# under $HOME/data. This library provides canonicalization and enforcement helpers
+# that skill bootstraps source before deriving workspace paths.
+#
+# Usage:
+#   source scripts/lib/agent-worktree-contract.sh
+#   require_home_data_path "$SOME_PATH" "SOME_PATH"
+#   # or use the role-specific helpers:
+#   plan_critic_bootstrap "$ISSUE" "critic-a"
+#   review_pr_bootstrap "$ISSUE"
+
+set -euo pipefail
+
+# canonicalize_contract_path <path>
+# Resolve symlinks and collapse .. traversals without requiring the path to exist.
+# Uses realpath -m (GNU coreutils) for canonical resolution.
+canonicalize_contract_path() {
+  local path="$1"
+  realpath -m "$path"
+}
+
+# require_home_data_path <path> <var_name>
+# Validates that a resolved path lives under $HOME/data. Exits non-zero with an
+# error message if the path escapes the contract boundary.
+require_home_data_path() {
+  local path="$1"
+  local var_name="$2"
+  local canonical
+  canonical="$(canonicalize_contract_path "$path")"
+  local home_data
+  home_data="$(canonicalize_contract_path "$HOME/data")"
+
+  if [[ "$canonical" != "$home_data"* ]]; then
+    echo "ERROR: $var_name='$path' resolves to '$canonical' which is outside '$home_data'" >&2
+    return 1
+  fi
+  echo "$canonical"
+}
+
+# validate_and_set_worktree_base <candidate> <var_name>
+# If candidate is set, validate it stays under $HOME/data. Returns the canonical path.
+validate_and_set_worktree_base() {
+  local candidate="$1"
+  local var_name="$2"
+  require_home_data_path "$candidate" "$var_name"
+}
+
+# validate_and_set_cargo_target_dir <candidate> <var_name>
+# If candidate is set, validate it stays under $HOME/data. Returns the canonical path.
+validate_and_set_cargo_target_dir() {
+  local candidate="$1"
+  local var_name="$2"
+  require_home_data_path "$candidate" "$var_name"
+}
+
+# plan_critic_bootstrap <issue> <critic_id>
+# Derives and validates the full workspace layout for a /plan critic.
+# Exports: WORKTREE_BASE, CARGO_TARGET_DIR, CRITIC_WORKTREE
+# Respects pre-seeded env vars but validates them; rejects hostile values.
+plan_critic_bootstrap() {
+  local issue="$1"
+  local critic_id="$2"
+  local session_id="${CLAUDE_SESSION_ID:-${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}}"
+
+  # Derive or validate WORKTREE_BASE
+  local candidate_base="${WORKTREE_BASE:-$HOME/data/$session_id/plan-$issue}"
+  WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")" || return 1
+  export WORKTREE_BASE
+
+  # Derive or validate CARGO_TARGET_DIR
+  local candidate_cargo="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
+  CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")" || return 1
+  export CARGO_TARGET_DIR
+
+  # Derive critic-specific worktree
+  CRITIC_WORKTREE="$WORKTREE_BASE/$critic_id"
+  CRITIC_WORKTREE="$(require_home_data_path "$CRITIC_WORKTREE" "CRITIC_WORKTREE")" || return 1
+  export CRITIC_WORKTREE
+}
+
+# review_pr_bootstrap <issue>
+# Derives and validates the full workspace layout for a /review-pr reviewer.
+# Exports: WORKTREE_BASE, CARGO_TARGET_DIR, REVIEWER_WORKTREE
+# Respects pre-seeded env vars but validates them; rejects hostile values.
+review_pr_bootstrap() {
+  local issue="$1"
+  local session_id="${CLAUDE_SESSION_ID:-${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}}"
+
+  # Derive or validate WORKTREE_BASE
+  local candidate_base="${WORKTREE_BASE:-$HOME/data/$session_id/review-pr-$issue}"
+  WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")" || return 1
+  export WORKTREE_BASE
+
+  # Derive or validate CARGO_TARGET_DIR
+  local candidate_cargo="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
+  CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")" || return 1
+  export CARGO_TARGET_DIR
+
+  # Derive reviewer-specific worktree
+  REVIEWER_WORKTREE="$WORKTREE_BASE/reviewer"
+  REVIEWER_WORKTREE="$(require_home_data_path "$REVIEWER_WORKTREE" "REVIEWER_WORKTREE")" || return 1
+  export REVIEWER_WORKTREE
+}

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -65,21 +65,31 @@ validate_and_set_cargo_target_dir() {
 # Derives and validates the full workspace layout for a /plan critic.
 # Exports: WORKTREE_BASE, CARGO_TARGET_DIR, CRITIC_WORKTREE
 # Respects pre-seeded env vars but validates them; rejects hostile values.
+# On failure, clears all derived vars to prevent stale-env escape.
 plan_critic_bootstrap() {
   local issue="$1"
   local critic_id="$2"
   local session_id="${CLAUDE_SESSION_ID:-${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}}"
 
+  # Capture incoming overrides before clearing, so we can validate them.
+  local incoming_base="${WORKTREE_BASE:-}"
+  local incoming_cargo="${CARGO_TARGET_DIR:-}"
+
+  # Clear derived vars on entry to prevent stale values from surviving a failure.
+  unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
+
   # Derive or validate WORKTREE_BASE
-  local candidate_base="${WORKTREE_BASE:-$HOME/data/$session_id/plan-$issue}"
+  local candidate_base="${incoming_base:-$HOME/data/$session_id/plan-$issue}"
   if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
     return 1
   fi
   export WORKTREE_BASE
 
   # Derive or validate CARGO_TARGET_DIR
-  local candidate_cargo="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
+  local candidate_cargo="${incoming_cargo:-$WORKTREE_BASE/cargo-target}"
   if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
     return 1
   fi
   export CARGO_TARGET_DIR
@@ -87,6 +97,7 @@ plan_critic_bootstrap() {
   # Derive critic-specific worktree
   CRITIC_WORKTREE="$WORKTREE_BASE/$critic_id"
   if ! CRITIC_WORKTREE="$(require_home_data_path "$CRITIC_WORKTREE" "CRITIC_WORKTREE")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR CRITIC_WORKTREE
     return 1
   fi
   export CRITIC_WORKTREE
@@ -96,20 +107,30 @@ plan_critic_bootstrap() {
 # Derives and validates the full workspace layout for a /review-pr reviewer.
 # Exports: WORKTREE_BASE, CARGO_TARGET_DIR, REVIEWER_WORKTREE
 # Respects pre-seeded env vars but validates them; rejects hostile values.
+# On failure, clears all derived vars to prevent stale-env escape.
 review_pr_bootstrap() {
   local issue="$1"
   local session_id="${CLAUDE_SESSION_ID:-${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}}"
 
+  # Capture incoming overrides before clearing, so we can validate them.
+  local incoming_base="${WORKTREE_BASE:-}"
+  local incoming_cargo="${CARGO_TARGET_DIR:-}"
+
+  # Clear derived vars on entry to prevent stale values from surviving a failure.
+  unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
+
   # Derive or validate WORKTREE_BASE
-  local candidate_base="${WORKTREE_BASE:-$HOME/data/$session_id/review-pr-$issue}"
+  local candidate_base="${incoming_base:-$HOME/data/$session_id/review-pr-$issue}"
   if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
     return 1
   fi
   export WORKTREE_BASE
 
   # Derive or validate CARGO_TARGET_DIR
-  local candidate_cargo="${CARGO_TARGET_DIR:-$WORKTREE_BASE/cargo-target}"
+  local candidate_cargo="${incoming_cargo:-$WORKTREE_BASE/cargo-target}"
   if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
     return 1
   fi
   export CARGO_TARGET_DIR
@@ -117,6 +138,7 @@ review_pr_bootstrap() {
   # Derive reviewer-specific worktree
   REVIEWER_WORKTREE="$WORKTREE_BASE/reviewer"
   if ! REVIEWER_WORKTREE="$(require_home_data_path "$REVIEWER_WORKTREE" "REVIEWER_WORKTREE")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR REVIEWER_WORKTREE
     return 1
   fi
   export REVIEWER_WORKTREE

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -101,13 +101,17 @@ test_plan_bootstrap_accepts_safe_preseeded_home_data_paths() {
     return
   fi
 
-  # Verify all paths contain $HOME/data
+  # Verify all paths are under $HOME/data (directory-boundary check, not prefix)
   local home_data
   home_data="$(realpath -m "$HOME/data")"
-  if echo "$output" | grep -v "^$home_data" | grep -q .; then
-    tap_not_ok "$desc" "Some paths not under \$HOME/data: $output"
-    return
-  fi
+  # Each output line must be exactly $home_data or start with $home_data/
+  local line
+  while IFS= read -r line; do
+    if [[ -n "$line" && "$line" != "$home_data" && "$line" != "$home_data/"* ]]; then
+      tap_not_ok "$desc" "Path not under \$HOME/data: $line"
+      return
+    fi
+  done <<< "$output"
 
   tap_ok "$desc"
 }
@@ -159,10 +163,13 @@ test_review_pr_bootstrap_requires_home_data_workspace() {
 
   local home_data
   home_data="$(realpath -m "$HOME/data")"
-  if echo "$output" | grep -v "^$home_data" | grep -q .; then
-    tap_not_ok "$desc" "Some default paths not under \$HOME/data: $output"
-    return
-  fi
+  local line
+  while IFS= read -r line; do
+    if [[ -n "$line" && "$line" != "$home_data" && "$line" != "$home_data/"* ]]; then
+      tap_not_ok "$desc" "Some default paths not under \$HOME/data: $line"
+      return
+    fi
+  done <<< "$output"
 
   tap_ok "$desc"
 }
@@ -192,17 +199,22 @@ test_default_bootstrap_layouts_stay_under_home_data() {
   local home_data
   home_data="$(realpath -m "$HOME/data")"
 
-  # Verify plan paths
-  if echo "$plan_out" | grep -v "^$home_data" | grep -q .; then
-    tap_not_ok "$desc" "Plan paths escape \$HOME/data: $plan_out"
-    return
-  fi
+  # Verify plan paths (directory-boundary check)
+  local line
+  while IFS= read -r line; do
+    if [[ -n "$line" && "$line" != "$home_data" && "$line" != "$home_data/"* ]]; then
+      tap_not_ok "$desc" "Plan paths escape \$HOME/data: $line"
+      return
+    fi
+  done <<< "$plan_out"
 
-  # Verify review paths
-  if echo "$review_out" | grep -v "^$home_data" | grep -q .; then
-    tap_not_ok "$desc" "Review paths escape \$HOME/data: $review_out"
-    return
-  fi
+  # Verify review paths (directory-boundary check)
+  while IFS= read -r line; do
+    if [[ -n "$line" && "$line" != "$home_data" && "$line" != "$home_data/"* ]]; then
+      tap_not_ok "$desc" "Review paths escape \$HOME/data: $line"
+      return
+    fi
+  done <<< "$review_out"
 
   # Verify expected structure
   if ! echo "$plan_out" | grep -q "data/default-test/plan-55"; then
@@ -315,14 +327,65 @@ test_claude_plan_synced() {
 }
 
 # --------------------------------------------------------------------------
+# Test: plan bootstrap rejects sibling-prefix WORKTREE_BASE (e.g. $HOME/data-evil)
+# --------------------------------------------------------------------------
+test_plan_bootstrap_rejects_sibling_prefix_worktree_base() {
+  local desc="plan bootstrap rejects sibling-prefix WORKTREE_BASE"
+
+  # Sibling-prefix: $HOME/data-evil shares the $HOME/data string prefix
+  local output
+  if output=$(WORKTREE_BASE="$HOME/data-evil/plan-999" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 999 critic-a" 2>&1); then
+    tap_not_ok "$desc (data-evil)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Sibling-prefix: $HOME/data2
+  if output=$(WORKTREE_BASE="$HOME/data2/plan-999" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 999 critic-a" 2>&1); then
+    tap_not_ok "$desc (data2)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr bootstrap rejects sibling-prefix paths
+# --------------------------------------------------------------------------
+test_review_pr_bootstrap_rejects_sibling_prefix() {
+  local desc="review-pr bootstrap rejects sibling-prefix paths"
+
+  # Sibling-prefix WORKTREE_BASE
+  local output
+  if output=$(WORKTREE_BASE="$HOME/data-evil/review-100" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100" 2>&1); then
+    tap_not_ok "$desc (base: data-evil)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Valid base but sibling-prefix CARGO_TARGET_DIR
+  if output=$(WORKTREE_BASE="$HOME/data/test-session/review-pr-100" \
+    CARGO_TARGET_DIR="$HOME/data-evil/cargo" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100" 2>&1); then
+    tap_not_ok "$desc (cargo: data-evil)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
 echo "TAP version 13"
 
 test_plan_bootstrap_rejects_hostile_worktree_base
 test_plan_bootstrap_rejects_hostile_cargo_target_dir
+test_plan_bootstrap_rejects_sibling_prefix_worktree_base
 test_plan_bootstrap_accepts_safe_preseeded_home_data_paths
 test_review_pr_bootstrap_rejects_hostile_worktree_base_and_cargo_target
+test_review_pr_bootstrap_rejects_sibling_prefix
 test_review_pr_bootstrap_requires_home_data_workspace
 test_default_bootstrap_layouts_stay_under_home_data
 test_skill_files_reference_shared_contract_helper

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # test-agent-worktree-contract.sh — TAP contract test for agent workspace placement.
 #
-# Verifies that /review-pr and /plan skill files enforce the ~/data workspace
+# Verifies that /review-pr and /plan skill bootstraps enforce the ~/data workspace
 # contract: all worktrees, cargo targets, and scratch dirs resolve under
-# $HOME/data/$SESSION_ID/..., and both skills explicitly forbid repo-root or
-# repo-parent worktree creation. Also verifies that .claude/skills/ copies
-# remain synchronized with their .github/skills/ counterparts.
+# $HOME/data/$SESSION_ID/..., and hostile/traversal env overrides are rejected.
+# Also verifies that .claude/skills/ copies remain synchronized with their
+# .github/skills/ counterparts and that skill docs reference the shared helper.
 #
 # Usage: bash scripts/test-agent-worktree-contract.sh
 # Exit: 0 if all tests pass, 1 otherwise.
@@ -17,6 +17,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 REVIEW_PR_SKILL="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
 PLAN_SKILL="$REPO_ROOT/.github/skills/plan/SKILL.md"
+CONTRACT_HELPER="$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
 
 PASS=0
 FAIL=0
@@ -36,121 +37,210 @@ tap_not_ok() {
 }
 
 # --------------------------------------------------------------------------
-# Test: review-pr workspace contract resolves under ~/data
+# Test: plan bootstrap rejects hostile WORKTREE_BASE
 # --------------------------------------------------------------------------
-test_review_pr_workspace_contract_resolves_under_home_data() {
-  local desc="review-pr workspace contract resolves under ~/data"
+test_plan_bootstrap_rejects_hostile_worktree_base() {
+  local desc="plan bootstrap rejects hostile WORKTREE_BASE"
 
-  # The skill must contain a reviewer workspace bootstrap that derives paths
-  # under $HOME/data. We look for the documented pattern.
-  if grep -q 'HOME/data/\$SESSION_ID/review-pr' "$REVIEW_PR_SKILL" ||
-     grep -q 'HOME/data/\${SESSION_ID}/review-pr' "$REVIEW_PR_SKILL" ||
-     grep -q '\~/data/\$SESSION_ID/review-pr' "$REVIEW_PR_SKILL" ||
-     grep -q '\$HOME/data/.*review-pr' "$REVIEW_PR_SKILL"; then
-    tap_ok "$desc"
-  else
-    tap_not_ok "$desc" "SKILL.md does not contain a ~/data/\$SESSION_ID/review-pr workspace derivation"
+  # Test 1: Absolute path outside $HOME/data
+  local output
+  if output=$(WORKTREE_BASE="/tmp/evil" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 999 critic-a" 2>&1); then
+    tap_not_ok "$desc (absolute outside)" "Should have failed but succeeded: $output"
+    return
   fi
+
+  # Test 2: Traversal that escapes $HOME/data
+  if output=$(WORKTREE_BASE="$HOME/data/../escape" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 999 critic-a" 2>&1); then
+    tap_not_ok "$desc (traversal)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  tap_ok "$desc"
 }
 
 # --------------------------------------------------------------------------
-# Test: plan workspace contract resolves under ~/data
+# Test: plan bootstrap rejects hostile CARGO_TARGET_DIR independently
 # --------------------------------------------------------------------------
-test_plan_workspace_contract_resolves_under_home_data() {
-  local desc="plan workspace contract resolves under ~/data"
+test_plan_bootstrap_rejects_hostile_cargo_target_dir() {
+  local desc="plan bootstrap rejects hostile CARGO_TARGET_DIR"
 
-  if grep -q 'HOME/data/\$SESSION_ID/plan' "$PLAN_SKILL" ||
-     grep -q 'HOME/data/\${SESSION_ID}/plan' "$PLAN_SKILL" ||
-     grep -q '\~/data/\$SESSION_ID/plan' "$PLAN_SKILL" ||
-     grep -q '\$HOME/data/.*plan-\$ISSUE' "$PLAN_SKILL"; then
-    tap_ok "$desc"
-  else
-    tap_not_ok "$desc" "SKILL.md does not contain a ~/data/\$SESSION_ID/plan workspace derivation"
+  # Valid WORKTREE_BASE but hostile CARGO_TARGET_DIR
+  local output
+  if output=$(WORKTREE_BASE="$HOME/data/test-session/plan-999" \
+    CARGO_TARGET_DIR="/tmp/evil-cargo" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 999 critic-a" 2>&1); then
+    tap_not_ok "$desc (absolute outside)" "Should have failed but succeeded: $output"
+    return
   fi
+
+  # Traversal CARGO_TARGET_DIR
+  if output=$(WORKTREE_BASE="$HOME/data/test-session/plan-999" \
+    CARGO_TARGET_DIR="$HOME/data/../escape/cargo" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 999 critic-a" 2>&1); then
+    tap_not_ok "$desc (traversal)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  tap_ok "$desc"
 }
 
 # --------------------------------------------------------------------------
-# Test: skill prompts forbid repo-root worktrees
+# Test: plan bootstrap accepts safe pre-seeded $HOME/data paths
 # --------------------------------------------------------------------------
-test_skill_prompts_forbid_repo_root_worktrees() {
-  local desc="skill prompts forbid repo-root worktrees"
-  local review_has_guard=false
-  local plan_has_guard=false
+test_plan_bootstrap_accepts_safe_preseeded_home_data_paths() {
+  local desc="plan bootstrap accepts safe pre-seeded HOME/data paths"
 
-  # Check review-pr skill for explicit prohibition
-  if grep -qi 'never.*worktree.*repo.*root\|never.*repo.*root.*worktree\|never.*create.*worktree.*outside.*~/data\|must not.*worktree.*outside.*\~/data\|do not.*create.*worktree.*outside\|never.*outside.*\$HOME/data\|must.*under.*\$HOME/data\|only.*under.*\$HOME/data' "$REVIEW_PR_SKILL"; then
-    review_has_guard=true
+  local output
+  if ! output=$(WORKTREE_BASE="$HOME/data/my-session/plan-42" \
+    CARGO_TARGET_DIR="$HOME/data/my-session/plan-42/cargo-target" \
+    CLAUDE_SESSION_ID="my-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 42 critic-b && echo \$WORKTREE_BASE && echo \$CARGO_TARGET_DIR && echo \$CRITIC_WORKTREE" 2>&1); then
+    tap_not_ok "$desc" "Should have succeeded but failed: $output"
+    return
   fi
 
-  # Check plan skill for explicit prohibition
-  if grep -qi 'never.*worktree.*repo.*root\|never.*repo.*root.*worktree\|never.*create.*worktree.*outside.*~/data\|must not.*worktree.*outside.*\~/data\|do not.*create.*worktree.*outside\|never.*outside.*\$HOME/data\|must.*under.*\$HOME/data\|only.*under.*\$HOME/data' "$PLAN_SKILL"; then
-    plan_has_guard=true
+  # Verify all paths contain $HOME/data
+  local home_data
+  home_data="$(realpath -m "$HOME/data")"
+  if echo "$output" | grep -v "^$home_data" | grep -q .; then
+    tap_not_ok "$desc" "Some paths not under \$HOME/data: $output"
+    return
   fi
 
-  if $review_has_guard && $plan_has_guard; then
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr bootstrap rejects hostile WORKTREE_BASE and CARGO_TARGET_DIR
+# --------------------------------------------------------------------------
+test_review_pr_bootstrap_rejects_hostile_worktree_base_and_cargo_target() {
+  local desc="review-pr bootstrap rejects hostile WORKTREE_BASE and CARGO_TARGET_DIR"
+
+  # Hostile WORKTREE_BASE
+  local output
+  if output=$(WORKTREE_BASE="/var/tmp/evil" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100" 2>&1); then
+    tap_not_ok "$desc (hostile base)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Hostile CARGO_TARGET_DIR with valid base
+  if output=$(WORKTREE_BASE="$HOME/data/test-session/review-pr-100" \
+    CARGO_TARGET_DIR="/opt/evil/cargo" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100" 2>&1); then
+    tap_not_ok "$desc (hostile cargo)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Traversal
+  if output=$(WORKTREE_BASE="$HOME/data/../../etc/evil" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100" 2>&1); then
+    tap_not_ok "$desc (traversal)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: review-pr bootstrap requires HOME/data workspace
+# --------------------------------------------------------------------------
+test_review_pr_bootstrap_requires_home_data_workspace() {
+  local desc="review-pr bootstrap requires HOME/data workspace"
+
+  local output
+  if ! output=$(WORKTREE_BASE="" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-sess" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 200 && echo \$WORKTREE_BASE && echo \$CARGO_TARGET_DIR && echo \$REVIEWER_WORKTREE" 2>&1); then
+    tap_not_ok "$desc" "Default bootstrap failed: $output"
+    return
+  fi
+
+  local home_data
+  home_data="$(realpath -m "$HOME/data")"
+  if echo "$output" | grep -v "^$home_data" | grep -q .; then
+    tap_not_ok "$desc" "Some default paths not under \$HOME/data: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: default bootstrap layouts stay under $HOME/data
+# --------------------------------------------------------------------------
+test_default_bootstrap_layouts_stay_under_home_data() {
+  local desc="default bootstrap layouts stay under HOME/data"
+
+  # Plan critic with no pre-seeded vars
+  local plan_out
+  if ! plan_out=$(WORKTREE_BASE="" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="default-test" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 55 critic-c && echo \$WORKTREE_BASE && echo \$CARGO_TARGET_DIR && echo \$CRITIC_WORKTREE" 2>&1); then
+    tap_not_ok "$desc" "Plan default failed: $plan_out"
+    return
+  fi
+
+  # Review-pr with no pre-seeded vars
+  local review_out
+  if ! review_out=$(WORKTREE_BASE="" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="default-test" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 55 && echo \$WORKTREE_BASE && echo \$CARGO_TARGET_DIR && echo \$REVIEWER_WORKTREE" 2>&1); then
+    tap_not_ok "$desc" "Review default failed: $review_out"
+    return
+  fi
+
+  local home_data
+  home_data="$(realpath -m "$HOME/data")"
+
+  # Verify plan paths
+  if echo "$plan_out" | grep -v "^$home_data" | grep -q .; then
+    tap_not_ok "$desc" "Plan paths escape \$HOME/data: $plan_out"
+    return
+  fi
+
+  # Verify review paths
+  if echo "$review_out" | grep -v "^$home_data" | grep -q .; then
+    tap_not_ok "$desc" "Review paths escape \$HOME/data: $review_out"
+    return
+  fi
+
+  # Verify expected structure
+  if ! echo "$plan_out" | grep -q "data/default-test/plan-55"; then
+    tap_not_ok "$desc" "Plan layout missing expected session/plan structure: $plan_out"
+    return
+  fi
+  if ! echo "$review_out" | grep -q "data/default-test/review-pr-55"; then
+    tap_not_ok "$desc" "Review layout missing expected session/review-pr structure: $review_out"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: skill files reference shared contract helper
+# --------------------------------------------------------------------------
+test_skill_files_reference_shared_contract_helper() {
+  local desc="skill files reference shared contract helper"
+
+  local plan_refs=false
+  local review_refs=false
+
+  if grep -q 'agent-worktree-contract.sh\|plan_critic_bootstrap' "$PLAN_SKILL"; then
+    plan_refs=true
+  fi
+
+  if grep -q 'agent-worktree-contract.sh\|review_pr_bootstrap' "$REVIEW_PR_SKILL"; then
+    review_refs=true
+  fi
+
+  if $plan_refs && $review_refs; then
     tap_ok "$desc"
   else
     local missing=""
-    $review_has_guard || missing="review-pr"
-    $plan_has_guard || missing="${missing:+$missing, }plan"
-    tap_not_ok "$desc" "Missing repo-root worktree prohibition in: $missing"
-  fi
-}
-
-# --------------------------------------------------------------------------
-# Test: review-pr bootstrap is self-seeding (works with or without env vars)
-# --------------------------------------------------------------------------
-test_review_pr_self_seeding() {
-  local desc="review-pr bootstrap is self-seeding (WORKTREE_BASE fallback)"
-
-  # The skill should show a ${WORKTREE_BASE:-...} or SESSION_ID fallback pattern
-  if grep -q 'WORKTREE_BASE:-\|SESSION_ID:-\|CLAUDE_SESSION_ID:-' "$REVIEW_PR_SKILL" ||
-     grep -q 'WORKTREE_BASE:=' "$REVIEW_PR_SKILL"; then
-    tap_ok "$desc"
-  else
-    tap_not_ok "$desc" "No self-seeding fallback (e.g. \${WORKTREE_BASE:-...}) found in review-pr SKILL.md"
-  fi
-}
-
-# --------------------------------------------------------------------------
-# Test: plan bootstrap is self-seeding (works with or without env vars)
-# --------------------------------------------------------------------------
-test_plan_self_seeding() {
-  local desc="plan bootstrap is self-seeding (WORKTREE_BASE fallback)"
-
-  if grep -q 'WORKTREE_BASE:-\|SESSION_ID:-\|CLAUDE_SESSION_ID:-' "$PLAN_SKILL" ||
-     grep -q 'WORKTREE_BASE:=' "$PLAN_SKILL"; then
-    tap_ok "$desc"
-  else
-    tap_not_ok "$desc" "No self-seeding fallback (e.g. \${WORKTREE_BASE:-...}) found in plan SKILL.md"
-  fi
-}
-
-# --------------------------------------------------------------------------
-# Test: review-pr CARGO_TARGET_DIR resolves under ~/data
-# --------------------------------------------------------------------------
-test_review_pr_cargo_target_under_data() {
-  local desc="review-pr CARGO_TARGET_DIR resolves under ~/data"
-
-  if grep -q 'CARGO_TARGET_DIR.*HOME/data\|CARGO_TARGET_DIR.*~/data' "$REVIEW_PR_SKILL" ||
-     grep -q 'CARGO_TARGET_DIR.*\$WORKTREE_BASE' "$REVIEW_PR_SKILL"; then
-    tap_ok "$desc"
-  else
-    tap_not_ok "$desc" "CARGO_TARGET_DIR not directed to ~/data in review-pr SKILL.md"
-  fi
-}
-
-# --------------------------------------------------------------------------
-# Test: plan CARGO_TARGET_DIR resolves under ~/data
-# --------------------------------------------------------------------------
-test_plan_cargo_target_under_data() {
-  local desc="plan CARGO_TARGET_DIR resolves under ~/data"
-
-  if grep -q 'CARGO_TARGET_DIR.*HOME/data\|CARGO_TARGET_DIR.*~/data' "$PLAN_SKILL" ||
-     grep -q 'CARGO_TARGET_DIR.*\$WORKTREE_BASE' "$PLAN_SKILL"; then
-    tap_ok "$desc"
-  else
-    tap_not_ok "$desc" "CARGO_TARGET_DIR not directed to ~/data in plan SKILL.md"
+    $plan_refs || missing="plan"
+    $review_refs || missing="${missing:+$missing, }review-pr"
+    tap_not_ok "$desc" "Missing helper reference in: $missing"
   fi
 }
 
@@ -163,11 +253,8 @@ test_claude_review_pr_synced() {
   local github_path="$REPO_ROOT/.github/skills/review-pr"
 
   if [ -L "$claude_path" ]; then
-    # It's a symlink — verify it resolves to the .github copy
     local target resolved expected
     target="$(readlink "$claude_path")"
-    # Guard: resolve the symlink target safely; broken/misdirected symlinks
-    # must emit tap_not_ok rather than aborting the script under set -e.
     if resolved="$(cd "$(dirname "$claude_path")" && cd "$target" 2>/dev/null && pwd)"; then
       if expected="$(cd "$github_path" 2>/dev/null && pwd)"; then
         if [ "$resolved" = "$expected" ]; then
@@ -182,7 +269,6 @@ test_claude_review_pr_synced() {
       tap_not_ok "$desc" "Symlink target '$target' does not resolve"
     fi
   elif [ -d "$claude_path" ]; then
-    # Not a symlink — verify content is identical
     if diff -r "$claude_path" "$github_path" > /dev/null 2>&1; then
       tap_ok "$desc (identical copy)"
     else
@@ -202,11 +288,8 @@ test_claude_plan_synced() {
   local github_path="$REPO_ROOT/.github/skills/plan"
 
   if [ -L "$claude_path" ]; then
-    # It's a symlink — verify it resolves to the .github copy
     local target resolved expected
     target="$(readlink "$claude_path")"
-    # Guard: resolve the symlink target safely; broken/misdirected symlinks
-    # must emit tap_not_ok rather than aborting the script under set -e.
     if resolved="$(cd "$(dirname "$claude_path")" && cd "$target" 2>/dev/null && pwd)"; then
       if expected="$(cd "$github_path" 2>/dev/null && pwd)"; then
         if [ "$resolved" = "$expected" ]; then
@@ -221,7 +304,6 @@ test_claude_plan_synced() {
       tap_not_ok "$desc" "Symlink target '$target' does not resolve"
     fi
   elif [ -d "$claude_path" ]; then
-    # Not a symlink — verify content is identical
     if diff -r "$claude_path" "$github_path" > /dev/null 2>&1; then
       tap_ok "$desc (identical copy)"
     else
@@ -237,13 +319,13 @@ test_claude_plan_synced() {
 # --------------------------------------------------------------------------
 echo "TAP version 13"
 
-test_review_pr_workspace_contract_resolves_under_home_data
-test_plan_workspace_contract_resolves_under_home_data
-test_skill_prompts_forbid_repo_root_worktrees
-test_review_pr_self_seeding
-test_plan_self_seeding
-test_review_pr_cargo_target_under_data
-test_plan_cargo_target_under_data
+test_plan_bootstrap_rejects_hostile_worktree_base
+test_plan_bootstrap_rejects_hostile_cargo_target_dir
+test_plan_bootstrap_accepts_safe_preseeded_home_data_paths
+test_review_pr_bootstrap_rejects_hostile_worktree_base_and_cargo_target
+test_review_pr_bootstrap_requires_home_data_workspace
+test_default_bootstrap_layouts_stay_under_home_data
+test_skill_files_reference_shared_contract_helper
 test_claude_review_pr_synced
 test_claude_plan_synced
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -376,6 +376,55 @@ test_review_pr_bootstrap_rejects_sibling_prefix() {
 }
 
 # --------------------------------------------------------------------------
+# Test: sourcing the helper does not mutate caller shell options
+# --------------------------------------------------------------------------
+test_sourcing_preserves_caller_shell_options() {
+  local desc="sourcing helper preserves caller shell options"
+
+  # Run in a subshell where nounset and pipefail are explicitly OFF,
+  # source the helper, then verify they remain OFF.
+  local output
+  output=$(bash -c '
+    # Ensure nounset and pipefail are OFF
+    set +u
+    set +o pipefail
+
+    # Capture initial state
+    before_u=$(set +o | grep nounset)
+    before_p=$(set +o | grep pipefail)
+
+    source "'"$CONTRACT_HELPER"'"
+
+    # Capture state after sourcing
+    after_u=$(set +o | grep nounset)
+    after_p=$(set +o | grep pipefail)
+
+    if [[ "$before_u" != "$after_u" ]]; then
+      echo "FAIL: nounset changed from [$before_u] to [$after_u]"
+      exit 1
+    fi
+    if [[ "$before_p" != "$after_p" ]]; then
+      echo "FAIL: pipefail changed from [$before_p] to [$after_p]"
+      exit 1
+    fi
+
+    # Also verify the helper still works (hostile path rejected)
+    if require_home_data_path "/tmp/evil" "TEST" 2>/dev/null; then
+      echo "FAIL: hostile path was not rejected after sourcing"
+      exit 1
+    fi
+
+    echo "OK"
+  ' 2>&1)
+
+  if [[ "$output" == "OK" ]]; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "$output"
+  fi
+}
+
+# --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
 echo "TAP version 13"
@@ -388,6 +437,7 @@ test_review_pr_bootstrap_rejects_hostile_worktree_base_and_cargo_target
 test_review_pr_bootstrap_rejects_sibling_prefix
 test_review_pr_bootstrap_requires_home_data_workspace
 test_default_bootstrap_layouts_stay_under_home_data
+test_sourcing_preserves_caller_shell_options
 test_skill_files_reference_shared_contract_helper
 test_claude_review_pr_synced
 test_claude_plan_synced

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -425,6 +425,139 @@ test_sourcing_preserves_caller_shell_options() {
 }
 
 # --------------------------------------------------------------------------
+# Test: stale CRITIC_WORKTREE is cleared after plan bootstrap rejection
+# --------------------------------------------------------------------------
+test_plan_bootstrap_clears_stale_vars_on_failure() {
+  local desc="plan bootstrap clears stale vars on failure (stale-env escape)"
+
+  # Pre-seed CRITIC_WORKTREE with a stale path outside $HOME/data, then call
+  # plan_critic_bootstrap with a hostile WORKTREE_BASE. After the bootstrap
+  # fails, CRITIC_WORKTREE must be empty — not the stale value.
+  local output
+  output=$(CRITIC_WORKTREE="/tmp/stale-critic" \
+    WORKTREE_BASE="/tmp/evil-base" \
+    CARGO_TARGET_DIR="" \
+    CLAUDE_SESSION_ID="test-session" \
+    bash -c '
+      source "'"$CONTRACT_HELPER"'"
+      plan_critic_bootstrap 999 critic-a
+      rc=$?
+      echo "rc=$rc"
+      echo "CRITIC_WORKTREE=${CRITIC_WORKTREE:-EMPTY}"
+      echo "WORKTREE_BASE=${WORKTREE_BASE:-EMPTY}"
+      echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-EMPTY}"
+    ' 2>&1)
+
+  # Bootstrap must fail
+  if ! echo "$output" | grep -q "rc=1"; then
+    tap_not_ok "$desc" "Expected rc=1, got: $output"
+    return
+  fi
+
+  # All derived vars must be cleared (not stale)
+  if echo "$output" | grep -q "CRITIC_WORKTREE=/tmp/stale-critic"; then
+    tap_not_ok "$desc" "CRITIC_WORKTREE still has stale value after failure: $output"
+    return
+  fi
+  if ! echo "$output" | grep -q "CRITIC_WORKTREE=EMPTY"; then
+    tap_not_ok "$desc" "CRITIC_WORKTREE not cleared: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: stale REVIEWER_WORKTREE is cleared after review-pr bootstrap rejection
+# --------------------------------------------------------------------------
+test_review_pr_bootstrap_clears_stale_vars_on_failure() {
+  local desc="review-pr bootstrap clears stale vars on failure (stale-env escape)"
+
+  # Pre-seed REVIEWER_WORKTREE with a stale path, give hostile WORKTREE_BASE.
+  local output
+  output=$(REVIEWER_WORKTREE="/tmp/stale-reviewer" \
+    WORKTREE_BASE="/tmp/evil-base" \
+    CARGO_TARGET_DIR="" \
+    CLAUDE_SESSION_ID="test-session" \
+    bash -c '
+      source "'"$CONTRACT_HELPER"'"
+      review_pr_bootstrap 100
+      rc=$?
+      echo "rc=$rc"
+      echo "REVIEWER_WORKTREE=${REVIEWER_WORKTREE:-EMPTY}"
+      echo "WORKTREE_BASE=${WORKTREE_BASE:-EMPTY}"
+      echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-EMPTY}"
+    ' 2>&1)
+
+  # Bootstrap must fail
+  if ! echo "$output" | grep -q "rc=1"; then
+    tap_not_ok "$desc" "Expected rc=1, got: $output"
+    return
+  fi
+
+  # All derived vars must be cleared
+  if echo "$output" | grep -q "REVIEWER_WORKTREE=/tmp/stale-reviewer"; then
+    tap_not_ok "$desc" "REVIEWER_WORKTREE still has stale value after failure: $output"
+    return
+  fi
+  if ! echo "$output" | grep -q "REVIEWER_WORKTREE=EMPTY"; then
+    tap_not_ok "$desc" "REVIEWER_WORKTREE not cleared: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: documented bootstrap snippet shape fails closed on hostile override
+# --------------------------------------------------------------------------
+test_documented_snippet_fails_closed() {
+  local desc="documented bootstrap snippet fails closed (no mkdir on hostile env)"
+
+  # Simulate the exact documented snippet from plan/SKILL.md and review-pr/SKILL.md
+  # with hostile pre-seeded vars. The || exit 1 guard must prevent mkdir from running.
+  local plan_output
+  plan_output=$(WORKTREE_BASE="/tmp/evil" \
+    CRITIC_WORKTREE="/tmp/stale-critic" \
+    CARGO_TARGET_DIR="" \
+    CLAUDE_SESSION_ID="test-session" \
+    bash -c '
+      REPO_ROOT="'"$(cd "$REPO_ROOT" && pwd)"'"
+      source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+      ISSUE=999
+      plan_critic_bootstrap "$ISSUE" "critic-a" || exit 1
+      mkdir -p "$CRITIC_WORKTREE"
+      echo "REACHED_MKDIR"
+    ' 2>&1) || true
+
+  if echo "$plan_output" | grep -q "REACHED_MKDIR"; then
+    tap_not_ok "$desc (plan)" "mkdir was reached despite hostile WORKTREE_BASE"
+    return
+  fi
+
+  local review_output
+  review_output=$(WORKTREE_BASE="/tmp/evil" \
+    REVIEWER_WORKTREE="/tmp/stale-reviewer" \
+    CARGO_TARGET_DIR="" \
+    CLAUDE_SESSION_ID="test-session" \
+    bash -c '
+      REPO_ROOT="'"$(cd "$REPO_ROOT" && pwd)"'"
+      source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+      ISSUE=100
+      review_pr_bootstrap "$ISSUE" || exit 1
+      mkdir -p "$REVIEWER_WORKTREE"
+      echo "REACHED_MKDIR"
+    ' 2>&1) || true
+
+  if echo "$review_output" | grep -q "REACHED_MKDIR"; then
+    tap_not_ok "$desc (review-pr)" "mkdir was reached despite hostile WORKTREE_BASE"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
 echo "TAP version 13"
@@ -433,10 +566,13 @@ test_plan_bootstrap_rejects_hostile_worktree_base
 test_plan_bootstrap_rejects_hostile_cargo_target_dir
 test_plan_bootstrap_rejects_sibling_prefix_worktree_base
 test_plan_bootstrap_accepts_safe_preseeded_home_data_paths
+test_plan_bootstrap_clears_stale_vars_on_failure
 test_review_pr_bootstrap_rejects_hostile_worktree_base_and_cargo_target
 test_review_pr_bootstrap_rejects_sibling_prefix
 test_review_pr_bootstrap_requires_home_data_workspace
+test_review_pr_bootstrap_clears_stale_vars_on_failure
 test_default_bootstrap_layouts_stay_under_home_data
+test_documented_snippet_fails_closed
 test_sourcing_preserves_caller_shell_options
 test_skill_files_reference_shared_contract_helper
 test_claude_review_pr_synced

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -558,6 +558,151 @@ test_documented_snippet_fails_closed() {
 }
 
 # --------------------------------------------------------------------------
+# Test: HOME poisoning is defeated (passwd-derived trust anchor)
+# --------------------------------------------------------------------------
+test_home_poisoning_defeated() {
+  local desc="HOME poisoning is defeated by passwd-derived trust anchor"
+
+  # Get the real home from passwd for reference
+  local real_home
+  real_home="$(getent passwd "$(id -un)" | cut -d: -f6)"
+
+  # Poison HOME to a fake directory. The contract should still validate
+  # against the real home (from passwd), not the poisoned $HOME.
+  local output
+
+  # Case 1: Path under fake HOME/data should be rejected
+  if output=$(HOME="/tmp/fakehome" \
+    WORKTREE_BASE="" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 200 && echo \$WORKTREE_BASE" 2>&1); then
+    # If it succeeded, the derived path should be under the REAL home, not fake
+    if echo "$output" | grep -q "/tmp/fakehome"; then
+      tap_not_ok "$desc" "Used poisoned HOME: $output"
+      return
+    fi
+    # It used real home — that's correct behavior
+    if echo "$output" | grep -q "$real_home/data"; then
+      tap_ok "$desc"
+      return
+    fi
+    tap_not_ok "$desc" "Unexpected path: $output"
+    return
+  fi
+
+  # Bootstrap failed — check if it correctly rejected the poisoned-HOME path
+  if echo "$output" | grep -q "outside"; then
+    # Correctly rejected because /tmp/fakehome/data is not under real home
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "Unexpected failure: $output"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: HOME poisoning with explicit override to fake home's data dir
+# --------------------------------------------------------------------------
+test_home_poisoning_explicit_override() {
+  local desc="HOME poisoning with explicit override rejected"
+
+  local real_home
+  real_home="$(getent passwd "$(id -un)" | cut -d: -f6)"
+
+  # Explicitly set WORKTREE_BASE to a path under the fake HOME/data
+  local output
+  if output=$(HOME="/tmp/fakehome" \
+    WORKTREE_BASE="/tmp/fakehome/data/test-session/review-pr-200" \
+    CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 200 && echo \$WORKTREE_BASE" 2>&1); then
+    tap_not_ok "$desc" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Should fail because /tmp/fakehome/data is not under real_home/data
+  if echo "$output" | grep -q "outside"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "Wrong failure reason: $output"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Test: shared in-bounds directory rejected (session-prefix enforcement)
+# --------------------------------------------------------------------------
+test_shared_inbounds_directory_rejected() {
+  local desc="shared in-bounds directory rejected by session-prefix check"
+
+  local real_home
+  real_home="$(getent passwd "$(id -un)" | cut -d: -f6)"
+
+  # Case 1: WORKTREE_BASE under $HOME/data but wrong session/issue prefix
+  local output
+  if output=$(WORKTREE_BASE="$real_home/data/shared/review-pr-100" \
+    CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100 && echo \$WORKTREE_BASE" 2>&1); then
+    tap_not_ok "$desc (review shared base)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Case 2: CARGO_TARGET_DIR under ~/data but wrong prefix
+  if output=$(WORKTREE_BASE="" \
+    CARGO_TARGET_DIR="$real_home/data/shared/cargo" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100 && echo \$CARGO_TARGET_DIR" 2>&1); then
+    tap_not_ok "$desc (review shared cargo)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Case 3: plan_critic_bootstrap with cross-session WORKTREE_BASE
+  if output=$(WORKTREE_BASE="$real_home/data/other-session/plan-42" \
+    CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 42 critic-a && echo \$WORKTREE_BASE" 2>&1); then
+    tap_not_ok "$desc (plan cross-session)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: correct session-prefix overrides still accepted
+# --------------------------------------------------------------------------
+test_correct_session_prefix_overrides_accepted() {
+  local desc="correct session-prefix overrides accepted"
+
+  local real_home
+  real_home="$(getent passwd "$(id -un)" | cut -d: -f6)"
+
+  # Exact prefix match — should succeed
+  local output
+  if ! output=$(WORKTREE_BASE="$real_home/data/my-session/plan-42" \
+    CARGO_TARGET_DIR="$real_home/data/my-session/plan-42/cargo-target" \
+    CLAUDE_SESSION_ID="my-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 42 critic-b && echo \$WORKTREE_BASE && echo \$CARGO_TARGET_DIR && echo \$CRITIC_WORKTREE" 2>&1); then
+    tap_not_ok "$desc (plan)" "Should have succeeded but failed: $output"
+    return
+  fi
+
+  # Review-pr with correct prefix
+  if ! output=$(WORKTREE_BASE="$real_home/data/my-session/review-pr-100" \
+    CARGO_TARGET_DIR="$real_home/data/my-session/review-pr-100/cargo-target" \
+    CLAUDE_SESSION_ID="my-session" \
+    bash -c "source '$CONTRACT_HELPER' && review_pr_bootstrap 100 && echo \$WORKTREE_BASE && echo \$CARGO_TARGET_DIR && echo \$REVIEWER_WORKTREE" 2>&1); then
+    tap_not_ok "$desc (review)" "Should have succeeded but failed: $output"
+    return
+  fi
+
+  # Subdirectory of expected prefix — should also succeed
+  if ! output=$(WORKTREE_BASE="$real_home/data/my-session/plan-42/subdir" \
+    CARGO_TARGET_DIR="$real_home/data/my-session/plan-42/subdir/cargo" \
+    CLAUDE_SESSION_ID="my-session" \
+    bash -c "source '$CONTRACT_HELPER' && plan_critic_bootstrap 42 critic-c && echo \$WORKTREE_BASE" 2>&1); then
+    tap_not_ok "$desc (subdirectory)" "Should have succeeded but failed: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
 echo "TAP version 13"
@@ -574,6 +719,10 @@ test_review_pr_bootstrap_clears_stale_vars_on_failure
 test_default_bootstrap_layouts_stay_under_home_data
 test_documented_snippet_fails_closed
 test_sourcing_preserves_caller_shell_options
+test_home_poisoning_defeated
+test_home_poisoning_explicit_override
+test_shared_inbounds_directory_rejected
+test_correct_session_prefix_overrides_accepted
 test_skill_files_reference_shared_contract_helper
 test_claude_review_pr_synced
 test_claude_plan_synced


### PR DESCRIPTION
Closes #2838

## Summary

Extracts workspace path validation into a shared shell helper (`scripts/lib/agent-worktree-contract.sh`) that canonicalizes paths with `realpath -m` and rejects any workspace variable resolving outside `$HOME/data`. Updates both `/plan` and `/review-pr` skill bootstraps to source this helper. Rewrites `scripts/test-agent-worktree-contract.sh` from grep-only assertions to behavior-first tests that execute the actual bootstrap logic under hostile absolute, traversal, safe, and default env overrides.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2838#issuecomment-4504201701)

## Test plan

- [x] `bash scripts/test-agent-worktree-contract.sh` — 19/19 TAP tests pass
- [x] `bash scripts/test-review-pr-skill-snippets.sh` — 13/13 tests pass

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)