### PR TITLE
Make register_published_target_has test helper idempotent

### DIFF
--- a/crates/history/tests/replay_integration.rs
+++ b/crates/history/tests/replay_integration.rs
@@ -74,10 +74,9 @@ fn register_published_target_has(fixtures: &mut HashMap<String, Vec<u8>>, target
         current_buckets: levels,
         hot_archive_buckets: make_test_hot_archive_buckets(),
     };
-    fixtures.insert(
-        checkpoint_path("history", target_checkpoint, "json"),
-        has.to_json().unwrap().into_bytes(),
-    );
+    fixtures
+        .entry(checkpoint_path("history", target_checkpoint, "json"))
+        .or_insert_with(|| has.to_json().unwrap().into_bytes());
 }
 
 fn record_marked(entries: &[Vec<u8>]) -> Vec<u8> {


### PR DESCRIPTION
Closes #2939

## Summary

The `register_published_target_has()` test helper in `crates/history/tests/replay_integration.rs` used `HashMap::insert()`, which silently overwrites any HAS fixture already registered at the covering checkpoint. This switches it to `entry().or_insert_with()` so the helper preserves a pre-seeded fixture instead of clobbering it, making it idempotent and safe to call after a test has staged its own fixture.

## Plan reference

[Triage Report — trivial short-circuit](https://github.com/stellar-experimental/henyey/issues/2939#issuecomment-4603890947)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (henyey-history tests, clean)
- [x] `cargo test -p henyey-history --test replay_integration` — 11 passed, 0 failed

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)