### PR TITLE
Guard pubnet RPC-up coverage in quickstart harness

### DIFF
--- a/scripts/test-quickstart-harness.sh
+++ b/scripts/test-quickstart-harness.sh
@@ -215,8 +215,22 @@ test_workflow_shard_probe_contract() {
         else
             tap_ok "pubnet_excludes_rpc_healthy"
         fi
+
+        # Check: pubnet shard DOES include stellar_rpc_up. Upstream
+        # internal-test.yml runs test_stellar_rpc_up.go on every shard whose
+        # `enable` contains 'rpc' (`if: contains(matrix.enable, 'rpc')`) with
+        # no pubnet exclusion — only rpc_healthy is gated off on pubnet. This
+        # positive assertion guards against silently dropping RPC-up coverage
+        # from the pubnet/core,rpc,horizon shard (parity residual from #2916,
+        # tracked in #2919).
+        if echo "$pubnet_probes" | grep -q 'test_stellar_rpc_up'; then
+            tap_ok "pubnet_includes_rpc_up"
+        else
+            tap_not_ok "pubnet_includes_rpc_up" "pubnet shard missing stellar_rpc_up (upstream runs it on every rpc-enabled shard)"
+        fi
     else
         tap_not_ok "pubnet_excludes_rpc_healthy" "no pubnet shard found"
+        tap_not_ok "pubnet_includes_rpc_up" "no pubnet shard found"
     fi
 
     # Check: local rpc shard includes test_friendbot.go (upstream runs friendbot
@@ -484,7 +498,7 @@ test_upstream_contract_validation() {
 }
 
 # --- Run all tests ---
-tap_plan 33
+tap_plan 34
 
 test_timeout_retry_on_targeted_shard
 test_non_timeout_failure_no_retry


### PR DESCRIPTION
Closes #2919

## Summary

Adds a positive contract assertion (`pubnet_includes_rpc_up`) to `scripts/test-quickstart-harness.sh` verifying that the `pubnet / core,rpc,horizon` shard in `.github/workflows/quickstart.yml` includes `test_stellar_rpc_up.go`. Upstream `internal-test.yml` runs RPC-up on every shard whose `enable` contains `rpc` (`if: ${{ contains(matrix.enable, 'rpc') }}`) with no pubnet exclusion — only `test_stellar_rpc_healthy.go` is gated off on pubnet (`&& matrix.network != 'pubnet'`).

The probe is present in the workflow today, but nothing in the harness guarded against silently dropping it. The harness previously only asserted the *negative* (pubnet excludes rpc_healthy) and the exclusion contract; this adds the missing *positive* parity guard. TAP plan bumped 33 → 34.

## Context

Force-converge residual from #2916 (Correctness critic, round 2): the plan's "Existing tests preserved" section omitted the pubnet RPC-up coverage. This closes that gap with a regression guard rather than relying on the probe staying in place by inspection.

## Test plan

- [x] `bash scripts/test-quickstart-harness.sh` → 34/34 pass
- [x] Negative check: removing `test_stellar_rpc_up.go` from the pubnet shard makes `pubnet_includes_rpc_up` fail (`not ok 13`), confirming the guard is real and not a tautology; restored after.
- [x] Verified against upstream `stellar/quickstart` `internal-test.yml` conditionals (RPC-up on every `rpc` enable; rpc_healthy excluded on pubnet).
- [x] pre-commit (cargo fmt + clippy) passed on push.

## Deviations from plan

The triage notes pointed at `.github/workflows/quickstart.yml`. The probe is already present there (matches upstream), so the real coverage-preservation gap was the absence of a regression guard — addressed in the contract harness `scripts/test-quickstart-harness.sh` (the file that enforces the shard/probe contract for that workflow). Single-file change, same intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)