### PR TITLE
Use simulation config in archive-skip recovery regression test

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -12701,7 +12701,7 @@ mod tests {
     async fn test_trigger_recovery_catchup_archive_skip_requests_bounded_scp_state() {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
-        let config = crate::config::ConfigBuilder::new()
+        let config = crate::config::ConfigBuilder::simulation()
             .database_path(db_path)
             .build();
         let app = App::new(config).await.unwrap();


### PR DESCRIPTION
Closes #2925

## Summary

Replaces `ConfigBuilder::new()` with `ConfigBuilder::simulation()` in the archive-skip bounded SCP state regression test. The simulation builder disables history archives (`get_enabled: false`), preventing unintended background network access that could make the test environment-dependent.

## Plan reference

[Triage report](https://github.com/stellar-experimental/henyey/issues/2925#issuecomment-2918709098)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-app -- -D warnings
- [x] `test_trigger_recovery_catchup_archive_skip_requests_bounded_scp_state` passes

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)