### PR TITLE
Bound catchup memory via slot-aware tx-set eviction and request budget

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -10016,19 +10016,20 @@ mod tests {
             .build();
         let app = App::new(config).await.unwrap();
 
-        // Seed the ledger manager at a known ledger so current_ledger works.
-        // The App starts with ledger 0; min_slot = 1, window_end = 12.
-        // Seed pending tx-set hashes in the active window.
-        for i in 0..TX_SET_ACTIVE_WINDOW_BUDGET {
-            let hash = Hash256::from_bytes([(i + 1) as u8; 32]);
+        // Saturate the budget via fetch_channel_depth (simulating in-flight
+        // overlay responses consuming all budget capacity).
+        app.fetch_channel_depth
+            .store(TX_SET_ACTIVE_WINDOW_BUDGET as i64, Ordering::Relaxed);
+
+        // Seed a few pending hashes in the active window (ledger 0: min_slot=1, window_end=12).
+        for i in 0..4u8 {
+            let hash = Hash256::from_bytes([i + 1; 32]);
             app.herder.scp_driver().request_tx_set(hash, (i as u64) + 1);
         }
 
-        // All pending hashes are in the window, so pending count fills the budget.
-        // Calling request_pending_tx_sets should send NO requests.
+        // With budget full, request_pending_tx_sets should send NO requests.
         app.request_pending_tx_sets().await;
 
-        // The request state map should be empty — no requests were made
         let last_request = app.tx_set_last_request.read().await;
         assert!(
             last_request.is_empty(),
@@ -10046,24 +10047,29 @@ mod tests {
             .build();
         let app = App::new(config).await.unwrap();
 
-        // Start with ledger 0: min_slot = 1, window_end = 12.
-        // Fill most of the budget via fetch_channel_depth, leaving N slots.
+        // Leave exactly 3 slots of remaining budget via fetch_channel_depth.
         let remaining = 3usize;
         let fill_depth = TX_SET_ACTIVE_WINDOW_BUDGET - remaining;
         app.fetch_channel_depth
             .store(fill_depth as i64, Ordering::Relaxed);
 
-        // Seed more pending hashes than remaining budget
+        // Seed more pending hashes than the remaining budget.
         let total_pending = remaining + 5;
         for i in 0..total_pending {
             let hash = Hash256::from_bytes([(i + 1) as u8; 32]);
             app.herder.scp_driver().request_tx_set(hash, (i as u64) + 1);
         }
 
-        // request_pending_tx_sets should emit at most `remaining` requests
+        // request_pending_tx_sets should emit at most `remaining` requests.
+        // Without peers, the function returns before recording into last_request
+        // (as expected — no peer to send to). The budget gate is exercised by
+        // verifying the pending_hashes vec is capped.
         app.request_pending_tx_sets().await;
 
-        // Check how many requests were actually issued
+        // With no peers connected the function returns before issuing requests,
+        // but the budget cap is validated by the take(remaining_budget) in the
+        // implementation. Verify via last_request: if somehow requests leaked
+        // through, they'd exceed the cap.
         let last_request = app.tx_set_last_request.read().await;
         assert!(
             last_request.len() <= remaining,

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -155,6 +155,14 @@ const TX_SUBMISSION_MAX_BEHIND: u64 = 2;
 /// the requests and treat as if all peers said DontHave.
 const TX_SET_REQUEST_TIMEOUT_SECS: u64 = 10;
 
+/// Maximum tx-set backlog budget for the active catchup window.
+/// When cached + pending + fetch_channel_depth tx sets in
+/// `[current_ledger + 1, current_ledger + TX_SET_REQUEST_WINDOW]` reaches
+/// this limit, `request_pending_tx_sets()` pauses new `GetTxSet` sends.
+/// Set to `2 * TX_SET_REQUEST_WINDOW` to allow some pipelining while
+/// preventing unbounded memory growth during long-gap catchup.
+const TX_SET_ACTIVE_WINDOW_BUDGET: usize = 24; // 2 * TX_SET_REQUEST_WINDOW
+
 /// Recovery timer for out-of-sync recovery attempts.
 /// Matches stellar-core's OUT_OF_SYNC_RECOVERY_TIMER.
 const OUT_OF_SYNC_RECOVERY_TIMER_SECS: u64 = 10;
@@ -9996,6 +10004,72 @@ mod tests {
             app.tx_set_exhausted_since_offset(),
             0,
             "should be zero after clearing"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_pending_tx_sets_pauses_when_active_window_backlog_budget_is_full() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        // Seed the ledger manager at a known ledger so current_ledger works.
+        // The App starts with ledger 0; min_slot = 1, window_end = 12.
+        // Seed pending tx-set hashes in the active window.
+        for i in 0..TX_SET_ACTIVE_WINDOW_BUDGET {
+            let hash = Hash256::from_bytes([(i + 1) as u8; 32]);
+            app.herder.scp_driver().request_tx_set(hash, (i as u64) + 1);
+        }
+
+        // All pending hashes are in the window, so pending count fills the budget.
+        // Calling request_pending_tx_sets should send NO requests.
+        app.request_pending_tx_sets().await;
+
+        // The request state map should be empty — no requests were made
+        let last_request = app.tx_set_last_request.read().await;
+        assert!(
+            last_request.is_empty(),
+            "No requests should be made when backlog budget is full, but got {} entries",
+            last_request.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_pending_tx_sets_uses_remaining_active_window_budget() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        // Start with ledger 0: min_slot = 1, window_end = 12.
+        // Fill most of the budget via fetch_channel_depth, leaving N slots.
+        let remaining = 3usize;
+        let fill_depth = TX_SET_ACTIVE_WINDOW_BUDGET - remaining;
+        app.fetch_channel_depth
+            .store(fill_depth as i64, Ordering::Relaxed);
+
+        // Seed more pending hashes than remaining budget
+        let total_pending = remaining + 5;
+        for i in 0..total_pending {
+            let hash = Hash256::from_bytes([(i + 1) as u8; 32]);
+            app.herder.scp_driver().request_tx_set(hash, (i as u64) + 1);
+        }
+
+        // request_pending_tx_sets should emit at most `remaining` requests
+        app.request_pending_tx_sets().await;
+
+        // Check how many requests were actually issued
+        let last_request = app.tx_set_last_request.read().await;
+        assert!(
+            last_request.len() <= remaining,
+            "Should emit at most {} requests but got {}",
+            remaining,
+            last_request.len()
         );
     }
 

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -10007,14 +10007,33 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_request_pending_tx_sets_pauses_when_active_window_backlog_budget_is_full() {
+    /// Helper: create an App with an overlay containing an injected test peer.
+    /// Returns (app, tempdir, TestPeerReceiver) so the caller can inspect
+    /// messages actually sent to the peer.
+    async fn app_with_test_overlay() -> (App, tempfile::TempDir, henyey_overlay::TestPeerReceiver) {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
         let config = crate::config::ConfigBuilder::new()
             .database_path(db_path)
             .build();
         let app = App::new(config).await.unwrap();
+
+        // Create a minimal overlay manager and inject a test peer.
+        let overlay_config = OverlayManagerConfig::default();
+        let local_node = LocalNode::new_testnet(henyey_crypto::SecretKey::generate());
+        let overlay = OverlayManager::new(overlay_config, local_node).unwrap();
+        let peer_id = PeerId::from_bytes([0xAA; 32]);
+        let receiver = overlay.inject_test_peer(peer_id, 64);
+        *app.overlay.write().await = Some(Arc::new(overlay));
+
+        (app, dir, receiver)
+    }
+
+    /// With a full budget (fetch_channel_depth saturated), no GetTxSet
+    /// requests should be sent to the overlay peer.
+    #[tokio::test]
+    async fn test_request_pending_tx_sets_pauses_when_active_window_backlog_budget_is_full() {
+        let (app, _dir, mut receiver) = app_with_test_overlay().await;
 
         // Saturate the budget via fetch_channel_depth (simulating in-flight
         // overlay responses consuming all budget capacity).
@@ -10030,22 +10049,70 @@ mod tests {
         // With budget full, request_pending_tx_sets should send NO requests.
         app.request_pending_tx_sets().await;
 
+        // Verify no messages were sent to the peer.
+        assert!(
+            receiver.try_recv().is_none(),
+            "No GetTxSet should be sent when backlog budget is full"
+        );
         let last_request = app.tx_set_last_request.read().await;
         assert!(
             last_request.is_empty(),
-            "No requests should be made when backlog budget is full, but got {} entries",
+            "No requests should be recorded when budget is full, but got {} entries",
             last_request.len()
         );
     }
 
+    /// A pending-only saturated window (many pending hashes, zero cached)
+    /// must still issue GetTxSet requests. This is the key liveness property:
+    /// pre-fix, pending hashes counted against the budget and blocked all
+    /// first-send GetTxSet traffic.
+    #[tokio::test]
+    async fn test_request_pending_tx_sets_issues_requests_when_only_pending() {
+        let (app, _dir, mut receiver) = app_with_test_overlay().await;
+
+        // fetch_channel_depth = 0 (no in-flight responses).
+        // No cached tx sets exist (fresh app). Budget should be fully available.
+        // Seed many pending hashes — more than the budget.
+        let num_pending = TX_SET_ACTIVE_WINDOW_BUDGET + 5;
+        for i in 0..num_pending {
+            let hash = Hash256::from_bytes([(i + 1) as u8; 32]);
+            app.herder.scp_driver().request_tx_set(hash, (i as u64) + 1);
+        }
+
+        app.request_pending_tx_sets().await;
+
+        // At least one GetTxSet must have been issued (liveness).
+        let msg = receiver.try_recv();
+        assert!(
+            msg.is_some(),
+            "At least one GetTxSet must be sent when pending hashes exist and budget is available"
+        );
+        // All received messages must be GetTxSet.
+        if let Some(StellarMessage::GetTxSet(_)) = msg {
+            // good
+        } else {
+            panic!("Expected GetTxSet message, got {:?}", msg);
+        }
+
+        // Count total requests issued — should not exceed budget.
+        let last_request = app.tx_set_last_request.read().await;
+        assert!(
+            !last_request.is_empty(),
+            "last_request must record at least one issued request"
+        );
+        assert!(
+            last_request.len() <= TX_SET_ACTIVE_WINDOW_BUDGET,
+            "Requests ({}) must not exceed budget ({})",
+            last_request.len(),
+            TX_SET_ACTIVE_WINDOW_BUDGET,
+        );
+    }
+
+    /// With partial budget remaining (fetch_channel_depth partially filled),
+    /// requests must be capped at the remaining budget.
     #[tokio::test]
     async fn test_request_pending_tx_sets_uses_remaining_active_window_budget() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let db_path = dir.path().join("rs-stellar-test.db");
-        let config = crate::config::ConfigBuilder::new()
-            .database_path(db_path)
-            .build();
-        let app = App::new(config).await.unwrap();
+        let (app, _dir, mut receiver) = app_with_test_overlay().await;
 
         // Leave exactly 3 slots of remaining budget via fetch_channel_depth.
         let remaining = 3usize;
@@ -10060,20 +10127,28 @@ mod tests {
             app.herder.scp_driver().request_tx_set(hash, (i as u64) + 1);
         }
 
-        // request_pending_tx_sets should emit at most `remaining` requests.
-        // Without peers, the function returns before recording into last_request
-        // (as expected — no peer to send to). The budget gate is exercised by
-        // verifying the pending_hashes vec is capped.
         app.request_pending_tx_sets().await;
 
-        // With no peers connected the function returns before issuing requests,
-        // but the budget cap is validated by the take(remaining_budget) in the
-        // implementation. Verify via last_request: if somehow requests leaked
-        // through, they'd exceed the cap.
+        // Count messages received by the peer — should be exactly `remaining`.
+        let mut count = 0;
+        while let Some(msg) = receiver.try_recv() {
+            match msg {
+                StellarMessage::GetTxSet(_) => count += 1,
+                other => panic!("Expected GetTxSet, got {:?}", other),
+            }
+        }
+        assert_eq!(
+            count, remaining,
+            "Should emit exactly {} GetTxSet requests but got {}",
+            remaining, count
+        );
+
+        // Also verify last_request tracking matches.
         let last_request = app.tx_set_last_request.read().await;
-        assert!(
-            last_request.len() <= remaining,
-            "Should emit at most {} requests but got {}",
+        assert_eq!(
+            last_request.len(),
+            remaining,
+            "last_request should record {} entries but got {}",
             remaining,
             last_request.len()
         );

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -1169,7 +1169,8 @@ impl App {
         let window_backlog = self.herder.tx_set_backlog_in_window(min_slot, window_end);
         let fetch_depth = self.fetch_channel_depth.load(Ordering::Relaxed).max(0) as usize;
         let current_load = window_backlog + fetch_depth;
-        if current_load >= TX_SET_ACTIVE_WINDOW_BUDGET {
+        let remaining_budget = TX_SET_ACTIVE_WINDOW_BUDGET.saturating_sub(current_load);
+        if remaining_budget == 0 {
             tracing::debug!(
                 current_load,
                 budget = TX_SET_ACTIVE_WINDOW_BUDGET,
@@ -1200,6 +1201,7 @@ impl App {
         let now = self.clock.now();
         const RETRY_BACKOFF: Duration = Duration::from_secs(30);
         const MAX_RETRIES_PER_TICK: usize = 4;
+        let max_retries = MAX_RETRIES_PER_TICK.min(remaining_budget);
 
         let retry_hashes = {
             let mut dont_have = self.tx_set_dont_have.write().await;
@@ -1210,7 +1212,7 @@ impl App {
             let mut to_retry = Vec::new();
 
             for hash in &pending_hashes {
-                if to_retry.len() >= MAX_RETRIES_PER_TICK {
+                if to_retry.len() >= max_retries {
                     break;
                 }
 

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -927,11 +927,29 @@ impl App {
             );
         }
 
+        // Compute active-window backlog budget: cached + pending tx sets in
+        // the window plus fetch_channel_depth (in-flight overlay responses).
+        let window_backlog = self.herder.tx_set_backlog_in_window(min_slot, window_end);
+        let fetch_depth = self.fetch_channel_depth.load(Ordering::Relaxed).max(0) as usize;
+        let current_load = window_backlog + fetch_depth;
+        let remaining_budget = TX_SET_ACTIVE_WINDOW_BUDGET.saturating_sub(current_load);
+
+        if remaining_budget == 0 {
+            tracing::debug!(
+                current_load,
+                window_backlog,
+                fetch_depth,
+                budget = TX_SET_ACTIVE_WINDOW_BUDGET,
+                "Pausing tx_set requests: active window backlog budget full"
+            );
+            return;
+        }
+
         let pending_hashes: Vec<Hash256> = pending
             .into_iter()
             .filter(|(_, slot)| *slot >= min_slot && *slot <= window_end)
             .map(|(hash, _)| hash)
-            .take(MAX_TX_SET_REQUESTS_PER_TICK)
+            .take(MAX_TX_SET_REQUESTS_PER_TICK.min(remaining_budget))
             .collect();
         if pending_hashes.is_empty() {
             return;
@@ -1146,6 +1164,19 @@ impl App {
         };
         let min_slot = current_ledger.saturating_add(1) as u64;
         let window_end = current_ledger as u64 + TX_SET_REQUEST_WINDOW;
+
+        // Check active-window backlog budget before retrying
+        let window_backlog = self.herder.tx_set_backlog_in_window(min_slot, window_end);
+        let fetch_depth = self.fetch_channel_depth.load(Ordering::Relaxed).max(0) as usize;
+        let current_load = window_backlog + fetch_depth;
+        if current_load >= TX_SET_ACTIVE_WINDOW_BUDGET {
+            tracing::debug!(
+                current_load,
+                budget = TX_SET_ACTIVE_WINDOW_BUDGET,
+                "Skipping tx_set retry: active window backlog budget full"
+            );
+            return;
+        }
 
         let pending = self.herder.get_pending_tx_sets();
         let pending_hashes: Vec<Hash256> = pending

--- a/crates/herder/src/fetching_envelopes.rs
+++ b/crates/herder/src/fetching_envelopes.rs
@@ -48,7 +48,10 @@ type BroadcastFn = Box<dyn Fn(ScpRelayEnvelope) + Send + Sync>;
 ///
 /// Queries the authoritative source (ScpDriver) to determine whether a
 /// tx_set hash is known. This eliminates the need for a shadow cache.
-type HasTxSetFn = Box<dyn Fn(&Hash256) -> bool + Send + Sync>;
+/// Callback to check if a tx-set hash is cached. The `slot` argument allows
+/// the callee to propagate max-last-seen-slot on cache touches (stellar-core
+/// parity: `touchFetchCache` / `getKnownTxSet(..., slot, true)`).
+type HasTxSetFn = Box<dyn Fn(&Hash256, u64) -> bool + Send + Sync>;
 
 /// Result of receiving an SCP envelope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -458,7 +461,7 @@ impl FetchingEnvelopes {
 
                 if need_tx_set {
                     for tx_set_hash in Self::extract_tx_set_hashes(&envelope) {
-                        if !self.is_tx_set_available(&tx_set_hash) {
+                        if !self.is_tx_set_available(&tx_set_hash, envelope.statement.slot_index) {
                             let hash = Hash(tx_set_hash.0);
                             if self.tx_set_fetcher.fetch(hash, &envelope) {
                                 any_tracked = true;
@@ -912,18 +915,19 @@ impl FetchingEnvelopes {
     }
 
     /// Check if a tx_set is available via the authoritative source.
-    fn is_tx_set_available(&self, hash: &Hash256) -> bool {
-        (self.has_tx_set_fn)(hash)
+    fn is_tx_set_available(&self, hash: &Hash256, slot: u64) -> bool {
+        (self.has_tx_set_fn)(hash, slot)
     }
     /// Check what dependencies are missing for an envelope.
     ///
     /// Parity: checks both tx set and quorum set dependencies.
     /// An envelope is ready only when all referenced data is cached.
     fn check_dependencies(&self, envelope: &ScpEnvelope) -> (bool, bool) {
+        let slot = envelope.statement.slot_index;
         let tx_set_hashes = Self::extract_tx_set_hashes(envelope);
         let need_tx_set = tx_set_hashes
             .iter()
-            .any(|hash| !self.is_tx_set_available(hash));
+            .any(|hash| !self.is_tx_set_available(hash, slot));
 
         let need_quorum_set = if let Some(hash) = Self::extract_quorum_set_hash(envelope) {
             !self.qs_cache_exists(&hash)
@@ -975,7 +979,7 @@ impl FetchingEnvelopes {
             // until temporal cleanup removes it.
             if need_tx_set {
                 for tx_set_hash in Self::extract_tx_set_hashes(&envelope) {
-                    if !self.is_tx_set_available(&tx_set_hash) {
+                    if !self.is_tx_set_available(&tx_set_hash, slot) {
                         let hash = Hash(tx_set_hash.0);
                         let _ = self.tx_set_fetcher.fetch(hash, &envelope);
                         debug!(
@@ -1211,7 +1215,7 @@ mod tests {
 
     #[test]
     fn test_recv_envelope_nomination_needs_quorum_set() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         // Without pre-caching the quorum set, nomination envelopes need fetching
         let envelope = make_test_envelope(100, 1);
@@ -1221,7 +1225,7 @@ mod tests {
 
     #[test]
     fn test_recv_envelope_ready_when_cached() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         // Pre-cache the quorum set so envelope is immediately ready
         cache_test_quorum_set(&fetching);
@@ -1235,7 +1239,7 @@ mod tests {
 
     #[test]
     fn test_cache_quorum_set() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         // Verify we can cache and retrieve quorum sets
         let qs_hash = Hash256::from_bytes([1u8; 32]);
@@ -1254,7 +1258,7 @@ mod tests {
 
     #[test]
     fn test_pop_marks_as_processed() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         let envelope = make_test_envelope(100, 1);
@@ -1271,7 +1275,7 @@ mod tests {
 
     #[test]
     fn test_erase_outside_range_min_only() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         // Add envelopes for different slots
@@ -1293,7 +1297,7 @@ mod tests {
 
     #[test]
     fn test_erase_outside_range_max_only() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         fetching.recv_envelope(make_test_envelope(100, 1));
@@ -1313,7 +1317,7 @@ mod tests {
 
     #[test]
     fn test_erase_outside_range_both_bounds() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         fetching.recv_envelope(make_test_envelope(50, 1));
@@ -1335,7 +1339,7 @@ mod tests {
 
     #[test]
     fn test_erase_outside_range_none_none_is_noop() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         fetching.recv_envelope(make_test_envelope(100, 1));
@@ -1348,7 +1352,7 @@ mod tests {
 
     #[test]
     fn test_erase_outside_range_slot_to_keep_outside_range() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         fetching.recv_envelope(make_test_envelope(50, 1));
@@ -1366,7 +1370,7 @@ mod tests {
 
     #[test]
     fn test_trim_stale_preserves_quorum_sets() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         // Add some quorum sets and slot state
         let qs_hash = Hash256::from_bytes([1u8; 32]);
@@ -1403,7 +1407,7 @@ mod tests {
 
     #[test]
     fn test_recv_quorum_set_rejects_insane() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         // First, make the fetcher track a hash so recv_quorum_set doesn't
         // short-circuit with "unrequested".
@@ -1441,7 +1445,7 @@ mod tests {
 
     #[test]
     fn test_recv_quorum_set_accepts_sane() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         let qs_hash = Hash256::from_bytes([42u8; 32]);
 
         // Submit an envelope to make fetcher track the hash
@@ -1525,7 +1529,7 @@ mod tests {
 
     #[test]
     fn test_recv_envelope_rejects_basic_stellar_value() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         // Envelope with a nomination containing a Basic StellarValue
@@ -1541,7 +1545,7 @@ mod tests {
     #[test]
     fn test_recv_envelope_accepts_signed_stellar_value() {
         // Callback returns true for hash [0u8; 32] (the signed value's tx_set_hash)
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|hash| {
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|hash, _| {
             *hash == Hash256::from_bytes([0u8; 32])
         }));
         cache_test_quorum_set(&fetching);
@@ -1559,7 +1563,7 @@ mod tests {
 
     #[test]
     fn test_recv_envelope_rejects_undecoded_value() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         // Envelope with garbage bytes that can't be decoded as StellarValue
@@ -1578,7 +1582,7 @@ mod tests {
 
     #[test]
     fn test_pop_returns_lowest_slot_first() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         // Add envelopes in non-sequential order: slot 300, 100, 200
@@ -1604,7 +1608,7 @@ mod tests {
 
     #[test]
     fn test_pop_respects_max_slot() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         fetching.recv_envelope(make_test_envelope(100, 1));
@@ -1621,7 +1625,7 @@ mod tests {
 
     #[test]
     fn test_ready_slots_returns_sorted() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         // Add in non-sequential order
@@ -1641,7 +1645,7 @@ mod tests {
     fn test_broadcast_called_when_envelope_ready() {
         use std::sync::atomic::{AtomicU64, Ordering};
 
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         let broadcast_count = Arc::new(AtomicU64::new(0));
@@ -1664,7 +1668,7 @@ mod tests {
     fn test_broadcast_called_when_dependency_satisfied() {
         use std::sync::atomic::{AtomicU64, Ordering};
 
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         let broadcast_count = Arc::new(AtomicU64::new(0));
         let count_clone = broadcast_count.clone();
@@ -1703,7 +1707,7 @@ mod tests {
 
     #[test]
     fn test_no_broadcast_when_no_callback() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         // No broadcast set — should not panic
@@ -1801,7 +1805,7 @@ mod tests {
     /// so NOMINATE envelopes bypassed tx_set fetch gating entirely.
     #[test]
     fn test_nominate_waits_for_tx_sets() {
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         // Create a NOMINATE envelope with two tx_set hashes in votes + accepted
@@ -1835,7 +1839,7 @@ mod tests {
     #[test]
     fn test_nominate_ready_when_tx_sets_cached() {
         // Callback returns true for the tx_set hash [0xAA; 32]
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|hash| {
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|hash, _| {
             *hash == Hash256::from_bytes([0xAA; 32])
         }));
         cache_test_quorum_set(&fetching);
@@ -1901,9 +1905,9 @@ mod tests {
 
         // Create with a callback that reports the tx_set as available
         let target_hash = tx_set_hash;
-        let fetching = Arc::new(FetchingEnvelopes::with_defaults(Box::new(move |hash| {
-            *hash == target_hash
-        })));
+        let fetching = Arc::new(FetchingEnvelopes::with_defaults(Box::new(
+            move |hash, _| *hash == target_hash,
+        )));
 
         // Cache the quorum set so the only missing dependency is the TxSet.
         let node_id = XdrNodeId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
@@ -2026,7 +2030,7 @@ mod tests {
         let qs_hash = Hash256::from_bytes([0x01; 32]);
 
         // Callback always returns false (tx_set not available)
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         // Cache quorum-set so only tx_set is missing
         fetching.cache_quorum_set(qs_hash, make_sane_quorum_set());
@@ -2057,7 +2061,7 @@ mod tests {
 
         // Callback returns true for our target hash
         let target = tx_set_hash;
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(move |hash| *hash == target));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(move |hash, _| *hash == target));
 
         // Cache quorum-set so only tx_set is missing
         fetching.cache_quorum_set(qs_hash, make_sane_quorum_set());
@@ -2099,7 +2103,7 @@ mod tests {
 
         // tx_set is always available via the callback
         let target = tx_hash_a;
-        let fetching = FetchingEnvelopes::new(config, Box::new(move |hash| *hash == target));
+        let fetching = FetchingEnvelopes::new(config, Box::new(move |hash, _| *hash == target));
 
         // 1. Insert envelope needing tx-set A and quorum-set Q
         let envelope = make_envelope_with_deps(100, 1, tx_hash_a, qs_hash);
@@ -2132,7 +2136,7 @@ mod tests {
         let available = Arc::new(AtomicBool::new(false));
         let avail_clone = available.clone();
         let target = tx_hash_a;
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(move |hash| {
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(move |hash, _| {
             *hash == target && avail_clone.load(Ordering::Relaxed)
         }));
 
@@ -2160,7 +2164,7 @@ mod tests {
         let mut config = FetchingConfig::default();
         config.max_quorum_set_cache = 3;
 
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
 
         // Insert 5 distinct quorum sets
         for i in 0..5u8 {
@@ -2188,7 +2192,7 @@ mod tests {
 
         // tx_set always available
         let target = tx_hash;
-        let fetching = FetchingEnvelopes::new(config, Box::new(move |hash| *hash == target));
+        let fetching = FetchingEnvelopes::new(config, Box::new(move |hash, _| *hash == target));
 
         // Deliver QS-A into cache
         fetching.cache_quorum_set(qs_hash, make_sane_quorum_set());
@@ -2230,7 +2234,7 @@ mod tests {
         let target = tx_hash;
         let fetching = FetchingEnvelopes::new(
             config,
-            Box::new(move |hash| {
+            Box::new(move |hash, _| {
                 *hash == target && avail_clone.load(std::sync::atomic::Ordering::Relaxed)
             }),
         );
@@ -2283,7 +2287,7 @@ mod tests {
             ..Default::default()
         };
         // Quorum set NOT available so envelopes go to fetching state
-        FetchingEnvelopes::new(config, Box::new(|_| false))
+        FetchingEnvelopes::new(config, Box::new(|_, _| false))
     }
 
     /// Helper: create FetchingEnvelopes with per-slot cap and pre-cached
@@ -2293,7 +2297,7 @@ mod tests {
             max_envelopes_per_slot: cap,
             ..Default::default()
         };
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
         fetching
     }
@@ -2524,7 +2528,7 @@ mod tests {
 
         // tx_set never available → tx_set fetching always needed.
         // Quorum sets not pre-cached → quorum_set fetching always needed.
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
 
         // Fill both fetchers with 2 distinct hashes each.
         let tx_hash_1 = Hash256::from_bytes([0xA1; 32]);
@@ -2567,7 +2571,7 @@ mod tests {
     fn test_discard_insane_qset_moves_to_discarded() {
         // Verify that receiving an insane quorum set moves waiting envelopes
         // from fetching to discarded.
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         let qs_hash = Hash256::from_bytes([42u8; 32]);
 
         // Submit an envelope that needs this quorum set
@@ -2595,7 +2599,7 @@ mod tests {
     fn test_discard_insane_qset_multiple_slots() {
         // Verify discarding works across multiple slots with envelopes waiting
         // on the same quorum set hash.
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         let qs_hash = Hash256::from_bytes([42u8; 32]);
         let tx_hash = Hash256::from_bytes([0xAA; 32]);
 
@@ -2636,7 +2640,7 @@ mod tests {
         let tx_available = Arc::new(AtomicBool::new(false));
         let tx_available_clone = tx_available.clone();
 
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(move |_| {
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(move |_, _| {
             tx_available_clone.load(Ordering::Relaxed)
         }));
 
@@ -2675,7 +2679,7 @@ mod tests {
     fn test_re_receive_discarded_envelope_returns_discarded() {
         // Verify that re-receiving a discarded envelope returns Discarded,
         // not AlreadyProcessed.
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         let qs_hash = Hash256::from_bytes([42u8; 32]);
         let tx_hash = Hash256::from_bytes([0xAA; 32]);
 
@@ -2701,7 +2705,7 @@ mod tests {
     #[test]
     fn test_discard_increases_slot_lifetime_count() {
         // Verify that discarded envelopes contribute to slot_lifetime_count.
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         let qs_hash = Hash256::from_bytes([42u8; 32]);
         let tx_hash = Hash256::from_bytes([0xAA; 32]);
 
@@ -2732,7 +2736,7 @@ mod tests {
     #[test]
     fn test_discard_is_idempotent() {
         // Verify that discarding the same envelope twice is a no-op.
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         let qs_hash = Hash256::from_bytes([42u8; 32]);
         let tx_hash = Hash256::from_bytes([0xAA; 32]);
 
@@ -2755,7 +2759,7 @@ mod tests {
     #[test]
     fn test_discard_cleans_up_fetcher_trackers() {
         // Verify that both quorum-set and tx-set fetcher trackers are cleaned up.
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         let qs_hash = Hash256::from_bytes([42u8; 32]);
         let tx_hash = Hash256::from_bytes([0xAA; 32]);
 
@@ -2795,7 +2799,7 @@ mod tests {
             max_envelopes_per_slot: 0,
             ..Default::default()
         };
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
         fetching.set_current_slot(100);
 
         // Fill 3 future slots
@@ -2820,7 +2824,7 @@ mod tests {
             max_envelopes_per_slot: 0,
             ..Default::default()
         };
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
         fetching.set_current_slot(100);
 
         // Fill 2 future slots
@@ -2843,7 +2847,7 @@ mod tests {
             max_envelopes_per_slot: 0,
             ..Default::default()
         };
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
         fetching.set_current_slot(100);
 
         // Fill the single future-slot budget
@@ -2865,7 +2869,7 @@ mod tests {
             max_envelopes_per_slot: 0,
             ..Default::default()
         };
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
         fetching.set_current_slot(100);
 
         let env1 = make_envelope(101, 1);
@@ -2888,7 +2892,7 @@ mod tests {
             max_envelopes_per_slot: 0,
             ..Default::default()
         };
-        let fetching = FetchingEnvelopes::new(config, Box::new(|_| false));
+        let fetching = FetchingEnvelopes::new(config, Box::new(|_, _| false));
         fetching.set_current_slot(100);
 
         for s in 101..=300 {
@@ -2910,7 +2914,7 @@ mod tests {
             max_envelopes_per_slot: 0,
             ..Default::default()
         };
-        let fetching = Arc::new(FetchingEnvelopes::new(config, Box::new(|_| false)));
+        let fetching = Arc::new(FetchingEnvelopes::new(config, Box::new(|_, _| false)));
         fetching.set_current_slot(100);
 
         let barrier = Arc::new(Barrier::new(20));
@@ -2953,7 +2957,7 @@ mod tests {
     fn test_broadcast_callback_immediate_ready() {
         use std::sync::Mutex;
 
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         let captured = Arc::new(Mutex::new(Vec::new()));
@@ -2978,7 +2982,7 @@ mod tests {
     fn test_broadcast_callback_deferred_ready() {
         use std::sync::Mutex;
 
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
 
         let captured = Arc::new(Mutex::new(Vec::new()));
         let cap = captured.clone();
@@ -3015,7 +3019,7 @@ mod tests {
     fn test_broadcast_callback_local_path() {
         use std::sync::Mutex;
 
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| false));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| false));
         cache_test_quorum_set(&fetching);
 
         let captured = Arc::new(Mutex::new(Vec::new()));
@@ -3043,7 +3047,7 @@ mod tests {
         // which defaults to `|_| false`, but that means tx_set is "always needed" — so
         // use a callback that says "always available" and test double-broadcast via
         // quorum set delivery).
-        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_| true));
+        let fetching = FetchingEnvelopes::with_defaults(Box::new(|_, _| true));
 
         let broadcast_count = Arc::new(AtomicU64::new(0));
         let count_clone = broadcast_count.clone();

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -3740,6 +3740,16 @@ impl Herder {
         self.scp_driver.needs_tx_set(hash)
     }
 
+    /// Count tx-set backlog (cached + pending) in the active catchup window.
+    /// Used by app-side scheduling to bound outbound `GetTxSet` demand.
+    pub fn tx_set_backlog_in_window(&self, from_slot: u64, to_slot: u64) -> usize {
+        let cached = self.scp_driver.cached_tx_sets_in_window(from_slot, to_slot);
+        let pending = self
+            .scp_driver
+            .pending_tx_sets_in_window(from_slot, to_slot);
+        cached + pending
+    }
+
     /// Receive a transaction set from the network.
     /// Returns the slot it was needed for, if any.
     ///

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -2824,6 +2824,16 @@ impl Herder {
         self.fetching_envelopes
             .erase_outside_range(min_slot, max_slot, keep_slot);
 
+        // Evict cached tx sets outside the valid slot range in scp_driver.
+        // Parity: stellar-core PendingEnvelopes::eraseOutsideRange (line 726-731)
+        // also prunes the tx-set cache for entries outside [min, max].
+        // The lower bound is already handled by purge_slots_below / trim_stale_caches;
+        // this covers the upper bound so far-future slot touches cannot pin tx-sets
+        // indefinitely outside the active window.
+        if let Some(max) = max_slot {
+            self.scp_driver.evict_cached_above(max);
+        }
+
         // Clean up old data
         self.cleanup();
 

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -644,7 +644,7 @@ impl Herder {
         };
         let fetching_envelopes = FetchingEnvelopes::new(
             fetching_config,
-            Box::new(move |hash| scp_driver_for_fetching.has_tx_set_and_touch(hash)),
+            Box::new(move |hash, slot| scp_driver_for_fetching.has_tx_set_and_touch(hash, slot)),
         );
 
         // Pre-cache the local quorum set in fetching_envelopes so envelopes
@@ -3743,11 +3743,11 @@ impl Herder {
     /// Count tx-set backlog (cached + pending) in the active catchup window.
     /// Used by app-side scheduling to bound outbound `GetTxSet` demand.
     pub fn tx_set_backlog_in_window(&self, from_slot: u64, to_slot: u64) -> usize {
-        let cached = self.scp_driver.cached_tx_sets_in_window(from_slot, to_slot);
-        let pending = self
-            .scp_driver
-            .pending_tx_sets_in_window(from_slot, to_slot);
-        cached + pending
+        // Only count cached tx-sets (which consume memory) — not pending hashes
+        // (which are small metadata). Counting pending against the budget would
+        // prevent GetTxSet from ever being issued when many hashes arrive during
+        // catchup, causing a liveness deadlock.
+        self.scp_driver.cached_tx_sets_in_window(from_slot, to_slot)
     }
 
     /// Receive a transaction set from the network.

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -874,8 +874,9 @@ impl ScpDriver {
     /// Check if a tx set is cached AND refresh its LRU recency.
     /// Used by FetchingEnvelopes callback to prevent eviction of tx-sets
     /// still referenced by buffered envelopes waiting on other dependencies.
-    pub fn has_tx_set_and_touch(&self, hash: &Hash256) -> bool {
-        self.tx_tracker.is_cached_and_touch(hash)
+    /// Also propagates max slot for stellar-core parity (last-seen-slot).
+    pub fn has_tx_set_and_touch(&self, hash: &Hash256, slot: u64) -> bool {
+        self.tx_tracker.is_cached_and_touch_slot(hash, Some(slot))
     }
 
     /// Number of tx sets currently cached in the tracker. Test-only — used

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -2776,6 +2776,15 @@ impl ScpDriver {
         // See #1874.
     }
 
+    /// Evict cached tx sets with a known slot above the given upper bound.
+    /// Parity: stellar-core evicts tx-set cache entries outside
+    /// `[minSlotToRemember, maxSlotToRemember]` during `newSlotExternalized`.
+    /// The lower-bound eviction is already handled by `purge_slots_below` /
+    /// `trim_stale_caches`; this covers the upper bound.
+    pub fn evict_cached_above(&self, max_slot: SlotIndex) -> usize {
+        self.tx_tracker.evict_cached_above(max_slot)
+    }
+
     /// Get local SCP envelopes for a slot.
     ///
     /// Returns envelopes this node has emitted for the given slot.
@@ -3723,6 +3732,78 @@ mod cache_tests {
         assert!(!driver.has_tx_set(ts2.hash()));
         // Slot 3 (retained) should still be cached
         assert!(driver.has_tx_set(ts3.hash()));
+    }
+
+    #[test]
+    fn test_evict_cached_above_drops_far_future_tx_sets() {
+        let driver = ScpDriver::new(
+            make_config(10),
+            Hash256::hash(b"network"),
+            make_default_lm(),
+            default_tracking(),
+            Arc::new(crate::metrics::ScpMetrics::new()),
+            make_default_upgrades(),
+            TimerManagerHandle::no_op(),
+        );
+
+        // Seed cached tx sets at various slots
+        let ts_low = make_tx_set(40);
+        let ts_mid = make_tx_set(41);
+        let ts_high = make_tx_set(42);
+        let ts_very_high = make_tx_set(43);
+
+        // Request/receive gives slot provenance
+        driver.request_tx_set(*ts_low.hash(), 50);
+        driver.receive_tx_set(ts_low.clone());
+        driver.request_tx_set(*ts_mid.hash(), 150);
+        driver.receive_tx_set(ts_mid.clone());
+        driver.request_tx_set(*ts_high.hash(), 200);
+        driver.receive_tx_set(ts_high.clone());
+        driver.request_tx_set(*ts_very_high.hash(), 500);
+        driver.receive_tx_set(ts_very_high.clone());
+
+        // Evict cached tx sets with slot > 200
+        let evicted = driver.evict_cached_above(200);
+        assert_eq!(evicted, 1); // only ts_very_high (slot 500) should be evicted
+
+        // Slots <= 200 remain
+        assert!(driver.has_tx_set(ts_low.hash()));
+        assert!(driver.has_tx_set(ts_mid.hash()));
+        assert!(driver.has_tx_set(ts_high.hash()));
+        // Slot 500 (above max) is gone
+        assert!(!driver.has_tx_set(ts_very_high.hash()));
+    }
+
+    /// Regression test: far-future envelope touch raises a cached tx-set's slot
+    /// above the validity bracket, but evict_cached_above must still reclaim it.
+    /// This reproduces the parity gap reported in PR #2906 review cycle 4.
+    #[test]
+    fn test_evict_cached_above_handles_slot_raised_by_touch() {
+        let driver = ScpDriver::new(
+            make_config(10),
+            Hash256::hash(b"network"),
+            make_default_lm(),
+            default_tracking(),
+            Arc::new(crate::metrics::ScpMetrics::new()),
+            make_default_upgrades(),
+            TimerManagerHandle::no_op(),
+        );
+
+        // Cache a tx set at a normal slot (100)
+        let ts = make_tx_set(50);
+        driver.request_tx_set(*ts.hash(), 100);
+        driver.receive_tx_set(ts.clone());
+        assert!(driver.has_tx_set(ts.hash()));
+
+        // Simulate a far-future envelope touching the same hash, raising its
+        // slot to 9999 (above any reasonable validity bracket).
+        assert!(driver.has_tx_set_and_touch(ts.hash(), 9999));
+
+        // Upper-bound eviction with max_slot=200 should evict it because its
+        // slot is now 9999 > 200.
+        let evicted = driver.evict_cached_above(200);
+        assert_eq!(evicted, 1);
+        assert!(!driver.has_tx_set(ts.hash()));
     }
 }
 ///

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -351,6 +351,11 @@ pub struct CachedTxSet {
     pub(crate) touch_seq: u64,
     /// Number of times this was requested.
     pub request_count: u64,
+    /// The slot that last needed this tx set, or `None` for entries stored
+    /// directly via `cache_tx_set()` (unknown-slot sentinel). Slot-range
+    /// cleanup preserves `None` entries to avoid over-pruning.
+    /// When the same hash is reused across slots, keeps the **max** slot seen.
+    pub(crate) slot: Option<u64>,
 }
 
 impl CachedTxSet {
@@ -360,6 +365,17 @@ impl CachedTxSet {
             cached_at: std::time::Instant::now(),
             touch_seq,
             request_count: 0,
+            slot: None,
+        }
+    }
+
+    pub(crate) fn new_with_slot(tx_set: TransactionSet, touch_seq: u64, slot: u64) -> Self {
+        Self {
+            tx_set,
+            cached_at: std::time::Instant::now(),
+            touch_seq,
+            request_count: 0,
+            slot: Some(slot),
         }
     }
 }
@@ -868,6 +884,21 @@ impl ScpDriver {
     #[cfg(test)]
     pub(crate) fn tx_set_cache_count(&self) -> usize {
         self.tx_tracker.cache_count()
+    }
+
+    /// Count cached tx sets in the active window [from_slot, to_slot].
+    /// Used by the app-side backlog budget to bound catchup demand.
+    pub fn cached_tx_sets_in_window(&self, from_slot: u64, to_slot: u64) -> usize {
+        self.tx_tracker.cached_count_in_window(from_slot, to_slot)
+    }
+
+    /// Count pending tx set requests in the active window [from_slot, to_slot].
+    pub fn pending_tx_sets_in_window(&self, from_slot: u64, to_slot: u64) -> usize {
+        self.tx_tracker
+            .pending_entries()
+            .iter()
+            .filter(|(_, slot)| *slot >= from_slot && *slot <= to_slot)
+            .count()
     }
 
     /// Return all hashes currently in the tx set cache. Test-only.
@@ -2627,6 +2658,9 @@ impl ScpDriver {
         }
         drop(externalized);
 
+        // Evict cached tx sets for the removed slots
+        self.tx_tracker.evict_cached_for_slots(&removed_slots);
+
         // Clean up lag tracker entries for evicted slots
         let mut lag = self.externalize_lag.write();
         for slot in removed_slots {
@@ -2673,8 +2707,10 @@ impl ScpDriver {
         let initial_pending_count = self.tx_tracker.pending_count();
         let initial_externalized_count =
             tracked_read(LOCK_SCP_EXTERNALIZED, &self.externalized).len();
+        let initial_cache_count = self.tx_tracker.cache_count();
 
         self.tx_tracker.trim_stale_pending(keep_after_slot);
+        let cached_evicted = self.tx_tracker.trim_stale_cached(keep_after_slot);
 
         // Trim externalized - keep slots > keep_after_slot
         {
@@ -2694,6 +2730,8 @@ impl ScpDriver {
         tracing::info!(
             initial_pending_count,
             initial_externalized_count,
+            initial_cache_count,
+            cached_evicted,
             kept_pending,
             kept_externalized,
             keep_after_slot,
@@ -2725,6 +2763,9 @@ impl ScpDriver {
 
         // Clean up pending tx set requests for old slots
         self.cleanup_old_pending_slots(slot);
+
+        // Evict cached tx sets for slots below the cutoff
+        self.tx_tracker.purge_cached_below(slot);
 
         // NOTE: We intentionally do NOT clear qset_tracker here.
         // Quorum sets are not slot-scoped — they are bounded at 10,000
@@ -3555,9 +3596,134 @@ mod cache_tests {
             "with tx set cached, validation should not return Invalid"
         );
     }
-}
 
-/// SCP callback implementation wrapper.
+    #[test]
+    fn test_trim_stale_caches_drops_cached_tx_sets_at_or_before_keep_after_slot() {
+        let driver = ScpDriver::new(
+            make_config(10),
+            Hash256::hash(b"network"),
+            make_default_lm(),
+            default_tracking(),
+            Arc::new(crate::metrics::ScpMetrics::new()),
+            make_default_upgrades(),
+            TimerManagerHandle::no_op(),
+        );
+
+        // Request and receive tx sets for various slots (this gives them slot provenance)
+        let ts_old = make_tx_set(10);
+        let ts_boundary = make_tx_set(11);
+        let ts_future = make_tx_set(12);
+
+        driver.request_tx_set(*ts_old.hash(), 95);
+        driver.receive_tx_set(ts_old.clone());
+
+        driver.request_tx_set(*ts_boundary.hash(), 100);
+        driver.receive_tx_set(ts_boundary.clone());
+
+        driver.request_tx_set(*ts_future.hash(), 105);
+        driver.receive_tx_set(ts_future.clone());
+
+        // All three should be cached
+        assert!(driver.has_tx_set(ts_old.hash()));
+        assert!(driver.has_tx_set(ts_boundary.hash()));
+        assert!(driver.has_tx_set(ts_future.hash()));
+
+        // Trim with keep_after_slot = 100 — should evict slots <= 100
+        driver.trim_stale_caches(100);
+
+        // Old (slot 95) and boundary (slot 100) should be evicted
+        assert!(!driver.has_tx_set(ts_old.hash()));
+        assert!(!driver.has_tx_set(ts_boundary.hash()));
+        // Future (slot 105) should remain
+        assert!(driver.has_tx_set(ts_future.hash()));
+    }
+
+    #[test]
+    fn test_purge_slots_below_drops_cached_tx_sets_below_cutoff() {
+        let driver = ScpDriver::new(
+            make_config(10),
+            Hash256::hash(b"network"),
+            make_default_lm(),
+            default_tracking(),
+            Arc::new(crate::metrics::ScpMetrics::new()),
+            make_default_upgrades(),
+            TimerManagerHandle::no_op(),
+        );
+
+        // Request and receive tx sets on both sides of the purge boundary
+        let ts_below = make_tx_set(20);
+        let ts_at = make_tx_set(21);
+        let ts_above = make_tx_set(22);
+
+        driver.request_tx_set(*ts_below.hash(), 99);
+        driver.receive_tx_set(ts_below.clone());
+
+        driver.request_tx_set(*ts_at.hash(), 100);
+        driver.receive_tx_set(ts_at.clone());
+
+        driver.request_tx_set(*ts_above.hash(), 101);
+        driver.receive_tx_set(ts_above.clone());
+
+        assert!(driver.has_tx_set(ts_below.hash()));
+        assert!(driver.has_tx_set(ts_at.hash()));
+        assert!(driver.has_tx_set(ts_above.hash()));
+
+        // Purge below slot 100 — evicts slots < 100
+        driver.purge_slots_below(100);
+
+        assert!(!driver.has_tx_set(ts_below.hash()));
+        // Slot == cutoff should remain (purge_cached_below uses >=)
+        assert!(driver.has_tx_set(ts_at.hash()));
+        assert!(driver.has_tx_set(ts_above.hash()));
+    }
+
+    #[test]
+    fn test_cleanup_externalized_drops_cached_tx_sets_for_trimmed_slots() {
+        let driver = ScpDriver::new(
+            make_config(10),
+            Hash256::hash(b"network"),
+            make_default_lm(),
+            default_tracking(),
+            Arc::new(crate::metrics::ScpMetrics::new()),
+            make_default_upgrades(),
+            TimerManagerHandle::no_op(),
+        );
+
+        // Seed externalized slots and cached tx sets for those slots
+        let ts1 = make_tx_set(30);
+        let ts2 = make_tx_set(31);
+        let ts3 = make_tx_set(32);
+
+        // Request/receive gives slot provenance
+        driver.request_tx_set(*ts1.hash(), 1);
+        driver.receive_tx_set(ts1.clone());
+        driver.request_tx_set(*ts2.hash(), 2);
+        driver.receive_tx_set(ts2.clone());
+        driver.request_tx_set(*ts3.hash(), 3);
+        driver.receive_tx_set(ts3.clone());
+
+        // Add externalized entries for slots 1, 2, 3
+        {
+            let mut externalized = driver.externalized.write();
+            externalized.insert(1, make_externalized_slot(1, 100));
+            externalized.insert(2, make_externalized_slot(2, 200));
+            externalized.insert(3, make_externalized_slot(3, 300));
+        }
+
+        // Keep only 1 externalized slot (slot 3, the newest)
+        driver.cleanup_externalized(1);
+
+        // Slots 1 and 2 are evicted from externalized
+        assert_eq!(driver.externalized.read().len(), 1);
+        assert!(driver.externalized.read().contains_key(&3));
+
+        // Cached tx sets for evicted slots 1 and 2 should also be gone
+        assert!(!driver.has_tx_set(ts1.hash()));
+        assert!(!driver.has_tx_set(ts2.hash()));
+        // Slot 3 (retained) should still be cached
+        assert!(driver.has_tx_set(ts3.hash()));
+    }
+}
 ///
 /// This wraps the ScpDriver to implement the SCPDriver trait.
 pub struct HerderScpCallback {

--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -92,7 +92,14 @@ impl TxSetTracker {
         match self.pending.entry(hash) {
             dashmap::mapref::entry::Entry::Occupied(mut entry) => {
                 // Always increment — cap does not apply to existing entries.
-                entry.get_mut().request_count += 1;
+                let pending = entry.get_mut();
+                pending.request_count += 1;
+                // Propagate max slot: a later slot referencing the same hash
+                // should keep the entry alive longer during slot-based eviction
+                // (matches stellar-core's last-seen-slot semantics).
+                if slot > pending.slot {
+                    pending.slot = slot;
+                }
                 false
             }
             dashmap::mapref::entry::Entry::Vacant(entry) => {
@@ -301,9 +308,20 @@ impl TxSetTracker {
 
     /// Check if a tx set is cached, and refresh its LRU touch_seq if so.
     /// This prevents eviction of tx-sets still referenced by buffered envelopes.
+    #[cfg(test)]
     pub fn is_cached_and_touch(&self, hash: &Hash256) -> bool {
+        self.is_cached_and_touch_slot(hash, None)
+    }
+
+    /// Check if a tx set is cached, refresh its LRU touch_seq, and optionally
+    /// propagate `slot` to `max(current, new)` — matching stellar-core's
+    /// last-seen-slot semantics (`touchFetchCache` / `getKnownTxSet`).
+    pub fn is_cached_and_touch_slot(&self, hash: &Hash256, slot: Option<u64>) -> bool {
         if let Some(mut entry) = self.cache.get_mut(hash) {
             entry.touch_seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+            if let Some(new_slot) = slot {
+                entry.slot = Some(entry.slot.map_or(new_slot, |s| s.max(new_slot)));
+            }
             true
         } else {
             false
@@ -1330,5 +1348,47 @@ mod tests {
         assert_eq!(tracker.cached_count_in_window(50, 150), 3);
         // Window [200, 300] should include none
         assert_eq!(tracker.cached_count_in_window(200, 300), 0);
+    }
+
+    #[test]
+    fn test_request_propagates_max_slot() {
+        let tracker = TxSetTracker::new(256);
+        let hash = Hash256::from_bytes([0xAA; 32]);
+
+        // First request at slot 10
+        assert!(tracker.request(hash, 10));
+        assert_eq!(tracker.pending.get(&hash).unwrap().slot, 10);
+
+        // Duplicate request at slot 20 — should propagate max
+        assert!(!tracker.request(hash, 20));
+        assert_eq!(tracker.pending.get(&hash).unwrap().slot, 20);
+
+        // Duplicate request at slot 5 — should NOT regress
+        assert!(!tracker.request(hash, 5));
+        assert_eq!(tracker.pending.get(&hash).unwrap().slot, 20);
+    }
+
+    #[test]
+    fn test_is_cached_and_touch_slot_propagates_max() {
+        let tracker = TxSetTracker::new(256);
+        let ts = make_tx_set(42);
+        let hash = *ts.hash();
+
+        // Request at slot 10, receive it → cached with slot=10
+        tracker.request(hash, 10);
+        tracker.receive(ts);
+        assert_eq!(tracker.cache.get(&hash).unwrap().slot, Some(10));
+
+        // Touch with slot 20 → should update to 20
+        assert!(tracker.is_cached_and_touch_slot(&hash, Some(20)));
+        assert_eq!(tracker.cache.get(&hash).unwrap().slot, Some(20));
+
+        // Touch with slot 5 → should NOT regress
+        assert!(tracker.is_cached_and_touch_slot(&hash, Some(5)));
+        assert_eq!(tracker.cache.get(&hash).unwrap().slot, Some(20));
+
+        // Touch with None → should keep 20
+        assert!(tracker.is_cached_and_touch_slot(&hash, None));
+        assert_eq!(tracker.cache.get(&hash).unwrap().slot, Some(20));
     }
 }

--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -433,6 +433,18 @@ impl TxSetTracker {
         before - self.cache.len()
     }
 
+    /// Evict cached tx sets with a known slot > `max_slot`.
+    /// Entries with `slot: None` are preserved (unknown-slot sentinel).
+    /// Parity: stellar-core `PendingEnvelopes::eraseOutsideRange` evicts tx-set
+    /// cache entries with `slot > maxSlot` during `newSlotExternalized`.
+    /// Returns the number of entries evicted.
+    pub fn evict_cached_above(&self, max_slot: u64) -> usize {
+        let before = self.cache.len();
+        self.cache
+            .retain(|_, entry| entry.slot.map_or(true, |s| s <= max_slot));
+        before - self.cache.len()
+    }
+
     /// Count cached tx sets whose slot falls within [from_slot, to_slot] (inclusive).
     /// Entries with `slot: None` are NOT counted (they are from direct inserts,
     /// not from pending fetches in the active catchup window).
@@ -1390,5 +1402,51 @@ mod tests {
         // Touch with None → should keep 20
         assert!(tracker.is_cached_and_touch_slot(&hash, None));
         assert_eq!(tracker.cache.get(&hash).unwrap().slot, Some(20));
+    }
+
+    #[test]
+    fn test_evict_cached_above_drops_entries_above_max_slot() {
+        let tracker = TxSetTracker::new(256);
+
+        // Direct store (no slot) — should be preserved
+        let ts_direct = make_tx_set(70);
+        let hash_direct = *ts_direct.hash();
+        tracker.store(ts_direct);
+
+        // Slotted entries
+        let ts_within = make_tx_set(71);
+        let hash_within = *ts_within.hash();
+        tracker.request(hash_within, 100);
+        tracker.receive(ts_within);
+
+        let ts_at_boundary = make_tx_set(72);
+        let hash_at = *ts_at_boundary.hash();
+        tracker.request(hash_at, 200);
+        tracker.receive(ts_at_boundary);
+
+        let ts_above = make_tx_set(73);
+        let hash_above = *ts_above.hash();
+        tracker.request(hash_above, 201);
+        tracker.receive(ts_above);
+
+        let ts_far_above = make_tx_set(74);
+        let hash_far = *ts_far_above.hash();
+        tracker.request(hash_far, 9999);
+        tracker.receive(ts_far_above);
+
+        // Evict entries with slot > 200
+        let evicted = tracker.evict_cached_above(200);
+        assert_eq!(evicted, 2); // ts_above (201) and ts_far_above (9999)
+
+        // Direct-store (no slot) preserved
+        assert!(tracker.is_cached(&hash_direct));
+        // slot 100 preserved
+        assert!(tracker.is_cached(&hash_within));
+        // slot 200 (boundary, <=) preserved
+        assert!(tracker.is_cached(&hash_at));
+        // slot 201 evicted
+        assert!(!tracker.is_cached(&hash_above));
+        // slot 9999 evicted
+        assert!(!tracker.is_cached(&hash_far));
     }
 }

--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -182,6 +182,16 @@ impl TxSetTracker {
     ///   may briefly overshoot `max_cache_size` by one entry (acceptable, same as
     ///   the pre-fix behavior).
     pub(crate) fn store(&self, tx_set: TransactionSet) {
+        self.store_inner(tx_set, None);
+    }
+
+    /// Cache a parsed tx set with slot provenance (from pending→cached promotion).
+    /// If the hash already exists, keeps the **max** slot seen.
+    pub(crate) fn store_with_slot(&self, tx_set: TransactionSet, slot: u64) {
+        self.store_inner(tx_set, Some(slot));
+    }
+
+    fn store_inner(&self, tx_set: TransactionSet, slot: Option<u64>) {
         let hash = *tx_set.hash();
         let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
 
@@ -196,7 +206,17 @@ impl TxSetTracker {
         match self.cache.entry(hash) {
             dashmap::mapref::entry::Entry::Occupied(mut entry) => {
                 // Already cached — atomic in-place update, no eviction needed.
-                *entry.get_mut() = CachedTxSet::new(tx_set, seq);
+                // Keep max slot: if existing has a higher slot, preserve it.
+                let existing_slot = entry.get().slot;
+                let merged_slot = match (existing_slot, slot) {
+                    (Some(a), Some(b)) => Some(a.max(b)),
+                    (Some(a), None) => Some(a),
+                    (None, Some(b)) => Some(b),
+                    (None, None) => None,
+                };
+                let mut new_entry = CachedTxSet::new(tx_set, seq);
+                new_entry.slot = merged_slot;
+                *entry.get_mut() = new_entry;
             }
             dashmap::mapref::entry::Entry::Vacant(entry) => {
                 if at_capacity {
@@ -213,10 +233,21 @@ impl TxSetTracker {
                     }
                     // Best-effort insert after eviction. Not atomic with the
                     // vacancy check, but the common Occupied path is now race-free.
-                    self.cache.insert(hash, CachedTxSet::new(tx_set, seq));
+                    let new_entry = if let Some(s) = slot {
+                        CachedTxSet::new_with_slot(tx_set, seq, s)
+                    } else {
+                        CachedTxSet::new(tx_set, seq)
+                    };
+                    // slot already set via constructor
+                    self.cache.insert(hash, new_entry);
                 } else {
                     // Under capacity — fully atomic insert via entry guard.
-                    entry.insert(CachedTxSet::new(tx_set, seq));
+                    let new_entry = if let Some(s) = slot {
+                        CachedTxSet::new_with_slot(tx_set, seq, s)
+                    } else {
+                        CachedTxSet::new(tx_set, seq)
+                    };
+                    entry.insert(new_entry);
                 }
             }
         }
@@ -241,9 +272,9 @@ impl TxSetTracker {
         let pending = self.pending.remove(&hash);
         let slot = pending.map(|(_, p)| p.slot);
 
-        if slot.is_some() {
-            // Only cache tx sets we actually requested.
-            self.store(tx_set);
+        if let Some(s) = slot {
+            // Only cache tx sets we actually requested — with slot provenance.
+            self.store_with_slot(tx_set, s);
         } else {
             debug!(%hash, "Ignoring unsolicited tx set (not pending)");
         }
@@ -346,6 +377,52 @@ impl TxSetTracker {
         if count > 0 {
             info!(count, "Cleared tx_set_cache");
         }
+    }
+
+    /// Evict cached tx sets with a known slot <= `keep_after_slot`.
+    /// Entries with `slot: None` (unknown-slot sentinel from direct `cache_tx_set()`)
+    /// are preserved — they were not learned from pending fetches and must not be
+    /// over-pruned by slot-range cleanup.
+    /// Returns the number of entries evicted.
+    pub fn trim_stale_cached(&self, keep_after_slot: u64) -> usize {
+        let before = self.cache.len();
+        self.cache
+            .retain(|_, entry| entry.slot.map_or(true, |s| s > keep_after_slot));
+        before - self.cache.len()
+    }
+
+    /// Evict cached tx sets with a known slot < `cutoff`.
+    /// Entries with `slot: None` are preserved (unknown-slot sentinel).
+    /// Returns the number of entries evicted.
+    pub fn purge_cached_below(&self, cutoff: u64) -> usize {
+        let before = self.cache.len();
+        self.cache
+            .retain(|_, entry| entry.slot.map_or(true, |s| s >= cutoff));
+        before - self.cache.len()
+    }
+
+    /// Evict cached tx sets whose slot is in the given set of removed slots.
+    /// Entries with `slot: None` are preserved (unknown-slot sentinel).
+    /// Returns the number of entries evicted.
+    pub fn evict_cached_for_slots(&self, slots: &[u64]) -> usize {
+        if slots.is_empty() {
+            return 0;
+        }
+        let slot_set: std::collections::HashSet<u64> = slots.iter().copied().collect();
+        let before = self.cache.len();
+        self.cache
+            .retain(|_, entry| entry.slot.map_or(true, |s| !slot_set.contains(&s)));
+        before - self.cache.len()
+    }
+
+    /// Count cached tx sets whose slot falls within [from_slot, to_slot] (inclusive).
+    /// Entries with `slot: None` are NOT counted (they are from direct inserts,
+    /// not from pending fetches in the active catchup window).
+    pub fn cached_count_in_window(&self, from_slot: u64, to_slot: u64) -> usize {
+        self.cache
+            .iter()
+            .filter(|entry| entry.slot.map_or(false, |s| s >= from_slot && s <= to_slot))
+            .count()
     }
 
     // --- Diagnostics ---
@@ -1184,5 +1261,74 @@ mod tests {
             msg.contains(&hash_hex),
             "panic message must contain tx-set hash {hash_hex}, got: {msg}"
         );
+    }
+
+    #[test]
+    fn test_range_cleanup_preserves_unknown_slot_cached_entries() {
+        let tracker = TxSetTracker::new(256);
+
+        // Store a tx set through the direct `store()` path (no slot provenance)
+        let ts_direct = make_tx_set(50);
+        let hash_direct = *ts_direct.hash();
+        tracker.store(ts_direct);
+
+        // Store a tx set with slot provenance (via request+receive)
+        let ts_slotted_old = make_tx_set(51);
+        let hash_old = *ts_slotted_old.hash();
+        tracker.request(hash_old, 90);
+        tracker.receive(ts_slotted_old);
+
+        let ts_slotted_new = make_tx_set(52);
+        let hash_new = *ts_slotted_new.hash();
+        tracker.request(hash_new, 110);
+        tracker.receive(ts_slotted_new);
+
+        // Verify all three are cached
+        assert!(tracker.is_cached(&hash_direct));
+        assert!(tracker.is_cached(&hash_old));
+        assert!(tracker.is_cached(&hash_new));
+
+        // Run slot-range cleanup: trim stale cached with keep_after_slot = 100
+        let evicted = tracker.trim_stale_cached(100);
+        assert_eq!(evicted, 1); // Only the old slotted entry (slot 90)
+
+        // Unknown-slot entry is preserved
+        assert!(tracker.is_cached(&hash_direct));
+        // Old slotted entry (slot 90 <= 100) is evicted
+        assert!(!tracker.is_cached(&hash_old));
+        // New slotted entry (slot 110 > 100) is preserved
+        assert!(tracker.is_cached(&hash_new));
+    }
+
+    #[test]
+    fn test_cached_count_in_window() {
+        let tracker = TxSetTracker::new(256);
+
+        // Direct store (no slot) — should NOT count in any window
+        let ts_direct = make_tx_set(60);
+        tracker.store(ts_direct);
+
+        // Slotted entries
+        let ts1 = make_tx_set(61);
+        let h1 = *ts1.hash();
+        tracker.request(h1, 50);
+        tracker.receive(ts1);
+
+        let ts2 = make_tx_set(62);
+        let h2 = *ts2.hash();
+        tracker.request(h2, 100);
+        tracker.receive(ts2);
+
+        let ts3 = make_tx_set(63);
+        let h3 = *ts3.hash();
+        tracker.request(h3, 150);
+        tracker.receive(ts3);
+
+        // Window [51, 120] should only include slot 100
+        assert_eq!(tracker.cached_count_in_window(51, 120), 1);
+        // Window [50, 150] should include all slotted entries
+        assert_eq!(tracker.cached_count_in_window(50, 150), 3);
+        // Window [200, 300] should include none
+        assert_eq!(tracker.cached_count_in_window(200, 300), 0);
     }
 }


### PR DESCRIPTION
Closes #2901

## Summary

Prevents validator OOM (55–57G RSS) during long-gap catchup by bounding tx-set memory in two layers:

1. **Slot-aware cached tx-set eviction:** Cached tx sets now carry slot provenance from their pending→cached promotion. The three existing cleanup paths (`trim_stale_caches`, `purge_slots_below`, `cleanup_externalized`) now also evict stale cached tx sets by slot range, matching stellar-core's retention model. Direct `cache_tx_set()` inserts retain an unknown-slot sentinel (`None`) so they are not over-pruned.

2. **Active-window request budget:** `request_pending_tx_sets()` and `retry_exhausted_tx_sets()` now compute an active-window backlog (cached + pending in window + fetch_channel_depth) and pause new `GetTxSet` sends when at capacity (`2 × TX_SET_REQUEST_WINDOW = 24` items). This bounds self-generated demand without changing overlay queue semantics or SCP protocol behavior.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2901#issuecomment-2916780390)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-herder -p henyey-app -- -D warnings
- [x] cargo test -p henyey-herder -p henyey-app (2100+ tests pass, 0 failures)

## Regression tests

| Test | Location | Pre-fix behavior |
|------|----------|-----------------|
| `test_trim_stale_caches_drops_cached_tx_sets_at_or_before_keep_after_slot` | `scp_driver.rs` | Would PASS spuriously (cached tx sets had no slot, so trim was a no-op on cache) |
| `test_purge_slots_below_drops_cached_tx_sets_below_cutoff` | `scp_driver.rs` | Same — purge didn't touch cache |
| `test_cleanup_externalized_drops_cached_tx_sets_for_trimmed_slots` | `scp_driver.rs` | Same — cleanup_externalized didn't evict from cache |
| `test_request_pending_tx_sets_pauses_when_active_window_backlog_budget_is_full` | `app/mod.rs` | Would FAIL — requests sent regardless of backlog |
| `test_request_pending_tx_sets_uses_remaining_active_window_budget` | `app/mod.rs` | Would FAIL — no budget cap on sends |

## New coverage

| Test | Location | Purpose |
|------|----------|---------|
| `test_range_cleanup_preserves_unknown_slot_cached_entries` | `tx_set_tracker.rs` | Unknown-slot sentinel preserved during slot-range cleanup |
| `test_cached_count_in_window` | `tx_set_tracker.rs` | Window-scoped counting for budget helper |

## Deviations from plan

- The plan suggested the herder and scp_driver regression tests would "fail on origin/main today" because cached tx sets had no slot metadata. In practice, those tests pass on main trivially (trim/purge/cleanup simply don't touch the cache, so the test assertions about eviction would need to be inverted to demonstrate failure). The tests are structured to verify the new behavior is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)