### PR TITLE
Fix low-watermark semantics in catchup/recovery callers

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -2544,17 +2544,19 @@ impl App {
                     // try_start_ledger_close immediately for any buffered
                     // ledgers that are already ready.
                     if let Some(overlay) = self.overlay().await {
-                        let current_ledger = self.current_ledger_seq();
+                        // Use the shared low-watermark helper instead of raw
+                        // current_ledger (#2904).
+                        let ledger_seq = self.scp_state_request_ledger_seq();
                         // Record timestamp before spawning so heartbeat/gap
                         // throttle sees this attempt and does not duplicate it.
                         *self.last_scp_state_request_at.write().await = self.clock.now();
                         henyey_common::spawn_observed(
                             "scp_state_request_after_catchup",
                             async move {
-                                let _ = overlay.request_scp_state(current_ledger).await;
+                                let _ = overlay.request_scp_state(ledger_seq).await;
                             },
                         );
-                        tracing::info!(current_ledger, "Spawned SCP state request after catchup");
+                        tracing::info!(ledger_seq, "Spawned SCP state request after catchup");
                     }
                 } else {
                     tracing::info!(

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -983,6 +983,8 @@ impl App {
 
         let overlay_clone = Arc::clone(&overlay);
         let envelope_count = envelopes.len();
+        // Use the shared low-watermark helper instead of raw current_ledger (#2904).
+        let ledger_seq = self.scp_state_request_ledger_seq();
         henyey_common::spawn_observed("scp_envelope_forwarding", async move {
             let broadcast_futures: Vec<_> = envelopes
                 .into_iter()
@@ -1005,7 +1007,6 @@ impl App {
                 );
             }
 
-            let ledger_seq = current_ledger;
             tracing::info!(
                 ledger_seq,
                 "Requesting SCP state from peers (recovery task)"
@@ -1553,7 +1554,8 @@ impl App {
                     // sees this attempt and does not immediately duplicate it.
                     *self.last_scp_state_request_at.write().await = self.clock.now();
                     let overlay_clone = std::sync::Arc::clone(&overlay);
-                    let ledger = current_ledger;
+                    // Use the shared low-watermark helper instead of raw current_ledger (#2904).
+                    let ledger = self.scp_state_request_ledger_seq();
                     henyey_common::spawn_observed(
                         "inter_checkpoint_scp_state_request",
                         async move {

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -2676,6 +2676,13 @@ impl App {
         self.request_scp_state_from_peers().await;
     }
 
+    /// Returns the low-watermark ledger sequence for outbound `GetScpState`
+    /// requests. Delegates to `Herder::get_min_ledger_seq_to_ask_peers()` so
+    /// all recovery/catchup callers use the same parity-correct formula.
+    pub(crate) fn scp_state_request_ledger_seq(&self) -> u32 {
+        self.herder.get_min_ledger_seq_to_ask_peers()
+    }
+
     /// Request SCP state from all connected peers.
     pub async fn request_scp_state_from_peers(&self) {
         let Some(overlay) = self.overlay().await else {

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -12861,6 +12861,37 @@ mod required_lm_behavioral_tests {
         assert_eq!(min_seq, 98);
     }
 
+    /// Regression test for #2904: when the herder's tracking consensus index
+    /// is far ahead of LCL (e.g. tracking = 200, LCL = 50), the unclamped
+    /// formula returns a low watermark below get_min_ledger_seq_to_remember().
+    /// stellar-core clamps with `max(low, getMinLedgerSeqToRemember())`.
+    #[test]
+    fn test_get_min_ledger_seq_to_ask_peers_clamps_to_remember_floor_when_tracking_ahead() {
+        let lm = make_ledger_manager_at_seq(50);
+        let herder = Herder::new(HerderConfig::default(), lm, TimerManagerHandle::no_op());
+        // Set to Tracking state with tracking_slot=201 → consensus_index=200
+        {
+            let mut state = tracked_write(LOCK_HERDER_STATE, &herder.state);
+            *state = HerderState::Tracking;
+        }
+        {
+            let mut ts = tracked_write(LOCK_TRACKING_STATE, &herder.tracking_state);
+            ts.is_tracking = true;
+            ts.consensus_index = 201;
+        }
+
+        // get_min_ledger_seq_to_remember() = 200 - 12 + 1 = 189
+        let min_seq = herder.get_min_ledger_seq_to_ask_peers();
+
+        // Without clamp: lcl=50, low=51, window=3, low=48
+        // With clamp: max(48, 189) = 189
+        assert_eq!(
+            min_seq, 189,
+            "get_min_ledger_seq_to_ask_peers must clamp to get_min_ledger_seq_to_remember \
+             when tracking is ahead of LCL (stellar-core parity)"
+        );
+    }
+
     /// ledger_close_duration() delegates directly to LedgerManager.
     #[test]
     fn test_ledger_close_duration_reads_from_lm() {

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1233,12 +1233,16 @@ impl Herder {
     }
 
     /// Compute the minimum ledger sequence to ask peers for SCP state.
+    ///
+    /// Parity: stellar-core `HerderImpl::getMinLedgerSeqToAskPeers()` —
+    /// computes a lookback from LCL, then clamps upward so we never ask for
+    /// slots the herder would immediately forget.
     pub fn get_min_ledger_seq_to_ask_peers(&self) -> u32 {
         let lcl = self.ledger_manager.current_ledger_seq();
         let mut low = lcl.saturating_add(1);
         let max_slots = self.config.max_externalized_slots.max(1) as u32;
         // Number of extra ledgers to keep beyond max_externalized_slots, matching
-        // stellar-core's LEDGER_VALIDITY_BRACKET lookback cushion.
+        // stellar-core's SCP_EXTRA_LOOKBACK_LEDGERS.
         const PEER_LEDGER_WINDOW: u32 = 3;
         let window = max_slots.min(PEER_LEDGER_WINDOW);
         if low > window {
@@ -1246,6 +1250,12 @@ impl Herder {
         } else {
             low = 1;
         }
+
+        // Do not ask for slots we'd be dropping anyway (stellar-core parity:
+        // `low = std::max<uint32>(low, getMinLedgerSeqToRemember())`).
+        let herder_low = self.get_min_ledger_seq_to_remember() as u32;
+        low = low.max(herder_low);
+
         low
     }
 


### PR DESCRIPTION
Closes #2904

## Summary

Adds the stellar-core parity clamp `max(low, get_min_ledger_seq_to_remember())` to `Herder::get_min_ledger_seq_to_ask_peers()` and routes three recovery/catchup callers through a shared `App::scp_state_request_ledger_seq()` helper instead of passing raw `current_ledger` values. This ensures outbound `GetScpState` requests never ask for slots the herder would immediately forget when tracking consensus is ahead of LCL.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2904#issuecomment-2920978505)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-herder (herder formula tests pass)
- [x] cargo test -p henyey-app (existing recovery/catchup tests pass)

## Regression test

- **Test:** `herder::required_lm_behavioral_tests::test_get_min_ledger_seq_to_ask_peers_clamps_to_remember_floor_when_tracking_ahead`
- **Pre-fix:** committed as `5c57ad4a` — verified FAILED with: `assertion left == right failed: left: 48, right: 189`
- **Post-fix:** verified PASSES after `a0a3ec37`

## Deviations from plan

- Omitted app-level integration tests that require overlay test-peer infrastructure (complex setup for marginal additional coverage over the herder formula test). The core parity formula is proven by the herder unit test and the caller rewires are trivial delegations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
