### PR TITLE
Clarify SCP acceptance boundary in slot_quorum_tracker comment

### DIFF
--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1926,9 +1926,11 @@ impl Herder {
 
         // Slot quorum tracker bookkeeping is deferred to
         // process_scp_envelope_with_tx_set, which is the SCP-acceptance
-        // boundary. This matches the timing of stellar-core's
-        // processSCPQueueUpToIndex: envelopes are only SCP-visible (and
-        // thus quorum-relevant) after they pass dependency admission.
+        // boundary. Envelopes are only quorum-relevant after SCP accepts
+        // them (Valid/ValidNew). Note: EXTERNALIZE envelopes for the
+        // current/past slot bypass dependency admission via the bypass
+        // path in process_scp_envelope, so the true boundary is SCP
+        // acceptance, not dependency resolution.
 
         // Pre-fetch tx sets from EXTERNALIZE envelopes immediately so they're
         // available by the time SCP processes the envelope. Uses the strict


### PR DESCRIPTION
Closes #2880

## Summary

Rewords the comment in `process_verified` that describes when `slot_quorum_tracker.record_envelope()` runs. The old wording said envelopes are quorum-relevant "after they pass dependency admission", but EXTERNALIZE envelopes for the current/past slot bypass dependency checking via the bypass path in `process_scp_envelope`. The updated comment describes the true boundary as "after SCP accepts the envelope (Valid/ValidNew)".

## Plan reference

[Triage Report comment](https://github.com/stellar-experimental/henyey/issues/2880#issuecomment-4512840449)

## Test plan

- [x] cargo fmt --check
- [x] Comment-only change, no behavioral impact

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)