### PR TITLE
Refresh OVERLAY and LEDGER spec-adherence reports

### DIFF
--- a/crates/ledger/SPEC_ADHERENCE.md
+++ b/crates/ledger/SPEC_ADHERENCE.md
@@ -2,10 +2,10 @@
 
 **Spec version:** 26 (stellar-core v26.0.1 / Protocol 26)
 **Crate:** crates/ledger (with cross-references to crates/app)
-**Last updated:** 2026-05-13
-**Overall adherence:** 79%
+**Last updated:** 2026-05-21
+**Overall adherence:** 82%
 
-**Counts:** Full 56 | Partial 9 | Absent 6 | Drift 3 | N/A 11
+**Counts:** Full 58 | Partial 8 | Absent 5 | Drift 3 | N/A 11
 
 > **Architectural note.** `crates/ledger` deliberately replaces stellar-core's
 > nested `LedgerTxn` chain with a flat `CloseLedgerState` wrapper composed of
@@ -28,7 +28,7 @@
 | §4.2 step 10 | `txSet.getContentsHash() == ledgerData.value.txSetHash` | Full | app/ledger_close.rs:1962 |
 | §4.2 step 12 | `prepareForApply` | Partial | app/ledger_close.rs:1982 (called pre-close, not inside `begin_close`) |
 | §4.3 | LedgerCloseMeta construction | Full | manager.rs:5832 `build_ledger_close_meta` |
-| §4.4 | Fee phase (`processFeesSeqNums`) | Partial | manager.rs:4044 `pre_deduct_all_fees_on_delta` (no `MAX_SEQ_NUM_TO_APPLY` markers) |
+| §4.4 | Fee phase (`processFeesSeqNums`) | Full | manager.rs:4044 `pre_deduct_all_fees_on_delta`; `MAX_SEQ_NUM_TO_APPLY` markers installed via `execution/tx_set.rs:165,347-371` `compute_max_seq_num_to_apply` |
 | §4.5 | Apply phase (sequential / parallel split) | Full | manager.rs:4044-4177 |
 | §4.6 | `txSetResultHash = sha256(txResultSet)` | Full | manager.rs:4768 |
 | §4.7 | `APPLYING → COMMITTING` transition | N/A | No `ApplyState` phase machine in Rust |
@@ -38,7 +38,7 @@
 | §4.11 | 8-step subtle sequence | Partial | Most steps inlined; LCL update before meta (Drift) |
 | §5 | Apply state phase machine | N/A | No `SETTING_UP_STATE / READY_TO_APPLY / APPLYING / COMMITTING` states |
 | §6.1 | Apply order, per-source seq-num ordering | Full | close.rs:603 `sorted_for_apply_sequential` |
-| §6.2 step 4 (P19+) | `accToMaxSeq` + `mergeSeen` | Absent | No `MAX_SEQ_NUM_TO_APPLY` plumbing in ledger crate |
+| §6.2 step 4 (P19+) | `accToMaxSeq` + `mergeSeen` | Full | `execution/tx_set.rs:347-371` `compute_max_seq_num_to_apply` scans txs for AccountMerge, builds per-source max-seq map, installs via `set_max_seq_num_to_apply`; regression-tested by `test_audit_577_max_seq_num_to_apply_with_pre_charged` |
 | §6.4 step 3 | `subSeed = SHA-256(base \|\| index)` | Full | execution/signatures.rs:615 `sub_sha256` |
 | §6.5 | Parallel Soroban phase (stages/clusters) | Full | execution/tx_set.rs:644 `execute_soroban_parallel_phase` |
 | §6.6 | `processPostTxSetApply` (Soroban refunds) | Full | execution/tx_set.rs:242,902 |
@@ -102,7 +102,7 @@
 - **§4.2 step 10 txset contents-hash.** Full. app/ledger_close.rs:1962 — done at app layer; ledger crate trusts `close_data.tx_set_hash()`.
 - **§4.2 step 11 `scpValue` assignment.** Full. manager.rs:4669 — `tx_set_hash` and `close_time` written into `header.scp_value` via `NextHeaderFields`.
 - **§4.2 step 12 `prepareForApply`.** Partial. app/ledger_close.rs:1982 validates pre-close but the ledger crate itself does not re-call it inside `begin_close`. Acceptable defense-in-depth boundary.
-- **§4.4 step 14-15 (fee phase + per-source seq).** Partial. manager.rs:4057 `pre_deduct_all_fees_on_delta` charges fees in a unified pre-pass; sequence-number advancement and pre-conditions are performed inside `TransactionExecutor::execute_transaction_with_fee_mode`. The `MAX_SEQ_NUM_TO_APPLY` marker (§4.4 step 15 / §6.2 step 7) is **Absent**.
+- **§4.4 step 14-15 (fee phase + per-source seq).** Full. manager.rs:4057 `pre_deduct_all_fees_on_delta` charges fees in a unified pre-pass; sequence-number advancement and pre-conditions are performed inside `TransactionExecutor::execute_transaction_with_fee_mode`. The `MAX_SEQ_NUM_TO_APPLY` marker (§4.4 step 15 / §6.2 step 7) is implemented at `execution/tx_set.rs:165,347-371` via `compute_max_seq_num_to_apply`.
 - **§4.6 result-set hash.** Full. manager.rs:4768 — streamed sha256 of all `TransactionResult` entries.
 - **§4.8 upgrades.** Full. close.rs:1358 `apply_to_header` handles `Version/BaseFee/MaxTxSetSize/BaseReserve/Flags`; manager.rs:4395 wraps each in capture/skip-on-error (parity with stellar-core's per-upgrade try/catch). `MaxSorobanTxSetSize` applied via close.rs:1412.
 - **§4.9 seal + persist.** Partial. manager.rs:4757 `commit`:
@@ -121,8 +121,8 @@
 - **§6.1 apply order.** Full. close.rs:603 `sorted_for_apply_sequential` xors `txSetHash` into account ordering; per-source seq strictly preserved.
 - **§6.2 fee phase.**
   - Step 1-3 (per-tx fee charge, seq advance, result capture): Full — fee deducted via `LedgerDelta::deduct_fee_from_account` (delta.rs:435) and `execution::pre_deduct_all_fees_on_delta`.
-  - Step 4 `accToMaxSeq` / `mergeSeen`: **Absent**. Two searches: grep `MAX_SEQ_NUM_TO_APPLY` and grep `mergeSeen` return no hits in crates/ledger; account-merge sequence-number safety is delegated to per-tx pre-condition check.
-  - Step 7 `MAX_SEQ_NUM_TO_APPLY` synthesis: **Absent** (same searches).
+  - Step 4 `accToMaxSeq` / `mergeSeen`: **Full**. `execution/tx_set.rs:347-371` `compute_max_seq_num_to_apply` scans all transactions for `AccountMerge` operations, builds a per-source max-sequence map, and installs it on the executor via `set_max_seq_num_to_apply`. Called at `tx_set.rs:165` during sequential-phase setup. Regression-tested by `test_audit_577_max_seq_num_to_apply_with_pre_charged`.
+  - Step 7 `MAX_SEQ_NUM_TO_APPLY` synthesis: **Full** (same function at tx_set.rs:347-371).
 - **§6.3 phase selection.** Full. manager.rs:4044 dispatches to `execute_soroban_parallel_phase` when V1 Soroban phase present.
 - **§6.4 sequential phase.** Full. `applySequentialPhase` steps 1-7 are inlined in `execution::run_transactions_on_executor` (execution/tx_set.rs:122) with `prepend_fee_event` for classic events (manager.rs:4218).
 - **§6.5 parallel Soroban phase.**
@@ -252,19 +252,17 @@ These `// LEDGER_SPEC §X` comments cite section numbers that have moved or are 
 ## Absent — Correctness-Relevant Gaps
 
 1. **INV-L4 `ConservationOfLumens`.** Not enforced at runtime. The downstream invariant crate has a stub (crates/invariant/PARITY_STATUS.md:25). Without it, an arithmetic bug in fee/refund/inflation paths could silently mint or burn XLM.
-2. **§6.2 step 4/7 `MAX_SEQ_NUM_TO_APPLY` + `mergeSeen`.** No plumbing for the Protocol-19+ marker that lets a later tx still observe its declared sequence number after an earlier tx merges the source. Validated by two searches: `grep MAX_SEQ_NUM_TO_APPLY` and `grep mergeSeen` over `crates/ledger/src/`. The actual cross-tx visibility may still be correct (a merged account can't re-appear in the same ledger absent restoration), but the explicit guard is missing.
-3. **§4.1 step 2 `finishPendingCompilation`.** No drain of pending Wasm compilations at close entry. Rust's `rebuild_module_cache` runs synchronously at upgrade boundaries (manager.rs:5694), so the failure mode (close starts while a compile thread is mid-flight) doesn't exist in the current single-threaded compile design — but if multi-threaded compile is added later this gap matters.
-4. **§6.5 `checkAllTxBundleInvariants`.** Parallel-cluster post-apply invariant hook absent (search: `grep checkAllTxBundleInvariants` and `grep tx_bundle_invariant` both empty). The single-tx invariant manager (execution/mod.rs:802) only fires per-op in classic path.
-5. **§14.2 root `AccountEntry` synthesis.** `initialize` does not create the network-id-derived root account; this must be done by the caller (typically by feeding genesis buckets). Replay/test flows that bypass the catchup-from-buckets path will not get a root account.
-6. **§12.2 P23 `Protocol23CorruptionDataVerifier`.** Optional in spec; not implemented. Acceptable for parity but flagged for completeness.
+2. **§4.1 step 2 `finishPendingCompilation`.** No drain of pending Wasm compilations at close entry. Rust's `rebuild_module_cache` runs synchronously at upgrade boundaries (manager.rs:5694), so the failure mode (close starts while a compile thread is mid-flight) doesn't exist in the current single-threaded compile design — but if multi-threaded compile is added later this gap matters.
+3. **§6.5 `checkAllTxBundleInvariants`.** Parallel-cluster post-apply invariant hook absent (search: `grep checkAllTxBundleInvariants` and `grep tx_bundle_invariant` both empty). The single-tx invariant manager (execution/mod.rs:802) only fires per-op in classic path.
+4. **§14.2 root `AccountEntry` synthesis.** `initialize` does not create the network-id-derived root account; this must be done by the caller (typically by feeding genesis buckets). Replay/test flows that bypass the catchup-from-buckets path will not get a root account.
+5. **§12.2 P23 `Protocol23CorruptionDataVerifier`.** Optional in spec; not implemented. Acceptable for parity but flagged for completeness.
 
 ---
 
 ## Recommendations
 
 1. **High priority — INV-L4.** Implement `ConservationOfLumens` runtime check; protocol-deterministic safety property.
-2. **High priority — §6.2 step 4/7.** Add explicit `MAX_SEQ_NUM_TO_APPLY` tracking (or confirm equivalence via a documented invariant that henyey's seq-bump-at-execute-time covers the same case).
-3. **Medium — §13.1 Drift.** Gate meta version on `initialLedgerVers` even if `MIN_LEDGER_PROTOCOL_VERSION=24`; cheap defense-in-depth.
-4. **Medium — §4.11 step ordering.** Re-order `commit_close` to occur AFTER `build_ledger_close_meta` to match the spec sequence and INV-L13 expectations.
-5. **Low — dangling anchors.** A mechanical pass renumbering 13 `// Spec: LEDGER_SPEC §...` comments to the regenerated v26.0.1 section numbers (table above).
-6. **Low — §14.2 `startNewLedger`.** Provide a `start_new_ledger(network_id) -> Result<()>` helper that synthesizes the genesis bucket lists with the network-id-derived root account.
+2. **Medium — §13.1 Drift.** Gate meta version on `initialLedgerVers` even if `MIN_LEDGER_PROTOCOL_VERSION=24`; cheap defense-in-depth.
+3. **Medium — §4.11 step ordering.** Re-order `commit_close` to occur AFTER `build_ledger_close_meta` to match the spec sequence and INV-L13 expectations.
+4. **Low — dangling anchors.** A mechanical pass renumbering 13 `// Spec: LEDGER_SPEC §...` comments to the regenerated v26.0.1 section numbers (table above).
+5. **Low — §14.2 `startNewLedger`.** Provide a `start_new_ledger(network_id) -> Result<()>` helper that synthesizes the genesis bucket lists with the network-id-derived root account.

--- a/crates/overlay/SPEC_ADHERENCE.md
+++ b/crates/overlay/SPEC_ADHERENCE.md
@@ -79,7 +79,7 @@ Counts (excluding Drift and N/A from denominator):
 | §11.2 | Start/Stop Collecting signed-message receipt | Full | App-owned: `crates/app/src/app/survey_impl.rs:941-956` `verify_survey_signature` verifies Ed25519 signature on incoming start/stop messages via `henyey_crypto::verify_from_raw_key`; `survey.rs:426-522` manages local phase transitions |
 | §11.3 | `SurveyRequest`/`SurveyResponse` flow | Full | App-owned: `crates/app/src/app/survey_impl.rs:488-790` handles all four survey message types (`handle_survey_request`, `handle_survey_response`, `handle_survey_start_collecting`, `handle_survey_stop_collecting`); dispatched from `lifecycle.rs:1669-1688`; includes signature verification (941-956) and rate-limiter integration |
 | §11.3 | Curve25519 sealed-box encryption/decryption | Full | App-owned: `crates/app/src/app/survey_impl.rs:674-680` (`seal_to_curve25519_public_key`) and `786-793` (`open_from_curve25519_secret_key`) via `henyey_crypto` |
-| §11.5 | `surveyorPermitted` (allowlist or tracked quorum) | Partial | `survey.rs:415-421` supports allowlist; tracked-quorum fallback not implemented |
+| §11.5 | `surveyorPermitted` (allowlist or tracked quorum) | Partial | App-owned: `crates/app/src/app/survey_impl.rs:964-983` — allowlist gate via `config.overlay.surveyor_keys` with fallback to `Herder::local_quorum_nodes()` (static local quorum-set membership). Divergence: stellar-core uses `Herder::getCurrentlyTrackedQuorum()` (`SurveyManager.cpp:834-845`) which reflects the dynamically tracked quorum, not the static local config. Called at lines 501, 565, 622 before processing survey start/stop/request. |
 | §11.6 | TimeSlicedNodeData / PeerData counters | Full | `survey.rs:74-212,491-521` |
 | §12.1 | ERROR_MSG: zero seq+MAC pre-key, normal HMAC post-key | Partial | Receive-side parity: `auth.rs:672-675` skips MAC verification for incoming ERROR_MSG. Outbound divergence: post-auth ERROR_MSG sent via `peer.send()` → `auth.wrap_message()` applies normal MAC/seq, unlike stellar-core `Hmac.cpp:72-79` which exempts outbound ERROR_MSG. |
 | §12.1 | ERROR_MSG drops connection | Full | `manager/peer_loop.rs:1046-1064` |
@@ -113,7 +113,7 @@ Counts (excluding Drift and N/A from denominator):
 | INV-O10 (SEND_MORE_EXTENDED validation) | Full | `flow_control.rs:979-1010` (numBytes!=0 + overflow guards) |
 | INV-O11 (Recv-side batch grants) | Partial | `flow_control.rs:1038-1065` emits SEND_MORE_EXTENDED on batch threshold, but the spec's `releaseAssert(mFloodDataProcessed <= BATCH_SIZE)` upper bound is not asserted |
 | INV-O12 (One PEERS per connection) | Full | `manager/peer_loop.rs:512-531,712-717` |
-| INV-O13 (Outbound role rejects PEERS) | Full | `manager/peer_loop.rs:522-524` rejects PEERS in **Inbound** role; spec says "an inbound role peer MUST NOT receive `PEERS`" — Rust enforces the same. Re-read confirms code matches. |
+| INV-O13 (Inbound role rejects PEERS) | Full | `manager/peer_loop.rs:522-524` rejects PEERS from **Inbound** direction peers (`REMOTE_CALLED_US`); spec says "an inbound role peer MUST NOT receive `PEERS`" — Rust enforces the same. |
 | INV-O14 (No flood while not synced) | Full | `manager/peer_loop.rs:693-697` |
 | INV-O15 (Survey signature verification) | Full | App-owned: `crates/app/src/app/survey_impl.rs:941-956` `verify_survey_signature` uses `henyey_crypto::verify_from_raw_key` on Ed25519 key extracted from `NodeId`; called before processing survey start/stop/request/response |
 | INV-O16 (Survey rate limit) | Full | `survey.rs:268-356` (`SurveyMessageLimiter`) |
@@ -121,7 +121,7 @@ Counts (excluding Drift and N/A from denominator):
 | INV-O18 (Banned peer rejection) | Full | `peer.rs:390-400`, `manager/connection.rs:378-381,685-687` |
 | INV-O19 (Drop idempotence) | Partial | State-machine guard (`peer.rs:932-939`) provides single-threaded idempotence; no atomic `mDropStarted` flag means truly-concurrent drops from different tasks would need to rely on the outbound channel's shutdown signal — works in practice but not as explicitly designed in stellar-core |
 
-Re-evaluation: INV-O13 — code is correct. Spec says "An inbound role peer (`REMOTE_CALLED_US`) MUST NOT receive `PEERS`"; the Rust code `if direction == ConnectionDirection::Inbound { return RejectWrongDirection }` matches that exactly. Reclassified to **Full** in the summary count.
+Re-evaluation: INV-O13 — code is correct. Spec says "An inbound role peer (`REMOTE_CALLED_US`) MUST NOT receive `PEERS`"; the Rust code `if direction == ConnectionDirection::Inbound { return RejectWrongDirection }` matches that exactly. The invariant name is corrected to "Inbound role rejects PEERS" to align with the spec language. Reclassified to **Full** in the summary count.
 
 Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
 

--- a/crates/overlay/SPEC_ADHERENCE.md
+++ b/crates/overlay/SPEC_ADHERENCE.md
@@ -3,10 +3,10 @@
 **Spec version:** 26 (Overlay Protocol v38–v39)
 **Crate:** crates/overlay
 **Last updated:** 2026-05-21
-**Overall adherence:** 82%
+**Overall adherence:** 81%
 
 Counts (excluding Drift and N/A from denominator):
-**Full 81 | Partial 15 | Absent 3 | Drift 2 | N/A 2**
+**Full 80 | Partial 16 | Absent 3 | Drift 2 | N/A 2**
 
 ## Summary table
 
@@ -57,7 +57,7 @@ Counts (excluding Drift and N/A from denominator):
 | §9.3 | `DONT_HAVE` reply for miss | Partial | Handled inbound (`message_handlers.rs:314-340`); outbound (sending DONT_HAVE for unknown items) lives in app callbacks |
 | §9.4 | PEERS broadcasting (≤50 entries, randomized) | Partial | `manager/mod.rs:1373-1415` builds message; MAX_PEERS_PER_MESSAGE cap applied; pool combines outbound+inbound but selection not strictly the spec's "sample 50 from outbound pool first" algorithm |
 | §9.4 | PEERS receipt: `ensureExists` per entry | Full | App-owned: `crates/app/src/app/peers.rs:293-338` `process_peer_list()` converts, filters, persists entries and adds to overlay; dispatched from `lifecycle.rs:1689` |
-| §9.4 | PEERS receipt: skip port==0, IPv6, private, self, localhost | Full | App-owned: `crates/app/src/app/peers.rs:293-338` filters invalid/duplicate/disallowed peers before persisting |
+| §9.4 | PEERS receipt: skip port==0, IPv6, private, self, localhost | Partial | App-owned: `crates/app/src/app/peers.rs:293-338` filters port==0, IPv6, private, localhost via `is_public_peer`; **missing explicit self-address filter** (stellar-core checks `Peer.cpp:2024-2030`) |
 | §9.4 | PEERS one-per-connection + role check (INV-O12, INV-O13) | Full | `manager/peer_loop.rs:505-531,700-718` |
 | §10.1 | Peer DB schema (ip, port, nextattempt, numfailures, type) | Full | `peer_manager.rs:14-25,222-238` |
 | §10.1 | Type lattice (PREFERRED upgrade, INBOUND no promote) | Full | `peer_manager.rs:577-615` |
@@ -81,7 +81,7 @@ Counts (excluding Drift and N/A from denominator):
 | §11.3 | Curve25519 sealed-box encryption/decryption | Full | App-owned: `crates/app/src/app/survey_impl.rs:674-680` (`seal_to_curve25519_public_key`) and `786-793` (`open_from_curve25519_secret_key`) via `henyey_crypto` |
 | §11.5 | `surveyorPermitted` (allowlist or tracked quorum) | Partial | `survey.rs:415-421` supports allowlist; tracked-quorum fallback not implemented |
 | §11.6 | TimeSlicedNodeData / PeerData counters | Full | `survey.rs:74-212,491-521` |
-| §12.1 | ERROR_MSG: zero seq+MAC pre-key, normal HMAC post-key | Full | `auth.rs:672-675,737-744` (Error skips MAC unconditionally — see Drift) |
+| §12.1 | ERROR_MSG: zero seq+MAC pre-key, normal HMAC post-key | Full | `auth.rs:672-675,737-744` (Error skips MAC unconditionally — matches spec §12.1 exemption) |
 | §12.1 | ERROR_MSG drops connection | Full | `manager/peer_loop.rs:1046-1064` |
 | §12.2 | ERR_MISC/ERR_DATA/ERR_CONF/ERR_AUTH/ERR_LOAD usage | Full | `peer.rs:557-576`, `manager/connection.rs:224`, `manager/peer_loop.rs:1079-1082` |
 | §12.3 | Drop-once idempotence (INV-O19) | Partial | No `mDropStarted`-style atomic flag in `peer.rs::close`; instead state machine + tokio drop semantics. Idempotence relies on `state != PeerState::Disconnected` guard (`peer.rs:932-939`), which is single-threaded per peer. |
@@ -142,9 +142,9 @@ Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
 - **Rust**: `Peer::handshake` blocks on `recv_hello` then `recv_auth`; any unexpected message returns `InvalidMessage`. Post-handshake, `is_handshake_message` checks block stray HELLO/AUTH (`peer_loop.rs:721-727`).
 - **Notes**: Implicit handling; no separate scheduler queue. Behavior matches in practice.
 
-### §9.4 — PEERS receipt (Full — app-owned)
+### §9.4 — PEERS receipt (Partial — app-owned)
 - **Claim**: For each entry in a received PEERS message: skip if port==0/IPv6/private/self/localhost; otherwise call `PeerManager::ensureExists`.
-- **Status**: **Full (app-owned)**. The stale 2026-05-13 audit incorrectly marked this Absent because it searched only `crates/overlay/`. The receive path is wired through `crates/app/src/app/lifecycle.rs:1689` which dispatches `StellarMessage::Peers` to `process_peer_list()` in `crates/app/src/app/peers.rs:293-338`. That function converts XDR peer addresses, filters invalid/duplicate/disallowed peers, persists them via `PeerManager::ensure_exists`, and refreshes known peers in the overlay.
+- **Status**: **Partial (app-owned)**. The stale 2026-05-13 audit incorrectly marked this Absent because it searched only `crates/overlay/`. The receive path is wired through `crates/app/src/app/lifecycle.rs:1689` which dispatches `StellarMessage::Peers` to `process_peer_list()` in `crates/app/src/app/peers.rs:293-338`. That function converts XDR peer addresses, filters port==0/IPv6/private/localhost via `filter_discovered_peers` + `is_public_peer` (lines 463-514), then persists via direct DB writes (`persist_peers` at lines 441-454) and calls `overlay.add_peers()`. **Gap**: no explicit self-address filter matching stellar-core's check at `Peer.cpp:2024-2030`.
 
 ### §11.3 — Survey request/response flow (Full — app-owned)
 - **Claim**: On `TIME_SLICED_SURVEY_REQUEST` receipt, validate via `SurveyMessageLimiter::addAndValidateRequest`, verify signature, fill `TopologyResponseBodyV2`, sealed-box encrypt with `encryptionKey`, sign response, broadcast.
@@ -166,12 +166,10 @@ Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
 - **Rust**: XDR decode errors surface as `OverlayError::Message`, propagated to the peer loop which logs and drops the peer (`peer_loop.rs:1334-1366`). The error message is *not* specifically `ERR_DATA` — the connection simply terminates without sending an outbound `ERROR_MSG`.
 - **Notes**: Drop happens; ERR_DATA is not transmitted. Lower-priority drift since the peer will see the TCP close.
 
-### §12.1 — ERROR_MSG MAC handling (Drift)
+### §12.1 — ERROR_MSG MAC handling (Full)
 - **Claim**: ERROR_MSG sent with zero seq+MAC pre-key, normal HMAC post-key.
 - **Rust**: `auth.rs:672-675` *always* skips MAC verification for incoming ERROR_MSG, regardless of whether keys are established.
 - **Notes**: Spec text actually says the receiver doesn't verify the MAC on ERROR_MSG (§12.1 lines 1304-1306) — so this is **NOT** drift. **Reclassify: Full.** The send path doesn't emit a real MAC even when keys are set (`peer.rs:557-576` uses `send_raw`), which matches the spec exemption.
-
-(Corrected tally: same as initial: Full 38 | Partial 11 | Absent 5.)
 
 ### §10.4 — Tick promote-inbound (Absent)
 - **Claim**: Step 8: "Promote inbound peers (open a parallel outbound connection to their address) to fill any leftover pending slots."

--- a/crates/overlay/SPEC_ADHERENCE.md
+++ b/crates/overlay/SPEC_ADHERENCE.md
@@ -3,10 +3,10 @@
 **Spec version:** 26 (Overlay Protocol v38–v39)
 **Crate:** crates/overlay
 **Last updated:** 2026-05-21
-**Overall adherence:** 81%
+**Overall adherence:** 80%
 
 Counts (excluding Drift and N/A from denominator):
-**Full 80 | Partial 16 | Absent 3 | Drift 2 | N/A 2**
+**Full 79 | Partial 17 | Absent 3 | Drift 2 | N/A 2**
 
 ## Summary table
 
@@ -81,7 +81,7 @@ Counts (excluding Drift and N/A from denominator):
 | §11.3 | Curve25519 sealed-box encryption/decryption | Full | App-owned: `crates/app/src/app/survey_impl.rs:674-680` (`seal_to_curve25519_public_key`) and `786-793` (`open_from_curve25519_secret_key`) via `henyey_crypto` |
 | §11.5 | `surveyorPermitted` (allowlist or tracked quorum) | Partial | `survey.rs:415-421` supports allowlist; tracked-quorum fallback not implemented |
 | §11.6 | TimeSlicedNodeData / PeerData counters | Full | `survey.rs:74-212,491-521` |
-| §12.1 | ERROR_MSG: zero seq+MAC pre-key, normal HMAC post-key | Full | `auth.rs:672-675,737-744` (Error skips MAC unconditionally — matches spec §12.1 exemption) |
+| §12.1 | ERROR_MSG: zero seq+MAC pre-key, normal HMAC post-key | Partial | Receive-side parity: `auth.rs:672-675` skips MAC verification for incoming ERROR_MSG. Outbound divergence: post-auth ERROR_MSG sent via `peer.send()` → `auth.wrap_message()` applies normal MAC/seq, unlike stellar-core `Hmac.cpp:72-79` which exempts outbound ERROR_MSG. |
 | §12.1 | ERROR_MSG drops connection | Full | `manager/peer_loop.rs:1046-1064` |
 | §12.2 | ERR_MISC/ERR_DATA/ERR_CONF/ERR_AUTH/ERR_LOAD usage | Full | `peer.rs:557-576`, `manager/connection.rs:224`, `manager/peer_loop.rs:1079-1082` |
 | §12.3 | Drop-once idempotence (INV-O19) | Partial | No `mDropStarted`-style atomic flag in `peer.rs::close`; instead state machine + tokio drop semantics. Idempotence relies on `state != PeerState::Disconnected` guard (`peer.rs:932-939`), which is single-threaded per peer. |
@@ -166,10 +166,11 @@ Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
 - **Rust**: XDR decode errors surface as `OverlayError::Message`, propagated to the peer loop which logs and drops the peer (`peer_loop.rs:1334-1366`). The error message is *not* specifically `ERR_DATA` — the connection simply terminates without sending an outbound `ERROR_MSG`.
 - **Notes**: Drop happens; ERR_DATA is not transmitted. Lower-priority drift since the peer will see the TCP close.
 
-### §12.1 — ERROR_MSG MAC handling (Full)
+### §12.1 — ERROR_MSG MAC handling (Partial)
 - **Claim**: ERROR_MSG sent with zero seq+MAC pre-key, normal HMAC post-key.
-- **Rust**: `auth.rs:672-675` *always* skips MAC verification for incoming ERROR_MSG, regardless of whether keys are established.
-- **Notes**: Spec text actually says the receiver doesn't verify the MAC on ERROR_MSG (§12.1 lines 1304-1306) — so this is **NOT** drift. **Reclassify: Full.** The send path doesn't emit a real MAC even when keys are set (`peer.rs:557-576` uses `send_raw`), which matches the spec exemption.
+- **Receive side (parity)**: `auth.rs:672-675` *always* skips MAC verification for incoming ERROR_MSG, regardless of whether keys are established. Matches stellar-core `Peer.cpp:1032-1035`.
+- **Send side (divergence)**: Post-auth ERROR_MSG goes through `send_error_and_drop` (`peer_loop.rs:306-314`) → `OutboundMessage::Send` → `peer.send()` (`peer.rs:738-751`) → `auth.wrap_message()`, which applies normal MAC/sequence. Stellar-core exempts outbound ERROR_MSG from MAC in `Hmac.cpp:72-79`. Pre-auth errors use `send_raw` (`peer.rs:573`) which is correct (no MAC before keys).
+- **Notes**: Partial because receive-side matches but outbound path diverges. The divergence is benign (peers accept MACed ERROR_MSG) but not spec-identical.
 
 ### §10.4 — Tick promote-inbound (Absent)
 - **Claim**: Step 8: "Promote inbound peers (open a parallel outbound connection to their address) to fill any leftover pending slots."

--- a/crates/overlay/SPEC_ADHERENCE.md
+++ b/crates/overlay/SPEC_ADHERENCE.md
@@ -2,11 +2,11 @@
 
 **Spec version:** 26 (Overlay Protocol v38–v39)
 **Crate:** crates/overlay
-**Last updated:** 2026-05-13
-**Overall adherence:** 71%
+**Last updated:** 2026-05-21
+**Overall adherence:** 82%
 
 Counts (excluding Drift and N/A from denominator):
-**Full 38 | Partial 11 | Absent 5 | Drift 3 | N/A 2**
+**Full 45 | Partial 9 | Absent 1 | Drift 2 | N/A 2**
 
 ## Summary table
 
@@ -56,8 +56,8 @@ Counts (excluding Drift and N/A from denominator):
 | §9.3 | `GET_TX_SET` response type-switch (TX_SET vs GENERALIZED_TX_SET) | Partial | Both message types exist in metrics; the protocol-version-aware response selection is owned by app layer, not surfaced here |
 | §9.3 | `DONT_HAVE` reply for miss | Partial | Handled inbound (`message_handlers.rs:314-340`); outbound (sending DONT_HAVE for unknown items) lives in app callbacks |
 | §9.4 | PEERS broadcasting (≤50 entries, randomized) | Partial | `manager/mod.rs:1373-1415` builds message; MAX_PEERS_PER_MESSAGE cap applied; pool combines outbound+inbound but selection not strictly the spec's "sample 50 from outbound pool first" algorithm |
-| §9.4 | PEERS receipt: `ensureExists` per entry | Absent | No production code calls `PeerManager::ensure_exists` from a received PEERS message (the `peer_manager.rs:281` function exists but receipt-side wiring is absent) |
-| §9.4 | PEERS receipt: skip port==0, IPv6, private, self, localhost | Absent | Cannot be enforced because PEERS payload isn't processed (see above) |
+| §9.4 | PEERS receipt: `ensureExists` per entry | Full | App-owned: `crates/app/src/app/peers.rs:293-338` `process_peer_list()` converts, filters, persists entries and adds to overlay; dispatched from `lifecycle.rs:1689` |
+| §9.4 | PEERS receipt: skip port==0, IPv6, private, self, localhost | Full | App-owned: `crates/app/src/app/peers.rs:293-338` filters invalid/duplicate/disallowed peers before persisting |
 | §9.4 | PEERS one-per-connection + role check (INV-O12, INV-O13) | Full | `manager/peer_loop.rs:505-531,700-718` |
 | §10.1 | Peer DB schema (ip, port, nextattempt, numfailures, type) | Full | `peer_manager.rs:14-25,222-238` |
 | §10.1 | Type lattice (PREFERRED upgrade, INBOUND no promote) | Full | `peer_manager.rs:577-615` |
@@ -67,18 +67,18 @@ Counts (excluding Drift and N/A from denominator):
 | §10.3 | `PREFERRED_PEERS_ONLY` reject | Full | `manager/connection.rs:211-216,711-715` |
 | §10.4 | Tick period 3 s (`PEER_AUTHENTICATION_TIMEOUT + 1`) | Full | `manager/tick.rs:26` |
 | §10.4 | DNS resolution every 600 s w/ linear backoff | Full | `manager/tick.rs:31-40,176-198` |
-| §10.4 | Random out-of-sync drop after 60 s | Partial | Tick supports DNS / slot fill; the `OUT_OF_SYNC_RECONNECT_DELAY` random drop is not surfaced in `tick.rs` per the local search |
+| §10.4 | Random out-of-sync drop after 60 s | Full | `manager/tick.rs:589-670` `maybe_drop_random_peer()` with `OUT_OF_SYNC_RECONNECT_DELAY = 60s`; tested via `test_maybe_drop_random_peer_drops_after_cooldown` et al. |
 | §10.4 | Promote inbound (open parallel outbound) | Absent | No promote-inbound logic found in `tick.rs` |
 | §10.5 | IPv6 silently ignored | Full | `lib.rs:530-535`, `manager/mod.rs:1398-1400` |
 | §10.5 | Private/localhost addresses ignored | Full | `lib.rs:457-483`, `manager/mod.rs:1431-1433` |
-| §10.6 | `PEERS` sample size 50 | Drift | `manager/mod.rs` uses `MAX_PEERS_PER_MESSAGE` cap; exact value not pinned to 50 in this audit — verify the constant equals 50 |
+| §10.6 | `PEERS` sample size 50 | Full | `manager/mod.rs:85` defines `MAX_PEERS_PER_MESSAGE = 50`; enforced at `mod.rs:1386` |
 | §10.7 | Ban check during HELLO | Full | `peer.rs:390-400`, `manager/connection.rs:378-381,685-687,1039-1041` (INV-O18) |
 | §10.7 | BanManager SQLite persistence | Full | `ban_manager.rs:48-126` |
 | §11.1 | Survey phase machine (Inactive/Collecting/Reporting) | Full | `survey.rs:62-575` |
 | §11.1 | COLLECTING max 30 min / REPORTING max 3 h | Full | `survey.rs:41-45,232-242,544-573` |
-| §11.2 | Start/Stop Collecting signed-message receipt | Partial | `survey.rs:426-522` provides start/stop API; no on-wire decoder verifying surveyor signature (INV-O15) before transitions |
-| §11.3 | `SurveyRequest`/`SurveyResponse` flow | Absent | No code processes incoming `TIME_SLICED_SURVEY_REQUEST` / `TIME_SLICED_SURVEY_RESPONSE` messages; metrics enumerate them but no handler exists |
-| §11.3 | Curve25519 sealed-box encryption/decryption | Absent | `curve25519Encrypt` / `curve25519Decrypt` not implemented in this crate (no `crypto_box_seal` / `sealed_box` import) |
+| §11.2 | Start/Stop Collecting signed-message receipt | Full | App-owned: `crates/app/src/app/survey_impl.rs:941-956` `verify_survey_signature` verifies Ed25519 signature on incoming start/stop messages via `henyey_crypto::verify_from_raw_key`; `survey.rs:426-522` manages local phase transitions |
+| §11.3 | `SurveyRequest`/`SurveyResponse` flow | Full | App-owned: `crates/app/src/app/survey_impl.rs:488-790` handles all four survey message types (`handle_survey_request`, `handle_survey_response`, `handle_survey_start_collecting`, `handle_survey_stop_collecting`); dispatched from `lifecycle.rs:1669-1688`; includes signature verification (941-956) and rate-limiter integration |
+| §11.3 | Curve25519 sealed-box encryption/decryption | Full | App-owned: `crates/app/src/app/survey_impl.rs:674-680` (`seal_to_curve25519_public_key`) and `786-793` (`open_from_curve25519_secret_key`) via `henyey_crypto` |
 | §11.5 | `surveyorPermitted` (allowlist or tracked quorum) | Partial | `survey.rs:415-421` supports allowlist; tracked-quorum fallback not implemented |
 | §11.6 | TimeSlicedNodeData / PeerData counters | Full | `survey.rs:74-212,491-521` |
 | §12.1 | ERROR_MSG: zero seq+MAC pre-key, normal HMAC post-key | Full | `auth.rs:672-675,737-744` (Error skips MAC unconditionally — see Drift) |
@@ -115,7 +115,7 @@ Counts (excluding Drift and N/A from denominator):
 | INV-O12 (One PEERS per connection) | Full | `manager/peer_loop.rs:512-531,712-717` |
 | INV-O13 (Outbound role rejects PEERS) | Drift | `manager/peer_loop.rs:522-524` rejects PEERS in **Inbound** role; spec says outbound role (`WE_CALLED_REMOTE`) MUST NOT receive PEERS. Verify: spec text §5.5 line 532 says "an inbound role peer MUST NOT receive `PEERS`" — Rust enforces the same. **Re-read confirms code matches.** Reclassify to Full. |
 | INV-O14 (No flood while not synced) | Full | `manager/peer_loop.rs:693-697` |
-| INV-O15 (Survey signature verification) | Absent | No Ed25519 signature verification on incoming survey messages (the start/stop/request/response handlers are missing entirely) |
+| INV-O15 (Survey signature verification) | Full | App-owned: `crates/app/src/app/survey_impl.rs:941-956` `verify_survey_signature` uses `henyey_crypto::verify_from_raw_key` on Ed25519 key extracted from `NodeId`; called before processing survey start/stop/request/response |
 | INV-O16 (Survey rate limit) | Full | `survey.rs:268-356` (`SurveyMessageLimiter`) |
 | INV-O17 (One survey at a time) | Full | `survey.rs:430-466` (`start_collecting` returns false if active) |
 | INV-O18 (Banned peer rejection) | Full | `peer.rs:390-400`, `manager/connection.rs:378-381,685-687` |
@@ -123,7 +123,7 @@ Counts (excluding Drift and N/A from denominator):
 
 Re-evaluation: INV-O13 — code is correct. Spec says "An inbound role peer (`REMOTE_CALLED_US`) MUST NOT receive `PEERS`"; the Rust code `if direction == ConnectionDirection::Inbound { return RejectWrongDirection }` matches that exactly. Reclassified to **Full** in the summary count.
 
-Corrected invariant tally: **Full 17 | Partial 2 | Absent 1**.
+Corrected invariant tally: **Full 18 | Partial 1 | Absent 0**.
 
 ## Detailed findings
 
@@ -142,19 +142,19 @@ Corrected invariant tally: **Full 17 | Partial 2 | Absent 1**.
 - **Rust**: `Peer::handshake` blocks on `recv_hello` then `recv_auth`; any unexpected message returns `InvalidMessage`. Post-handshake, `is_handshake_message` checks block stray HELLO/AUTH (`peer_loop.rs:721-727`).
 - **Notes**: Implicit handling; no separate scheduler queue. Behavior matches in practice.
 
-### §9.4 — PEERS receipt (Absent)
+### §9.4 — PEERS receipt (Full — app-owned)
 - **Claim**: For each entry in a received PEERS message: skip if port==0/IPv6/private/self/localhost; otherwise call `PeerManager::ensureExists`.
-- **Rust search**: 
-  1. Symbol search `ensure_exists` (`peer_manager.rs:281`) — function exists but only called from tests.
-  2. Free-text grep `StellarMessage::Peers(.*)` in non-test code — only `manager/peer_loop.rs:518` (presence-check) and `manager/mod.rs:2211` (in tests).
-- **Conclusion**: No production code ingests received PEERS payload into the peer database. The peer is dropped if PEERS arrives in wrong role or twice (INV-O12/O13), but the body is discarded. This bounds peer discovery to DNS + `KNOWN_PEERS`, which is functional for production but breaks the spec's gossip-based peer discovery story.
+- **Status**: **Full (app-owned)**. The stale 2026-05-13 audit incorrectly marked this Absent because it searched only `crates/overlay/`. The receive path is wired through `crates/app/src/app/lifecycle.rs:1689` which dispatches `StellarMessage::Peers` to `process_peer_list()` in `crates/app/src/app/peers.rs:293-338`. That function converts XDR peer addresses, filters invalid/duplicate/disallowed peers, persists them via `PeerManager::ensure_exists`, and refreshes known peers in the overlay.
 
-### §11.3 — Survey request/response flow (Absent)
+### §11.3 — Survey request/response flow (Full — app-owned)
 - **Claim**: On `TIME_SLICED_SURVEY_REQUEST` receipt, validate via `SurveyMessageLimiter::addAndValidateRequest`, verify signature, fill `TopologyResponseBodyV2`, sealed-box encrypt with `encryptionKey`, sign response, broadcast.
-- **Rust search**:
-  1. `grep -rn "TimeSlicedSurveyRequest\|recvSurvey\|process_survey" crates/overlay/src/` — only metric-classification mentions; no handlers.
-  2. `grep -rn "curve25519Encrypt\|crypto_box_seal\|sealedbox\|encryptionKey" crates/overlay/src/` — zero hits.
-- **Conclusion**: Survey state machine and rate-limiter exist (`survey.rs`), but the wire-level handling of survey request/response (signature verify + decrypt + encrypt) is absent from the overlay crate. PARITY_STATUS attributes this to "app/survey_impl.rs"; this audit cannot confirm the app side. **Recommendation**: even if app owns the crypto, the overlay should at minimum gate inbound survey messages on `surveyorPermitted` and the rate limiter — and that wiring is also missing.
+- **Status**: **Full (app-owned)**. The stale 2026-05-13 audit searched only `crates/overlay/src/` and missed the app-layer implementation. The full dispatch chain is:
+  1. `crates/app/src/app/lifecycle.rs:1669-1688` dispatches all four survey message types.
+  2. `crates/app/src/app/survey_impl.rs:488-790` handles `handle_survey_request`, `handle_survey_response`, `handle_survey_start_collecting`, `handle_survey_stop_collecting`.
+  3. `crates/app/src/app/survey_impl.rs:941-956` `verify_survey_signature` performs Ed25519 signature verification via `henyey_crypto::verify_from_raw_key`.
+  4. `crates/app/src/app/survey_impl.rs:674-680` encrypts response bodies via `henyey_crypto::seal_to_curve25519_public_key`.
+  5. `crates/app/src/app/survey_impl.rs:786-793` decrypts response bodies via `henyey_crypto::open_from_curve25519_secret_key`.
+  6. Rate limiting is enforced via `survey.rs:268-356` (`SurveyMessageLimiter`) in the overlay crate.
 
 ### §12.3 — Drop-to-close 5 s delay (Absent)
 - **Claim**: Drop schedules `TCPPeer::shutdown` 5 s later to drain the final `ERROR_MSG`.
@@ -177,19 +177,18 @@ Corrected invariant tally: **Full 17 | Partial 2 | Absent 1**.
 - **Claim**: Step 8: "Promote inbound peers (open a parallel outbound connection to their address) to fill any leftover pending slots."
 - **Rust**: `tick.rs:1-200` covers DNS, preferred peers, random drop; no code opens a parallel outbound to an existing inbound peer.
 
-### §10.4 — Random out-of-sync drop (Partial)
+### §10.4 — Random out-of-sync drop (Full)
 - **Claim**: Step 6: when `availableAuthSlots == 0` and out-of-sync ≥ 60 s, drop one random non-preferred outbound.
-- **Rust**: Constant referenced in spec (`OUT_OF_SYNC_RECONNECT_DELAY = 60 s`) is not surfaced in `tick.rs`. Could not locate `drop_random_peer` in the tick loop — but `manager/mod.rs` does have `disconnect()` / `ban_peer()` machinery. Likely missing the connecting glue.
+- **Status**: **Full**. The stale 2026-05-13 audit missed `maybe_drop_random_peer` at `manager/tick.rs:589-670`. The function implements the exact spec behavior: when not tracking consensus and outbound slots are full, starts a cooldown timer (`OUT_OF_SYNC_RECONNECT_DELAY = 60s` at tick.rs:572), and after cooldown drops a random non-preferred outbound peer. Called from the tick loop at tick.rs:287-291. Comprehensively tested (`test_maybe_drop_random_peer_drops_after_cooldown`, `test_maybe_drop_random_peer_skips_preferred`, `test_maybe_drop_random_peer_only_drops_outbound`, etc.).
 
-### §10.6 — PEERS sample size (Drift)
+### §10.6 — PEERS sample size (Full)
 - **Claim**: "Up to 50 entries" (XDR vector ≤ 100).
-- **Rust**: `manager/mod.rs:1373-1415` uses `MAX_PEERS_PER_MESSAGE` (value not confirmed by this audit; appears in `manager/mod.rs` but its definition site wasn't read). **Action**: verify the constant equals 50 in `manager/mod.rs`.
+- **Status**: **Full**. `manager/mod.rs:85` defines `const MAX_PEERS_PER_MESSAGE: usize = 50;` and it is enforced at `mod.rs:1386`.
 
 ## Drift items (require human review)
 
 1. **§4.2 / RFC 5531 bit 31 reinterpretation**: Both the henyey codec and stellar-core treat the high bit as a per-frame "authenticated" flag. The spec (§4.2 lines 230-244) says the high bit is RFC 5531's "last fragment" marker, set on every message. The Rust implementation matches stellar-core (`codec.rs:128-145`: `is_authenticated = !matches!(...Hello(_))`), so this is mutual deviation from the strict RFC and the spec text. **Probably the spec text should be updated** to acknowledge the auth-flag overload.
 2. **§5.4.4 / `GET_SCP_STATE(0)` vs `getMinLedgerSeqToAskPeers()`**: Rust always sends 0; spec expects a computed value. Likely a Rust gap (would benefit from app-callback for catchup state).
-3. **§10.6 / PEERS sample size**: Constant pinned to spec value (50) not verified in this audit; if it's a different number (e.g., 100), bring it to 50.
 
 ## Dangling Spec anchors
 
@@ -203,12 +202,9 @@ No dangling anchors. (Older codebase comments cite §5.4 as well — also valid.
 
 ## Recommendations
 
-1. **High priority — INV-O15 / §11.3 survey wire path**: Add inbound handlers for the four survey message types in the overlay layer, with `surveyorPermitted` check, signature verification, and rate-limiter integration. Even if encryption stays in the app crate, the overlay must gate forwarding.
-2. **High priority — §9.4 PEERS ingestion**: Wire `StellarMessage::Peers(addrs)` receipt to call `PeerManager::ensure_exists` per non-private IPv4 entry. Currently PEERS is dropped on the floor, breaking gossip-based peer discovery.
-3. **Medium — §12.3 drop-to-close delay**: Add a 5 s deferred socket shutdown so peers receive the final `ERROR_MSG` before RST. Helps operational debugging.
-4. **Medium — §5.4.4 `GET_SCP_STATE` min-ledger seq**: Add app callback or local state to compute `getMinLedgerSeqToAskPeers()`; currently sends 0.
-5. **Medium — §10.4 random out-of-sync drop + promote-inbound**: Implement steps 6 and 8 of the tick algorithm. Important for connection diversity under load.
-6. **Low — §5.4.2 cert refresh**: Currently one cert per `AuthContext`; could move to a process-lifetime shared cert with 30-min refresh, but functionally equivalent and not consensus-affecting.
-7. **Low — §13.4 explicit `ERR_DATA` on crypto failure**: Emit an outbound `ERROR_MSG(ERR_DATA, ...)` before dropping on XDR/HMAC decode errors, instead of silent close.
-8. **Cosmetic — §10.6 PEERS sample size pin**: Verify `MAX_PEERS_PER_MESSAGE == 50` in `manager/mod.rs`.
-9. **Cosmetic — INV-O11 assert**: Add `debug_assert!(state.flood_data_processed <= self.config.flow_control_send_more_batch_size)` after each batch increment in `flow_control.rs::end_message_processing`.
+1. **Medium — §12.3 drop-to-close delay**: Add a 5 s deferred socket shutdown so peers receive the final `ERROR_MSG` before RST. Helps operational debugging.
+2. **Medium — §5.4.4 `GET_SCP_STATE` min-ledger seq**: Add app callback or local state to compute `getMinLedgerSeqToAskPeers()`; currently sends 0.
+3. **Medium — §10.4 promote-inbound**: Implement step 8 of the tick algorithm (open parallel outbound to existing inbound peers). Important for connection diversity under load.
+4. **Low — §5.4.2 cert refresh**: Currently one cert per `AuthContext`; could move to a process-lifetime shared cert with 30-min refresh, but functionally equivalent and not consensus-affecting.
+5. **Low — §13.4 explicit `ERR_DATA` on crypto failure**: Emit an outbound `ERROR_MSG(ERR_DATA, ...)` before dropping on XDR/HMAC decode errors, instead of silent close.
+6. **Cosmetic — INV-O11 assert**: Add `debug_assert!(state.flood_data_processed <= self.config.flow_control_send_more_batch_size)` after each batch increment in `flow_control.rs::end_message_processing`.

--- a/crates/overlay/SPEC_ADHERENCE.md
+++ b/crates/overlay/SPEC_ADHERENCE.md
@@ -6,7 +6,7 @@
 **Overall adherence:** 82%
 
 Counts (excluding Drift and N/A from denominator):
-**Full 45 | Partial 9 | Absent 1 | Drift 2 | N/A 2**
+**Full 81 | Partial 15 | Absent 3 | Drift 2 | N/A 2**
 
 ## Summary table
 
@@ -113,7 +113,7 @@ Counts (excluding Drift and N/A from denominator):
 | INV-O10 (SEND_MORE_EXTENDED validation) | Full | `flow_control.rs:979-1010` (numBytes!=0 + overflow guards) |
 | INV-O11 (Recv-side batch grants) | Partial | `flow_control.rs:1038-1065` emits SEND_MORE_EXTENDED on batch threshold, but the spec's `releaseAssert(mFloodDataProcessed <= BATCH_SIZE)` upper bound is not asserted |
 | INV-O12 (One PEERS per connection) | Full | `manager/peer_loop.rs:512-531,712-717` |
-| INV-O13 (Outbound role rejects PEERS) | Drift | `manager/peer_loop.rs:522-524` rejects PEERS in **Inbound** role; spec says outbound role (`WE_CALLED_REMOTE`) MUST NOT receive PEERS. Verify: spec text §5.5 line 532 says "an inbound role peer MUST NOT receive `PEERS`" — Rust enforces the same. **Re-read confirms code matches.** Reclassify to Full. |
+| INV-O13 (Outbound role rejects PEERS) | Full | `manager/peer_loop.rs:522-524` rejects PEERS in **Inbound** role; spec says "an inbound role peer MUST NOT receive `PEERS`" — Rust enforces the same. Re-read confirms code matches. |
 | INV-O14 (No flood while not synced) | Full | `manager/peer_loop.rs:693-697` |
 | INV-O15 (Survey signature verification) | Full | App-owned: `crates/app/src/app/survey_impl.rs:941-956` `verify_survey_signature` uses `henyey_crypto::verify_from_raw_key` on Ed25519 key extracted from `NodeId`; called before processing survey start/stop/request/response |
 | INV-O16 (Survey rate limit) | Full | `survey.rs:268-356` (`SurveyMessageLimiter`) |
@@ -123,7 +123,7 @@ Counts (excluding Drift and N/A from denominator):
 
 Re-evaluation: INV-O13 — code is correct. Spec says "An inbound role peer (`REMOTE_CALLED_US`) MUST NOT receive `PEERS`"; the Rust code `if direction == ConnectionDirection::Inbound { return RejectWrongDirection }` matches that exactly. Reclassified to **Full** in the summary count.
 
-Corrected invariant tally: **Full 18 | Partial 1 | Absent 0**.
+Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
 
 ## Detailed findings
 


### PR DESCRIPTION
Closes #2873

## Summary

Refreshes the OVERLAY and LEDGER spec-adherence reports against current `main`. Corrects stale false-negative rows (survey, PEERS, random-drop, PEERS-one-per-connection), adds app-owned implementation citations, and reconciles internal count inconsistencies.

## Changes

**OVERLAY (`crates/overlay/SPEC_ADHERENCE.md`):**
- Upgraded 4 rows from Absent/Partial to Full (survey §11.x, random-drop §10.4, PEERS-sample §10.6, INV-O13)
- Downgraded §12.1 ERROR_MSG MAC from Full to Partial: receive-side MAC skip matches stellar-core, but outbound post-auth ERROR_MSG still goes through normal MAC/seq path
- Downgraded §9.4 "skip self" to Partial (missing self-address filter vs stellar-core)
- Added detailed app-owned sections for §9.4 PEERS receipt, §11.3 survey flow
- Fixed header counts: Full 79 | Partial 17 | Absent 3 | Drift 2 | N/A 2
- Removed stale internal tallies and normalized §12.1 labeling

**LEDGER (`crates/ledger/SPEC_ADHERENCE.md`):**
- Reclassified `MAX_SEQ_NUM_TO_APPLY` / `accToMaxSeq` with current implementation citations
- Refreshed summary counts

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] Documentation-only change; no test target required

## Deviations from plan

- §9.4 PEERS receipt downgraded to Partial instead of Full after reviewer correctly identified missing self-address filter
- §12.1 ERROR_MSG MAC downgraded from Full to Partial after parity reviewer identified outbound divergence from stellar-core Hmac.cpp:72-79

🤖 Generated with [Claude Code](https://claude.com/claude-code)