### PR TITLE
Align out-of-sync recovery with stellar-core bounded pull

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -104,5 +104,8 @@ henyey-herder = { workspace = true, features = ["test-utils", "test-support"] }
 # Enable test-only instrumentation on henyey-overlay (e.g.
 # `OverlayManager::inject_test_peer`) for handle_flood_demand regression tests.
 henyey-overlay = { workspace = true, features = ["test-utils"] }
+# Enable test-only helpers on henyey-scp (e.g. test_inject_nomination_envelope)
+# for the #2909 recovery rebroadcast regression test.
+henyey-scp = { workspace = true, features = ["test-helpers"] }
 serde_yaml = "0.9"
 regex = "1"

--- a/crates/app/PARITY_STATUS.md
+++ b/crates/app/PARITY_STATUS.md
@@ -255,6 +255,7 @@ Features not yet implemented. These ARE counted against parity %.
 - **Post-catchup convergence**: Fixed several convergence failures including dead loops targeting stale checkpoints, deadlocks from frozen `latest_externalized`, and SCP EXTERNALIZE envelope emission for validator nodes (March–April 2026).
 - **TX queue parity**: Implemented stellar-core `updateQueue` semantics with correct invalidation and revalidation ordering (March 2026).
 - **Audit fixes**: Resolved audit findings including config passphrase matching, quorum threshold rounding, unsolicited quorum set rejection, compat config validator entry validation, and compat `SURVEYOR_KEYS` translation (March–April 2026).
+- **Out-of-sync recovery parity (#2909)**: Recovery now matches stellar-core's two-part sequence: rebroadcast only current-slot `getLatestMessagesSend(lcl+1)` envelopes, then issue bounded `GetScpState` pull to up to 2 random authenticated peers (previously flooded historical envelopes from `getSCPState(lcl-5)` and broadcast `GetScpState` to all peers).
 - **Survey protocol**: Time-sliced surveys successfully collect and report topology data from testnet peers.
 
 ## Parity Calculation

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -2543,21 +2543,9 @@ impl App {
                     // pending_catchup_complete branch also kicks off
                     // try_start_ledger_close immediately for any buffered
                     // ledgers that are already ready.
-                    if let Some(overlay) = self.overlay().await {
-                        // Use the shared low-watermark helper instead of raw
-                        // current_ledger (#2904).
-                        let ledger_seq = self.scp_state_request_ledger_seq();
-                        // Record timestamp before spawning so heartbeat/gap
-                        // throttle sees this attempt and does not duplicate it.
-                        *self.last_scp_state_request_at.write().await = self.clock.now();
-                        henyey_common::spawn_observed(
-                            "scp_state_request_after_catchup",
-                            async move {
-                                let _ = overlay.request_scp_state(ledger_seq).await;
-                            },
-                        );
-                        tracing::info!(ledger_seq, "Spawned SCP state request after catchup");
-                    }
+                    // Use the shared helper which records timestamp + computes
+                    // low-watermark + dispatches bounded pull (#2909).
+                    self.request_scp_state_and_record().await;
                 } else {
                     tracing::info!(
                         ledger_seq = result.ledger_seq,

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -958,12 +958,17 @@ impl App {
     ///
     /// Spawns a background task to avoid blocking the event loop.
     async fn broadcast_recovery_scp_state(&self, current_ledger: u32) {
-        let from_slot = current_ledger.saturating_sub(5) as u64;
-        tracing::debug!(from_slot, "Getting SCP state for recovery");
-        let envelopes = self.herder.get_scp_state(from_slot);
+        // Parity: stellar-core `HerderImpl::maybeTriggerNextLedger` (HerderImpl.cpp:554-560)
+        // rebroadcasts only the current slot's latest messages, then issues a
+        // bounded GetScpState pull. Previously we dumped historical envelopes
+        // from get_scp_state(current_ledger - 5) and broadcast GetScpState to
+        // ALL peers, causing periodic backpressure episodes (#2909).
+        let next_slot = current_ledger as u64 + 1;
+        let envelopes = self.herder.scp().get_latest_messages_send(next_slot);
         tracing::debug!(
+            next_slot,
             envelope_count = envelopes.len(),
-            "Got SCP state for recovery"
+            "Got latest messages for recovery rebroadcast"
         );
 
         let Some(overlay) = self.overlay().await else {
@@ -977,15 +982,18 @@ impl App {
             return;
         }
 
-        // Record timestamp before spawning so heartbeat/gap throttle sees
+        // Record timestamp before dispatching so heartbeat/gap throttle sees
         // this attempt and does not immediately duplicate it.
         *self.last_scp_state_request_at.write().await = self.clock.now();
 
+        // Step 1: Rebroadcast current-slot latest envelopes to all peers.
         let overlay_clone = Arc::clone(&overlay);
         let envelope_count = envelopes.len();
-        // Use the shared low-watermark helper instead of raw current_ledger (#2904).
+        // Step 2: Bounded pull — GetScpState to up to 2 random peers.
         let ledger_seq = self.scp_state_request_ledger_seq();
+
         henyey_common::spawn_observed("scp_envelope_forwarding", async move {
+            // Rebroadcast current-slot envelopes.
             let broadcast_futures: Vec<_> = envelopes
                 .into_iter()
                 .map(|envelope| {
@@ -1003,15 +1011,16 @@ impl App {
             if broadcast_count > 0 {
                 tracing::info!(
                     broadcast_count,
-                    "Broadcast SCP envelopes during out-of-sync recovery"
+                    "Broadcast current-slot SCP envelopes during out-of-sync recovery"
                 );
             }
 
+            // Bounded pull: request SCP state from up to 2 random peers.
             tracing::info!(
                 ledger_seq,
-                "Requesting SCP state from peers (recovery task)"
+                "Requesting SCP state from peers (recovery task, bounded pull)"
             );
-            match overlay_clone.request_scp_state(ledger_seq).await {
+            match overlay_clone.request_scp_state(ledger_seq) {
                 Ok(count) => {
                     tracing::info!(
                         ledger_seq,
@@ -1553,20 +1562,14 @@ impl App {
                     // Record timestamp before spawning so heartbeat/gap throttle
                     // sees this attempt and does not immediately duplicate it.
                     *self.last_scp_state_request_at.write().await = self.clock.now();
-                    let overlay_clone = std::sync::Arc::clone(&overlay);
                     // Use the shared low-watermark helper instead of raw current_ledger (#2904).
                     let ledger = self.scp_state_request_ledger_seq();
-                    henyey_common::spawn_observed(
-                        "inter_checkpoint_scp_state_request",
-                        async move {
-                            if let Err(e) = overlay_clone.request_scp_state(ledger).await {
-                                tracing::debug!(
-                                    error = %e,
-                                    "Failed to request SCP state during inter-checkpoint recovery"
-                                );
-                            }
-                        },
-                    );
+                    if let Err(e) = overlay.request_scp_state(ledger) {
+                        tracing::debug!(
+                            error = %e,
+                            "Failed to request SCP state during inter-checkpoint recovery"
+                        );
+                    }
                 }
 
                 // Retry exhausted tx_set fetches with 30s per-hash backoff.

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -957,7 +957,7 @@ impl App {
     /// Broadcast recent SCP envelopes and request SCP state from peers.
     ///
     /// Spawns a background task to avoid blocking the event loop.
-    async fn broadcast_recovery_scp_state(&self, current_ledger: u32) {
+    pub(crate) async fn broadcast_recovery_scp_state(&self, current_ledger: u32) {
         // Parity: stellar-core `HerderImpl::maybeTriggerNextLedger` (HerderImpl.cpp:554-560)
         // rebroadcasts only the current slot's latest messages, then issues a
         // bounded GetScpState pull. Previously we dumped historical envelopes

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -2683,7 +2683,12 @@ impl App {
         self.herder.get_min_ledger_seq_to_ask_peers()
     }
 
-    /// Request SCP state from all connected peers.
+    /// Request SCP state from up to 2 random authenticated peers using the
+    /// shared low-watermark. This is the canonical dispatch point for all
+    /// GetScpState pulls (lifecycle, recovery, catchup, simulation).
+    ///
+    /// Parity: mirrors stellar-core's `getMoreSCPState()` bounded-pull
+    /// semantics (HerderImpl.cpp:2643-2658).
     pub async fn request_scp_state_from_peers(&self) {
         let Some(overlay) = self.overlay().await else {
             return;
@@ -2695,14 +2700,13 @@ impl App {
             return;
         }
 
-        // Request SCP state from a low watermark similar to stellar-core behavior.
-        let ledger_seq = self.herder.get_min_ledger_seq_to_ask_peers();
-        match overlay.request_scp_state(ledger_seq).await {
+        let ledger_seq = self.scp_state_request_ledger_seq();
+        match overlay.request_scp_state(ledger_seq) {
             Ok(count) => {
                 tracing::info!(
                     ledger_seq,
                     peers_sent = count,
-                    "Requested SCP state from peers"
+                    "Requested SCP state from peers (bounded pull)"
                 );
             }
             Err(e) => {

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -12434,4 +12434,166 @@ mod tests {
             }
         }
     }
+
+    /// Regression test for #2909: request_scp_state_from_peers uses the
+    /// low-watermark ledger seq from scp_state_request_ledger_seq() and
+    /// request_scp_state_and_record advances the timestamp.
+    #[tokio::test]
+    async fn test_request_scp_state_from_peers_records_attempt_and_uses_low_watermark() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        // Inject 3 test peers so bounded pull has targets.
+        let overlay_config = OverlayManagerConfig::default();
+        let local_node = LocalNode::new_testnet(henyey_crypto::SecretKey::generate());
+        let overlay = OverlayManager::new(overlay_config, local_node).unwrap();
+        let peer1 = PeerId::from_bytes([0xA1; 32]);
+        let peer2 = PeerId::from_bytes([0xA2; 32]);
+        let peer3 = PeerId::from_bytes([0xA3; 32]);
+        let mut rx1 = overlay.inject_test_peer(peer1, 64);
+        let mut rx2 = overlay.inject_test_peer(peer2, 64);
+        let mut rx3 = overlay.inject_test_peer(peer3, 64);
+        *app.overlay.write().await = Some(Arc::new(overlay));
+
+        // Record timestamp before the request.
+        let before = *app.last_scp_state_request_at.read().await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+        // Execute the shared request path.
+        app.request_scp_state_and_record().await;
+
+        // Assert: timestamp advanced.
+        let after = *app.last_scp_state_request_at.read().await;
+        assert!(
+            after > before,
+            "request_scp_state_and_record must advance last_scp_state_request_at"
+        );
+
+        // Assert: exactly 2 of 3 peers received GetScpState with the low-watermark seq.
+        let expected_seq = app.scp_state_request_ledger_seq();
+        let msg1 = rx1.try_recv();
+        let msg2 = rx2.try_recv();
+        let msg3 = rx3.try_recv();
+        let received: Vec<_> = [msg1, msg2, msg3].into_iter().flatten().collect();
+        assert_eq!(
+            received.len(),
+            2,
+            "Bounded pull should send to exactly 2 of 3 peers, got {}",
+            received.len()
+        );
+        for msg in &received {
+            match msg {
+                stellar_xdr::curr::StellarMessage::GetScpState(seq) => {
+                    assert_eq!(
+                        *seq, expected_seq,
+                        "GetScpState should use low-watermark seq {}, got {}",
+                        expected_seq, seq
+                    );
+                }
+                other => {
+                    panic!("Expected GetScpState({}), got {:?}", expected_seq, other);
+                }
+            }
+        }
+    }
+
+    /// Regression test for #2909: out-of-sync recovery rebroadcasts only
+    /// current-slot latest envelopes (get_latest_messages_send(current_ledger+1))
+    /// and then issues bounded GetScpState to at most 2 peers.
+    #[tokio::test]
+    async fn test_out_of_sync_recovery_uses_latest_slot_rebroadcast_then_bounded_scp_pull() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        // Inject 3 test peers.
+        let overlay_config = OverlayManagerConfig::default();
+        let local_node = LocalNode::new_testnet(henyey_crypto::SecretKey::generate());
+        let overlay = OverlayManager::new(overlay_config, local_node).unwrap();
+        let peer1 = PeerId::from_bytes([0xB1; 32]);
+        let peer2 = PeerId::from_bytes([0xB2; 32]);
+        let peer3 = PeerId::from_bytes([0xB3; 32]);
+        let mut rx1 = overlay.inject_test_peer(peer1, 64);
+        let mut rx2 = overlay.inject_test_peer(peer2, 64);
+        let mut rx3 = overlay.inject_test_peer(peer3, 64);
+        *app.overlay.write().await = Some(Arc::new(overlay));
+
+        // Current ledger for this test.
+        let current_ledger: u32 = 100;
+
+        // Record timestamp before the call.
+        let before = *app.last_scp_state_request_at.read().await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+        // Execute the recovery broadcast path directly.
+        app.broadcast_recovery_scp_state(current_ledger).await;
+
+        // Assert: timestamp advanced (recovery records the attempt).
+        let after = *app.last_scp_state_request_at.read().await;
+        assert!(
+            after > before,
+            "broadcast_recovery_scp_state must advance last_scp_state_request_at"
+        );
+
+        // Give the spawned task a moment to complete.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Drain all messages from peers. Since get_latest_messages_send returns
+        // empty in unit tests (no SCP slot state), only the GetScpState bounded
+        // pull should be present. Exactly 2 of 3 peers should receive it.
+        let drain =
+            |rx: &mut henyey_overlay::TestPeerReceiver| -> Vec<stellar_xdr::curr::StellarMessage> {
+                let mut msgs = Vec::new();
+                while let Some(msg) = rx.try_recv() {
+                    msgs.push(msg);
+                }
+                msgs
+            };
+        let msgs1 = drain(&mut rx1);
+        let msgs2 = drain(&mut rx2);
+        let msgs3 = drain(&mut rx3);
+
+        // Collect GetScpState messages.
+        let expected_seq = app.scp_state_request_ledger_seq();
+        let get_scp_state_count: usize = [&msgs1, &msgs2, &msgs3]
+            .iter()
+            .map(|msgs| {
+                msgs.iter()
+                    .filter(|m| matches!(m, stellar_xdr::curr::StellarMessage::GetScpState(s) if *s == expected_seq))
+                    .count()
+            })
+            .sum();
+
+        assert_eq!(
+            get_scp_state_count, 2,
+            "Bounded pull should send GetScpState to exactly 2 of 3 peers, got {}",
+            get_scp_state_count
+        );
+
+        // Assert no historical envelope broadcast (no ScpMessage from
+        // get_scp_state(current_ledger - 5) pattern — only current-slot
+        // envelopes from get_latest_messages_send would appear as ScpMessage).
+        // In unit tests, get_latest_messages_send returns empty so there should
+        // be no ScpMessage at all.
+        let scp_msg_count: usize = [&msgs1, &msgs2, &msgs3]
+            .iter()
+            .map(|msgs| {
+                msgs.iter()
+                    .filter(|m| matches!(m, stellar_xdr::curr::StellarMessage::ScpMessage(_)))
+                    .count()
+            })
+            .sum();
+        assert_eq!(
+            scp_msg_count, 0,
+            "No historical SCP envelopes should be broadcast (get_latest_messages_send is empty in unit test), got {}",
+            scp_msg_count
+        );
+    }
 }

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -12504,8 +12504,17 @@ mod tests {
     /// Regression test for #2909: out-of-sync recovery rebroadcasts only
     /// current-slot latest envelopes (get_latest_messages_send(current_ledger+1))
     /// and then issues bounded GetScpState to at most 2 peers.
+    ///
+    /// This test seeds the herder with both current-slot and older-slot SCP
+    /// history, then asserts that only the current-slot envelope is rebroadcast.
+    /// On origin/main (pre-fix), the recovery path used get_scp_state(current_ledger - 5)
+    /// which would have broadcast the older envelopes too.
     #[tokio::test]
     async fn test_out_of_sync_recovery_uses_latest_slot_rebroadcast_then_bounded_scp_pull() {
+        use stellar_xdr::curr::{
+            NodeId, PublicKey, ScpNomination, ScpStatement, ScpStatementPledges, Signature, Uint256,
+        };
+
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
         let config = crate::config::ConfigBuilder::new()
@@ -12523,10 +12532,69 @@ mod tests {
         let mut rx1 = overlay.inject_test_peer(peer1, 64);
         let mut rx2 = overlay.inject_test_peer(peer2, 64);
         let mut rx3 = overlay.inject_test_peer(peer3, 64);
+        // Mark overlay as running so broadcast() doesn't bail with NotStarted.
+        overlay.set_running_for_test();
         *app.overlay.write().await = Some(Arc::new(overlay));
 
         // Current ledger for this test.
         let current_ledger: u32 = 100;
+        let next_slot: u64 = current_ledger as u64 + 1; // 101
+
+        // Helper to create a test nomination envelope for a given slot.
+        let make_nom_envelope = |slot_index: u64, node_bytes: u8| -> ScpEnvelope {
+            let node_id = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([node_bytes; 32])));
+            let nomination = ScpNomination {
+                quorum_set_hash: stellar_xdr::curr::Hash([0xAA; 32]),
+                votes: vec![vec![slot_index as u8].try_into().unwrap()]
+                    .try_into()
+                    .unwrap(),
+                accepted: vec![].try_into().unwrap(),
+            };
+            ScpEnvelope {
+                statement: ScpStatement {
+                    node_id,
+                    slot_index,
+                    pledges: ScpStatementPledges::Nominate(nomination),
+                },
+                signature: Signature(Vec::new().try_into().unwrap_or_default()),
+            }
+        };
+
+        // Seed the SCP with a CURRENT-SLOT envelope (slot 101).
+        // This should be returned by get_latest_messages_send(101).
+        let current_slot_env = make_nom_envelope(next_slot, 0x01);
+        app.herder
+            .scp()
+            .test_inject_nomination_envelope(next_slot, current_slot_env.clone());
+
+        // Seed OLDER slots (95, 96) with envelopes that would appear in
+        // get_scp_state(current_ledger - 5) = get_scp_state(95).
+        // These must NOT be rebroadcast by the fixed recovery path.
+        let old_node_id = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([0x02; 32])));
+        let old_env_95 = make_nom_envelope(95, 0x02);
+        let old_env_96 = make_nom_envelope(96, 0x03);
+        app.herder
+            .scp()
+            .test_inject_slot_state(95, old_node_id.clone(), old_env_95);
+        let old_node_id_2 = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([0x03; 32])));
+        app.herder
+            .scp()
+            .test_inject_slot_state(96, old_node_id_2, old_env_96);
+
+        // Verify preconditions: get_scp_state(95) returns the older envelopes.
+        let old_state = app.herder.get_scp_state(95);
+        assert!(
+            !old_state.is_empty(),
+            "Precondition: older slots should have SCP state seeded"
+        );
+
+        // Verify precondition: get_latest_messages_send(101) returns only current-slot.
+        let latest_msgs = app.herder.scp().get_latest_messages_send(next_slot);
+        assert_eq!(
+            latest_msgs.len(),
+            1,
+            "Precondition: current slot should have exactly 1 latest message"
+        );
 
         // Record timestamp before the call.
         let before = *app.last_scp_state_request_at.read().await;
@@ -12545,9 +12613,7 @@ mod tests {
         // Give the spawned task a moment to complete.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        // Drain all messages from peers. Since get_latest_messages_send returns
-        // empty in unit tests (no SCP slot state), only the GetScpState bounded
-        // pull should be present. Exactly 2 of 3 peers should receive it.
+        // Drain all messages from peers.
         let drain =
             |rx: &mut henyey_overlay::TestPeerReceiver| -> Vec<stellar_xdr::curr::StellarMessage> {
                 let mut msgs = Vec::new();
@@ -12560,7 +12626,51 @@ mod tests {
         let msgs2 = drain(&mut rx2);
         let msgs3 = drain(&mut rx3);
 
-        // Collect GetScpState messages.
+        // Collect ScpMessage envelopes sent to peers (the rebroadcast leg).
+        let all_scp_msgs: Vec<&ScpEnvelope> = [&msgs1, &msgs2, &msgs3]
+            .iter()
+            .flat_map(|msgs| {
+                msgs.iter().filter_map(|m| match m {
+                    stellar_xdr::curr::StellarMessage::ScpMessage(env) => Some(env),
+                    _ => None,
+                })
+            })
+            .collect();
+
+        // Assert: only current-slot envelopes are rebroadcast, NOT historical ones.
+        // The current-slot envelope is broadcast to ALL peers (broadcast()),
+        // so we expect it to appear 3 times (once per peer).
+        assert!(
+            !all_scp_msgs.is_empty(),
+            "Recovery should rebroadcast at least the current-slot envelope"
+        );
+        for env in &all_scp_msgs {
+            assert_eq!(
+                env.statement.slot_index, next_slot,
+                "Only current-slot (101) envelopes should be rebroadcast, \
+                 but found envelope for slot {}. This means the old \
+                 get_scp_state(current_ledger - 5) path is still active.",
+                env.statement.slot_index
+            );
+        }
+
+        // Assert: no older-slot envelopes leaked through.
+        let older_slot_msgs: Vec<_> = all_scp_msgs
+            .iter()
+            .filter(|env| env.statement.slot_index < next_slot)
+            .collect();
+        assert!(
+            older_slot_msgs.is_empty(),
+            "Historical envelopes from older slots must not be rebroadcast, \
+             but found {} from slots: {:?}",
+            older_slot_msgs.len(),
+            older_slot_msgs
+                .iter()
+                .map(|e| e.statement.slot_index)
+                .collect::<Vec<_>>()
+        );
+
+        // Collect GetScpState messages (the bounded pull leg).
         let expected_seq = app.scp_state_request_ledger_seq();
         let get_scp_state_count: usize = [&msgs1, &msgs2, &msgs3]
             .iter()
@@ -12575,25 +12685,6 @@ mod tests {
             get_scp_state_count, 2,
             "Bounded pull should send GetScpState to exactly 2 of 3 peers, got {}",
             get_scp_state_count
-        );
-
-        // Assert no historical envelope broadcast (no ScpMessage from
-        // get_scp_state(current_ledger - 5) pattern — only current-slot
-        // envelopes from get_latest_messages_send would appear as ScpMessage).
-        // In unit tests, get_latest_messages_send returns empty so there should
-        // be no ScpMessage at all.
-        let scp_msg_count: usize = [&msgs1, &msgs2, &msgs3]
-            .iter()
-            .map(|msgs| {
-                msgs.iter()
-                    .filter(|m| matches!(m, stellar_xdr::curr::StellarMessage::ScpMessage(_)))
-                    .count()
-            })
-            .sum();
-        assert_eq!(
-            scp_msg_count, 0,
-            "No historical SCP envelopes should be broadcast (get_latest_messages_send is empty in unit test), got {}",
-            scp_msg_count
         );
     }
 }

--- a/crates/overlay/PARITY_STATUS.md
+++ b/crates/overlay/PARITY_STATUS.md
@@ -326,6 +326,7 @@ Corresponds to: `OverlayManager.h`, `OverlayManagerImpl.h`
 | `getRandomInboundAuthenticatedPeers()` | N/A | None |
 | `getRandomOutboundAuthenticatedPeers()` | N/A | None |
 | `getConnectedPeer()` | (via DashMap lookup) | Full |
+| `getMoreSCPState()` (bounded 2-peer pull) | `request_scp_state()` — selects up to 2 random authenticated peers | Full |
 | `maybeAddInboundConnection()` | (in listener accept flow) | Full |
 | `addOutboundConnection()` | (in connector flow) | Full |
 | `removePeer()` | (via peer drop) | Full |

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -2004,6 +2004,16 @@ impl OverlayManager {
         );
         TestPeerReceiver { rx: outbound_rx }
     }
+
+    /// Mark the overlay as running for testing purposes.
+    ///
+    /// This allows `broadcast()` to proceed without calling `start()`,
+    /// which would spin up listener/connector background tasks.
+    #[doc(hidden)]
+    pub fn set_running_for_test(&self) {
+        self.running
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 #[cfg(test)]

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -1722,9 +1722,38 @@ impl OverlayManager {
     }
 
     /// Request SCP state from all peers.
-    pub async fn request_scp_state(&self, ledger_seq: u32) -> Result<usize> {
+    /// Request SCP state from up to 2 random authenticated peers.
+    ///
+    /// Parity: stellar-core `HerderImpl::getMoreSCPState()` (HerderImpl.cpp:2643-2658)
+    /// selects up to 2 random authenticated peers for `GetScpState` requests
+    /// rather than flooding all connected peers.
+    pub fn request_scp_state(&self, ledger_seq: u32) -> Result<usize> {
+        use rand::seq::SliceRandom;
+
         let message = StellarMessage::GetScpState(ledger_seq);
-        self.broadcast(message).await
+        let peers = self.connected_peers();
+        if peers.is_empty() {
+            return Ok(0);
+        }
+
+        // Select up to 2 random peers, matching stellar-core's bounded pull.
+        let mut rng = rand::thread_rng();
+        let selected: Vec<&PeerId> = peers
+            .choose_multiple(&mut rng, 2.min(peers.len()))
+            .collect();
+
+        let mut sent = 0usize;
+        for peer_id in &selected {
+            match self.try_send_to(peer_id, message.clone()) {
+                Ok(()) => sent += 1,
+                Err(e) => {
+                    debug!(peer = %peer_id, error = %e, "Failed to send GetScpState to peer");
+                }
+            }
+        }
+
+        debug!(ledger_seq, sent, "Sent GetScpState to random peers");
+        Ok(sent)
     }
 
     /// Request a transaction set by hash from all peers.
@@ -4303,5 +4332,79 @@ mod tests {
         // Dedup: config resolved and discovered have same canonical_key
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].host, "10.0.0.1");
+    }
+
+    /// Regression test for #2909: request_scp_state targets at most 2 random
+    /// authenticated peers instead of broadcasting to all connected peers.
+    #[test]
+    fn test_request_scp_state_targets_two_authenticated_peers() {
+        let shared = test_shared_state(vec![]);
+
+        // Insert 3 authenticated test peers.
+        let peer1 = PeerId::from_bytes([1u8; 32]);
+        let peer2 = PeerId::from_bytes([2u8; 32]);
+        let peer3 = PeerId::from_bytes([3u8; 32]);
+        let addr1: std::net::SocketAddr = "10.0.0.1:11625".parse().unwrap();
+        let addr2: std::net::SocketAddr = "10.0.0.2:11625".parse().unwrap();
+        let addr3: std::net::SocketAddr = "10.0.0.3:11625".parse().unwrap();
+
+        let mut rx1 = insert_fake_peer(
+            &shared,
+            peer1,
+            addr1,
+            crate::connection::ConnectionDirection::Outbound,
+        );
+        let mut rx2 = insert_fake_peer(
+            &shared,
+            peer2,
+            addr2,
+            crate::connection::ConnectionDirection::Outbound,
+        );
+        let mut rx3 = insert_fake_peer(
+            &shared,
+            peer3,
+            addr3,
+            crate::connection::ConnectionDirection::Outbound,
+        );
+
+        // Build an OverlayManager that uses this shared state.
+        let config = OverlayConfig::testnet();
+        let secret = henyey_crypto::SecretKey::generate();
+        let local_node = LocalNode::new_testnet(secret);
+        let mut manager = OverlayManager::new(config, local_node).unwrap();
+        // Replace the internal shared state with ours (which has peers).
+        manager.peers = shared.peers.clone();
+        manager.peer_info_cache = shared.peer_info_cache.clone();
+        manager.running = shared.running.clone();
+
+        let ledger_seq = 100u32;
+        let result = manager.request_scp_state(ledger_seq).unwrap();
+
+        // At most 2 peers should receive the message.
+        assert!(
+            result <= 2,
+            "request_scp_state should target at most 2 peers, got {}",
+            result
+        );
+        assert!(
+            result >= 1,
+            "request_scp_state should target at least 1 peer when peers are connected"
+        );
+
+        // Count how many peers actually received the message.
+        let got1 = rx1.try_recv().is_ok();
+        let got2 = rx2.try_recv().is_ok();
+        let got3 = rx3.try_recv().is_ok();
+        let total_received = [got1, got2, got3].iter().filter(|&&x| x).count();
+
+        assert_eq!(
+            total_received, result as usize,
+            "Number of peers that received the message should match return count"
+        );
+        assert!(
+            total_received <= 2,
+            "At most 2 peers should receive GetScpState, got {}",
+            total_received
+        );
     }
 }

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -396,6 +396,7 @@ pub(super) struct PeerHandle {
 }
 
 /// Messages sent to a peer task via the outbound channel.
+#[derive(Debug)]
 pub(super) enum OutboundMessage {
     /// Direct send (non-flood, e.g. GetTxSet, ScpQuorumset response).
     Send(StellarMessage),
@@ -1721,7 +1722,6 @@ impl OverlayManager {
         *advertised_inbound = inbound_peers;
     }
 
-    /// Request SCP state from all peers.
     /// Request SCP state from up to 2 random authenticated peers.
     ///
     /// Parity: stellar-core `HerderImpl::getMoreSCPState()` (HerderImpl.cpp:2643-2658)
@@ -4380,31 +4380,46 @@ mod tests {
         let ledger_seq = 100u32;
         let result = manager.request_scp_state(ledger_seq).unwrap();
 
-        // At most 2 peers should receive the message.
-        assert!(
-            result <= 2,
-            "request_scp_state should target at most 2 peers, got {}",
+        // Exactly 2 peers should receive the message (3 connected, bound is 2,
+        // channels have ample capacity so no send failures).
+        assert_eq!(
+            result, 2,
+            "request_scp_state should target exactly 2 peers when 3 are connected, got {}",
             result
         );
-        assert!(
-            result >= 1,
-            "request_scp_state should target at least 1 peer when peers are connected"
-        );
 
-        // Count how many peers actually received the message.
-        let got1 = rx1.try_recv().is_ok();
-        let got2 = rx2.try_recv().is_ok();
-        let got3 = rx3.try_recv().is_ok();
-        let total_received = [got1, got2, got3].iter().filter(|&&x| x).count();
+        // Validate that exactly 2 peers received GetScpState(ledger_seq).
+        let msg1 = rx1.try_recv().ok();
+        let msg2 = rx2.try_recv().ok();
+        let msg3 = rx3.try_recv().ok();
 
+        let received: Vec<_> = [msg1, msg2, msg3].into_iter().flatten().collect();
         assert_eq!(
-            total_received, result as usize,
-            "Number of peers that received the message should match return count"
+            received.len(),
+            2,
+            "Exactly 2 of 3 peers should receive GetScpState, got {}",
+            received.len()
         );
-        assert!(
-            total_received <= 2,
-            "At most 2 peers should receive GetScpState, got {}",
-            total_received
-        );
+
+        // Verify each received message is the correct GetScpState(ledger_seq).
+        for msg in &received {
+            match msg {
+                super::OutboundMessage::Send(stellar_xdr::curr::StellarMessage::GetScpState(
+                    seq,
+                )) => {
+                    assert_eq!(
+                        *seq, ledger_seq,
+                        "GetScpState should contain ledger_seq {}, got {}",
+                        ledger_seq, seq
+                    );
+                }
+                other => {
+                    panic!(
+                        "Expected OutboundMessage::Send(GetScpState({})), got {:?}",
+                        ledger_seq, other
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/scp/src/nomination.rs
+++ b/crates/scp/src/nomination.rs
@@ -1122,6 +1122,21 @@ impl NominationProtocol {
     pub(crate) fn candidates(&self) -> &BTreeSet<Value> {
         &self.candidates
     }
+
+    /// Test-only: inject an envelope as the latest nomination envelope.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn test_set_last_envelope(&mut self, envelope: ScpEnvelope) {
+        self.last_envelope = Some(envelope);
+    }
+
+    /// Test-only: inject an envelope into latest_nominations for a node.
+    ///
+    /// This makes `process_current_state` (used by `get_scp_state`) return
+    /// the envelope when iterating the slot's state.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn test_inject_latest_nomination(&mut self, node_id: NodeId, envelope: ScpEnvelope) {
+        self.latest_nominations.insert(node_id, envelope);
+    }
 }
 
 impl Default for NominationProtocol {

--- a/crates/scp/src/scp.rs
+++ b/crates/scp/src/scp.rs
@@ -411,6 +411,34 @@ impl<D: SCPDriver> SCP<D> {
         slot.test_set_got_v_blocking(true);
     }
 
+    /// Test-only: inject a nomination envelope into a slot's latest messages.
+    ///
+    /// Creates the slot if needed, marks it `fully_validated`, and sets the
+    /// envelope as the nomination protocol's `last_envelope`. This makes
+    /// `get_latest_messages_send(slot_index)` return the injected envelope.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn test_inject_nomination_envelope(&self, slot_index: u64, envelope: ScpEnvelope) {
+        let mut slots = self.slots.write();
+        let slot = self.get_or_create_slot(&mut slots, slot_index);
+        slot.test_set_fully_validated(true);
+        slot.nomination_mut().test_set_last_envelope(envelope);
+    }
+
+    /// Test-only: inject a nomination envelope into a slot's `latest_nominations`
+    /// map (keyed by `node_id`).
+    ///
+    /// Creates the slot if needed and marks it `fully_validated`. This makes
+    /// `get_scp_state(from_slot)` (via `process_current_state`) return the
+    /// envelope when iterating the slot.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn test_inject_slot_state(&self, slot_index: u64, node_id: NodeId, envelope: ScpEnvelope) {
+        let mut slots = self.slots.write();
+        let slot = self.get_or_create_slot(&mut slots, slot_index);
+        slot.test_set_fully_validated(true);
+        slot.nomination_mut()
+            .test_inject_latest_nomination(node_id, envelope);
+    }
+
     /// Get all envelopes for a specific slot.
     pub fn get_slot_envelopes(&self, slot_index: u64) -> Vec<ScpEnvelope> {
         let slots = self.slots.read();


### PR DESCRIPTION
Closes #2909

## Summary

Replaces the historical all-peer SCP state flood in out-of-sync recovery with stellar-core's parity-correct two-part sequence: rebroadcast only current-slot `getLatestMessagesSend(lcl+1)` envelopes, then issue bounded `GetScpState` pull to up to 2 random authenticated peers (matching `HerderImpl.cpp:554-560` + `2643-2658`).

This eliminates the periodic recovery-escalation flapping episodes (~7-13min every ~3.5h) observed on the mainnet validator post-#2907, which were caused by flooding `GetScpState` to all peers and rebroadcasting historical envelopes from 5 slots back.

## Plan reference

[Force-Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2909#issuecomment-plan)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-overlay --lib (443 tests pass)
- [x] cargo test -p henyey-app --lib (956 tests pass)

## Regression test

- **Test:** `crates/overlay/src/manager/mod.rs::test_request_scp_state_targets_two_authenticated_peers`
- **Pre-fix:** On `origin/main`, `request_scp_state()` uses `broadcast()` which sends to ALL peers (would fail the <= 2 assertion)
- **Post-fix:** Verified PASSES — only 2 out of 3 peers receive the message

## Key changes

- `OverlayManager::request_scp_state()`: no longer async, selects up to 2 random authenticated peers via `connected_peers()` + `try_send_to()` instead of `broadcast()`
- `broadcast_recovery_scp_state()`: uses `herder.scp().get_latest_messages_send(current_ledger + 1)` instead of `herder.get_scp_state(current_ledger - 5)`
- Post-catchup SCP state request uses the shared `request_scp_state_and_record()` helper
- Parity status docs updated for both overlay and app crates

## Deviations from plan

- The plan called for 3 separate regression tests. The overlay test (`test_request_scp_state_targets_two_authenticated_peers`) is included as it's the most critical contract (2-peer bound). The two app-level tests requiring full App construction with test overlay peers were deferred — the existing 956 app tests passing validates the integration, and the overlay unit test locks the core behavioral contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)