### PR TITLE
Include covering checkpoint value in CheckpointNotYetPublished error message

### DIFF
--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -146,6 +146,7 @@ pub(super) fn checkpoint_publication_gate(has_current_ledger: u32, target: u32) 
     if has_current_ledger < target_checkpoint {
         return Err(HistoryError::CheckpointNotYetPublished {
             target,
+            covering_checkpoint: target_checkpoint,
             has_current: has_current_ledger,
         });
     }
@@ -1380,10 +1381,18 @@ mod tests {
         match err {
             HistoryError::CheckpointNotYetPublished {
                 target: t,
+                covering_checkpoint: cp,
                 has_current: hc,
             } => {
                 assert_eq!(t, target);
+                assert_eq!(cp, target_ckpt);
                 assert_eq!(hc, has_current);
+                // The covering checkpoint must surface in the rendered message
+                // so on-call debugging needn't recompute checkpoint math.
+                assert!(
+                    err.to_string().contains(&target_ckpt.to_string()),
+                    "error message must include the covering checkpoint value"
+                );
             }
             other => panic!("expected CheckpointNotYetPublished, got {other:?}"),
         }

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -527,12 +527,17 @@ pub enum HistoryError {
     /// and [`is_hash_mismatch`](HistoryError::is_hash_mismatch). See #2931.
     #[error(
         "catchup target checkpoint not yet published: target ledger {target} \
-         requires archive currentLedger >= its covering checkpoint, but archive \
-         HAS currentLedger is {has_current}"
+         requires archive currentLedger >= its covering checkpoint \
+         {covering_checkpoint}, but archive HAS currentLedger is {has_current}"
     )]
     CheckpointNotYetPublished {
         /// The catchup target ledger sequence.
         target: u32,
+        /// The covering checkpoint for `target` (`checkpoint_containing(target)`),
+        /// i.e. the archive `currentLedger` value required for the target to be
+        /// considered published. Included so on-call debugging does not have to
+        /// recompute the checkpoint math from the log line.
+        covering_checkpoint: u32,
         /// The archive HAS `currentLedger` observed at gate time.
         has_current: u32,
     },
@@ -735,6 +740,7 @@ mod tests {
         // force a full bucket-apply reset).
         let err = HistoryError::CheckpointNotYetPublished {
             target: 62845439,
+            covering_checkpoint: 62845439,
             has_current: 62845375,
         };
         assert!(
@@ -744,6 +750,17 @@ mod tests {
         assert!(
             !err.is_hash_mismatch(),
             "CheckpointNotYetPublished must not be treated as a hash mismatch"
+        );
+        // The covering checkpoint value must appear in the rendered message so
+        // on-call debugging needn't recompute checkpoint math from the log line.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("62845439"),
+            "message must include the covering checkpoint value: {msg}"
+        );
+        assert!(
+            msg.contains("62845375"),
+            "message must still include the archive HAS currentLedger: {msg}"
         );
     }
 


### PR DESCRIPTION
Closes #2941

## Summary

The `CheckpointNotYetPublished` error previously reported only the catchup `target` ledger and the archive HAS `currentLedger`, forcing on-call debugging to recompute `checkpoint_containing(target)` by hand to understand the gate. This adds a `covering_checkpoint` field to the variant and surfaces it in the rendered message, so the required published frontier is reported directly.

## Plan reference

Trivial short-circuit — Implementation Notes in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2941).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-history --all-targets -- -D warnings (clean)
- [x] cargo test -p henyey-history (526 + targeted tests pass)

Updated `error::tests::test_checkpoint_not_yet_published_is_transient` and `catchup::replay::tests::test_knit_lcl_mismatch_unpublished_checkpoint_is_transient` to assert the covering checkpoint value now appears in the rendered message.

## Deviations from plan

None. (Triage referenced line 532; the variant had shifted to line 528 in current main but is otherwise as described.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)