### PR TITLE
Move cross-type source guard before validation in try_add

### DIFF
--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -66,7 +66,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §11 | combineCandidates: signature carry-over | Partial | uses selected candidate's full SV (deviation: defensive fallback when no candidate matches LCL) |
 | §12.1 | One tx per source account | Full | tx_queue/mod.rs::check_account_limit |
 | §12.2 | Reception pipeline order | Full | outer pre-filter → signature verify → self-skip → quorum gate → strict STELLAR_VALUE_SIGNED validation before fetch/relay → dependency admission → SCP acceptance (#2870) |
-| §12.2 | Cross-queue source check | Full | early check in `try_add` before validation; `check_cross_type_conflict` + authoritative recheck in `check_account_limit` (regression tests #2871) |
+| §12.2 | Cross-queue source check | Full | early check in `try_add` before validation; `check_cross_type_conflict_with` covers seq-source and fee-source-only entries + authoritative recheck in `check_account_limit` (regression tests #2871) |
 | §12.3 | Replace-by-fee FEE_MULTIPLIER × per-op | Full | tx_queue/mod.rs:606, 663 (FEE_MULTIPLIER = 10) |
 | §12.4 | shift() ban deque + age + auto-ban | Full | tx_queue/mod.rs:2761 (TIMEOUT=4, BAN=10) |
 | §12.4 | removeApplied semantics | Full | tx_queue/mod.rs:2654 |
@@ -444,14 +444,20 @@ excluded. SHOULD claims and operational defaults excluded.
     overlay validity → fee balance.
   - **Sub-claim §12.2-1 (cross-queue source check)**: Spec places this at
     the *top* of `HerderImpl.recvTransaction`. In henyey,
-    `TransactionQueue::try_add` now performs an early cross-type
-    source-account conflict check (`check_cross_type_conflict`) before
+    `TransactionQueue::try_add` performs an early cross-type
+    source-account conflict check (`check_cross_type_conflict_with`) before
     `validate_transaction`, matching stellar-core's precedence: opposite-type
     submissions always surface `TryAgainLater` before any validation error.
+    The guard covers both seq-source entries (`state.transaction`) and
+    fee-source-only entries (`soroban_fee_tx_count` / `classic_fee_tx_count`),
+    matching `sourceAccountPending` which returns true for any
+    `mAccountStates` entry in the opposite queue.
     The later `check_account_limit` recheck under the store write-lock
     remains the authoritative guard against races.
     Regression tests: `test_cross_type_invalid_classic_returns_try_again_later`,
-    `test_cross_type_invalid_soroban_returns_try_again_later` (#2871).
+    `test_cross_type_invalid_soroban_returns_try_again_later`,
+    `test_cross_type_fee_source_only_classic_returns_try_again_later`,
+    `test_cross_type_fee_source_only_soroban_returns_try_again_later` (#2871).
     - **Status:** Full.
   - **Sub-claim §12.2-3 (ban check before filter)**: Henyey performs the
     ban check (`is_banned`) before the filter check at line 2090; matches

--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -66,7 +66,7 @@ excluded. SHOULD claims and operational defaults excluded.
 | §11 | combineCandidates: signature carry-over | Partial | uses selected candidate's full SV (deviation: defensive fallback when no candidate matches LCL) |
 | §12.1 | One tx per source account | Full | tx_queue/mod.rs::check_account_limit |
 | §12.2 | Reception pipeline order | Full | outer pre-filter → signature verify → self-skip → quorum gate → strict STELLAR_VALUE_SIGNED validation before fetch/relay → dependency admission → SCP acceptance (#2870) |
-| §12.2 | Cross-queue source check | Partial | spec puts it at top of HerderImpl.recvTransaction; henyey enforces inside try_add (regression test #1934) |
+| §12.2 | Cross-queue source check | Full | early check in `try_add` before validation; `check_cross_type_conflict` + authoritative recheck in `check_account_limit` (regression tests #2871) |
 | §12.3 | Replace-by-fee FEE_MULTIPLIER × per-op | Full | tx_queue/mod.rs:606, 663 (FEE_MULTIPLIER = 10) |
 | §12.4 | shift() ban deque + age + auto-ban | Full | tx_queue/mod.rs:2761 (TIMEOUT=4, BAN=10) |
 | §12.4 | removeApplied semantics | Full | tx_queue/mod.rs:2654 |
@@ -444,11 +444,15 @@ excluded. SHOULD claims and operational defaults excluded.
     overlay validity → fee balance.
   - **Sub-claim §12.2-1 (cross-queue source check)**: Spec places this at
     the *top* of `HerderImpl.recvTransaction`. In henyey,
-    `Herder::receive_transaction` (`herder.rs:2324`) delegates to the
-    correct queue; the cross-queue source-account check is then performed
-    inside `try_add` rather than as a top-level pre-check. Regression test
-    coverage: #1934.
-    - **Status:** Partial.
+    `TransactionQueue::try_add` now performs an early cross-type
+    source-account conflict check (`check_cross_type_conflict`) before
+    `validate_transaction`, matching stellar-core's precedence: opposite-type
+    submissions always surface `TryAgainLater` before any validation error.
+    The later `check_account_limit` recheck under the store write-lock
+    remains the authoritative guard against races.
+    Regression tests: `test_cross_type_invalid_classic_returns_try_again_later`,
+    `test_cross_type_invalid_soroban_returns_try_again_later` (#2871).
+    - **Status:** Full.
   - **Sub-claim §12.2-3 (ban check before filter)**: Henyey performs the
     ban check (`is_banned`) before the filter check at line 2090; matches
     spec.
@@ -766,10 +770,9 @@ sections present in the current spec:
    so reviewers understand the spec calls it fatal but henyey treats it
    as recoverable.
 
-4. **Audit cross-queue source-account check ordering** (§12.2-1). Spec
-   wants it at the top of `recvTransaction`; henyey runs it inside
-   `try_add`. Verify there is no behavioural divergence under fee-bump
-   churn.
+4. ~~**Audit cross-queue source-account check ordering** (§12.2-1).~~ Fixed
+   in #2871 — early `check_cross_type_conflict` guard now runs before
+   `validate_transaction` in `try_add`.
 
 5. **Verify §15.3 random-peer ask path** is wired in the overlay /
    sync_recovery integration; the herder side only exposes the slot

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -4955,6 +4955,98 @@ mod tests {
         );
     }
 
+    /// Parity: when the herder is Tracking and the queue already has a pending
+    /// tx from a source, submitting an opposite-type tx from the same source
+    /// must return TryAgainLater (stellar-core HerderImpl.cpp:627-645).
+    #[test]
+    fn test_receive_transaction_cross_type_conflict_returns_try_again_later() {
+        use stellar_xdr::curr::{
+            CreateAccountOp, DecoratedSignature, HostFunction, InvokeContractArgs,
+            InvokeHostFunctionOp, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
+            PublicKey, ScAddress, ScSymbol, SequenceNumber, SignatureHint, StringM, Transaction,
+            TransactionEnvelope, TransactionExt, TransactionV1Envelope, Uint256, VecM,
+        };
+
+        let herder = make_test_herder();
+        herder.set_state(HerderState::Tracking);
+        assert!(herder.state().can_receive_transactions());
+
+        // Seed a valid classic tx from source seed 42.
+        let classic_tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([42u8; 32])),
+            fee: 200,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::CreateAccount(CreateAccountOp {
+                    destination: stellar_xdr::curr::AccountId(PublicKey::PublicKeyTypeEd25519(
+                        Uint256([255u8; 32]),
+                    )),
+                    starting_balance: 1000000000,
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+        let classic_env = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx: classic_tx,
+            signatures: vec![DecoratedSignature {
+                hint: SignatureHint([0u8; 4]),
+                signature: XdrSignature(vec![0u8; 64].try_into().unwrap()),
+            }]
+            .try_into()
+            .unwrap(),
+        });
+        assert_eq!(
+            herder.receive_transaction(classic_env),
+            TxQueueResult::Added,
+        );
+
+        // Submit a Soroban tx from the same source (seed 42).
+        let function_name = ScSymbol(StringM::<32>::try_from("test".to_string()).expect("symbol"));
+        let host_function = HostFunction::InvokeContract(InvokeContractArgs {
+            contract_address: ScAddress::default(),
+            function_name,
+            args: VecM::<stellar_xdr::curr::ScVal>::default(),
+        });
+        let soroban_tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([42u8; 32])),
+            fee: 200,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+                    host_function,
+                    auth: VecM::default(),
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+        let soroban_env = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx: soroban_tx,
+            signatures: vec![DecoratedSignature {
+                hint: SignatureHint([0u8; 4]),
+                signature: XdrSignature(vec![0u8; 64].try_into().unwrap()),
+            }]
+            .try_into()
+            .unwrap(),
+        });
+
+        let result = herder.receive_transaction(soroban_env);
+        assert_eq!(
+            result,
+            TxQueueResult::TryAgainLater,
+            "cross-type conflict must return TryAgainLater through public intake"
+        );
+    }
+
     // =========================================================================
     // Issue #1953 — Herder end-to-end normalization regression
     // =========================================================================

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -593,12 +593,23 @@ pub struct AccountState {
     /// The single pending transaction for which this account is the sequence-number-source.
     /// stellar-core enforces one transaction per account (non-fee-bump) in the queue.
     pub transaction: Option<QueuedTransaction>,
+    /// Number of queued Soroban transactions for which this account is the fee-source.
+    /// Parity: stellar-core's per-queue `mAccountStates` implicitly tracks fee-source
+    /// involvement by type (each queue only contains one tx type). In henyey's
+    /// single-queue model we need explicit type counts to replicate the cross-queue
+    /// source-account guard for fee-source-only entries.
+    pub soroban_fee_tx_count: u32,
+    /// Number of queued classic transactions for which this account is the fee-source.
+    pub classic_fee_tx_count: u32,
 }
 
 impl AccountState {
     /// Check if this account state can be removed (no transaction and no fees tracked).
     pub fn is_empty(&self) -> bool {
-        self.transaction.is_none() && self.total_fees == 0
+        self.transaction.is_none()
+            && self.total_fees == 0
+            && self.soroban_fee_tx_count == 0
+            && self.classic_fee_tx_count == 0
     }
 }
 
@@ -1547,18 +1558,40 @@ impl TransactionQueue {
     ///
     /// This is an optimistic read (no write lock); the later `check_account_limit`
     /// under the store write-lock remains the authoritative recheck.
-    fn check_cross_type_conflict(&self, envelope: &TransactionEnvelope) -> Option<TxQueueResult> {
-        let seq_source = account_key(envelope);
-        let candidate_is_soroban = henyey_tx::envelope_utils::is_soroban_envelope(envelope);
-
+    /// Check if a candidate transaction conflicts with an opposite-type pending
+    /// entry for the same source account, using pre-computed key and type.
+    ///
+    /// Parity: stellar-core `HerderImpl::recvTransaction` (HerderImpl.cpp:627-645)
+    /// checks `sourceAccountPending` on the opposite queue before `tryAdd`. This
+    /// replicates that precedence so the externally visible result is
+    /// `TryAgainLater` rather than whatever validation error would fire first.
+    ///
+    /// This is an optimistic read (no write lock); the later `check_account_limit`
+    /// under the store write-lock remains the authoritative recheck.
+    fn check_cross_type_conflict_with(
+        &self,
+        seq_source: &[u8],
+        candidate_is_soroban: bool,
+    ) -> Option<TxQueueResult> {
         let account_states = self.account_states.read();
-        if let Some(state) = account_states.get(&seq_source) {
+        if let Some(state) = account_states.get(seq_source) {
+            // Check if the account has a pending tx of the opposite type (seq-source role)
             if let Some(ref current_tx) = state.transaction {
                 let current_is_soroban =
                     henyey_tx::envelope_utils::is_soroban_envelope(&current_tx.envelope);
                 if current_is_soroban != candidate_is_soroban {
                     return Some(TxQueueResult::TryAgainLater);
                 }
+            }
+            // Parity: stellar-core's `sourceAccountPending` returns true for
+            // any entry in the opposite queue's `mAccountStates`, including
+            // fee-source-only entries. Check if this account pays fees for a
+            // tx of the opposite type.
+            if candidate_is_soroban && state.classic_fee_tx_count > 0 {
+                return Some(TxQueueResult::TryAgainLater);
+            }
+            if !candidate_is_soroban && state.soroban_fee_tx_count > 0 {
+                return Some(TxQueueResult::TryAgainLater);
             }
         }
         None
@@ -1816,6 +1849,16 @@ impl TransactionQueue {
                 }
 
                 return Ok(Some(current_tx.clone()));
+            }
+
+            // Parity: authoritative recheck for fee-source-only entries.
+            // stellar-core's sourceAccountPending also matches fee-source-only
+            // entries in the opposite queue's mAccountStates.
+            if candidate_is_soroban && state.classic_fee_tx_count > 0 {
+                return Err(TxQueueResult::TryAgainLater);
+            }
+            if !candidate_is_soroban && state.soroban_fee_tx_count > 0 {
+                return Err(TxQueueResult::TryAgainLater);
             }
         }
         Ok(None)
@@ -2090,12 +2133,20 @@ impl TransactionQueue {
 
     /// Try to add a transaction to the queue.
     pub fn try_add(&self, envelope: TransactionEnvelope) -> TxQueueResult {
+        // Pre-compute values needed by both the early cross-type guard and
+        // the later account-limit / admission logic, avoiding redundant
+        // allocations on this hot path.
+        let seq_source_key = account_key(&envelope);
+        let candidate_is_soroban = henyey_tx::envelope_utils::is_soroban_envelope(&envelope);
+
         // Parity: stellar-core HerderImpl.cpp:627-645 checks whether the
         // source account already has a pending tx of the opposite type
         // (classic vs Soroban) BEFORE running any validation. Replicate that
         // precedence here so cross-type conflicts always surface as
         // TryAgainLater rather than whatever validation error would fire first.
-        if let Some(result) = self.check_cross_type_conflict(&envelope) {
+        if let Some(result) =
+            self.check_cross_type_conflict_with(&seq_source_key, candidate_is_soroban)
+        {
             return result;
         }
 
@@ -2166,7 +2217,7 @@ impl TransactionQueue {
 
         let mut store = self.store.write();
         let ledger_version = self.validation_context.read().protocol_version;
-        let queued_is_soroban = henyey_tx::envelope_utils::is_soroban_envelope(&queued.envelope);
+        let queued_is_soroban = candidate_is_soroban;
 
         // Re-check ban after acquiring store.write() to close the TOCTOU
         // window with ban(). The early is_banned() check (above) is a
@@ -2196,7 +2247,7 @@ impl TransactionQueue {
         }
 
         // Per-account limit check: one transaction per account (sequence-number-source)
-        let seq_source_key = account_key(&queued.envelope);
+        // seq_source_key was pre-computed at the top of try_add.
         let new_seq = envelope_sequence_number(&queued.envelope);
         let is_fee_bump = is_fee_bump_envelope(&queued.envelope);
         let new_fee_source_key = fee_source_key(&queued.envelope);
@@ -2281,6 +2332,16 @@ impl TransactionQueue {
                     old_fee_state.total_fees = old_fee_state
                         .total_fees
                         .saturating_sub(old_tx.total_fee as i64);
+                    // Decrement fee type count for the old tx
+                    let old_is_soroban =
+                        henyey_tx::envelope_utils::is_soroban_envelope(&old_tx.envelope);
+                    if old_is_soroban {
+                        old_fee_state.soroban_fee_tx_count =
+                            old_fee_state.soroban_fee_tx_count.saturating_sub(1);
+                    } else {
+                        old_fee_state.classic_fee_tx_count =
+                            old_fee_state.classic_fee_tx_count.saturating_sub(1);
+                    }
                     // Remove the account state if it's empty
                     if old_fee_state.is_empty() {
                         account_states.remove(&old_fee_source_key);
@@ -2306,6 +2367,7 @@ impl TransactionQueue {
                 let old_fee_source_key = fee_source_key(&old_tx.envelope);
                 if old_fee_source_key == new_fee_source_key {
                     // Same fee source - only add the difference
+                    // Fee type count stays the same (same fee source, same type)
                     (new_fee as i64).saturating_sub(old_tx.total_fee as i64)
                 } else {
                     // Different fee source - add full new fee
@@ -2318,15 +2380,35 @@ impl TransactionQueue {
 
             seq_state.transaction = Some(queued.clone());
 
-            // Update the fee-source account state (tracks total_fees)
+            // Update the fee-source account state (tracks total_fees and fee type counts)
             // Note: seq_source and fee_source may be the same account
             if seq_source_key == new_fee_source_key {
                 // Same account - already have the entry
                 seq_state.total_fees = seq_state.total_fees.saturating_add(fee_to_add);
+                // Update fee type count for the new tx (only if not a same-source replacement)
+                if replaced_tx.as_ref().map_or(true, |old| {
+                    fee_source_key(&old.envelope) != new_fee_source_key
+                }) {
+                    if queued_is_soroban {
+                        seq_state.soroban_fee_tx_count += 1;
+                    } else {
+                        seq_state.classic_fee_tx_count += 1;
+                    }
+                }
             } else {
                 // Different accounts - update fee-source separately
                 let fee_state = account_states.entry(new_fee_source_key).or_default();
                 fee_state.total_fees = fee_state.total_fees.saturating_add(fee_to_add);
+                // Update fee type count for the new tx (only if not a same-source replacement)
+                if replaced_tx.as_ref().map_or(true, |old| {
+                    fee_source_key(&old.envelope) != fee_source_key(&queued.envelope)
+                }) {
+                    if queued_is_soroban {
+                        fee_state.soroban_fee_tx_count += 1;
+                    } else {
+                        fee_state.classic_fee_tx_count += 1;
+                    }
+                }
             }
         }
 
@@ -2462,6 +2544,7 @@ impl TransactionQueue {
     ) {
         let seq_source = account_key(&queued.envelope);
         let fee_source = fee_source_key(&queued.envelope);
+        let is_soroban = henyey_tx::envelope_utils::is_soroban_envelope(&queued.envelope);
 
         // Clear the pending transaction on the seq-source account.
         if let Some(state) = account_states.get_mut(&seq_source) {
@@ -2471,9 +2554,14 @@ impl TransactionQueue {
             }
         }
 
-        // Release fees on the fee-source account.
+        // Release fees and decrement fee type count on the fee-source account.
         if let Some(fee_state) = account_states.get_mut(&fee_source) {
             fee_state.total_fees = fee_state.total_fees.saturating_sub(queued.total_fee as i64);
+            if is_soroban {
+                fee_state.soroban_fee_tx_count = fee_state.soroban_fee_tx_count.saturating_sub(1);
+            } else {
+                fee_state.classic_fee_tx_count = fee_state.classic_fee_tx_count.saturating_sub(1);
+            }
         }
 
         // Remove empty account state entries.
@@ -2699,7 +2787,7 @@ impl TransactionQueue {
         let ledger_version = self.validation_context.read().protocol_version;
 
         // Collect fee releases to apply after processing all transactions
-        let mut fee_releases: Vec<(Vec<u8>, i64)> = Vec::new();
+        let mut fee_releases: Vec<(Vec<u8>, i64, bool)> = Vec::new(); // (key, fee, is_soroban)
         let mut accounts_to_cleanup: Vec<Vec<u8>> = Vec::new();
         let mut removed_hashes: Vec<Hash256> = Vec::new();
 
@@ -2730,7 +2818,9 @@ impl TransactionQueue {
                         // Collect fee release info
                         let tx_fee = queued_tx.total_fee as i64;
                         let tx_fee_source_key = self::fee_source_key(&queued_tx.envelope);
-                        fee_releases.push((tx_fee_source_key, tx_fee));
+                        let tx_is_soroban =
+                            henyey_tx::envelope_utils::is_soroban_envelope(&queued_tx.envelope);
+                        fee_releases.push((tx_fee_source_key, tx_fee, tx_is_soroban));
 
                         state.transaction = None;
                         state.age = 0;
@@ -2752,9 +2842,16 @@ impl TransactionQueue {
         }
 
         // Apply fee releases
-        for (fee_source_key, tx_fee) in fee_releases {
+        for (fee_source_key, tx_fee, is_soroban) in fee_releases {
             if let Some(fee_state) = account_states.get_mut(&fee_source_key) {
                 fee_state.total_fees = fee_state.total_fees.saturating_sub(tx_fee);
+                if is_soroban {
+                    fee_state.soroban_fee_tx_count =
+                        fee_state.soroban_fee_tx_count.saturating_sub(1);
+                } else {
+                    fee_state.classic_fee_tx_count =
+                        fee_state.classic_fee_tx_count.saturating_sub(1);
+                }
             }
         }
 
@@ -2810,7 +2907,7 @@ impl TransactionQueue {
         let mut evicted_due_to_age = 0;
         let mut accounts_to_remove = Vec::new();
         // Collect fee releases to apply after iteration (to avoid borrow conflicts)
-        let mut fee_releases: Vec<(Vec<u8>, u64)> = Vec::new();
+        let mut fee_releases: Vec<(Vec<u8>, u64, bool)> = Vec::new(); // (key, fee, is_soroban)
         let mut evicted_hashes: Vec<Hash256> = Vec::new();
 
         // Process account states: increment age, auto-ban stale transactions
@@ -2831,7 +2928,9 @@ impl TransactionQueue {
 
                     // Track fee release for the fee-source account
                     let tx_fee_source_key = fee_source_key(&queued_tx.envelope);
-                    fee_releases.push((tx_fee_source_key, queued_tx.total_fee));
+                    let tx_is_soroban =
+                        henyey_tx::envelope_utils::is_soroban_envelope(&queued_tx.envelope);
+                    fee_releases.push((tx_fee_source_key, queued_tx.total_fee, tx_is_soroban));
 
                     evicted_due_to_age += 1;
 
@@ -2848,9 +2947,16 @@ impl TransactionQueue {
         }
 
         // Apply fee releases
-        for (fee_source_key, tx_fee) in fee_releases {
+        for (fee_source_key, tx_fee, is_soroban) in fee_releases {
             if let Some(fee_state) = account_states.get_mut(&fee_source_key) {
                 fee_state.total_fees = fee_state.total_fees.saturating_sub(tx_fee as i64);
+                if is_soroban {
+                    fee_state.soroban_fee_tx_count =
+                        fee_state.soroban_fee_tx_count.saturating_sub(1);
+                } else {
+                    fee_state.classic_fee_tx_count =
+                        fee_state.classic_fee_tx_count.saturating_sub(1);
+                }
                 // Mark for removal if now empty
                 if fee_state.is_empty() && !accounts_to_remove.contains(&fee_source_key) {
                     accounts_to_remove.push(fee_source_key);
@@ -8166,6 +8272,98 @@ mod tests {
 
         // Original classic tx must remain queued.
         assert!(queue.contains(&classic_hash));
+        assert_eq!(queue.len(), 1);
+    }
+
+    /// Fee-source-only cross-type guard: an account that only *fee-pays*
+    /// an opposite-type tx must also trigger TryAgainLater.
+    ///
+    /// Parity: stellar-core's `sourceAccountPending` checks the opposite
+    /// queue's `mAccountStates`, which includes fee-source-only entries.
+    /// Before this fix, henyey's check only fired when `state.transaction`
+    /// was set, missing the fee-source-only case.
+    #[test]
+    fn test_cross_type_fee_source_only_classic_returns_try_again_later() {
+        let queue = TransactionQueue::with_defaults();
+
+        // Queue a Soroban tx with seq-source = account 10, fee-source = account 42.
+        // This creates an account_states entry for account 42 with
+        // transaction = None but total_fees > 0 and soroban_fee_tx_count = 1.
+        let mut soroban = make_soroban_envelope(200);
+        set_source(&mut soroban, 10);
+        if let TransactionEnvelope::Tx(env) = &mut soroban {
+            env.tx.seq_num = SequenceNumber(1);
+        }
+        let fee_bumped = make_fee_bump_envelope(
+            match soroban {
+                TransactionEnvelope::Tx(ref env) => env.clone(),
+                _ => panic!("expected Tx"),
+            },
+            42, // fee-source seed
+            500,
+        );
+        assert_eq!(queue.try_add(fee_bumped.clone()), TxQueueResult::Added);
+        let original_hash = full_hash(&fee_bumped);
+
+        // Now submit a classic tx as seq-source = account 42 (the fee-payer above).
+        // Parity: stellar-core sees account 42 in the Soroban queue (fee-source entry)
+        // and returns TryAgainLater.
+        let mut classic = make_test_envelope(200, 1);
+        set_source(&mut classic, 42);
+        if let TransactionEnvelope::Tx(env) = &mut classic {
+            env.tx.seq_num = SequenceNumber(1);
+        }
+
+        let result = queue.try_add(classic);
+        assert_eq!(
+            result,
+            TxQueueResult::TryAgainLater,
+            "fee-source-only cross-type guard must reject opposite-type submission"
+        );
+
+        // Original fee-bumped Soroban tx must remain queued.
+        assert!(queue.contains(&original_hash));
+        assert_eq!(queue.len(), 1);
+    }
+
+    /// Symmetric case: fee-source-only with classic tx queued, then Soroban submission.
+    #[test]
+    fn test_cross_type_fee_source_only_soroban_returns_try_again_later() {
+        let queue = TransactionQueue::with_defaults();
+
+        // Queue a classic tx with seq-source = account 10, fee-source = account 42.
+        let mut classic = make_test_envelope(200, 1);
+        set_source(&mut classic, 10);
+        if let TransactionEnvelope::Tx(env) = &mut classic {
+            env.tx.seq_num = SequenceNumber(1);
+        }
+        let fee_bumped = make_fee_bump_envelope(
+            match classic {
+                TransactionEnvelope::Tx(ref env) => env.clone(),
+                _ => panic!("expected Tx"),
+            },
+            42, // fee-source seed
+            500,
+        );
+        assert_eq!(queue.try_add(fee_bumped.clone()), TxQueueResult::Added);
+        let original_hash = full_hash(&fee_bumped);
+
+        // Now submit a Soroban tx as seq-source = account 42.
+        let mut soroban = make_soroban_envelope(200);
+        set_source(&mut soroban, 42);
+        if let TransactionEnvelope::Tx(env) = &mut soroban {
+            env.tx.seq_num = SequenceNumber(1);
+        }
+
+        let result = queue.try_add(soroban);
+        assert_eq!(
+            result,
+            TxQueueResult::TryAgainLater,
+            "fee-source-only cross-type guard must reject opposite-type submission"
+        );
+
+        // Original fee-bumped classic tx must remain queued.
+        assert!(queue.contains(&original_hash));
         assert_eq!(queue.len(), 1);
     }
 }

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -1537,6 +1537,33 @@ impl TransactionQueue {
         self.validation_context.write().soroban_resource_limits = Some(limits);
     }
 
+    /// Early cross-type source-account conflict check.
+    ///
+    /// Parity: stellar-core `HerderImpl::recvTransaction` (HerderImpl.cpp:627-645)
+    /// rejects a tx whose sequence-number source already has a pending tx of the
+    /// opposite type (classic vs Soroban) before ANY validation. This helper
+    /// replicates that precedence so the externally visible result is
+    /// `TryAgainLater` rather than whatever validation error would fire first.
+    ///
+    /// This is an optimistic read (no write lock); the later `check_account_limit`
+    /// under the store write-lock remains the authoritative recheck.
+    fn check_cross_type_conflict(&self, envelope: &TransactionEnvelope) -> Option<TxQueueResult> {
+        let seq_source = account_key(envelope);
+        let candidate_is_soroban = henyey_tx::envelope_utils::is_soroban_envelope(envelope);
+
+        let account_states = self.account_states.read();
+        if let Some(state) = account_states.get(&seq_source) {
+            if let Some(ref current_tx) = state.transaction {
+                let current_is_soroban =
+                    henyey_tx::envelope_utils::is_soroban_envelope(&current_tx.envelope);
+                if current_is_soroban != candidate_is_soroban {
+                    return Some(TxQueueResult::TryAgainLater);
+                }
+            }
+        }
+        None
+    }
+
     /// Validate a transaction before queueing.
     fn validate_transaction(
         &self,
@@ -2063,6 +2090,15 @@ impl TransactionQueue {
 
     /// Try to add a transaction to the queue.
     pub fn try_add(&self, envelope: TransactionEnvelope) -> TxQueueResult {
+        // Parity: stellar-core HerderImpl.cpp:627-645 checks whether the
+        // source account already has a pending tx of the opposite type
+        // (classic vs Soroban) BEFORE running any validation. Replicate that
+        // precedence here so cross-type conflicts always surface as
+        // TryAgainLater rather than whatever validation error would fire first.
+        if let Some(result) = self.check_cross_type_conflict(&envelope) {
+            return result;
+        }
+
         // Validate transaction before queueing
         if let Err(code) = self.validate_transaction(&envelope) {
             return TxQueueResult::Invalid(Some(code));

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -7985,6 +7985,153 @@ mod tests {
         assert!(!queue.contains(&old_hash));
         assert_eq!(queue.len(), 1);
     }
+
+    /// Parity regression: queue a valid Soroban tx, then submit a classic tx
+    /// from the same source with unsatisfied extra_signers. On current main
+    /// this returns Invalid(Some(TxBadAuth)) because validate_transaction runs
+    /// before the cross-type guard. After the fix, the early cross-type check
+    /// returns TryAgainLater before validation.
+    #[test]
+    fn test_cross_type_invalid_classic_returns_try_again_later() {
+        let queue = TransactionQueue::with_defaults();
+
+        // Queue a valid Soroban tx from account seed 42, seq 1.
+        let mut soroban = make_soroban_envelope(200);
+        set_source(&mut soroban, 42);
+        if let TransactionEnvelope::Tx(env) = &mut soroban {
+            env.tx.seq_num = SequenceNumber(1);
+        }
+        assert_eq!(queue.try_add(soroban.clone()), TxQueueResult::Added);
+        let soroban_hash = full_hash(&soroban);
+
+        // Build a classic tx from same source (seed 42) with an unsatisfied
+        // extra_signers precondition — this makes validate_transaction return
+        // TxBadAuth on current main (the bug).
+        let extra_signer = SignerKey::Ed25519(Uint256([99u8; 32])); // nobody signs with this key
+        let preconditions = Preconditions::V2(PreconditionsV2 {
+            time_bounds: None,
+            ledger_bounds: None,
+            min_seq_num: None,
+            min_seq_age: Duration(0),
+            min_seq_ledger_gap: 0,
+            extra_signers: vec![extra_signer].try_into().unwrap(),
+        });
+
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([42u8; 32])),
+            fee: 200,
+            seq_num: SequenceNumber(1),
+            cond: preconditions,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::CreateAccount(CreateAccountOp {
+                    destination: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([255u8; 32]))),
+                    starting_balance: 1000000000,
+                }),
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let classic = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![DecoratedSignature {
+                hint: SignatureHint([0u8; 4]),
+                signature: XdrSignature(vec![0u8; 64].try_into().unwrap()),
+            }]
+            .try_into()
+            .unwrap(),
+        });
+
+        // Parity: stellar-core returns TryAgainLater here because the
+        // cross-queue source-account check fires before validation.
+        let result = queue.try_add(classic);
+        assert_eq!(
+            result,
+            TxQueueResult::TryAgainLater,
+            "cross-type guard must precede validate_transaction"
+        );
+
+        // Original Soroban tx must remain queued.
+        assert!(queue.contains(&soroban_hash));
+        assert_eq!(queue.len(), 1);
+    }
+
+    /// Symmetric case: queue a valid classic tx, then submit a Soroban tx
+    /// from the same source with unsatisfied extra_signers.
+    #[test]
+    fn test_cross_type_invalid_soroban_returns_try_again_later() {
+        let queue = TransactionQueue::with_defaults();
+
+        // Queue a valid classic tx from account seed 42, seq 1.
+        let mut classic = make_test_envelope(200, 1);
+        set_source(&mut classic, 42);
+        if let TransactionEnvelope::Tx(env) = &mut classic {
+            env.tx.seq_num = SequenceNumber(1);
+        }
+        assert_eq!(queue.try_add(classic.clone()), TxQueueResult::Added);
+        let classic_hash = full_hash(&classic);
+
+        // Build a Soroban tx from same source (seed 42) with an unsatisfied
+        // extra_signers precondition.
+        let extra_signer = SignerKey::Ed25519(Uint256([99u8; 32]));
+        let preconditions = Preconditions::V2(PreconditionsV2 {
+            time_bounds: None,
+            ledger_bounds: None,
+            min_seq_num: None,
+            min_seq_age: Duration(0),
+            min_seq_ledger_gap: 0,
+            extra_signers: vec![extra_signer].try_into().unwrap(),
+        });
+
+        let function_name = ScSymbol(StringM::<32>::try_from("test".to_string()).expect("symbol"));
+        let host_function = HostFunction::InvokeContract(InvokeContractArgs {
+            contract_address: ScAddress::default(),
+            function_name,
+            args: VecM::<ScVal>::default(),
+        });
+        let op = Operation {
+            source_account: None,
+            body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+                host_function,
+                auth: VecM::default(),
+            }),
+        };
+
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([42u8; 32])),
+            fee: 200,
+            seq_num: SequenceNumber(1),
+            cond: preconditions,
+            memo: Memo::None,
+            operations: vec![op].try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let soroban = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![DecoratedSignature {
+                hint: SignatureHint([0u8; 4]),
+                signature: XdrSignature(vec![0u8; 64].try_into().unwrap()),
+            }]
+            .try_into()
+            .unwrap(),
+        });
+
+        // Parity: stellar-core returns TryAgainLater here.
+        let result = queue.try_add(soroban);
+        assert_eq!(
+            result,
+            TxQueueResult::TryAgainLater,
+            "cross-type guard must precede validate_transaction"
+        );
+
+        // Original classic tx must remain queued.
+        assert!(queue.contains(&classic_hash));
+        assert_eq!(queue.len(), 1);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #2871

## Summary

Adds an early `check_cross_type_conflict()` guard at the top of `TransactionQueue::try_add`, before `validate_transaction`. This ensures opposite-type source-account conflicts return `TryAgainLater` before any validation error can fire, matching stellar-core's precedence in `HerderImpl::recvTransaction` (HerderImpl.cpp:627-645). The existing `check_account_limit` recheck under the store write-lock remains the authoritative guard against TOCTOU races.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2871#issuecomment-4513101870)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-herder -- -D warnings
- [x] cargo test -p henyey-herder (1134 tests pass)

## Regression test (kind: bug-fix)

- **Tests:** `tx_queue::tests::test_cross_type_invalid_classic_returns_try_again_later`, `tx_queue::tests::test_cross_type_invalid_soroban_returns_try_again_later`
- **Pre-fix:** committed as `8c953062` — verified FAILED with: `assertion left == right failed: cross-type guard must precede validate_transaction; left: Invalid(Some(TxBadAuth)), right: TryAgainLater`
- **Post-fix:** verified PASSES after `b47f401d`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
