### PR TITLE
Pass gh pr merge flags as separate argv entries in attempt_merge

### DIFF
--- a/scripts/lib/review-pr-merge.sh
+++ b/scripts/lib/review-pr-merge.sh
@@ -49,8 +49,10 @@ attempt_merge() {
   mkdir -p "$scratch_dir"
   local stderr_file="$scratch_dir/merge-stderr-$$-$pr_num.tmp"
 
-  # Try admin merge first
-  if _review_pr_exec_merge "$pr_num" "$repo" "--squash --admin" "$stderr_file"; then
+  # Try admin merge first. Flags are passed as SEPARATE arguments (not a single
+  # "--squash --admin" string) so gh receives two distinct flags rather than one
+  # bogus "--squash --admin" flag it rejects with "unknown flag" (see #2949).
+  if _review_pr_exec_merge "$pr_num" "$repo" "$stderr_file" --squash --admin; then
     rm -f "$stderr_file"
     echo "merged"
     return 0
@@ -61,8 +63,9 @@ attempt_merge() {
 
   # Classify the failure: does it contain the exact auto-merge hint?
   if _is_auto_hint_failure "$stderr_content"; then
-    # Retry with --auto (without --admin since GH CLI rejects that combo)
-    if _review_pr_exec_merge "$pr_num" "$repo" "--squash --auto" "$stderr_file"; then
+    # Retry with --auto (without --admin since GH CLI rejects that combo).
+    # Flags passed as separate arguments (see #2949).
+    if _review_pr_exec_merge "$pr_num" "$repo" "$stderr_file" --squash --auto; then
       rm -f "$stderr_file"
       echo "auto-merge-armed"
       return 0
@@ -308,20 +311,24 @@ check_armed_pr_health() {
 # Internal helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-# _review_pr_exec_merge PR_NUM REPO FLAGS STDERR_FILE
-# Execute gh pr merge with given flags. Mockable via REVIEW_PR_MERGE_CMD.
+# _review_pr_exec_merge PR_NUM REPO STDERR_FILE FLAG...
+# Execute gh pr merge with the given flags. Each merge flag is a SEPARATE
+# trailing argument (e.g. `--squash --admin`), NOT a single space-joined string,
+# so gh receives distinct flags rather than one bogus "--squash --admin" flag
+# (see #2949). Mockable via REVIEW_PR_MERGE_CMD.
 # Returns: exit code of the merge command.
 _review_pr_exec_merge() {
   local pr_num="$1"
   local repo="$2"
-  local flags="$3"
-  local stderr_file="$4"
+  local stderr_file="$3"
+  shift 3
+  # Remaining positional args ("$@") are the individual merge flags.
 
   if [[ -n "${REVIEW_PR_MERGE_CMD:-}" ]]; then
-    # Test mode: call the mock function
-    $REVIEW_PR_MERGE_CMD "$pr_num" "$repo" "$flags" 2>"$stderr_file"
+    # Test mode: call the mock function, forwarding each flag as its own arg.
+    $REVIEW_PR_MERGE_CMD "$pr_num" "$repo" "$@" 2>"$stderr_file"
   else
-    gh pr merge "$pr_num" --repo "$repo" $flags 2>"$stderr_file"
+    gh pr merge "$pr_num" --repo "$repo" "$@" 2>"$stderr_file"
   fi
 }
 

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -39,7 +39,7 @@ export REVIEW_PR_SCRATCH_DIR="$TEST_ROOT/merge-scratch"
 mkdir -p "$REVIEW_PR_SCRATCH_DIR"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=47
+TAP_PLAN=49
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -334,6 +334,44 @@ set -e
 [[ "$RESULT" == "hard-failure:permission denied: token lacks admin access" ]] && \
   tap_ok "unexpected admin merge failure stays terminal" || \
   tap_fail "unexpected admin merge failure stays terminal" "got: $RESULT"
+unset REVIEW_PR_MERGE_CMD
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST 13b: attempt_merge passes --squash --admin as SEPARATE argv entries (#2949)
+# ══════════════════════════════════════════════════════════════════════════════
+# Regression for #2949: the merge flags must reach `gh pr merge` as two distinct
+# arguments (`--squash` `--admin`), NOT as a single quoted "--squash --admin"
+# string (which gh rejects with "unknown flag: --squash --admin"). The mock
+# records the flag argv count and the individual flag tokens it received.
+#
+# Contract: _review_pr_exec_merge passes the flags as trailing positional args
+# (argv index 3..N), so a mock sees pr_num=$1, repo=$2, and each flag as its
+# own $3, $4, ... — `$# - 2` is the flag count.
+
+MOCK_FLAG_ARGC=0
+MOCK_FLAG_TOKENS=""
+mock_merge_record_argv() {
+  local pr_num="$1" repo="$2"
+  shift 2
+  MOCK_FLAG_ARGC="$#"
+  MOCK_FLAG_TOKENS="$*"
+  return 0
+}
+
+export REVIEW_PR_MERGE_CMD=mock_merge_record_argv
+MOCK_FLAG_ARGC=0
+MOCK_FLAG_TOKENS=""
+RESULT=$(attempt_merge 2949)
+# Re-run without subshell capture so the mock's variable writes are visible
+# (the command-substitution above runs the mock in a subshell, discarding its
+# variable mutations). attempt_merge is idempotent for a "merged" result.
+MOCK_FLAG_ARGC=0
+MOCK_FLAG_TOKENS=""
+attempt_merge 2949 >/dev/null
+assert_eq "2" "$MOCK_FLAG_ARGC" \
+  "attempt_merge passes admin merge flags as 2 separate argv entries (#2949)"
+assert_eq "--squash --admin" "$MOCK_FLAG_TOKENS" \
+  "attempt_merge admin flags are --squash and --admin (#2949)"
 unset REVIEW_PR_MERGE_CMD
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/scripts/test-review-pr-skill-snippets.sh
+++ b/scripts/test-review-pr-skill-snippets.sh
@@ -243,7 +243,7 @@ assert_eq "APPROVE" "$STATE" "latest comment wins when multiple verdicts exist"
 
 MERGE_CALL_NUM=0
 mock_merge_auto_hint() {
-  local pr_num="$1" repo="$2" flags="$3"
+  local pr_num="$1"; shift 2; local flags="$*"   # ignore repo
   MERGE_CALL_NUM=$((MERGE_CALL_NUM + 1))
   if [[ "$flags" == *"--admin"* ]]; then
     echo "X Pull request stellar-experimental/henyey#$pr_num is not mergeable: the merge commit cannot be cleanly created." >&2
@@ -291,7 +291,7 @@ unset REVIEW_PR_AUTO_MERGE_FILE
 # When --auto also fails (e.g. autoMergeAllowed: false), result is hard-failure.
 
 mock_merge_auto_both_fail() {
-  local pr_num="$1" repo="$2" flags="$3"
+  shift 2; local flags="$*"   # ignore pr_num/repo; classify by flags
   if [[ "$flags" == *"--admin"* ]]; then
     echo "To have the pull request merged after all the requirements have been met, add the \`--auto\` flag." >&2
     return 1
@@ -316,7 +316,7 @@ unset REVIEW_PR_MERGE_CMD
 # ══════════════════════════════════════════════════════════════════════════════
 
 mock_merge_other_failure() {
-  local pr_num="$1" repo="$2" flags="$3"
+  shift 2; local flags="$*"   # ignore pr_num/repo; classify by flags
   if [[ "$flags" == *"--admin"* ]]; then
     echo "permission denied: token lacks admin access" >&2
     return 1
@@ -351,7 +351,7 @@ unset REVIEW_PR_MERGE_CMD
 MOCK_FLAG_ARGC=0
 MOCK_FLAG_TOKENS=""
 mock_merge_record_argv() {
-  local pr_num="$1" repo="$2"
+  # $1=pr_num, $2=repo (both ignored); $3.. are the individual merge flags.
   shift 2
   MOCK_FLAG_ARGC="$#"
   MOCK_FLAG_TOKENS="$*"
@@ -425,7 +425,7 @@ mkdir -p "$CUSTOM_SCRATCH"
 export REVIEW_PR_SCRATCH_DIR="$CUSTOM_SCRATCH"
 
 mock_merge_success() {
-  local pr_num="$1" repo="$2" flags="$3"
+  # Args (pr_num, repo, flags...) are intentionally ignored; always succeeds.
   return 0
 }
 export REVIEW_PR_MERGE_CMD=mock_merge_success


### PR DESCRIPTION
Closes #2949

## Summary

`scripts/lib/review-pr-merge.sh`'s `attempt_merge` passed the squash-admin merge flags to `_review_pr_exec_merge` as a single space-joined `"--squash --admin"` string. The mockable test path forwarded that whole string as one argument, so the mock saw one bogus flag instead of two — exactly the `unknown flag: --squash --admin` rejection observed in #2938 during `/review-pr 2920`. This change restructures the helper to take the merge flags as separate trailing positional arguments and forwards them via `"$@"` to both the mock and the real `gh pr merge` invocation, so the auto-merge path passes `--squash` and `--admin` as two distinct flags.

## Plan reference

Trivial short-circuit — implemented from the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2949#issuecomment-4604194710) Implementation Notes (no separate /plan).

## Test plan

- [x] `scripts/test-review-pr-skill-snippets.sh` — all 49 tests pass
- [x] shellcheck (via docker `koalaman/shellcheck:stable`, severity=warning) — clean on both modified scripts
- [x] `bash -n` syntax check on both scripts

## Regression test (kind: bug-fix)

- **Test:** `scripts/test-review-pr-skill-snippets.sh` — "attempt_merge passes admin merge flags as 2 separate argv entries (#2949)"
- **Pre-fix:** committed as `a8c1e30bf905d5ca1d0adc619d5a0f398329367d` — verified FAILED: `expected='2' actual='1'` (flags arrived as one argv entry)
- **Post-fix:** verified PASSES after `d3f8edc42c76891b84ae92399bc27f64ac926e79`

## Deviations from plan

- Also updated the four existing merge mocks (`mock_merge_auto_hint`, `mock_merge_auto_both_fail`, `mock_merge_other_failure`, `mock_merge_success`) to match the new variadic-flag contract and stay shellcheck-clean. Required for the test suite to keep passing under the new helper signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)