### PR TITLE
Handle deferred auto-merge in /review-pr skill

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -105,20 +105,23 @@ if [[ $? -ne 0 ]]; then
 elif [[ "$AUTO_MERGE_STATE" == "true" ]]; then
   # PR is OPEN and auto-merge is armed. GitHub will merge it automatically
   # once branch protection requirements are met. Don't re-run reviewers or
-  # re-file follow-up issues — just post a waiting comment and exit.
-  gh pr comment $PR_NUM --repo stellar-experimental/henyey \
-    --body "## Review: Auto-merge armed — waiting
+  # re-file follow-up issues — just ensure a waiting comment exists and exit.
+  ALREADY_COMMENTED=$(has_armed_waiting_comment $PR_NUM)
+  if [[ "$ALREADY_COMMENTED" != "true" ]]; then
+    gh pr comment $PR_NUM --repo stellar-experimental/henyey \
+      --body "## Review: Auto-merge armed — waiting
 
 Auto-merge was previously enabled on this PR. GitHub will merge automatically once all branch protection checks pass. Re-picking on next tick to verify completion.
 
 CI age: check \`autoMergeRequest\` state on next tick."
+  fi
 
   gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
   exit 0
 fi
 ```
 
-This short-circuit prevents duplicate reviewer runs and duplicate follow-up issue filing on subsequent ticks while waiting for GitHub to complete the deferred merge.
+This short-circuit prevents duplicate reviewer runs and duplicate follow-up issue filing on subsequent ticks while waiting for GitHub to complete the deferred merge. The `has_armed_waiting_comment` check ensures idempotency: if a waiting comment was already posted on a previous tick, no duplicate is created.
 
 ## Step 1 — Read the PR + CI state
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -40,15 +40,12 @@ source "$REPO_ROOT/scripts/lib/review-pr-merge.sh"
 Classify the linked PR state (distinguishes OPEN, MERGED, and CLOSED-without-merge):
 
 ```bash
-PR_STATE=$(classify_linked_pr_state $ISSUE)
-PR_STATE_RC=$?
-
-# API failure — retry once, then block
-if [[ $PR_STATE_RC -ne 0 ]]; then
+if ! PR_STATE=$(classify_linked_pr_state $ISSUE); then
+  # API failure — retry once, then block
   sleep 5
-  PR_STATE=$(classify_linked_pr_state $ISSUE) || {
+  if ! PR_STATE=$(classify_linked_pr_state $ISSUE); then
     echo "## Review: API Failure" && exit 1
-  }
+  fi
 fi
 ```
 
@@ -97,8 +94,7 @@ Handle each state:
 Before spawning reviewers or filing follow-up issues, check whether this PR already has auto-merge enabled from a previous tick:
 
 ```bash
-AUTO_MERGE_STATE=$(is_auto_merge_armed $PR_NUM)
-if [[ $? -ne 0 ]]; then
+if ! AUTO_MERGE_STATE=$(is_auto_merge_armed $PR_NUM); then
   # API failure checking auto-merge state — safe to proceed with normal review
   # since worst case is a redundant reviewer run. Log the issue.
   echo "Warning: could not check auto-merge state (API failure)" >&2
@@ -106,7 +102,7 @@ elif [[ "$AUTO_MERGE_STATE" == "true" ]]; then
   # PR is OPEN and auto-merge is armed. Before short-circuiting, verify that
   # CI is healthy — if CI went red or stuck while waiting, we must bounce or
   # block rather than wait indefinitely.
-  ARMED_HEALTH=$(check_armed_pr_health $PR_NUM)
+  ARMED_HEALTH=$(check_armed_pr_health $PR_NUM) || ARMED_HEALTH="error"
   case "$ARMED_HEALTH" in
     healthy)
       # CI green or still running within budget. Don't re-run reviewers or
@@ -407,8 +403,15 @@ elif [ "$(echo "$ROLLUP" | jq '[.[] | select(
        or (.status == null and (.state | ascii_upcase) == "PENDING")
      )] | length')" -gt 0 ]; then
   CI_STATE="running"
-else
+elif [ "$(echo "$ROLLUP" | jq '[.[] | select(
+       ((.conclusion // "") | ascii_upcase) as $c |
+       $c == "SUCCESS" or $c == "SKIPPED" or $c == "NEUTRAL"
+       or ((.state // "") | ascii_upcase) == "SUCCESS"
+     )] | length')" -eq "$CI_TOTAL" ]; then
   CI_STATE="green"
+else
+  # Unexpected conclusions (ACTION_REQUIRED, STARTUP_FAILURE, etc.) — treat as red
+  CI_STATE="red"
 fi
 ```
 
@@ -634,7 +637,9 @@ the workspace contract (all scratch state under `~/data/$SESSION_ID/review-pr-$I
 export REVIEW_PR_SCRATCH_DIR="${WORKTREE_BASE:-$(eval echo "~$(id -un)")/data/${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}/review-pr-$ISSUE}"
 mkdir -p "$REVIEW_PR_SCRATCH_DIR"
 
-MERGE_RESULT=$(attempt_merge $PR_NUM)
+if ! MERGE_RESULT=$(attempt_merge $PR_NUM); then
+  MERGE_RESULT="hard-failure:attempt_merge returned nonzero"
+fi
 ```
 
 Handle the result:

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -157,6 +157,19 @@ Auto-merge was armed but the PR now has merge conflicts. Bouncing back to \`/do\
       gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
       exit 0
       ;;
+    no-ci)
+      # No CI checks detected — cannot treat as green. This may indicate a
+      # workflow misconfiguration, disabled Actions, or permissions issue.
+      # Block for operator investigation.
+      gh pr merge $PR_NUM --repo stellar-experimental/henyey --disable-auto
+      gh pr comment $PR_NUM --repo stellar-experimental/henyey \
+        --body "## Review: Auto-merge cancelled — no CI detected
+
+Auto-merge was armed but no CI checks are present on this PR. This may indicate a workflow misconfiguration or disabled Actions. Blocking for operator investigation."
+      bash .github/skills/shared/scripts/move-issue-status.sh $ISSUE blocked
+      gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
+      exit 0
+      ;;
     error)
       # Could not check health — proceed with normal review as a safe fallback.
       echo "Warning: could not check armed PR health (API failure), proceeding with full review" >&2

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -41,21 +41,68 @@ Classify the linked PR state (distinguishes OPEN, MERGED, and CLOSED-without-mer
 
 ```bash
 PR_STATE=$(classify_linked_pr_state $ISSUE)
+PR_STATE_RC=$?
+
+# API failure — retry once, then block
+if [[ $PR_STATE_RC -ne 0 ]]; then
+  sleep 5
+  PR_STATE=$(classify_linked_pr_state $ISSUE) || {
+    echo "## Review: API Failure" && exit 1
+  }
+fi
+```
+
+Extract `PR_NUM` and route based on state:
+
+```bash
+case "$PR_STATE" in
+  open:*)
+    PR_NUM="${PR_STATE#open:}"
+    # Proceed to Step 0.5
+    ;;
+  merged:*)
+    PR_NUM="${PR_STATE#merged:}"
+    # PR already merged — recover merge SHA and follow-up issues, then finalize
+    MERGE_SHA=$(gh pr view "$PR_NUM" --repo stellar-experimental/henyey \
+      --json mergeCommit --jq '.mergeCommit.oid')
+    # Recover previously filed follow-up issue numbers from the armed comment
+    FOLLOWUP_ISSUES=$(gh pr view "$PR_NUM" --repo stellar-experimental/henyey \
+      --json comments --jq '
+        [.comments[].body
+         | select(contains("## Review: Auto-merge armed"))
+         | capture("Follow-up issues filed:\\*\\* (?<nums>[^\n]+)"; "g") | .nums]
+        | last // "none"')
+    # Run Step 7.4 cleanup/done path with recovered metadata and exit
+    ;;
+  closed:*)
+    # PR was closed without merge — bug in /do
+    # Post ## Review: No PR Linked, move to ready-for-doing, unassign, exit
+    ;;
+  missing)
+    # No linked PRs — same handling as closed
+    ;;
+esac
 ```
 
 Handle each state:
 
-- **`open:<number>`** → extract `PR_NUM` and proceed to Step 0.5.
-- **`merged:<number>`** → the PR was already merged (e.g. by a previous `/review-pr` tick that armed auto-merge and GH completed it). Recover the merge SHA via `gh pr view <number> --repo stellar-experimental/henyey --json mergeCommit --jq '.mergeCommit.oid'`, run the Step 7.4 cleanup/done path, and exit.
+- **`open:<number>`** → `PR_NUM` extracted above; proceed to Step 0.5.
+- **`merged:<number>`** → the PR was already merged (e.g. by a previous `/review-pr` tick that armed auto-merge and GH completed it). Recover the merge SHA via `gh pr view <number> --json mergeCommit --jq '.mergeCommit.oid'` and follow-up issue numbers from the `## Review: Auto-merge armed` comment body. Run the Step 7.4 cleanup/done path and exit.
 - **`closed:<number>`** → PR was closed without merge. That's a bug in `/do`. Post `## Review: No PR Linked` and move the issue back to `ready-for-doing`. Unassign. Exit.
 - **`missing`** → no linked PRs at all. Same handling as `closed`.
+- **`error:<message>`** → API failure. Retry once after 5s; if still failing, leave assigned and exit non-zero.
 
 ### Step 0.5 — Check if auto-merge is already armed
 
 Before spawning reviewers or filing follow-up issues, check whether this PR already has auto-merge enabled from a previous tick:
 
 ```bash
-if [[ "$(is_auto_merge_armed $PR_NUM)" == "true" ]]; then
+AUTO_MERGE_STATE=$(is_auto_merge_armed $PR_NUM)
+if [[ $? -ne 0 ]]; then
+  # API failure checking auto-merge state — safe to proceed with normal review
+  # since worst case is a redundant reviewer run. Log the issue.
+  echo "Warning: could not check auto-merge state (API failure)" >&2
+elif [[ "$AUTO_MERGE_STATE" == "true" ]]; then
   # PR is OPEN and auto-merge is armed. GitHub will merge it automatically
   # once branch protection requirements are met. Don't re-run reviewers or
   # re-file follow-up issues — just post a waiting comment and exit.

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -103,25 +103,69 @@ if [[ $? -ne 0 ]]; then
   # since worst case is a redundant reviewer run. Log the issue.
   echo "Warning: could not check auto-merge state (API failure)" >&2
 elif [[ "$AUTO_MERGE_STATE" == "true" ]]; then
-  # PR is OPEN and auto-merge is armed. GitHub will merge it automatically
-  # once branch protection requirements are met. Don't re-run reviewers or
-  # re-file follow-up issues — just ensure a waiting comment exists and exit.
-  ALREADY_COMMENTED=$(has_armed_waiting_comment $PR_NUM)
-  if [[ "$ALREADY_COMMENTED" != "true" ]]; then
-    gh pr comment $PR_NUM --repo stellar-experimental/henyey \
-      --body "## Review: Auto-merge armed — waiting
+  # PR is OPEN and auto-merge is armed. Before short-circuiting, verify that
+  # CI is healthy — if CI went red or stuck while waiting, we must bounce or
+  # block rather than wait indefinitely.
+  ARMED_HEALTH=$(check_armed_pr_health $PR_NUM)
+  case "$ARMED_HEALTH" in
+    healthy)
+      # CI green or still running within budget. Don't re-run reviewers or
+      # re-file follow-up issues — just ensure a waiting comment exists and exit.
+      ALREADY_COMMENTED=$(has_armed_waiting_comment $PR_NUM)
+      if [[ "$ALREADY_COMMENTED" != "true" ]]; then
+        gh pr comment $PR_NUM --repo stellar-experimental/henyey \
+          --body "## Review: Auto-merge armed — waiting
 
 Auto-merge was previously enabled on this PR. GitHub will merge automatically once all branch protection checks pass. Re-picking on next tick to verify completion.
 
-CI age: check \`autoMergeRequest\` state on next tick."
-  fi
+CI state: healthy. Next check on next tick."
+      fi
+      gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
+      exit 0
+      ;;
+    ci-red)
+      # CI failed while auto-merge was armed. GitHub won't merge it. Cancel
+      # auto-merge and bounce to /do for investigation.
+      gh pr merge $PR_NUM --repo stellar-experimental/henyey --disable-auto
+      gh pr comment $PR_NUM --repo stellar-experimental/henyey \
+        --body "## Review: Auto-merge cancelled — CI red
 
-  gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
-  exit 0
+Auto-merge was armed but CI has failures. Disabling auto-merge and bouncing back to \`/do\` for investigation."
+      bash .github/skills/shared/scripts/move-issue-status.sh $ISSUE ready-for-doing
+      gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
+      exit 0
+      ;;
+    ci-stuck)
+      # CI running but exceeded wall-clock budget. Block.
+      gh pr merge $PR_NUM --repo stellar-experimental/henyey --disable-auto
+      gh pr comment $PR_NUM --repo stellar-experimental/henyey \
+        --body "## Review: Auto-merge cancelled — CI stuck
+
+Auto-merge was armed but CI has been running past the stuck threshold. Blocking for operator investigation."
+      bash .github/skills/shared/scripts/move-issue-status.sh $ISSUE blocked
+      gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
+      exit 0
+      ;;
+    not-mergeable)
+      # PR has merge conflicts. Cancel auto-merge and bounce.
+      gh pr merge $PR_NUM --repo stellar-experimental/henyey --disable-auto
+      gh pr comment $PR_NUM --repo stellar-experimental/henyey \
+        --body "## Review: Auto-merge cancelled — merge conflicts
+
+Auto-merge was armed but the PR now has merge conflicts. Bouncing back to \`/do\` for rebase."
+      bash .github/skills/shared/scripts/move-issue-status.sh $ISSUE ready-for-doing
+      gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
+      exit 0
+      ;;
+    error)
+      # Could not check health — proceed with normal review as a safe fallback.
+      echo "Warning: could not check armed PR health (API failure), proceeding with full review" >&2
+      ;;
+  esac
 fi
 ```
 
-This short-circuit prevents duplicate reviewer runs and duplicate follow-up issue filing on subsequent ticks while waiting for GitHub to complete the deferred merge. The `has_armed_waiting_comment` check ensures idempotency: if a waiting comment was already posted on a previous tick, no duplicate is created.
+This short-circuit prevents duplicate reviewer runs and duplicate follow-up issue filing on subsequent ticks while waiting for GitHub to complete the deferred merge. The `has_armed_waiting_comment` check ensures idempotency: if a waiting comment was already posted on a previous tick, no duplicate is created. Critically, it still checks CI state on every tick — if CI goes red or gets stuck while auto-merge is armed, the skill cancels auto-merge and routes the issue appropriately rather than waiting indefinitely.
 
 ## Step 1 — Read the PR + CI state
 

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -30,20 +30,48 @@ You do **not** review the code yourself — you orchestrate two independent revi
 
 ## Step 0 — Find the PR
 
+Source the shared merge helper for linked-PR state classification and merge execution:
+
 ```bash
-# Use raw GraphQL — `gh issue view --json closedByPullRequestsReferences` silently
-# omits the `state` subfield, so `select(.state == "OPEN")` would never match and
-# PR_NUM would always be empty even when an OPEN PR exists.
-PR_NUM=$(gh api graphql -f query='{
-  repository(owner: "stellar-experimental", name: "henyey") {
-    issue(number: '"$ISSUE"') {
-      closedByPullRequestsReferences(first: 5) { nodes { number state } }
-    }
-  }
-}' --jq '.data.repository.issue.closedByPullRequestsReferences.nodes | map(select(.state == "OPEN")) | .[0].number // empty')
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/lib/review-pr-merge.sh"
 ```
 
-If `PR_NUM` is empty, the issue is in `in-review` but has no open PR — that's a bug in `/do`. Post `## Review: No PR Linked` and move the issue back to `ready-for-doing`. Unassign. Exit.
+Classify the linked PR state (distinguishes OPEN, MERGED, and CLOSED-without-merge):
+
+```bash
+PR_STATE=$(classify_linked_pr_state $ISSUE)
+```
+
+Handle each state:
+
+- **`open:<number>`** → extract `PR_NUM` and proceed to Step 0.5.
+- **`merged:<number>`** → the PR was already merged (e.g. by a previous `/review-pr` tick that armed auto-merge and GH completed it). Recover the merge SHA via `gh pr view <number> --repo stellar-experimental/henyey --json mergeCommit --jq '.mergeCommit.oid'`, run the Step 7.4 cleanup/done path, and exit.
+- **`closed:<number>`** → PR was closed without merge. That's a bug in `/do`. Post `## Review: No PR Linked` and move the issue back to `ready-for-doing`. Unassign. Exit.
+- **`missing`** → no linked PRs at all. Same handling as `closed`.
+
+### Step 0.5 — Check if auto-merge is already armed
+
+Before spawning reviewers or filing follow-up issues, check whether this PR already has auto-merge enabled from a previous tick:
+
+```bash
+if [[ "$(is_auto_merge_armed $PR_NUM)" == "true" ]]; then
+  # PR is OPEN and auto-merge is armed. GitHub will merge it automatically
+  # once branch protection requirements are met. Don't re-run reviewers or
+  # re-file follow-up issues — just post a waiting comment and exit.
+  gh pr comment $PR_NUM --repo stellar-experimental/henyey \
+    --body "## Review: Auto-merge armed — waiting
+
+Auto-merge was previously enabled on this PR. GitHub will merge automatically once all branch protection checks pass. Re-picking on next tick to verify completion.
+
+CI age: check \`autoMergeRequest\` state on next tick."
+
+  gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
+  exit 0
+fi
+```
+
+This short-circuit prevents duplicate reviewer runs and duplicate follow-up issue filing on subsequent ticks while waiting for GitHub to complete the deferred merge.
 
 ## Step 1 — Read the PR + CI state
 
@@ -489,11 +517,30 @@ Collect the list of newly-filed issue numbers — they'll be referenced in the m
 
 #### 7.3 Merge
 
+Use the shared merge helper which handles the deferred-merge path:
+
 ```bash
-gh pr merge $PR_NUM --repo stellar-experimental/henyey --squash --admin
+MERGE_RESULT=$(attempt_merge $PR_NUM)
 ```
 
-The `--admin` flag means the agent must be authenticated as a repo admin. If your token doesn't have admin, the merge will fail — at which point operator intervention is needed (file a follow-up issue documenting the merge-permission gap; do NOT downgrade to non-admin merge that might silently bypass CI).
+Handle the result:
+
+- **`merged`** → immediate merge succeeded. Proceed to Step 7.4 cleanup.
+- **`auto-merge-armed`** → GitHub cannot create the merge commit cleanly right now but will merge automatically once conditions are met. Post a waiting comment recording the follow-up issue numbers filed in Step 7.2:
+
+  ```markdown
+  ## Review: Auto-merge armed
+
+  Enabled deferred auto-merge (squash). GitHub will merge once branch protection checks pass.
+
+  **Follow-up issues filed:** #N1, #N2 (or "none")
+
+  Re-picking on next tick to verify merge completion.
+  ```
+
+  Unassign and exit. The next `/review-pr` tick will detect the `MERGED` state via `classify_linked_pr_state` and run cleanup, or detect `OPEN + armed` via `is_auto_merge_armed` and short-circuit to waiting.
+
+- **`hard-failure:<stderr>`** → merge failed for a reason other than the auto-merge hint. Leave the issue in `in-review`; file a follow-up issue documenting the merge-permission gap; do NOT downgrade to non-admin merge that might silently bypass CI. Post `## Review: Merge Failed` with the stderr content.
 
 #### 7.4 Clean up
 
@@ -638,7 +685,8 @@ Exit.
 | Reviewer sub-agent fails to post | Retry once. If still failing, treat as `CHANGES_REQUESTED` and bounce. |
 | Reviewer's comment doesn't match the expected header/verdict shape | Treat as `pending`; if it stays malformed after Step 4 completes, bounce with a `## Review: Malformed Verdict` note. |
 | No PR linked | Bounce to `ready-for-doing` with `## Review: No PR Linked`. |
-| `gh pr merge --admin` fails (token lacks admin) | Leave the issue in `in-review`; file a follow-up issue documenting the gap; do NOT degrade to a non-admin merge that might bypass CI gates. |
+| `gh pr merge --admin` fails with auto-merge hint | Retry with `--auto` (deferred merge). If `--auto` also fails, hard failure. See Step 7.3. |
+| `gh pr merge --admin` fails (other error, e.g. token lacks admin) | Leave the issue in `in-review`; file a follow-up issue documenting the gap; do NOT degrade to a non-admin merge that might bypass CI gates. |
 | GH API failure | Retry once after 5s; if still failing, leave assigned and exit non-zero. |
 
 ## Workspace contract

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -567,9 +567,16 @@ Collect the list of newly-filed issue numbers — they'll be referenced in the m
 
 #### 7.3 Merge
 
-Use the shared merge helper which handles the deferred-merge path:
+Use the shared merge helper which handles the deferred-merge path. The helper
+requires `REVIEW_PR_SCRATCH_DIR` to be set to a session-scoped directory under
+the workspace contract (all scratch state under `~/data/$SESSION_ID/review-pr-$ISSUE/`):
 
 ```bash
+# Derive scratch dir from the workspace contract. review_pr_bootstrap exports
+# WORKTREE_BASE = ~/data/$SESSION_ID/review-pr-$ISSUE — reuse it for merge scratch.
+export REVIEW_PR_SCRATCH_DIR="${WORKTREE_BASE:-$(eval echo "~$(id -un)")/data/${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}/review-pr-$ISSUE}"
+mkdir -p "$REVIEW_PR_SCRATCH_DIR"
+
 MERGE_RESULT=$(attempt_merge $PR_NUM)
 ```
 

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -188,6 +188,95 @@ has_armed_waiting_comment() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# check_armed_pr_health PR_NUM
+#
+# For an OPEN PR with auto-merge armed, checks CI/mergeability state to detect
+# failures that require intervention (rather than blindly waiting forever).
+#
+# Output on stdout: one of:
+#   "healthy"           — CI green or still running within budget; safe to wait
+#   "ci-red"            — CI has failures; auto-merge will never fire
+#   "ci-stuck"          — CI running but exceeded wall-clock budget (60 min)
+#   "not-mergeable"     — PR has merge conflicts or was closed
+#   "error"             — API failure checking state
+#
+# Returns: 0 always (caller decides action based on output).
+# ─────────────────────────────────────────────────────────────────────────────
+check_armed_pr_health() {
+  local pr_num="$1"
+  local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
+  local ci_stuck_minutes="${CI_STUCK_AFTER_MINUTES:-60}"
+
+  local pr_data
+  if ! pr_data=$(_review_pr_fetch_armed_health "$pr_num" "$repo"); then
+    echo "error"
+    return 0
+  fi
+
+  # Check mergeability
+  local mergeable
+  mergeable=$(echo "$pr_data" | jq -r '.mergeable // "UNKNOWN"')
+  if [[ "$mergeable" == "CONFLICTING" ]]; then
+    echo "not-mergeable"
+    return 0
+  fi
+
+  # Classify CI from statusCheckRollup
+  local rollup ci_total
+  rollup=$(echo "$pr_data" | jq '.statusCheckRollup // []')
+  ci_total=$(echo "$rollup" | jq 'length')
+
+  if [[ "$ci_total" -eq 0 ]]; then
+    # No CI at all — treat as healthy (auto-merge may have different requirements)
+    echo "healthy"
+    return 0
+  fi
+
+  # Check for red (any failure/cancelled/timed_out)
+  local red_count
+  red_count=$(echo "$rollup" | jq '[.[] | select(
+    ((.conclusion // "") | ascii_upcase) as $c |
+    $c == "FAILURE" or $c == "CANCELLED" or $c == "TIMED_OUT"
+    or ((.state // "") | ascii_upcase) as $s | $s == "FAILURE" or $s == "ERROR"
+  )] | length')
+  if [[ "$red_count" -gt 0 ]]; then
+    echo "ci-red"
+    return 0
+  fi
+
+  # Check for running
+  local running_count
+  running_count=$(echo "$rollup" | jq '[.[] | select(
+    (.status != null and (.status | ascii_upcase) != "COMPLETED")
+    or (.status == null and (.state | ascii_upcase) == "PENDING")
+  )] | length')
+  if [[ "$running_count" -gt 0 ]]; then
+    # Check wall-clock age
+    local oldest_start
+    oldest_start=$(echo "$pr_data" | jq -r '.oldestRunStart // ""')
+    if [[ -n "$oldest_start" && "$oldest_start" != "null" ]]; then
+      local now_epoch start_epoch age_min
+      now_epoch=$(date +%s)
+      start_epoch=$(date -d "$oldest_start" +%s 2>/dev/null || echo "0")
+      if [[ "$start_epoch" -gt 0 ]]; then
+        age_min=$(( (now_epoch - start_epoch) / 60 ))
+        if [[ "$age_min" -gt "$ci_stuck_minutes" ]]; then
+          echo "ci-stuck"
+          return 0
+        fi
+      fi
+    fi
+    # Running within budget
+    echo "healthy"
+    return 0
+  fi
+
+  # All checks completed and none failed → green
+  echo "healthy"
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Internal helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -273,5 +362,26 @@ _review_pr_fetch_issue_comments() {
     cat "$REVIEW_PR_ISSUE_COMMENTS_FILE"
   else
     gh api "repos/$repo/issues/$pr_num/comments" --paginate --jq '.[].body'
+  fi
+}
+
+# _review_pr_fetch_armed_health PR_NUM REPO
+# Fetches PR health data (mergeability + CI rollup) for armed-PR checking.
+# Mockable via REVIEW_PR_ARMED_HEALTH_FILE.
+_review_pr_fetch_armed_health() {
+  local pr_num="$1"
+  local repo="$2"
+
+  if [[ -n "${REVIEW_PR_ARMED_HEALTH_FILE:-}" ]]; then
+    cat "$REVIEW_PR_ARMED_HEALTH_FILE"
+  else
+    local head_ref pr_json oldest_start
+    pr_json=$(gh pr view "$pr_num" --repo "$repo" \
+      --json statusCheckRollup,mergeable,headRefName)
+    head_ref=$(echo "$pr_json" | jq -r '.headRefName')
+    oldest_start=$(gh run list --repo "$repo" --branch "$head_ref" --limit 20 \
+      --json startedAt,status \
+      --jq '[.[] | select(.status != "completed")] | min_by(.startedAt) | .startedAt // ""' 2>/dev/null || echo "")
+    echo "$pr_json" | jq --arg os "$oldest_start" '. + {oldestRunStart: $os}'
   fi
 }

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -267,7 +267,17 @@ check_armed_pr_health() {
           echo "ci-stuck"
           return 0
         fi
+      else
+        # startedAt present but unparseable — cannot determine age; treat as stuck
+        echo "ci-stuck"
+        return 0
       fi
+    else
+      # No startedAt available (e.g. pending StatusContext without a start
+      # timestamp). We cannot determine how long the check has been waiting,
+      # so treat it as stuck to avoid an infinite-wait path.
+      echo "ci-stuck"
+      return 0
     fi
     # Running within budget
     echo "healthy"

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -36,7 +36,16 @@ attempt_merge() {
   local pr_num="$1"
   local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
 
-  local scratch_dir="${REVIEW_PR_SCRATCH_DIR:-${HOME}/data/review-pr-scratch}"
+  # REVIEW_PR_SCRATCH_DIR must be set by the caller (typically via
+  # review_pr_bootstrap which exports WORKTREE_BASE). Falling back to a shared
+  # directory would violate the workspace contract that requires all scratch
+  # state under ~/data/$SESSION_ID/review-pr-$ISSUE/.
+  if [[ -z "${REVIEW_PR_SCRATCH_DIR:-}" ]]; then
+    echo "hard-failure:REVIEW_PR_SCRATCH_DIR is not set — caller must export a session-scoped scratch directory before calling attempt_merge"
+    return 1
+  fi
+
+  local scratch_dir="$REVIEW_PR_SCRATCH_DIR"
   mkdir -p "$scratch_dir"
   local stderr_file="$scratch_dir/merge-stderr-$$-$pr_num.tmp"
 

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -197,6 +197,7 @@ has_armed_waiting_comment() {
 #   "healthy"           — CI green or still running within budget; safe to wait
 #   "ci-red"            — CI has failures; auto-merge will never fire
 #   "ci-stuck"          — CI running but exceeded wall-clock budget (60 min)
+#   "no-ci"             — No CI checks detected; cannot treat as green
 #   "not-mergeable"     — PR has merge conflicts or was closed
 #   "error"             — API failure checking state
 #
@@ -227,8 +228,10 @@ check_armed_pr_health() {
   ci_total=$(echo "$rollup" | jq 'length')
 
   if [[ "$ci_total" -eq 0 ]]; then
-    # No CI at all — treat as healthy (auto-merge may have different requirements)
-    echo "healthy"
+    # No CI checks detected — this must not be treated as green. The PR may
+    # have a workflow misconfiguration, disabled Actions, or permissions issue
+    # that prevents checks from starting. Surface it so the operator can act.
+    echo "no-ci"
     return 0
   fi
 
@@ -375,13 +378,19 @@ _review_pr_fetch_armed_health() {
   if [[ -n "${REVIEW_PR_ARMED_HEALTH_FILE:-}" ]]; then
     cat "$REVIEW_PR_ARMED_HEALTH_FILE"
   else
-    local head_ref pr_json oldest_start
+    local pr_json oldest_start
     pr_json=$(gh pr view "$pr_num" --repo "$repo" \
-      --json statusCheckRollup,mergeable,headRefName)
-    head_ref=$(echo "$pr_json" | jq -r '.headRefName')
-    oldest_start=$(gh run list --repo "$repo" --branch "$head_ref" --limit 20 \
-      --json startedAt,status \
-      --jq '[.[] | select(.status != "completed")] | min_by(.startedAt) | .startedAt // ""' 2>/dev/null || echo "")
+      --json statusCheckRollup,mergeable,headRefName) || return 1
+
+    # Derive oldest in-progress check start time from the statusCheckRollup
+    # itself (scoped to this PR's head commit), not from branch-wide gh run list.
+    oldest_start=$(echo "$pr_json" | jq -r '
+      [.statusCheckRollup // [] | .[]
+       | select((.status != null and (.status | ascii_upcase) != "COMPLETED")
+                or (.status == null and (.state | ascii_upcase) == "PENDING"))
+       | .startedAt // empty]
+      | sort | .[0] // ""')
+
     echo "$pr_json" | jq --arg os "$oldest_start" '. + {oldestRunStart: $os}'
   fi
 }

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -274,8 +274,23 @@ check_armed_pr_health() {
     return 0
   fi
 
-  # All checks completed and none failed → green
-  echo "healthy"
+  # All checks completed — verify positive green (only SUCCESS/SKIPPED/NEUTRAL
+  # for CheckRun conclusions, or state=SUCCESS for StatusContext). Anything else
+  # (ACTION_REQUIRED, STARTUP_FAILURE, STALE, etc.) is suspicious.
+  local green_count
+  green_count=$(echo "$rollup" | jq '[.[] | select(
+    ((.conclusion // "") | ascii_upcase) as $c |
+    $c == "SUCCESS" or $c == "SKIPPED" or $c == "NEUTRAL"
+    or ((.state // "") | ascii_upcase) == "SUCCESS"
+  )] | length')
+  if [[ "$green_count" -eq "$ci_total" ]]; then
+    echo "healthy"
+    return 0
+  fi
+
+  # Some checks completed with unexpected conclusions (e.g. ACTION_REQUIRED,
+  # STARTUP_FAILURE) — treat as red since auto-merge may never fire.
+  echo "ci-red"
   return 0
 }
 

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -6,6 +6,7 @@
 #   - attempt_merge PR_NUM  — try admin merge, classify failure, retry with --auto
 #   - classify_linked_pr_state ISSUE — distinguish OPEN, MERGED, CLOSED-without-merge
 #   - is_auto_merge_armed PR_NUM — check if PR has autoMergeRequest set
+#   - has_armed_waiting_comment PR_NUM — check if waiting comment already posted
 #
 # Requires: Bash 4+, jq, gh CLI authenticated.
 # Does NOT set shell options (set -e, -u, etc.) — callers control strictness.
@@ -151,6 +152,33 @@ is_auto_merge_armed() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# has_armed_waiting_comment PR_NUM
+#
+# Checks whether a "## Review: Auto-merge armed — waiting" comment already
+# exists on the PR. Used to make the OPEN+armed short-circuit idempotent:
+# if the comment already exists, we skip posting another one.
+#
+# Output: "true" or "false" on stdout.
+# Returns: 0 always (best-effort; defaults to "false" on error).
+# ─────────────────────────────────────────────────────────────────────────────
+has_armed_waiting_comment() {
+  local pr_num="$1"
+  local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
+
+  local comments
+  if ! comments=$(_review_pr_fetch_issue_comments "$pr_num" "$repo"); then
+    echo "false"
+    return 0
+  fi
+
+  if echo "$comments" | grep -qF "## Review: Auto-merge armed — waiting"; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Internal helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -223,5 +251,18 @@ _review_pr_fetch_auto_merge_state() {
   else
     gh pr view "$pr_num" --repo "$repo" --json autoMergeRequest \
       --jq '.autoMergeRequest != null'
+  fi
+}
+
+# _review_pr_fetch_issue_comments PR_NUM REPO
+# Fetches issue/PR-level comments. Mockable via REVIEW_PR_ISSUE_COMMENTS_FILE.
+_review_pr_fetch_issue_comments() {
+  local pr_num="$1"
+  local repo="$2"
+
+  if [[ -n "${REVIEW_PR_ISSUE_COMMENTS_FILE:-}" ]]; then
+    cat "$REVIEW_PR_ISSUE_COMMENTS_FILE"
+  else
+    gh api "repos/$repo/issues/$pr_num/comments" --paginate --jq '.[].body'
   fi
 }

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Shared merge helpers for the /review-pr skill.
+#
+# Provides:
+#   - attempt_merge PR_NUM  — try admin merge, classify failure, retry with --auto
+#   - classify_linked_pr_state ISSUE — distinguish OPEN, MERGED, CLOSED-without-merge
+#   - is_auto_merge_armed PR_NUM — check if PR has autoMergeRequest set
+#
+# Requires: Bash 4+, jq, gh CLI authenticated.
+# Does NOT set shell options (set -e, -u, etc.) — callers control strictness.
+# Idempotent: safe to source multiple times.
+#
+
+[[ -n "${_REVIEW_PR_MERGE_LOADED:-}" ]] && return 0
+_REVIEW_PR_MERGE_LOADED=1
+
+# ─────────────────────────────────────────────────────────────────────────────
+# attempt_merge PR_NUM
+#
+# Attempts to merge the PR using admin squash merge. On failure, classifies the
+# error:
+#   - If the error contains the exact "add the `--auto` flag" hint from GitHub,
+#     retries with `gh pr merge --squash --auto` (deferred merge).
+#   - Any other failure is reported as-is (hard failure).
+#
+# Output on stdout: one of:
+#   "merged"           — immediate merge succeeded
+#   "auto-merge-armed" — deferred merge enabled via --auto
+#   "hard-failure:<stderr>" — unrecoverable merge error
+#
+# Returns: 0 on merged or auto-merge-armed, 1 on hard failure.
+# ─────────────────────────────────────────────────────────────────────────────
+attempt_merge() {
+  local pr_num="$1"
+  local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
+
+  local stderr_file
+  stderr_file=$(mktemp)
+
+  # Try admin merge first
+  if _review_pr_exec_merge "$pr_num" "$repo" "--squash --admin" "$stderr_file"; then
+    rm -f "$stderr_file"
+    echo "merged"
+    return 0
+  fi
+
+  local stderr_content
+  stderr_content=$(cat "$stderr_file")
+
+  # Classify the failure: does it contain the exact auto-merge hint?
+  if _is_auto_hint_failure "$stderr_content"; then
+    # Retry with --auto (without --admin since GH CLI rejects that combo)
+    if _review_pr_exec_merge "$pr_num" "$repo" "--squash --auto" "$stderr_file"; then
+      rm -f "$stderr_file"
+      echo "auto-merge-armed"
+      return 0
+    fi
+
+    # --auto also failed — hard failure
+    stderr_content=$(cat "$stderr_file")
+    rm -f "$stderr_file"
+    echo "hard-failure:$stderr_content"
+    return 1
+  fi
+
+  # Not an auto-hint failure — hard failure
+  rm -f "$stderr_file"
+  echo "hard-failure:$stderr_content"
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# classify_linked_pr_state ISSUE
+#
+# Given an issue number, queries all linked PRs and returns the state:
+#   "open:<pr_number>"    — an open PR is linked
+#   "merged:<pr_number>"  — no open PR, but a merged one exists
+#   "closed:<pr_number>"  — PR was closed without merge
+#   "missing"             — no linked PRs at all
+#
+# Returns: 0 always.
+# ─────────────────────────────────────────────────────────────────────────────
+classify_linked_pr_state() {
+  local issue_num="$1"
+  local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
+
+  local linked_prs
+  linked_prs=$(_review_pr_fetch_linked_prs "$issue_num" "$repo")
+
+  if [[ -z "$linked_prs" || "$linked_prs" == "null" ]]; then
+    echo "missing"
+    return 0
+  fi
+
+  # Check for OPEN first
+  local open_pr
+  open_pr=$(echo "$linked_prs" | jq -r '[.[] | select(.state == "OPEN")] | .[0].number // empty')
+  if [[ -n "$open_pr" ]]; then
+    echo "open:$open_pr"
+    return 0
+  fi
+
+  # Check for MERGED
+  local merged_pr
+  merged_pr=$(echo "$linked_prs" | jq -r '[.[] | select(.state == "MERGED")] | .[0].number // empty')
+  if [[ -n "$merged_pr" ]]; then
+    echo "merged:$merged_pr"
+    return 0
+  fi
+
+  # Check for CLOSED (without merge)
+  local closed_pr
+  closed_pr=$(echo "$linked_prs" | jq -r '[.[] | select(.state == "CLOSED")] | .[0].number // empty')
+  if [[ -n "$closed_pr" ]]; then
+    echo "closed:$closed_pr"
+    return 0
+  fi
+
+  echo "missing"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_auto_merge_armed PR_NUM
+#
+# Checks whether a PR has autoMergeRequest set (deferred auto-merge enabled).
+#
+# Output: "true" or "false" on stdout.
+# Returns: 0 always.
+# ─────────────────────────────────────────────────────────────────────────────
+is_auto_merge_armed() {
+  local pr_num="$1"
+  local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
+
+  local auto_merge
+  auto_merge=$(_review_pr_fetch_auto_merge_state "$pr_num" "$repo")
+
+  if [[ "$auto_merge" == "true" ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Internal helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+# _review_pr_exec_merge PR_NUM REPO FLAGS STDERR_FILE
+# Execute gh pr merge with given flags. Mockable via REVIEW_PR_MERGE_CMD.
+# Returns: exit code of the merge command.
+_review_pr_exec_merge() {
+  local pr_num="$1"
+  local repo="$2"
+  local flags="$3"
+  local stderr_file="$4"
+
+  if [[ -n "${REVIEW_PR_MERGE_CMD:-}" ]]; then
+    # Test mode: call the mock function
+    $REVIEW_PR_MERGE_CMD "$pr_num" "$repo" "$flags" 2>"$stderr_file"
+  else
+    gh pr merge "$pr_num" --repo "$repo" $flags 2>"$stderr_file"
+  fi
+}
+
+# _is_auto_hint_failure STDERR_CONTENT
+# Returns 0 if stderr contains the exact GitHub hint to add --auto flag.
+_is_auto_hint_failure() {
+  local stderr="$1"
+  # Match the exact GitHub error pattern
+  if echo "$stderr" | grep -qF "add the \`--auto\` flag"; then
+    return 0
+  fi
+  # Also match without backtick formatting (some GH CLI versions)
+  if echo "$stderr" | grep -qF "add the --auto flag"; then
+    return 0
+  fi
+  return 1
+}
+
+# _review_pr_fetch_linked_prs ISSUE REPO
+# Fetches linked PRs for an issue. Mockable via REVIEW_PR_LINKED_PRS_FILE.
+_review_pr_fetch_linked_prs() {
+  local issue_num="$1"
+  local repo="$2"
+
+  if [[ -n "${REVIEW_PR_LINKED_PRS_FILE:-}" ]]; then
+    cat "$REVIEW_PR_LINKED_PRS_FILE"
+  else
+    local owner repo_name
+    owner=$(echo "$repo" | cut -d/ -f1)
+    repo_name=$(echo "$repo" | cut -d/ -f2)
+    gh api graphql -F num="$issue_num" -f query="
+      query(\$num: Int!) {
+        repository(owner: \"$owner\", name: \"$repo_name\") {
+          issue(number: \$num) {
+            closedByPullRequestsReferences(first: 5) {
+              nodes { number state }
+            }
+          }
+        }
+      }
+    " --jq '.data.repository.issue.closedByPullRequestsReferences.nodes'
+  fi
+}
+
+# _review_pr_fetch_auto_merge_state PR_NUM REPO
+# Fetches whether autoMergeRequest is set. Mockable via REVIEW_PR_AUTO_MERGE_FILE.
+_review_pr_fetch_auto_merge_state() {
+  local pr_num="$1"
+  local repo="$2"
+
+  if [[ -n "${REVIEW_PR_AUTO_MERGE_FILE:-}" ]]; then
+    cat "$REVIEW_PR_AUTO_MERGE_FILE"
+  else
+    gh pr view "$pr_num" --repo "$repo" --json autoMergeRequest \
+      --jq '.autoMergeRequest != null'
+  fi
+}

--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -35,8 +35,9 @@ attempt_merge() {
   local pr_num="$1"
   local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
 
-  local stderr_file
-  stderr_file=$(mktemp)
+  local scratch_dir="${REVIEW_PR_SCRATCH_DIR:-${HOME}/data/review-pr-scratch}"
+  mkdir -p "$scratch_dir"
+  local stderr_file="$scratch_dir/merge-stderr-$$-$pr_num.tmp"
 
   # Try admin merge first
   if _review_pr_exec_merge "$pr_num" "$repo" "--squash --admin" "$stderr_file"; then
@@ -78,15 +79,19 @@ attempt_merge() {
 #   "merged:<pr_number>"  — no open PR, but a merged one exists
 #   "closed:<pr_number>"  — PR was closed without merge
 #   "missing"             — no linked PRs at all
+#   "error:<message>"     — API call failed
 #
-# Returns: 0 always.
+# Returns: 0 on success, 1 on API failure.
 # ─────────────────────────────────────────────────────────────────────────────
 classify_linked_pr_state() {
   local issue_num="$1"
   local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
 
   local linked_prs
-  linked_prs=$(_review_pr_fetch_linked_prs "$issue_num" "$repo")
+  if ! linked_prs=$(_review_pr_fetch_linked_prs "$issue_num" "$repo"); then
+    echo "error:failed to fetch linked PRs"
+    return 1
+  fi
 
   if [[ -z "$linked_prs" || "$linked_prs" == "null" ]]; then
     echo "missing"
@@ -125,15 +130,18 @@ classify_linked_pr_state() {
 #
 # Checks whether a PR has autoMergeRequest set (deferred auto-merge enabled).
 #
-# Output: "true" or "false" on stdout.
-# Returns: 0 always.
+# Output: "true", "false", or "error" on stdout.
+# Returns: 0 on success, 1 on API failure.
 # ─────────────────────────────────────────────────────────────────────────────
 is_auto_merge_armed() {
   local pr_num="$1"
   local repo="${REVIEW_PR_REPO:-stellar-experimental/henyey}"
 
   local auto_merge
-  auto_merge=$(_review_pr_fetch_auto_merge_state "$pr_num" "$repo")
+  if ! auto_merge=$(_review_pr_fetch_auto_merge_state "$pr_num" "$repo"); then
+    echo "error"
+    return 1
+  fi
 
   if [[ "$auto_merge" == "true" ]]; then
     echo "true"

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -34,7 +34,7 @@ cleanup
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=27
+TAP_PLAN=29
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -401,6 +401,28 @@ else
   tap_fail "SKILL.md documents explicit PR_NUM extraction from PR_STATE" \
     "SKILL.md missing PR_NUM extraction from open: state"
 fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 19: has_armed_waiting_comment returns true when comment exists
+# ══════════════════════════════════════════════════════════════════════════════
+
+WAITING_COMMENTS_FILE="$TEST_ROOT/waiting-comments.txt"
+printf '## Review: Auto-merge armed — waiting\n\nAuto-merge was previously enabled.\n' > "$WAITING_COMMENTS_FILE"
+export REVIEW_PR_ISSUE_COMMENTS_FILE="$WAITING_COMMENTS_FILE"
+RESULT=$(has_armed_waiting_comment 9999)
+assert_eq "true" "$RESULT" "has_armed_waiting_comment detects existing comment"
+unset REVIEW_PR_ISSUE_COMMENTS_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 20: has_armed_waiting_comment returns false when no comment exists
+# ══════════════════════════════════════════════════════════════════════════════
+
+NO_WAITING_FILE="$TEST_ROOT/no-waiting-comments.txt"
+printf '## Review: Merge Failed\n\nSome other comment body.\n' > "$NO_WAITING_FILE"
+export REVIEW_PR_ISSUE_COMMENTS_FILE="$NO_WAITING_FILE"
+RESULT=$(has_armed_waiting_comment 9999)
+assert_eq "false" "$RESULT" "has_armed_waiting_comment returns false when missing"
+unset REVIEW_PR_ISSUE_COMMENTS_FILE
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 unset REVIEW_PR_COMMENTS_FILE

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -34,7 +34,7 @@ cleanup
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=21
+TAP_PLAN=27
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -341,6 +341,65 @@ if grep -q 'review-pr-merge.sh' "$SKILL_FILE" && grep -q 'auto-merge.*armed' "$S
 else
   tap_fail "SKILL.md references merge helper and auto-merge armed path" \
     "SKILL.md missing references to review-pr-merge.sh or auto-merge armed"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 15: classify_linked_pr_state propagates API failure
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Use a file that doesn't exist to simulate API failure
+export REVIEW_PR_LINKED_PRS_FILE="/nonexistent/path/should-fail.json"
+set +e
+RESULT=$(classify_linked_pr_state 9999)
+RC=$?
+set -e
+assert_eq "1" "$RC" "classify_linked_pr_state returns 1 on API failure"
+[[ "$RESULT" == error:* ]] && \
+  tap_ok "classify_linked_pr_state outputs error: on API failure" || \
+  tap_fail "classify_linked_pr_state outputs error: on API failure" "got: $RESULT"
+unset REVIEW_PR_LINKED_PRS_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 16: is_auto_merge_armed propagates API failure
+# ══════════════════════════════════════════════════════════════════════════════
+
+export REVIEW_PR_AUTO_MERGE_FILE="/nonexistent/path/should-fail.json"
+set +e
+RESULT=$(is_auto_merge_armed 9999)
+RC=$?
+set -e
+assert_eq "1" "$RC" "is_auto_merge_armed returns 1 on API failure"
+assert_eq "error" "$RESULT" "is_auto_merge_armed outputs error on API failure"
+unset REVIEW_PR_AUTO_MERGE_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 17: attempt_merge uses REVIEW_PR_SCRATCH_DIR instead of mktemp
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Set a custom scratch dir and verify attempt_merge uses it (no mktemp)
+CUSTOM_SCRATCH="$TEST_ROOT/custom-scratch"
+mkdir -p "$CUSTOM_SCRATCH"
+export REVIEW_PR_SCRATCH_DIR="$CUSTOM_SCRATCH"
+
+mock_merge_success() {
+  local pr_num="$1" repo="$2" flags="$3"
+  return 0
+}
+export REVIEW_PR_MERGE_CMD=mock_merge_success
+RESULT=$(attempt_merge 1234)
+assert_eq "merged" "$RESULT" "attempt_merge uses REVIEW_PR_SCRATCH_DIR (no mktemp)"
+unset REVIEW_PR_MERGE_CMD REVIEW_PR_SCRATCH_DIR
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 18: SKILL.md documents PR_NUM extraction from PR_STATE
+# ══════════════════════════════════════════════════════════════════════════════
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+if grep -q 'PR_NUM=.*PR_STATE#open:' "$SKILL_FILE"; then
+  tap_ok "SKILL.md documents explicit PR_NUM extraction from PR_STATE"
+else
+  tap_fail "SKILL.md documents explicit PR_NUM extraction from PR_STATE" \
+    "SKILL.md missing PR_NUM extraction from open: state"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -21,8 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEST_ROOT="$REPO_ROOT/data/test-review-pr-snippets"
 
-# ── Source the library under test ─────────────────────────────────────────────
+# ── Source the libraries under test ───────────────────────────────────────────
 source "$SCRIPT_DIR/lib/review-pr-verdicts.sh"
+source "$SCRIPT_DIR/lib/review-pr-merge.sh"
 
 # ── Cleanup ──────────────────────────────────────────────────────────────────
 cleanup() {
@@ -33,7 +34,7 @@ cleanup
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=13
+TAP_PLAN=21
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -228,6 +229,119 @@ export REVIEW_PR_COMMENTS_FILE="$TEST_ROOT/multi-comments.json"
 VERDICTS=$(fetch_reviewer_verdict_comments 999 "2026-05-19T03:00:00Z")
 STATE=$(latest_reviewer_verdict_state "Correctness" "$VERDICTS")
 assert_eq "APPROVE" "$STATE" "latest comment wins when multiple verdicts exist"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 9: attempt_merge retries with --auto on auto-hint failure
+# ══════════════════════════════════════════════════════════════════════════════
+# Stub gh so the first --admin call fails with the exact auto-hint error
+# and the second --auto call succeeds.
+
+MERGE_CALL_NUM=0
+mock_merge_auto_hint() {
+  local pr_num="$1" repo="$2" flags="$3"
+  MERGE_CALL_NUM=$((MERGE_CALL_NUM + 1))
+  if [[ "$flags" == *"--admin"* ]]; then
+    echo "X Pull request stellar-experimental/henyey#$pr_num is not mergeable: the merge commit cannot be cleanly created." >&2
+    echo "To have the pull request merged after all the requirements have been met, add the \`--auto\` flag." >&2
+    return 1
+  elif [[ "$flags" == *"--auto"* ]]; then
+    return 0
+  fi
+  return 1
+}
+
+export REVIEW_PR_MERGE_CMD=mock_merge_auto_hint
+MERGE_CALL_NUM=0
+RESULT=$(attempt_merge 2875)
+RC=$?
+assert_eq "auto-merge-armed" "$RESULT" "attempt_merge retries with --auto on auto-hint failure"
+assert_eq "0" "$RC" "attempt_merge returns 0 on auto-merge-armed"
+unset REVIEW_PR_MERGE_CMD
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 10: classify_linked_pr_state prefers merged PR when no open PR exists
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo '[{"number": 2875, "state": "MERGED"}]' > "$TEST_ROOT/linked-prs-merged.json"
+export REVIEW_PR_LINKED_PRS_FILE="$TEST_ROOT/linked-prs-merged.json"
+
+RESULT=$(classify_linked_pr_state 2877)
+assert_eq "merged:2875" "$RESULT" "classify_linked_pr_state returns merged when no open PR"
+unset REVIEW_PR_LINKED_PRS_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 11: is_auto_merge_armed short-circuits to wait when armed
+# ══════════════════════════════════════════════════════════════════════════════
+
+echo "true" > "$TEST_ROOT/auto-merge-armed.txt"
+export REVIEW_PR_AUTO_MERGE_FILE="$TEST_ROOT/auto-merge-armed.txt"
+
+RESULT=$(is_auto_merge_armed 2875)
+assert_eq "true" "$RESULT" "is_auto_merge_armed returns true when autoMergeRequest is set"
+unset REVIEW_PR_AUTO_MERGE_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 12: attempt_merge auto rejection stays hard failure
+# ══════════════════════════════════════════════════════════════════════════════
+# When --auto also fails (e.g. autoMergeAllowed: false), result is hard-failure.
+
+mock_merge_auto_both_fail() {
+  local pr_num="$1" repo="$2" flags="$3"
+  if [[ "$flags" == *"--admin"* ]]; then
+    echo "To have the pull request merged after all the requirements have been met, add the \`--auto\` flag." >&2
+    return 1
+  elif [[ "$flags" == *"--auto"* ]]; then
+    echo "auto-merge is not allowed for this repository" >&2
+    return 1
+  fi
+  return 1
+}
+
+export REVIEW_PR_MERGE_CMD=mock_merge_auto_both_fail
+set +e
+RESULT=$(attempt_merge 2875)
+RC=$?
+set -e
+[[ "$RESULT" == hard-failure:* ]] && tap_ok "attempt_merge auto rejection stays hard failure" || tap_fail "attempt_merge auto rejection stays hard failure" "got: $RESULT"
+assert_eq "1" "$RC" "attempt_merge returns 1 on hard failure"
+unset REVIEW_PR_MERGE_CMD
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 13: unexpected admin merge failure stays terminal (no --auto retry)
+# ══════════════════════════════════════════════════════════════════════════════
+
+mock_merge_other_failure() {
+  local pr_num="$1" repo="$2" flags="$3"
+  if [[ "$flags" == *"--admin"* ]]; then
+    echo "permission denied: token lacks admin access" >&2
+    return 1
+  fi
+  # Should never reach --auto path
+  echo "UNEXPECTED: should not have retried with --auto" >&2
+  return 1
+}
+
+export REVIEW_PR_MERGE_CMD=mock_merge_other_failure
+set +e
+RESULT=$(attempt_merge 2875)
+RC=$?
+set -e
+[[ "$RESULT" == "hard-failure:permission denied: token lacks admin access" ]] && \
+  tap_ok "unexpected admin merge failure stays terminal" || \
+  tap_fail "unexpected admin merge failure stays terminal" "got: $RESULT"
+unset REVIEW_PR_MERGE_CMD
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 14: SKILL.md references merge helper and wait path
+# ══════════════════════════════════════════════════════════════════════════════
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+if grep -q 'review-pr-merge.sh' "$SKILL_FILE" && grep -q 'auto-merge.*armed' "$SKILL_FILE"; then
+  tap_ok "SKILL.md references merge helper and auto-merge armed path"
+else
+  tap_fail "SKILL.md references merge helper and auto-merge armed path" \
+    "SKILL.md missing references to review-pr-merge.sh or auto-merge armed"
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 unset REVIEW_PR_COMMENTS_FILE

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -33,8 +33,13 @@ trap cleanup EXIT
 cleanup
 mkdir -p "$TEST_ROOT"
 
+# Default scratch dir for attempt_merge tests (workspace-contract compliant location).
+# Individual tests that exercise the "unset" path will unset this explicitly.
+export REVIEW_PR_SCRATCH_DIR="$TEST_ROOT/merge-scratch"
+mkdir -p "$REVIEW_PR_SCRATCH_DIR"
+
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=29
+TAP_PLAN=31
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -423,6 +428,33 @@ export REVIEW_PR_ISSUE_COMMENTS_FILE="$NO_WAITING_FILE"
 RESULT=$(has_armed_waiting_comment 9999)
 assert_eq "false" "$RESULT" "has_armed_waiting_comment returns false when missing"
 unset REVIEW_PR_ISSUE_COMMENTS_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 21: attempt_merge fails when REVIEW_PR_SCRATCH_DIR is unset
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Ensure REVIEW_PR_SCRATCH_DIR is unset to exercise the default (production) path
+unset REVIEW_PR_SCRATCH_DIR 2>/dev/null || true
+unset REVIEW_PR_MERGE_CMD 2>/dev/null || true
+RESULT=$(attempt_merge 1234) && RC=$? || RC=$?
+if [[ $RC -ne 0 ]] && echo "$RESULT" | grep -qF "REVIEW_PR_SCRATCH_DIR is not set"; then
+  tap_ok "attempt_merge fails with clear error when REVIEW_PR_SCRATCH_DIR unset"
+else
+  tap_fail "attempt_merge fails with clear error when REVIEW_PR_SCRATCH_DIR unset" \
+    "Expected hard-failure about unset REVIEW_PR_SCRATCH_DIR, got rc=$RC result='$RESULT'"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 22: SKILL.md exports REVIEW_PR_SCRATCH_DIR before attempt_merge
+# ══════════════════════════════════════════════════════════════════════════════
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+if grep -B5 'attempt_merge' "$SKILL_FILE" | grep -qF "REVIEW_PR_SCRATCH_DIR"; then
+  tap_ok "SKILL.md exports REVIEW_PR_SCRATCH_DIR before calling attempt_merge"
+else
+  tap_fail "SKILL.md exports REVIEW_PR_SCRATCH_DIR before calling attempt_merge" \
+    "SKILL.md does not set REVIEW_PR_SCRATCH_DIR before attempt_merge call"
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 unset REVIEW_PR_COMMENTS_FILE

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -604,7 +604,7 @@ fi
 # TEST 31: check_armed_pr_health returns "no-ci" on empty statusCheckRollup
 # ══════════════════════════════════════════════════════════════════════════════
 
-HEALTH_DATA=$(mktemp)
+HEALTH_DATA="$TEST_ROOT/empty-rollup-health.json"
 cat > "$HEALTH_DATA" <<'HEALTHJSON'
 {"statusCheckRollup":[],"mergeable":"MERGEABLE","headRefName":"do/issue-2877","oldestRunStart":""}
 HEALTHJSON
@@ -624,6 +624,86 @@ if grep -q 'no-ci' "$SKILL_FILE" && grep -q 'no CI detected' "$SKILL_FILE"; then
 else
   tap_fail "SKILL.md handles no-ci case in OPEN+armed path" \
     "SKILL.md missing no-ci handling in armed path"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 33: check_armed_pr_health returns ci-red on ACTION_REQUIRED conclusion
+# ══════════════════════════════════════════════════════════════════════════════
+
+HEALTH_DATA="$TEST_ROOT/action-required-health.json"
+cat > "$HEALTH_DATA" <<'HEALTHJSON'
+{"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"ACTION_REQUIRED","name":"codeql"}],"mergeable":"MERGEABLE","headRefName":"do/issue-2877","oldestRunStart":""}
+HEALTHJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_DATA"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "ci-red" "$RESULT" "check_armed_pr_health returns ci-red on ACTION_REQUIRED"
+rm -f "$HEALTH_DATA"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 34: check_armed_pr_health returns ci-red on STARTUP_FAILURE conclusion
+# ══════════════════════════════════════════════════════════════════════════════
+
+HEALTH_DATA="$TEST_ROOT/startup-failure-health.json"
+cat > "$HEALTH_DATA" <<'HEALTHJSON'
+{"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"STARTUP_FAILURE","name":"build"}],"mergeable":"MERGEABLE","headRefName":"do/issue-2877","oldestRunStart":""}
+HEALTHJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_DATA"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "ci-red" "$RESULT" "check_armed_pr_health returns ci-red on STARTUP_FAILURE"
+rm -f "$HEALTH_DATA"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 35: check_armed_pr_health returns healthy only on SUCCESS/SKIPPED/NEUTRAL
+# ══════════════════════════════════════════════════════════════════════════════
+
+HEALTH_DATA="$TEST_ROOT/mixed-green-health.json"
+cat > "$HEALTH_DATA" <<'HEALTHJSON'
+{"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS","name":"build"},{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SKIPPED","name":"optional"},{"__typename":"CheckRun","status":"COMPLETED","conclusion":"NEUTRAL","name":"info"}],"mergeable":"MERGEABLE","headRefName":"do/issue-2877","oldestRunStart":""}
+HEALTHJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_DATA"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "healthy" "$RESULT" "check_armed_pr_health returns healthy on SUCCESS/SKIPPED/NEUTRAL"
+rm -f "$HEALTH_DATA"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 36: SKILL.md uses errexit-safe patterns for command substitutions
+# ══════════════════════════════════════════════════════════════════════════════
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+# Verify the old unsafe pattern (VAR=$(...) followed by $?) is gone
+if grep -q 'PR_STATE_RC=\$?' "$SKILL_FILE"; then
+  tap_fail "SKILL.md uses errexit-safe command substitutions" \
+    "Still contains PR_STATE_RC=\$? pattern (unsafe under set -e)"
+elif ! grep -q 'if ! PR_STATE=\$(classify_linked_pr_state' "$SKILL_FILE"; then
+  tap_fail "SKILL.md uses errexit-safe command substitutions" \
+    "Missing 'if ! PR_STATE=\$(classify_linked_pr_state' errexit-safe pattern"
+elif ! grep -q 'if ! MERGE_RESULT=\$(attempt_merge' "$SKILL_FILE"; then
+  tap_fail "SKILL.md uses errexit-safe command substitutions" \
+    "Missing 'if ! MERGE_RESULT=\$(attempt_merge' errexit-safe pattern"
+elif ! grep -q 'if ! AUTO_MERGE_STATE=\$(is_auto_merge_armed' "$SKILL_FILE"; then
+  tap_fail "SKILL.md uses errexit-safe command substitutions" \
+    "Missing 'if ! AUTO_MERGE_STATE=\$(is_auto_merge_armed' errexit-safe pattern"
+else
+  tap_ok "SKILL.md uses errexit-safe command substitutions"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 37: SKILL.md CI classifier requires positive green match (not fallthrough)
+# ══════════════════════════════════════════════════════════════════════════════
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+# The Step 5 classifier should explicitly check for SUCCESS/SKIPPED/NEUTRAL,
+# not use a bare 'else CI_STATE="green"' which lets ACTION_REQUIRED through.
+if grep -A2 'CI_STATE="green"' "$SKILL_FILE" | grep -q 'SUCCESS.*SKIPPED.*NEUTRAL'; then
+  tap_ok "SKILL.md CI classifier requires positive green match"
+elif grep -B5 'CI_STATE="green"' "$SKILL_FILE" | grep -q 'SUCCESS.*SKIPPED.*NEUTRAL'; then
+  tap_ok "SKILL.md CI classifier requires positive green match"
+else
+  tap_fail "SKILL.md CI classifier requires positive green match" \
+    "CI_STATE=green not guarded by positive SUCCESS/SKIPPED/NEUTRAL check"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -39,7 +39,7 @@ export REVIEW_PR_SCRATCH_DIR="$TEST_ROOT/merge-scratch"
 mkdir -p "$REVIEW_PR_SCRATCH_DIR"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=41
+TAP_PLAN=47
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -669,7 +669,23 @@ rm -f "$HEALTH_DATA"
 unset REVIEW_PR_ARMED_HEALTH_FILE
 
 # ══════════════════════════════════════════════════════════════════════════════
-# TEST 36: SKILL.md uses errexit-safe patterns for command substitutions
+# TEST 36: check_armed_pr_health returns ci-stuck on pending StatusContext with no startedAt
+# ══════════════════════════════════════════════════════════════════════════════
+# Regression for #2877: a PENDING StatusContext without a startedAt field was
+# classified as "healthy", allowing infinite wait. Must return "ci-stuck".
+
+HEALTH_DATA="$TEST_ROOT/pending-statuscontext-no-start.json"
+cat > "$HEALTH_DATA" <<'HEALTHJSON'
+{"statusCheckRollup":[{"__typename":"StatusContext","state":"PENDING"}],"mergeable":"MERGEABLE","headRefName":"do/issue-2877","oldestRunStart":""}
+HEALTHJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_DATA"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "ci-stuck" "$RESULT" "check_armed_pr_health returns ci-stuck on pending StatusContext (no startedAt)"
+rm -f "$HEALTH_DATA"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 37: SKILL.md uses errexit-safe patterns for command substitutions
 # ══════════════════════════════════════════════════════════════════════════════
 
 SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
@@ -691,7 +707,7 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════════════════
-# TEST 37: SKILL.md CI classifier requires positive green match (not fallthrough)
+# TEST 38: SKILL.md CI classifier requires positive green match (not fallthrough)
 # ══════════════════════════════════════════════════════════════════════════════
 
 SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -39,7 +39,7 @@ export REVIEW_PR_SCRATCH_DIR="$TEST_ROOT/merge-scratch"
 mkdir -p "$REVIEW_PR_SCRATCH_DIR"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=31
+TAP_PLAN=39
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -454,6 +454,150 @@ if grep -B5 'attempt_merge' "$SKILL_FILE" | grep -qF "REVIEW_PR_SCRATCH_DIR"; th
 else
   tap_fail "SKILL.md exports REVIEW_PR_SCRATCH_DIR before calling attempt_merge" \
     "SKILL.md does not set REVIEW_PR_SCRATCH_DIR before attempt_merge call"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 23: check_armed_pr_health returns "healthy" when CI is green
+# ══════════════════════════════════════════════════════════════════════════════
+
+HEALTH_FILE="$TEST_ROOT/armed-health-green.json"
+cat > "$HEALTH_FILE" <<'EOJSON'
+{
+  "statusCheckRollup": [
+    {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"}
+  ],
+  "mergeable": "MERGEABLE",
+  "headRefName": "do/issue-2877",
+  "oldestRunStart": null
+}
+EOJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_FILE"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "healthy" "$RESULT" "check_armed_pr_health returns healthy when CI green"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 24: check_armed_pr_health returns "ci-red" when CI has failures
+# ══════════════════════════════════════════════════════════════════════════════
+
+HEALTH_FILE="$TEST_ROOT/armed-health-red.json"
+cat > "$HEALTH_FILE" <<'EOJSON'
+{
+  "statusCheckRollup": [
+    {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"name": "test", "status": "COMPLETED", "conclusion": "FAILURE"}
+  ],
+  "mergeable": "MERGEABLE",
+  "headRefName": "do/issue-2877",
+  "oldestRunStart": null
+}
+EOJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_FILE"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "ci-red" "$RESULT" "check_armed_pr_health returns ci-red when CI has failures"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 25: check_armed_pr_health returns "ci-stuck" when running past budget
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Use a start time 90 minutes ago (budget is 60)
+PAST_START=$(date -d "90 minutes ago" --iso-8601=seconds)
+HEALTH_FILE="$TEST_ROOT/armed-health-stuck.json"
+cat > "$HEALTH_FILE" <<EOJSON
+{
+  "statusCheckRollup": [
+    {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"name": "integration", "status": "IN_PROGRESS", "conclusion": null}
+  ],
+  "mergeable": "MERGEABLE",
+  "headRefName": "do/issue-2877",
+  "oldestRunStart": "$PAST_START"
+}
+EOJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_FILE"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "ci-stuck" "$RESULT" "check_armed_pr_health returns ci-stuck when past budget"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 26: check_armed_pr_health returns "healthy" when running within budget
+# ══════════════════════════════════════════════════════════════════════════════
+
+RECENT_START=$(date -d "5 minutes ago" --iso-8601=seconds)
+HEALTH_FILE="$TEST_ROOT/armed-health-running.json"
+cat > "$HEALTH_FILE" <<EOJSON
+{
+  "statusCheckRollup": [
+    {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"name": "integration", "status": "IN_PROGRESS", "conclusion": null}
+  ],
+  "mergeable": "MERGEABLE",
+  "headRefName": "do/issue-2877",
+  "oldestRunStart": "$RECENT_START"
+}
+EOJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_FILE"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "healthy" "$RESULT" "check_armed_pr_health returns healthy when running within budget"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 27: check_armed_pr_health returns "not-mergeable" on conflicts
+# ══════════════════════════════════════════════════════════════════════════════
+
+HEALTH_FILE="$TEST_ROOT/armed-health-conflict.json"
+cat > "$HEALTH_FILE" <<'EOJSON'
+{
+  "statusCheckRollup": [
+    {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS"}
+  ],
+  "mergeable": "CONFLICTING",
+  "headRefName": "do/issue-2877",
+  "oldestRunStart": null
+}
+EOJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_FILE"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "not-mergeable" "$RESULT" "check_armed_pr_health returns not-mergeable on conflicts"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 28: check_armed_pr_health returns "error" on API failure
+# ══════════════════════════════════════════════════════════════════════════════
+
+export REVIEW_PR_ARMED_HEALTH_FILE="/nonexistent/path/should-fail.json"
+RESULT=$(check_armed_pr_health 9999)
+assert_eq "error" "$RESULT" "check_armed_pr_health returns error on API failure"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 29: SKILL.md uses check_armed_pr_health in OPEN+armed path
+# ══════════════════════════════════════════════════════════════════════════════
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+if grep -q 'check_armed_pr_health' "$SKILL_FILE" && grep -q 'ci-red' "$SKILL_FILE"; then
+  tap_ok "SKILL.md uses check_armed_pr_health with CI-red handling in armed path"
+else
+  tap_fail "SKILL.md uses check_armed_pr_health with CI-red handling in armed path" \
+    "SKILL.md missing check_armed_pr_health or ci-red handling in armed path"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 30: OPEN+armed path does NOT unconditionally exit (checks CI first)
+# ══════════════════════════════════════════════════════════════════════════════
+# Structural assertion: the SKILL.md armed path must check health before exiting.
+# The old bug was: `exit 0` immediately after detecting armed state without CI check.
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+# Verify the pattern: after is_auto_merge_armed == "true", the next action is
+# check_armed_pr_health (not an immediate exit 0).
+if grep -A5 'AUTO_MERGE_STATE.*==.*true' "$SKILL_FILE" | grep -q 'check_armed_pr_health'; then
+  tap_ok "OPEN+armed path checks CI health before deciding (not unconditional exit)"
+else
+  tap_fail "OPEN+armed path checks CI health before deciding (not unconditional exit)" \
+    "SKILL.md still takes unconditional exit in armed path without CI check"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -39,7 +39,7 @@ export REVIEW_PR_SCRATCH_DIR="$TEST_ROOT/merge-scratch"
 mkdir -p "$REVIEW_PR_SCRATCH_DIR"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=39
+TAP_PLAN=41
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -598,6 +598,32 @@ if grep -A5 'AUTO_MERGE_STATE.*==.*true' "$SKILL_FILE" | grep -q 'check_armed_pr
 else
   tap_fail "OPEN+armed path checks CI health before deciding (not unconditional exit)" \
     "SKILL.md still takes unconditional exit in armed path without CI check"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 31: check_armed_pr_health returns "no-ci" on empty statusCheckRollup
+# ══════════════════════════════════════════════════════════════════════════════
+
+HEALTH_DATA=$(mktemp)
+cat > "$HEALTH_DATA" <<'HEALTHJSON'
+{"statusCheckRollup":[],"mergeable":"MERGEABLE","headRefName":"do/issue-2877","oldestRunStart":""}
+HEALTHJSON
+export REVIEW_PR_ARMED_HEALTH_FILE="$HEALTH_DATA"
+RESULT=$(check_armed_pr_health 2885)
+assert_eq "no-ci" "$RESULT" "check_armed_pr_health returns no-ci on empty rollup"
+rm -f "$HEALTH_DATA"
+unset REVIEW_PR_ARMED_HEALTH_FILE
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 32: SKILL.md handles no-ci case in OPEN+armed path
+# ══════════════════════════════════════════════════════════════════════════════
+
+SKILL_FILE="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
+if grep -q 'no-ci' "$SKILL_FILE" && grep -q 'no CI detected' "$SKILL_FILE"; then
+  tap_ok "SKILL.md handles no-ci case in OPEN+armed path"
+else
+  tap_fail "SKILL.md handles no-ci case in OPEN+armed path" \
+    "SKILL.md missing no-ci handling in armed path"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2877

## Summary

Makes `/review-pr` handle GitHub's "add the --auto flag" admin-merge failure as a deferred-merge path, then correctly wait/finalize on later ticks instead of misclassifying the PR as missing. Adds `check_armed_pr_health` to verify CI health on every tick when auto-merge is armed, preventing indefinite spinning on failed/stuck/missing CI.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2877#issuecomment-4513845783)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] `bash scripts/test-review-pr-skill-snippets.sh` passes (TAP `1..47`, all 47 tests pass)

## Regression test

- **Test (TAP 21):** "SKILL.md references merge helper and auto-merge armed path"
  - **Pre-fix commit:** `85d20e4e` (test-adding commit, before SKILL.md integration at `4d70aa4d`)
  - **Pre-fix result:** FAILS — the SKILL.md at that point does not contain merge helper references or auto-merge armed path documentation.
  - **Post-fix:** PASSES from `4d70aa4d` onward (SKILL.md updated to reference the new helper).

- **Test (TAP 45):** "check_armed_pr_health returns ci-stuck on pending StatusContext (no startedAt)"
  - **Pre-fix commit:** `33176b62` (PR head before this fix)
  - **Pre-fix result:** FAILS — the function returned `healthy` for a pending StatusContext with no `startedAt`, creating an infinite-wait path.
  - **Post-fix commit:** `6c75d524`
  - **Post-fix result:** PASSES — returns `ci-stuck` when no start timestamp is available.

**Note:** Tests 14 ("attempt_merge retries with --auto") and 16 ("classify_linked_pr_state returns merged") exercise helper functions introduced in the same commit as the tests (`85d20e4e`). They pass from that commit onward because the helpers they test were added together with the tests. The actual `/review-pr` integration regression is captured by Test 21 (SKILL.md structural integration) and Test 45 (pending-StatusContext infinite-wait fix).

## Deviations from plan

- Added `check_armed_pr_health` helper (not in original converged plan) to address Risk reviewer feedback about OPEN+armed path skipping CI checks.
- Health check dispatches to bounce/block/wait depending on CI state rather than the plan's simpler unconditional wait-and-exit approach.
- Added `no-ci` state (empty `statusCheckRollup`) as a distinct blocking condition per reviewer feedback about fail-open on missing CI.
- Replaced branch-wide `gh run list` with `statusCheckRollup`-based timestamps per reviewer feedback about false ci-stuck classification.
- Fixed pending StatusContext infinite-wait by treating missing `startedAt` as `ci-stuck` rather than `healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
