### PR TITLE
Document §5.1 trigger-setup preconditions as split Partial parity

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -4324,6 +4324,51 @@ mod tests {
         );
     }
 
+    /// Regression test for #2868 — §5.1 trigger setup preconditions parity.
+    ///
+    /// Verifies that `try_trigger_consensus` skips the consensus trigger when
+    /// the node's LCL is behind the tracking slot (i.e. `current_ledger + 1 <
+    /// tracking_slot`), matching stellar-core's `isSynced()` precondition in
+    /// `setupTriggerNextLedger`.
+    ///
+    /// Parity: stellar-core HerderImpl.cpp — `trackingConsensusLedgerIndex()`
+    /// requires `lastClosedLedger + 1 == trackingConsensusLedgerIndex`.
+    #[tokio::test]
+    async fn test_try_trigger_consensus_skips_when_lcl_behind_tracking_slot() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+
+        let app = App::new(config).await.unwrap();
+
+        // After init the LCL is at genesis (ledger 1).
+        let current_ledger = app.current_ledger_seq();
+        assert_eq!(current_ledger, 1, "LCL should be at genesis");
+
+        // Bootstrap to enter Tracking state, then override tracking_slot to 5
+        // — well ahead of current_ledger + 1 = 2. This simulates a node that
+        // fell behind the network's consensus frontier.
+        app.herder.bootstrap(1);
+        app.herder.set_tracking_for_testing(5, 1000);
+        assert!(app.herder.is_tracking());
+        assert!(
+            (current_ledger as u64) + 1 < app.herder.tracking_slot().get(),
+            "precondition: LCL+1 must be behind tracking_slot"
+        );
+
+        let attempts_before = app.consensus_trigger_attempts.load(Ordering::Relaxed);
+
+        app.try_trigger_consensus().await;
+
+        let attempts_after = app.consensus_trigger_attempts.load(Ordering::Relaxed);
+        assert_eq!(
+            attempts_after, attempts_before,
+            "consensus_trigger_attempts must NOT increment when LCL is behind tracking slot"
+        );
+    }
+
     #[tokio::test]
     async fn test_sync_recovery_callback_is_applying_ledger() {
         let dir = tempfile::tempdir().expect("temp dir");

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -4328,12 +4328,14 @@ mod tests {
     ///
     /// Verifies that `try_trigger_consensus` skips the consensus trigger when
     /// the node's LCL is behind the tracking slot (i.e. `current_ledger + 1 <
-    /// tracking_slot`), matching stellar-core's `isSynced()` precondition in
-    /// `setupTriggerNextLedger`.
+    /// tracking_slot`), matching stellar-core's soft early-return in
+    /// `HerderImpl::triggerNextLedger()` (HerderImpl.cpp:1456-1461) when
+    /// `!isSynced()`.
     ///
-    /// Parity: stellar-core HerderImpl.cpp — `nextConsensusLedgerIndex()`
-    /// (== `tracking_slot()` in henyey) requires
-    /// `lastClosedLedger + 1 == nextConsensusLedgerIndex`.
+    /// Note: this is distinct from `setupTriggerNextLedger()` which uses
+    /// fail-fast `releaseAssert` preconditions (HerderImpl.cpp:1237-1249).
+    /// Henyey's `try_trigger_consensus` implements the soft skip path, not
+    /// the fatal assertion path.
     #[tokio::test]
     async fn test_try_trigger_consensus_skips_when_lcl_behind_tracking_slot() {
         let dir = tempfile::tempdir().expect("temp dir");

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -4331,8 +4331,9 @@ mod tests {
     /// tracking_slot`), matching stellar-core's `isSynced()` precondition in
     /// `setupTriggerNextLedger`.
     ///
-    /// Parity: stellar-core HerderImpl.cpp — `trackingConsensusLedgerIndex()`
-    /// requires `lastClosedLedger + 1 == trackingConsensusLedgerIndex`.
+    /// Parity: stellar-core HerderImpl.cpp — `nextConsensusLedgerIndex()`
+    /// (== `tracking_slot()` in henyey) requires
+    /// `lastClosedLedger + 1 == nextConsensusLedgerIndex`.
     #[tokio::test]
     async fn test_try_trigger_consensus_skips_when_lcl_behind_tracking_slot() {
         let dir = tempfile::tempdir().expect("temp dir");

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -105,7 +105,7 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `lostSync()` | `SyncRecoveryManager::record_lost_sync()` | Full |
 | `checkCloseTime()` | `check_envelope_close_time()` | Full |
 | `ctValidityOffset()` | _(not implemented)_ | None |
-| `setupTriggerNextLedger()` | _(not implemented)_ | None |
+| `setupTriggerNextLedger()` | Split: `App::try_trigger_consensus()` (behind/applying gates) + `Herder::trigger_next_ledger()` (lcl_matches_slot) | Partial — behind/applying/not-tracking guards match; `LCL >= tracking` uses corrective recovery instead of stellar-core's fail-fast assertion; trigger-time / `ctValidityOffset()` tracked separately (#2702) |
 | `startOutOfSyncTimer()` | `SyncRecoveryManager` | Full |
 | `outOfSyncRecovery()` | `out_of_sync_recovery()` | Full |
 | `broadcast()` | `flush_tx_adverts()` in `App` | Partial — priority-ordered via `TransactionQueue::broadcast_with_visitor()` with DEX-lane flood budget, budget-neutral skipped txs, arb flood damping, and ban-on-damping; broadcast period uses `flood_tx_period_ms` (200 ms) matching stellar-core `FLOOD_TX_PERIOD_MS`; missing dedicated flood queue, mark-on-attempt, separate advert flush timer |

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -81,7 +81,7 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `getMinLedgerSeqToRemember()` | `get_min_ledger_seq_to_remember()` | Full |
 | `isNewerNominationOrBallotSt()` | _(not implemented)_ | None |
 | `getMostRecentCheckpointSeq()` | `get_most_recent_checkpoint_seq()` | Full |
-| `triggerNextLedger()` | `trigger_next_ledger()` | Full | Henyey adds an `is_nominating` idempotency guard that skips duplicate triggers while nomination is active. stellar-core logs and continues on duplicate calls but never invokes them in a retry loop. Observable SCP behavior is unchanged. |
+| `triggerNextLedger()` | `trigger_next_ledger()` | Partial | Henyey adds an `is_nominating` idempotency guard that skips duplicate triggers while nomination is active. stellar-core logs and continues on duplicate calls but never invokes them in a retry loop. Observable SCP behavior is unchanged. Remaining divergence: stellar-core re-checks `mLedgerManager.isApplying()` after tx-set construction (HerderImpl.cpp:1583-1585) before nomination; henyey re-checks slot staleness (`lcl_matches_slot`) but does not re-check the applying flag at that post-build point. |
 | Nomination value caching (timer lambda capture) | `cached_nomination_value` field + `handle_nomination_timeout()` | Full |
 | `setInSyncAndTriggerNextLedger()` | `trigger_next_ledger()` | Full |
 | `resolveNodeID()` | _(not implemented)_ | None |
@@ -105,7 +105,7 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `lostSync()` | `SyncRecoveryManager::record_lost_sync()` | Full |
 | `checkCloseTime()` | `check_envelope_close_time()` | Full |
 | `ctValidityOffset()` | _(not implemented)_ | None |
-| `setupTriggerNextLedger()` | Split: `App::try_trigger_consensus()` (behind/applying gates) + `Herder::trigger_next_ledger()` (lcl_matches_slot) | Partial — behind/applying/not-tracking pre-entry guards match; remaining divergences: (1) `LCL >= tracking` uses corrective recovery instead of stellar-core's fail-fast assertion, (2) no post-build `isApplying()` suppression before nomination (stellar-core HerderImpl.cpp:1579-1585 re-checks applying after tx-set construction); trigger-time / `ctValidityOffset()` tracked separately (#2702) |
+| `setupTriggerNextLedger()` | Split: `App::try_trigger_consensus()` (behind/applying gates) + `Herder::trigger_next_ledger()` (lcl_matches_slot) | Partial — behind/applying/not-tracking pre-entry guards match; remaining divergences: (1) `LCL >= tracking` uses corrective recovery instead of stellar-core's fail-fast assertion, (2) no post-build `isApplying()` suppression before nomination (stellar-core triggerNextLedger HerderImpl.cpp:1583-1585 re-checks applying after tx-set construction); trigger-time / `ctValidityOffset()` tracked separately (#2702) |
 | `startOutOfSyncTimer()` | `SyncRecoveryManager` | Full |
 | `outOfSyncRecovery()` | `out_of_sync_recovery()` | Full |
 | `broadcast()` | `flush_tx_adverts()` in `App` | Partial — priority-ordered via `TransactionQueue::broadcast_with_visitor()` with DEX-lane flood budget, budget-neutral skipped txs, arb flood damping, and ban-on-damping; broadcast period uses `flood_tx_period_ms` (200 ms) matching stellar-core `FLOOD_TX_PERIOD_MS`; missing dedicated flood queue, mark-on-attempt, separate advert flush timer |

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -105,7 +105,7 @@ Corresponds to: `Herder.h`, `HerderImpl.h`
 | `lostSync()` | `SyncRecoveryManager::record_lost_sync()` | Full |
 | `checkCloseTime()` | `check_envelope_close_time()` | Full |
 | `ctValidityOffset()` | _(not implemented)_ | None |
-| `setupTriggerNextLedger()` | Split: `App::try_trigger_consensus()` (behind/applying gates) + `Herder::trigger_next_ledger()` (lcl_matches_slot) | Partial — behind/applying/not-tracking guards match; `LCL >= tracking` uses corrective recovery instead of stellar-core's fail-fast assertion; trigger-time / `ctValidityOffset()` tracked separately (#2702) |
+| `setupTriggerNextLedger()` | Split: `App::try_trigger_consensus()` (behind/applying gates) + `Herder::trigger_next_ledger()` (lcl_matches_slot) | Partial — behind/applying/not-tracking pre-entry guards match; remaining divergences: (1) `LCL >= tracking` uses corrective recovery instead of stellar-core's fail-fast assertion, (2) no post-build `isApplying()` suppression before nomination (stellar-core HerderImpl.cpp:1579-1585 re-checks applying after tx-set construction); trigger-time / `ctValidityOffset()` tracked separately (#2702) |
 | `startOutOfSyncTimer()` | `SyncRecoveryManager` | Full |
 | `outOfSyncRecovery()` | `out_of_sync_recovery()` | Full |
 | `broadcast()` | `flush_tx_adverts()` in `App` | Partial — priority-ordered via `TransactionQueue::broadcast_with_visitor()` with DEX-lane flood budget, budget-neutral skipped txs, arb flood damping, and ban-on-damping; broadcast period uses `flood_tx_period_ms` (200 ms) matching stellar-core `FLOOD_TX_PERIOD_MS`; missing dedicated flood queue, mark-on-attempt, separate advert flush timer |

--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -2,7 +2,7 @@
 
 **Spec version:** 26 (stellar-core v26.0.1 / Protocol 26)
 **Crate:** crates/herder
-**Last updated:** 2026-05-13
+**Last updated:** 2026-05-21
 **Overall adherence:** 86%
 
 **Tally:** Full 51 | Partial 7 | Absent 1 | Drift 2 | N/A 4
@@ -21,7 +21,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §4 | State machine transitions | Full | state.rs:82 + herder.rs:980 |
 | §4 | INV: BOOTING regression forbidden | Full | state.rs:82-88 |
 | §4 | trackingConsensusLedgerIndex >= LCL | Full | herder.rs:1066 (corrective; deviation) |
-| §5.1 | Trigger setup preconditions | Partial | herder.rs:2399-2444 (lcl_matches_slot only) |
+| §5.1 | Trigger setup preconditions | Partial | App::try_trigger_consensus (behind/applying) + herder.rs:2399-2444 (lcl_matches_slot); diverges on LCL≥tracking corrective recovery |
 | §5.1 | ctValidityOffset adjustment of trigger time | Absent | not found |
 | §5.1 | MANUAL_CLOSE skips trigger | Full | herder.rs:1758 (suppress_scp gate) |
 | §5.2 | triggerNextLedger pipeline | Full | herder.rs:2399 + build_nomination_value |
@@ -162,12 +162,20 @@ excluded. SHOULD claims and operational defaults excluded.
 - **§5.1-1 (MUST)** Trigger requires `LedgerManager.isApplying() == false`,
   `Herder.isTracking() == true`, `trackingConsensusLedgerIndex() ==
   LCL.ledgerSeq`, `LedgerManager.isSynced() == true`.
-  - **Rust:** `herder.rs:2399-2444` gates on `is_validator + is_tracking +
-    lcl_matches_slot`. The `isApplying` check is performed by the caller in
-    the app/dispatcher; `lcl_matches_slot` covers `tracking == lcl + 1`.
-  - **Status:** Partial — `isApplying` and `isSynced` are dispatched
-    outside this crate (acceptable for the architectural split); the
-    invariant is preserved at the dispatcher level.
+  - **Rust:** Split across app and herder layers:
+    - `App::try_trigger_consensus()` (`crates/app/src/app/consensus.rs`)
+      gates on `is_tracking()`, `current_ledger + 1 < tracking_slot`
+      (behind/not-synced skip), and `is_applying_ledger()`.
+    - `Herder::trigger_next_ledger()` (`herder.rs:2399-2444`) gates on
+      `is_validator + is_tracking + lcl_matches_slot`.
+    - `Herder::assert_lcl_consistency()` handles the `LCL >= tracking_slot`
+      case by repairing tracking to `lcl + 1` and continuing — a
+      **divergence** from stellar-core which release-asserts / throws via
+      `trackingConsensusLedgerIndex()` and `setupTriggerNextLedger()`.
+  - **Status:** Partial — the automatic trigger guards (behind, applying,
+    not-tracking) are preserved across the app/herder split; the `LCL >=
+    tracking` corrective-recovery path diverges from stellar-core's
+    fail-fast equality precondition.
 
 - **§5.1-2 (MUST)** "Trigger time is computed as `lastBallotStart +
   expectedLedgerCloseTime`…" and "MUST be advanced by `ctValidityOffset`".

--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -21,7 +21,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §4 | State machine transitions | Full | state.rs:82 + herder.rs:980 |
 | §4 | INV: BOOTING regression forbidden | Full | state.rs:82-88 |
 | §4 | trackingConsensusLedgerIndex >= LCL | Full | herder.rs:1066 (corrective; deviation) |
-| §5.1 | Trigger setup preconditions | Partial | consensus.rs:121-163 (behind/applying gates) + herder.rs:2399-2444 (lcl_matches_slot); diverges: (1) LCL≥tracking uses corrective recovery instead of fail-fast assertion, (2) no post-build `isApplying()` suppression before nomination (stellar-core HerderImpl.cpp:1579-1585) |
+| §5.1 | Trigger setup preconditions | Partial | consensus.rs:121-163 (behind/applying gates) + herder.rs:2399-2444 (lcl_matches_slot); diverges: (1) LCL≥tracking uses corrective recovery instead of fail-fast assertion, (2) no post-build `isApplying()` suppression before nomination (stellar-core triggerNextLedger HerderImpl.cpp:1583-1585) |
 | §5.1 | ctValidityOffset adjustment of trigger time | Absent | not found |
 | §5.1 | MANUAL_CLOSE skips trigger | Full | herder.rs:1758 (suppress_scp gate) |
 | §5.2 | triggerNextLedger pipeline | Full | herder.rs:2399 + build_nomination_value |
@@ -209,6 +209,11 @@ excluded. SHOULD claims and operational defaults excluded.
     - Step 9 (publish to pending envelopes): `cache_tx_set` /
       `pending_envelopes`.
     - Step 10 (post-build LCL re-check): `trigger_next_ledger:2475-2481`.
+      Note: stellar-core also re-checks `mLedgerManager.isApplying()` at this
+      point (HerderImpl.cpp:1583-1585), suppressing nomination if a concurrent
+      ledger close started during tx-set construction. Henyey checks slot
+      staleness (`lcl_matches_slot`) but does not re-check the applying flag
+      here — this is a known partial-parity gap tracked under §5.1.
     - Step 11 (upgrades): `build_nomination_value:3079-3172` + filter on
       `UpgradeType::max_size()`.
     - Step 12 (non-validator stop): `trigger_next_ledger:2400-2402`.

--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -21,7 +21,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §4 | State machine transitions | Full | state.rs:82 + herder.rs:980 |
 | §4 | INV: BOOTING regression forbidden | Full | state.rs:82-88 |
 | §4 | trackingConsensusLedgerIndex >= LCL | Full | herder.rs:1066 (corrective; deviation) |
-| §5.1 | Trigger setup preconditions | Partial | App::try_trigger_consensus (behind/applying) + herder.rs:2399-2444 (lcl_matches_slot); diverges on LCL≥tracking corrective recovery |
+| §5.1 | Trigger setup preconditions | Partial | consensus.rs:121-163 (behind/applying gates) + herder.rs:2399-2444 (lcl_matches_slot); diverges: (1) LCL≥tracking uses corrective recovery instead of fail-fast assertion, (2) no post-build `isApplying()` suppression before nomination (stellar-core HerderImpl.cpp:1579-1585) |
 | §5.1 | ctValidityOffset adjustment of trigger time | Absent | not found |
 | §5.1 | MANUAL_CLOSE skips trigger | Full | herder.rs:1758 (suppress_scp gate) |
 | §5.2 | triggerNextLedger pipeline | Full | herder.rs:2399 + build_nomination_value |


### PR DESCRIPTION
Closes #2868

## Summary

Documents the §5.1 trigger-setup preconditions as a split **Partial** implementation across `App::try_trigger_consensus()` and `Herder::trigger_next_ledger()`. Adds a focused test proving the `current_ledger + 1 < tracking_slot` gate blocks nomination when the node is behind. Updates SPEC_ADHERENCE.md and PARITY_STATUS.md to accurately describe the divergence: henyey uses corrective recovery via `assert_lcl_consistency()` instead of stellar-core's fail-fast equality precondition.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2868#issuecomment-4510052509)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-app -- -D warnings
- [x] `cargo test -p henyey-app test_try_trigger_consensus` — both tests pass

## Existing tests preserved

- [x] `cargo test -p henyey-app test_try_trigger_consensus_skips_while_applying` — passes
- [x] `cargo test -p henyey-app test_try_trigger_consensus_skips_when_lcl_behind_tracking_slot` — passes
- [x] `cargo test -p henyey-herder test_assert_lcl_consistency_recovers_when_lcl_equals_tracking_slot` — passes
- [x] `cargo test -p henyey-herder test_assert_lcl_consistency_recovers_when_lcl_ahead_of_tracking` — passes
- [x] `cargo test -p henyey-herder test_trigger_next_ledger_skips_stale_slot` — passes

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)