### PR TITLE
Gate knit/replay on published target checkpoint to avoid FATAL state-wipe

### DIFF
--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -1297,4 +1297,86 @@ mod tests {
             "expected InvalidPreviousHash without SCP anchor, got: {err}"
         );
     }
+
+    // ---------------------------------------------------------------
+    // #2931: published-checkpoint precondition gate.
+    //
+    // Restores the upstream HAS-publication gate (stellar-core
+    // `GetHistoryArchiveStateWork` retry-until-published) that henyey's
+    // cloned-local ReplayOnly fast path omitted. The gate keys off archive
+    // HAS truth (`currentLedger`), NOT the local externalized counter.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_knit_lcl_mismatch_unpublished_checkpoint_is_transient() {
+        // Mirrors the #2931 crash scenario: a ReplayOnly attempt targets
+        // ledgers in checkpoint 62845439 while the archive's published
+        // frontier (HAS currentLedger) is still on the prior checkpoint.
+        //
+        // The archive's checkpoint header at the LCL diverges from the
+        // (correct) local LCL — on origin/main this surfaces as a fatal
+        // KnitLclHashMismatch and wipes state. With the publication gate the
+        // attempt is short-circuited as a TRANSIENT CheckpointNotYetPublished
+        // BEFORE any knit/replay, so it is retried instead of wiping.
+        let target = 62845437; // in checkpoint 62845439
+        let target_ckpt = crate::checkpoint::checkpoint_containing(target);
+        // Archive has only published through the prior checkpoint.
+        let has_current = target_ckpt - crate::checkpoint::checkpoint_frequency();
+
+        let err = checkpoint_publication_gate(has_current, target)
+            .expect_err("gate must reject an unpublished target checkpoint");
+
+        match err {
+            HistoryError::CheckpointNotYetPublished {
+                target: t,
+                has_current: hc,
+            } => {
+                assert_eq!(t, target);
+                assert_eq!(hc, has_current);
+            }
+            other => panic!("expected CheckpointNotYetPublished, got {other:?}"),
+        }
+        assert!(
+            !err.is_fatal_catchup_failure(),
+            "unpublished-checkpoint knit attempt must be transient, not fatal"
+        );
+        assert!(
+            !err.is_hash_mismatch(),
+            "unpublished-checkpoint knit attempt must not be a hash mismatch"
+        );
+    }
+
+    #[test]
+    fn test_knit_lcl_mismatch_published_checkpoint_remains_fatal() {
+        // When the target checkpoint IS published (HAS currentLedger covers
+        // it), the publication gate passes and a genuine knit divergence
+        // against the local LCL stays fatal — preserving §11.2 parity for
+        // real local corruption (no over-broadening of the transient path).
+        let target = 62845437;
+        let target_ckpt = crate::checkpoint::checkpoint_containing(target);
+
+        // Gate passes: archive has published the covering checkpoint.
+        assert!(
+            checkpoint_publication_gate(target_ckpt, target).is_ok(),
+            "gate must pass once the covering checkpoint is published"
+        );
+        // The gate must also pass when the archive frontier is well ahead
+        // of the covering checkpoint (steady-state operation).
+        assert!(
+            checkpoint_publication_gate(target_ckpt + 1000, target).is_ok(),
+            "gate must pass when the archive frontier is ahead of the target"
+        );
+        // And a current-checkpoint divergence is still fatal (case 3).
+        let lcl = make_test_lcl(100, h(0x10), h(0x09));
+        let entry = make_test_entry(100, h(0xBB), h(0x09));
+        let err = knit_to_lcl_decision(&entry, &lcl).unwrap_err();
+        assert!(
+            matches!(err, HistoryError::KnitLclHashMismatch { .. }),
+            "published-checkpoint divergence must stay KnitLclHashMismatch"
+        );
+        assert!(
+            err.is_fatal_catchup_failure(),
+            "published-checkpoint knit divergence must remain fatal"
+        );
+    }
 }

--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -116,6 +116,42 @@ pub(super) fn knit_to_lcl_decision(
     Ok(KnitDecision::Apply)
 }
 
+/// Published-checkpoint precondition gate for the knit/replay path (#2931).
+///
+/// Mirrors stellar-core's `GetHistoryArchiveStateWork` retry-until-published
+/// precondition (`CatchupWork.cpp` HAS fetch with retries; covered by
+/// `LedgerApplyManagerImpl`'s wait for the following checkpoint) that
+/// henyey's cloned-local `ReplayOnly` fast path optimized away. stellar-core
+/// has no such fast path and always fetches the HAS before applying a
+/// checkpoint, so a target whose covering checkpoint is not yet published is
+/// never attempted upstream.
+///
+/// The gate keys off **archive HAS truth** (`has_current_ledger`, the
+/// archive's published frontier), NOT the local externalized counter — using
+/// the local counter would reintroduce the stale-counter deadlock that the
+/// original `catchup_impl` guard removal (proceeding anyway) addressed.
+///
+/// Returns:
+/// - `Ok(())` when `has_current_ledger >= checkpoint_containing(target)` (the
+///   covering checkpoint is published; proceed to knit/replay).
+/// - `Err(CheckpointNotYetPublished { .. })` (transient) otherwise, so the
+///   attempt is retried with backoff instead of triggering a FATAL
+///   state-wipe on a knit-to-LCL mismatch against a stale archive header.
+///
+/// HAS **unreachability** (network/404) is handled by the caller as a
+/// transient download error and never reaches this gate — keeping the error
+/// taxonomy distinct (HAS-unreachable vs HAS-behind).
+pub(super) fn checkpoint_publication_gate(has_current_ledger: u32, target: u32) -> Result<()> {
+    let target_checkpoint = crate::checkpoint::checkpoint_containing(target);
+    if has_current_ledger < target_checkpoint {
+        return Err(HistoryError::CheckpointNotYetPublished {
+            target,
+            has_current: has_current_ledger,
+        });
+    }
+    Ok(())
+}
+
 /// Maximum number of retry attempts for the download-and-replay pipeline.
 ///
 /// Matches stellar-core's `BasicWork::RETRY_A_FEW` used by
@@ -396,6 +432,21 @@ impl CatchupManager {
         ledger_manager: &LedgerManager,
     ) -> Result<(HeaderSnapshot, u32, String)> {
         use henyey_common::NetworkId;
+
+        // #2931: published-checkpoint precondition gate. Runs BEFORE any
+        // checkpoint-file / LCL-header fetch in this attempt so the stale
+        // archive header at the LCL (refetched in download_ledger_data) can
+        // never surface a knit-to-LCL mismatch against an unpublished target.
+        //
+        // Fetch the HAS for the target's covering checkpoint and require the
+        // archive's published frontier (currentLedger) to cover it. HAS
+        // unreachability (network/404) maps to a transient download/
+        // CatchupFailed error here (distinct taxonomy); a reachable HAS whose
+        // currentLedger is behind the target checkpoint yields the transient
+        // CheckpointNotYetPublished so the attempt is retried, not wiped.
+        let target_checkpoint = crate::checkpoint::checkpoint_containing(target);
+        let (target_has, _has_archive) = self.download_has(target_checkpoint).await?;
+        checkpoint_publication_gate(target_has.current_ledger(), target)?;
 
         // Download ledger data for replay
         self.update_progress(

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -513,6 +513,30 @@ pub enum HistoryError {
     #[error("fatal: ledger chain disagrees with local state (§9.5 fatal failure)")]
     FatalChainDisagreement,
 
+    /// Transient: the catchup target's covering checkpoint has not yet been
+    /// published to the history archive (the archive HAS `currentLedger` is
+    /// still behind `checkpoint_containing(target)`).
+    ///
+    /// This restores the precondition stellar-core enforces via
+    /// `GetHistoryArchiveStateWork` (retry-until-published) before knit/replay,
+    /// which henyey's cloned-local `ReplayOnly` fast path optimized away. A
+    /// knit-to-LCL boundary mismatch produced against an unpublished/stale
+    /// archive checkpoint is an archive-not-ready condition that must be
+    /// **retried**, not treated as local-state corruption. It is therefore
+    /// **excluded** from [`is_fatal_catchup_failure`](HistoryError::is_fatal_catchup_failure)
+    /// and [`is_hash_mismatch`](HistoryError::is_hash_mismatch). See #2931.
+    #[error(
+        "catchup target checkpoint not yet published: target ledger {target} \
+         requires archive currentLedger >= its covering checkpoint, but archive \
+         HAS currentLedger is {has_current}"
+    )]
+    CheckpointNotYetPublished {
+        /// The catchup target ledger sequence.
+        target: u32,
+        /// The archive HAS `currentLedger` observed at gate time.
+        has_current: u32,
+    },
+
     /// Unsupported ledger version detected during chain verification (§9.3 step 2e).
     #[error("unsupported ledger version {version} at ledger {ledger} (supported: {min}..={max})")]
     UnsupportedLedgerVersion {

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -703,6 +703,27 @@ mod tests {
     }
 
     #[test]
+    fn test_checkpoint_not_yet_published_is_transient() {
+        // #2931: a knit/replay attempt against an archive checkpoint that has
+        // not yet been published is a TRANSIENT archive-not-ready condition.
+        // It must NOT be classified as a fatal catchup failure (which would
+        // trigger a state-wipe) nor as a typed hash mismatch (which would
+        // force a full bucket-apply reset).
+        let err = HistoryError::CheckpointNotYetPublished {
+            target: 62845439,
+            has_current: 62845375,
+        };
+        assert!(
+            !err.is_fatal_catchup_failure(),
+            "CheckpointNotYetPublished must be transient, not fatal"
+        );
+        assert!(
+            !err.is_hash_mismatch(),
+            "CheckpointNotYetPublished must not be treated as a hash mismatch"
+        );
+    }
+
+    #[test]
     fn test_verify_hash_mismatch_info_new_unlogged_and_into() {
         let expected = Hash256::ZERO;
         let actual = Hash256::from([0xAB; 32]);

--- a/crates/history/tests/replay_integration.rs
+++ b/crates/history/tests/replay_integration.rs
@@ -49,6 +49,37 @@ fn make_test_hot_archive_buckets() -> Option<Vec<HASBucketLevel>> {
     )
 }
 
+/// #2931: register a published-frontier HAS for the catchup target's covering
+/// checkpoint so the replay path's published-checkpoint precondition gate
+/// (`checkpoint_publication_gate`) passes. The replay path now fetches the HAS
+/// at `checkpoint_containing(target)` and requires its `currentLedger` to cover
+/// that checkpoint before knit/replay — mirroring an archive that has already
+/// published the target. Idempotent: safe to call even if a HAS is already
+/// registered at the covering checkpoint.
+fn register_published_target_has(fixtures: &mut HashMap<String, Vec<u8>>, target: u32) {
+    let target_checkpoint = henyey_history::checkpoint::checkpoint_containing(target);
+    let mut levels = Vec::with_capacity(BUCKET_LIST_LEVELS);
+    for _ in 0..BUCKET_LIST_LEVELS {
+        levels.push(HASBucketLevel {
+            curr: "0".repeat(64),
+            snap: "0".repeat(64),
+            next: Default::default(),
+        });
+    }
+    let has = HistoryArchiveState {
+        version: 2,
+        server: Some("rs-stellar-core test".to_string()),
+        current_ledger: target_checkpoint,
+        network_passphrase: Some("Test SDF Network ; September 2015".to_string()),
+        current_buckets: levels,
+        hot_archive_buckets: make_test_hot_archive_buckets(),
+    };
+    fixtures.insert(
+        checkpoint_path("history", target_checkpoint, "json"),
+        has.to_json().unwrap().into_bytes(),
+    );
+}
+
 fn record_marked(entries: &[Vec<u8>]) -> Vec<u8> {
     let mut out = Vec::new();
     for entry in entries {
@@ -280,6 +311,10 @@ async fn test_catchup_replay_bucket_hash_verification() {
         gzip_bytes(&tx_result_xdr),
     );
 
+    // #2931: serve the published-frontier HAS at the target's covering
+    // checkpoint so the replay path's publication gate passes.
+    register_published_target_has(&mut fixtures, target);
+
     let fixtures = Arc::new(fixtures);
     let app =
         Router::new()
@@ -485,6 +520,12 @@ async fn test_catchup_recent_large_gap_replays_with_parity() {
             gzip_bytes(&[]),
         );
     }
+
+    // #2931: the replay path now fetches the HAS for the target's covering
+    // checkpoint and requires the archive's published frontier (currentLedger)
+    // to cover it before knit/replay. Serve a published-frontier HAS at the
+    // covering checkpoint so the publication gate passes.
+    register_published_target_has(&mut fixtures, target);
 
     // Serve fixtures via Axum
     let fixtures = Arc::new(fixtures);
@@ -824,6 +865,10 @@ async fn test_catchup_self_corrects_lcl_protocol_from_archive() {
         has.to_json().unwrap().into_bytes(),
     );
 
+    // #2931: serve the published-frontier HAS at the target's covering
+    // checkpoint so the replay path's publication gate passes.
+    register_published_target_has(&mut fixtures, target);
+
     // Serve via Axum
     let fixtures = Arc::new(fixtures);
     let app =
@@ -1063,6 +1108,10 @@ async fn test_replay_hash_mismatch_produces_replay_hash_mismatch_error() {
         checkpoint_path("results", data_checkpoint, "xdr.gz"),
         gzip_bytes(&tx_result_xdr),
     );
+
+    // #2931: serve the published-frontier HAS at the target's covering
+    // checkpoint so the replay path's publication gate passes.
+    register_published_target_has(&mut fixtures, target);
 
     let fixtures = Arc::new(fixtures);
     let app =
@@ -1349,6 +1398,10 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
         checkpoint_path("results", data_checkpoint, "xdr.gz"),
         gzip_bytes(&tx_result_xdr),
     );
+
+    // #2931: serve the published-frontier HAS at the target's covering
+    // checkpoint so the replay path's publication gate passes.
+    register_published_target_has(&mut fixtures, target);
 
     let fixtures = Arc::new(fixtures);
     let app =


### PR DESCRIPTION
Closes #2931

## Summary

A `RecoveryEscalation` Minimal catchup running the cloned-local `ReplayOnly` fast path against an **unpublished/stale** archive checkpoint re-fetched the LCL header from the not-yet-published checkpoint file. The stale archive header diverged from the (correct) local LCL, producing a §11.2 case-3 `KnitLclHashMismatch` that `is_fatal_catchup_failure()` classified as fatal — triggering a FATAL state-wipe shutdown (#2931, recurrence of #2886; validator down ~4.5h).

This restores the published-checkpoint precondition stellar-core enforces before knit/replay (`GetHistoryArchiveStateWork` retry-until-published) that henyey's fast path optimized away. A new transient `HistoryError::CheckpointNotYetPublished` variant (excluded from `is_fatal_catchup_failure` and `is_hash_mismatch`) plus a `checkpoint_publication_gate` at the top of `download_verify_and_replay_once` — **before** any checkpoint-file / LCL-header fetch — fetch the HAS for `checkpoint_containing(target)` and require the archive's published frontier (`currentLedger`) to cover it. A reachable-but-behind HAS is retried with backoff instead of wiping; HAS-unreachable stays a transient `CatchupFailed` (distinct taxonomy). A genuine knit divergence against a **confirmed-published** checkpoint stays fatal, preserving §11.2 parity for real local corruption.

The gate keys off **archive HAS truth** (`currentLedger`), never the local externalized counter, so it does not reintroduce the stale-counter deadlock that the original "proceeding anyway" guard removal addressed.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2931#issuecomment-4602983692)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (and `-p henyey-history --tests -D warnings`)
- [x] `cargo test -p henyey-history` — 526 lib + 11 replay_integration + catchup_integration + doctests all pass

## Regression test (kind: bug-fix)

- **Tests:**
  - `crates/history/src/catchup/replay.rs::test_knit_lcl_mismatch_unpublished_checkpoint_is_transient`
  - `crates/history/src/catchup/replay.rs::test_knit_lcl_mismatch_published_checkpoint_remains_fatal`
  - `crates/history/src/error.rs::test_checkpoint_not_yet_published_is_transient`
- **Pre-fix:** committed as `c11a6a08` — verified FAILED (the `CheckpointNotYetPublished` variant and `checkpoint_publication_gate` did not exist → tests did not compile).
- **Post-fix:** verified PASS after `ab28836c`.

## Deviations from plan

- The pre-existing `replay_integration.rs` ReplayOnly tests needed a HAS fixture at the target's covering checkpoint (the new gate fetches it). Added a small `register_published_target_has` test helper and a call in each affected test — a test-fixture update mandated by the new production HAS fetch, not a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)