### PR TITLE
Escape literal expression delimiters in quickstart validate-contract comments

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -203,7 +203,10 @@ jobs:
             # --- Exact artifact name validation ---
             # The contract specifies artifact_name_pattern: "image-quickstart-{tag}-{arch}.tar"
             # Upstream internal-build.yml constructs the artifact name using expressions like:
-            #   image-quickstart-${{ inputs.tag ... }}-${{ matrix.arch }}
+            #   image-quickstart-<inputs.tag expr>-<matrix.arch expr>
+            # (the angle-bracket placeholders stand in for GHA expression syntax;
+            #  literal expression delimiters are avoided here so the workflow file
+            #  itself stays parseable — see #2933.)
             # We validate: (a) the exact "image-quickstart-" prefix with tag/arch interpolation,
             # and (b) our concrete expected_artifact_name decomposes correctly from the pattern.
             #
@@ -236,7 +239,7 @@ jobs:
 
             # --- Exact image tag validation ---
             # The contract specifies image_tag_pattern: "quickstart:{tag}-{arch}"
-            # Upstream tags the image as quickstart:${{ inputs.tag }}-${{ matrix.arch }}
+            # Upstream tags the image as quickstart:<inputs.tag expr>-<matrix.arch expr>
             # or similar. Validate the "quickstart:" prefix with tag-arch interpolation.
             IMAGE_TAG_PREFIX="quickstart:"
             if grep -q "${IMAGE_TAG_PREFIX}" "$INTERNAL"; then
@@ -250,7 +253,7 @@ jobs:
 
             # Validate the image tag template follows the exact {tag}-{arch} structure.
             # Upstream must tag as: quickstart:<tag_expr>-<arch_expr>.
-            # Reject shapes like quickstart:${{ inputs.tag }} (missing arch).
+            # Reject shapes like quickstart:<inputs.tag expr> (missing arch).
             TAG_REGEX="${IMAGE_TAG_PREFIX}"'\$\{\{[^}]*(tag|inputs\.tag|matrix\.tag)[^}]*\}\}-\$\{\{[^}]*(arch|matrix\.arch|inputs\.arch)[^}]*\}\}'
             if grep -qE "$TAG_REGEX" "$INTERNAL"; then
               echo "✓ internal-build.yml image tag matches {tag}-{arch} structure"


### PR DESCRIPTION
Closes #2933

## Summary

The `validate-contract` job's `run: |` block in `.github/workflows/quickstart.yml` contained three documentation comments with literal `${{ ... }}` example expressions. GitHub Actions evaluates `${{ ... }}` inside a `run:` block before the shell ever sees the `#` comment, so these examples made the entire workflow invalid (`Invalid workflow file ... Unexpected symbol: '..'`), producing zero jobs. This PR replaces the three literal examples with angle-bracket placeholders (`<inputs.tag expr>`, `<matrix.arch expr>`), preserving the documented intent while removing the parser trigger.

The escaped `\$\{\{ ... \}\}` regex strings on the matching `if grep` lines (231, 258) were never the trigger and are left unchanged.

## Plan reference

Trivial short-circuit — Implementation Notes in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2933).

## Test plan

- [x] No literal `${{` remains on any comment line (`grep -nE '^\s*#.*\$\{\{'` returns nothing)
- [x] YAML parses; all four jobs (`setup`, `validate-contract`, `build`, `test`) present
- [x] `actionlint 1.7.12` reports the workflow clean (exit 0)
- [x] All remaining `${{ }}` expressions are well-formed (no stray `..`)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)