### PR TITLE
Pin gated catchup replay downloads to the publication-gate archive

### DIFF
--- a/crates/history/src/catchup/download.rs
+++ b/crates/history/src/catchup/download.rs
@@ -111,15 +111,23 @@ impl CatchupManager {
     ///
     /// Uses archive rotation: each attempt tries a different archive, cycling
     /// through them to provide failover when one archive is unavailable.
+    ///
+    /// Returns the parsed HAS together with the `Arc<HistoryArchive>` that
+    /// served it. Callers in the gated replay path (#2940) pin subsequent
+    /// ledger-data downloads to this exact archive so the archive that passed
+    /// the #2937 publication gate is the same one that supplies the ledger
+    /// data — closing the cross-archive bypass where a second stale-but-serving
+    /// archive could serve data that never satisfied the gate. The archive's
+    /// name (for metric labels) is derived via `archive.name()` at call sites.
     pub(super) async fn download_has(
         &self,
         checkpoint_seq: u32,
-    ) -> Result<(HistoryArchiveState, String)> {
+    ) -> Result<(HistoryArchiveState, Arc<HistoryArchive>)> {
         let num_archives = self.archives.len() as u32;
         for attempt in 0..num_archives {
             let archive = self.select_archive(attempt);
             match archive.fetch_checkpoint_has(checkpoint_seq).await {
-                Ok(has) => return Ok((has, archive.name().to_owned())),
+                Ok(has) => return Ok((has, Arc::clone(archive))),
                 Err(e) => {
                     warn!(
                         "Failed to download HAS from archive {}: {}",
@@ -328,11 +336,23 @@ impl CatchupManager {
     /// is empty when `from_ledger == 0` (genesis), when LCL sits on a
     /// checkpoint boundary (LCL-1 in a prior file, no overlap), or when
     /// there is no work to do.
+    ///
+    /// # Pinning (#2940)
+    ///
+    /// When `pinned` is `Some(archive)`, every download issued here (the LCL
+    /// header via `download_checkpoint_header` and each checkpoint payload via
+    /// `download_checkpoint_ledger_data`) is served from that archive **only**
+    /// — no rotation, no cross-archive fallback. This is used by the gated
+    /// replay path so the archive that passed the #2937 publication gate is the
+    /// same archive that supplies the ledger data. When `pinned` is `None`
+    /// (bucket-apply phase / non-gated callers), the existing fixed-order
+    /// rotation over `&self.archives` is used.
     pub(super) async fn download_ledger_data(
         &mut self,
         from_ledger: u32,
         to_ledger: u32,
         initial_lcl: LclContext,
+        pinned: Option<&Arc<HistoryArchive>>,
     ) -> Result<(Vec<LedgerData>, Vec<LedgerHeaderHistoryEntry>, String)> {
         let mut data = Vec::new();
         let mut knit_entries: Vec<LedgerHeaderHistoryEntry> = Vec::new();
@@ -367,7 +387,8 @@ impl CatchupManager {
         // We use download_checkpoint_header (lightweight single-header fetch)
         // rather than downloading the full checkpoint data.
         let mut current_lcl = if from_ledger > 0 {
-            let (lcl_header, lcl_hash) = self.download_checkpoint_header(from_ledger).await?;
+            let (lcl_header, lcl_hash) =
+                self.download_checkpoint_header(from_ledger, pinned).await?;
             LclContext::new(lcl_header.ledger_version, lcl_hash)
         } else {
             // from_ledger == 0 means "before genesis"; use caller-provided context.
@@ -380,8 +401,9 @@ impl CatchupManager {
 
             if let std::collections::hash_map::Entry::Vacant(e) = checkpoint_cache.entry(checkpoint)
             {
-                let (downloaded, archive_name) =
-                    self.download_checkpoint_ledger_data(checkpoint).await?;
+                let (downloaded, archive_name) = self
+                    .download_checkpoint_ledger_data(checkpoint, pinned)
+                    .await?;
                 last_archive_name = archive_name;
                 e.insert(downloaded);
             }
@@ -453,10 +475,22 @@ impl CatchupManager {
     async fn download_checkpoint_ledger_data(
         &self,
         checkpoint: u32,
+        pinned: Option<&Arc<HistoryArchive>>,
     ) -> Result<(CheckpointLedgerData, String)> {
+        // #2940: when pinned, serve from that archive only (no rotation). The
+        // single-element slice keeps the rotation loop below uniform.
+        let pinned_slice;
+        let archives: &[Arc<HistoryArchive>] = match pinned {
+            Some(archive) => {
+                pinned_slice = [Arc::clone(archive)];
+                &pinned_slice
+            }
+            None => &self.archives,
+        };
+
         // Try each archive until one succeeds
         let mut last_archive_name = String::new();
-        for archive in &self.archives {
+        for archive in archives {
             last_archive_name = archive.name().to_owned();
             match self.try_download_checkpoint(archive, checkpoint).await {
                 Ok(data) => {
@@ -566,8 +600,19 @@ impl CatchupManager {
     pub(super) async fn download_checkpoint_header(
         &self,
         ledger_seq: u32,
+        pinned: Option<&Arc<HistoryArchive>>,
     ) -> Result<(LedgerHeader, Hash256)> {
-        for archive in &self.archives {
+        // #2940: when pinned, serve from that archive only (no rotation).
+        let pinned_slice;
+        let archives: &[Arc<HistoryArchive>] = match pinned {
+            Some(archive) => {
+                pinned_slice = [Arc::clone(archive)];
+                &pinned_slice
+            }
+            None => &self.archives,
+        };
+
+        for archive in archives {
             match archive.fetch_ledger_header_with_hash(ledger_seq).await {
                 Ok((header, hash)) => {
                     debug!(
@@ -700,6 +745,97 @@ mod tests {
                 "expected metric literal {literal} in catchup/download.rs",
             );
         }
+    }
+
+    /// Build a `CatchupManager` over the given archive URLs (in order), backed
+    /// by a temp bucket dir + in-memory DB. Returns the `TempDir` guard first so
+    /// callers destructure `let (_tmp, mgr) = ...` (drop order: mgr before tmp).
+    fn make_manager_with_archives(urls: &[&str]) -> (tempfile::TempDir, CatchupManager) {
+        let db = Database::open_in_memory().expect("in-memory db");
+        let tmp_dir = tempfile::tempdir().expect("temp dir");
+        let bucket_manager =
+            BucketManager::new(tmp_dir.path().to_path_buf()).expect("bucket manager");
+        let archives: Vec<_> = urls
+            .iter()
+            .map(|u| crate::HistoryArchive::new(u).expect("archive"))
+            .collect();
+        (
+            tmp_dir,
+            super::super::CatchupManager::new(archives, bucket_manager, db),
+        )
+    }
+
+    /// #2940: `download_has` returns the `Arc<HistoryArchive>` that actually
+    /// served the HAS — not merely the first archive in the list. Here the
+    /// first archive is dead (bad host) and the second serves the checkpoint,
+    /// so the returned archive's `base_url` must be the second fixture's.
+    #[tokio::test]
+    async fn test_download_has_returns_serving_archive() {
+        let checkpoint = 63u32;
+        let fixture = match crate::test_utils::build_single_checkpoint_archive(checkpoint).await {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("skipping test: {e}");
+                return;
+            }
+        };
+        // First archive: an unreachable host (HAS fetch fails); second: the
+        // live fixture. download_has must rotate to and return the live one.
+        let dead_url = "http://127.0.0.1:1/";
+        let (_tmp, mgr) = make_manager_with_archives(&[dead_url, &fixture.base_url]);
+
+        let (has, archive) = mgr.download_has(checkpoint).await.expect("download_has");
+        assert_eq!(has.current_ledger(), checkpoint);
+        assert_eq!(
+            archive.base_url().as_str(),
+            fixture.base_url.as_str(),
+            "returned archive must be the one that actually served the HAS"
+        );
+    }
+
+    /// #2940: a pinned `download_checkpoint_header` issues the request against
+    /// the pinned archive ONLY. Pinning to the live fixture succeeds even when
+    /// it is not first in the list; pinning to a dead archive fails without
+    /// falling back; and `None` preserves rotation (finds the live archive).
+    #[tokio::test]
+    async fn test_download_checkpoint_header_pin_targets_only_pinned() {
+        let checkpoint = 63u32;
+        let fixture = match crate::test_utils::build_single_checkpoint_archive(checkpoint).await {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("skipping test: {e}");
+                return;
+            }
+        };
+        let dead_url = "http://127.0.0.1:1/";
+        // Order [live, dead]: the live archive is index 0.
+        let (_tmp, mgr) = make_manager_with_archives(&[&fixture.base_url, dead_url]);
+        let live = Arc::clone(&mgr.archives[0]);
+        let dead = Arc::clone(&mgr.archives[1]);
+
+        // Pinned to the live archive → succeeds.
+        let (header, _hash) = mgr
+            .download_checkpoint_header(checkpoint, Some(&live))
+            .await
+            .expect("pinned-to-live header download");
+        assert_eq!(header.ledger_seq, checkpoint);
+
+        // Pinned to the dead archive → fails, with NO fallback to the live one.
+        let err = mgr
+            .download_checkpoint_header(checkpoint, Some(&dead))
+            .await
+            .expect_err("pinned-to-dead header download must fail without fallback");
+        assert!(
+            matches!(err, HistoryError::CatchupFailed(_)),
+            "expected CatchupFailed, got: {err:?}"
+        );
+
+        // None → rotation finds the live archive (index 0) and succeeds.
+        let (header, _hash) = mgr
+            .download_checkpoint_header(checkpoint, None)
+            .await
+            .expect("unpinned header download rotates to live archive");
+        assert_eq!(header.ledger_seq, checkpoint);
     }
 
     /// Stage E: download counters in this module must carry the `"archive"` label.

--- a/crates/history/src/catchup/mod.rs
+++ b/crates/history/src/catchup/mod.rs
@@ -633,8 +633,9 @@ impl CatchupManager {
         checkpoint_seq: u32,
     ) -> Result<(HistoryArchiveState, String)> {
         match self.download_has(checkpoint_seq).await {
-            Ok((has, archive_name)) => match self.verify_has(&has, checkpoint_seq) {
+            Ok((has, archive)) => match self.verify_has(&has, checkpoint_seq) {
                 Ok(()) => {
+                    let archive_name = archive.name().to_owned();
                     metrics::counter!(
                         "stellar_history_download_history_archive_state_success_total",
                         "archive" => archive_name.clone(),
@@ -645,7 +646,7 @@ impl CatchupManager {
                 Err(e) => {
                     metrics::counter!(
                         "stellar_history_download_history_archive_state_failure_total",
-                        "archive" => archive_name,
+                        "archive" => archive.name().to_owned(),
                     )
                     .increment(1);
                     Err(e)
@@ -738,8 +739,9 @@ impl CatchupManager {
         let buckets = self.download_buckets(&bucket_hashes).await?;
 
         // Steps 4-5: Apply buckets and initialize LedgerManager
-        let (checkpoint_header, checkpoint_hash) =
-            self.download_checkpoint_header(checkpoint_seq).await?;
+        let (checkpoint_header, checkpoint_hash) = self
+            .download_checkpoint_header(checkpoint_seq, None)
+            .await?;
 
         self.apply_buckets_and_init_ledger_manager(
             &has,
@@ -881,8 +883,9 @@ impl CatchupManager {
                 let buckets = self.download_buckets(&bucket_hashes).await?;
 
                 // Apply buckets and initialize LedgerManager
-                let (checkpoint_header, checkpoint_hash) =
-                    self.download_checkpoint_header(bucket_apply_at).await?;
+                let (checkpoint_header, checkpoint_hash) = self
+                    .download_checkpoint_header(bucket_apply_at, None)
+                    .await?;
 
                 self.apply_buckets_and_init_ledger_manager(
                     &has,
@@ -909,7 +912,7 @@ impl CatchupManager {
                                 "Case 1 replay: initializing ledger manager from existing state at LCL {}",
                                 lcl
                             );
-                            let (header, hash) = self.download_checkpoint_header(lcl).await?;
+                            let (header, hash) = self.download_checkpoint_header(lcl, None).await?;
                             ledger_manager
                                 .initialize(
                                     state.bucket_list,
@@ -939,7 +942,9 @@ impl CatchupManager {
                 checkpoint_seq
             );
         }
-        let (header, hash) = self.download_checkpoint_header(checkpoint_seq).await?;
+        let (header, hash) = self
+            .download_checkpoint_header(checkpoint_seq, None)
+            .await?;
         self.replay_and_finish(
             target,
             checkpoint_seq,

--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -446,8 +446,24 @@ impl CatchupManager {
         // currentLedger is behind the target checkpoint yields the transient
         // CheckpointNotYetPublished so the attempt is retried, not wiped.
         let target_checkpoint = crate::checkpoint::checkpoint_containing(target);
-        let (target_has, _has_archive) = self.download_has(target_checkpoint).await?;
+        let (target_has, gate_archive) = self.download_has(target_checkpoint).await?;
         checkpoint_publication_gate(target_has.current_ledger(), target)?;
+
+        // #2940: pin every ledger-data download in this attempt to the exact
+        // archive that served `target_has` and passed the publication gate.
+        // This guarantees the archive whose published frontier satisfied the
+        // gate is the same archive that supplies the LCL header and checkpoint
+        // payloads — closing the cross-archive bypass where a different stale-
+        // but-serving archive could supply ledger data that never satisfied the
+        // gate (#2931 knit-to-LCL / state-wipe path under archive asymmetry).
+        //
+        // The pin is re-derived on every call to this method (i.e. per replay
+        // attempt) — never cached across attempts — since `download_has`
+        // re-scans archives from index 0 each time. A pinned download that
+        // fails returns an error for this attempt (no intra-attempt cross-
+        // archive fallback); the outer retry loop then re-runs the whole
+        // attempt, re-running the gate and re-selecting the archive, so a down
+        // archive is still rotated at the attempt boundary.
 
         // Download ledger data for replay
         self.update_progress(
@@ -456,7 +472,7 @@ impl CatchupManager {
             "Downloading ledger data",
         );
         let (ledger_data, knit_entries, archive_name) = self
-            .download_ledger_data(download_from, target, lcl)
+            .download_ledger_data(download_from, target, lcl, Some(&gate_archive))
             .await?;
 
         // CATCHUP_SPEC §11.2: apply the 5-case knit-to-LCL decision matrix

--- a/crates/history/tests/replay_integration.rs
+++ b/crates/history/tests/replay_integration.rs
@@ -2139,3 +2139,325 @@ async fn test_checkpoint_data_config_rejects_non_minimal_depth() {
         "error should mention Minimal requirement, got: {msg2}"
     );
 }
+
+/// Regression test for #2940: a gated catchup replay attempt must download
+/// ledger data ONLY from the archive that served `target_has` and passed the
+/// #2937 publication gate — it must never fall back to a different archive for
+/// the LCL header or checkpoint payload within the same attempt.
+///
+/// Setup: two archives ordered [B, A].
+/// - Archive A ("good"): serves the bucket-apply checkpoint HAS, the gate HAS
+///   at the target's covering checkpoint, and a *correct* `ledger/{ckpt}.xdr.gz`
+///   for the data checkpoint (header chain that knits to LCL and replays
+///   cleanly).
+/// - Archive B ("divergent"): serves the bucket-apply checkpoint HAS so the
+///   out-of-scope bucket-apply phase can proceed, but **404s the gate HAS**
+///   (`history/{target_checkpoint}.json`) and serves a *divergent*
+///   `ledger/{ckpt}.xdr.gz` whose header64 hash differs from A's.
+///
+/// Because B is first in the list, the publication gate's `download_has`
+/// rotation tries B (404 on the gate HAS), then A (serves it) → the gate
+/// archive is A. Under the pre-#2940 unpinned behaviour, the subsequent
+/// fixed-order ledger-data download would hit B first and consume B's
+/// divergent header64 → knit/chain mismatch and catchup failure. With the
+/// pin, ledger data is fetched from A only and catchup succeeds against A's
+/// data.
+#[tokio::test]
+async fn test_catchup_pins_downloads_to_gate_archive() {
+    let checkpoint = 63u32;
+    let target = 64u32;
+    let data_checkpoint = henyey_history::checkpoint::checkpoint_containing(target);
+
+    let bucket_list = empty_bucket_list();
+    let checkpoint_bucket_hash = combined_bucket_list_hash(bucket_list.hash());
+    let mut bucket_list_after = bucket_list.clone();
+    let default_next_states: Vec<Option<henyey_bucket::PendingMergeState>> =
+        vec![None; BUCKET_LIST_LEVELS];
+    let load_empty = |_hash: &Hash256| -> henyey_bucket::Result<Bucket> { Ok(Bucket::empty()) };
+    bucket_list_after
+        .restart_merges_from_has(checkpoint, 25, &default_next_states, load_empty, true)
+        .await
+        .expect("restart merges");
+    bucket_list_after
+        .add_batch(
+            target,
+            25,
+            stellar_xdr::curr::BucketListType::Live,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("bucket add batch");
+    let replay_bucket_hash = combined_bucket_list_hash(bucket_list_after.hash());
+
+    let header63 = make_header(
+        checkpoint,
+        Hash256::ZERO,
+        checkpoint_bucket_hash,
+        Hash256::ZERO,
+        Hash256::ZERO,
+    );
+    let header63_hash = verify::compute_header_hash(&header63).expect("header63 hash");
+
+    let tx_set = TransactionSet {
+        previous_ledger_hash: Hash(*header63_hash.as_bytes()),
+        txs: VecM::default(),
+    };
+    let tx_set_hash = verify::compute_tx_set_hash(&TransactionSetVariant::Classic(tx_set.clone()))
+        .expect("tx set hash");
+
+    let result_set = TransactionResultSet {
+        results: VecM::default(),
+    };
+    let result_xdr = result_set
+        .to_xdr(stellar_xdr::curr::Limits::none())
+        .expect("tx result xdr");
+    let tx_result_hash = Hash256::hash(&result_xdr);
+
+    // Archive A's correct header64 (knits to LCL=63, replays cleanly).
+    let header64 = make_header(
+        target,
+        header63_hash,
+        replay_bucket_hash,
+        tx_set_hash,
+        tx_result_hash,
+    );
+    let header64_hash = verify::compute_header_hash(&header64).expect("header64 hash");
+
+    // Archive B's DIVERGENT header64: a *different* previous_ledger_hash so it
+    // cannot knit to LCL=63. If B's ledger data is consumed, the §11.2
+    // knit-to-LCL decision matrix (which runs unconditionally, independent of
+    // replay_config) rejects it with a fatal KnitCurrentLedgerPrevHashMismatch
+    // → catchup fails. So success vs failure cleanly distinguishes "used A"
+    // (knits) from "used B" (does not knit).
+    let header64_divergent = make_header(
+        target,
+        Hash256::from_bytes([0xAB; 32]),
+        replay_bucket_hash,
+        tx_set_hash,
+        tx_result_hash,
+    );
+    let header64_divergent_hash =
+        verify::compute_header_hash(&header64_divergent).expect("divergent header64 hash");
+    assert_ne!(
+        header64_hash, header64_divergent_hash,
+        "divergent header must differ from the good header"
+    );
+
+    // Checkpoint-63 headers (ledgers 63) — identical on both archives so the
+    // out-of-scope bucket-apply phase succeeds regardless of which archive
+    // serves it.
+    let headers_xdr_ckpt63 = {
+        let entry63 = LedgerHeaderHistoryEntry {
+            hash: header63_hash.into(),
+            header: header63.clone(),
+            ext: LedgerHeaderHistoryEntryExt::default(),
+        };
+        record_marked(&[entry63
+            .to_xdr(stellar_xdr::curr::Limits::none())
+            .expect("header63 xdr")])
+    };
+
+    let make_data_checkpoint_headers = |entry_hash: Hash256, header: LedgerHeader| -> Vec<u8> {
+        let entry64 = LedgerHeaderHistoryEntry {
+            hash: entry_hash.into(),
+            header,
+            ext: LedgerHeaderHistoryEntryExt::default(),
+        };
+        record_marked(&[entry64
+            .to_xdr(stellar_xdr::curr::Limits::none())
+            .expect("header64 xdr")])
+    };
+    let headers_xdr_good = make_data_checkpoint_headers(header64_hash, header64.clone());
+    let headers_xdr_divergent =
+        make_data_checkpoint_headers(header64_divergent_hash, header64_divergent);
+
+    let tx_history_entry = TransactionHistoryEntry {
+        ledger_seq: target,
+        tx_set: tx_set.clone(),
+        ext: TransactionHistoryEntryExt::V0,
+    };
+    let tx_history_xdr = record_marked(&[tx_history_entry
+        .to_xdr(stellar_xdr::curr::Limits::none())
+        .expect("tx history xdr")]);
+    let tx_result_entry = TransactionHistoryResultEntry {
+        ledger_seq: target,
+        tx_result_set: result_set,
+        ext: TransactionHistoryResultEntryExt::default(),
+    };
+    let tx_result_xdr = record_marked(&[tx_result_entry
+        .to_xdr(stellar_xdr::curr::Limits::none())
+        .expect("tx result history xdr")]);
+
+    let mut levels = Vec::with_capacity(BUCKET_LIST_LEVELS);
+    for _ in 0..BUCKET_LIST_LEVELS {
+        levels.push(HASBucketLevel {
+            curr: "0".repeat(64),
+            snap: "0".repeat(64),
+            next: Default::default(),
+        });
+    }
+    let has_ckpt63 = HistoryArchiveState {
+        version: 2,
+        server: Some("rs-stellar-core test".to_string()),
+        current_ledger: checkpoint,
+        network_passphrase: Some("Test SDF Network ; September 2015".to_string()),
+        current_buckets: levels,
+        hot_archive_buckets: make_test_hot_archive_buckets(),
+    };
+
+    // Build the per-archive fixture map. `good = true` produces archive A
+    // (correct ledger data + gate HAS); `good = false` produces archive B
+    // (divergent ledger data, no gate HAS).
+    let build_fixtures = |good: bool| -> HashMap<String, Vec<u8>> {
+        let mut fixtures: HashMap<String, Vec<u8>> = HashMap::new();
+        // Bucket-apply checkpoint HAS + headers + (empty) tx/results — shared.
+        fixtures.insert(
+            checkpoint_path("history", checkpoint, "json"),
+            has_ckpt63.to_json().unwrap().into_bytes(),
+        );
+        fixtures.insert(
+            checkpoint_path("ledger", checkpoint, "xdr.gz"),
+            gzip_bytes(&headers_xdr_ckpt63),
+        );
+        fixtures.insert(
+            checkpoint_path("transactions", checkpoint, "xdr.gz"),
+            gzip_bytes(&[]),
+        );
+        fixtures.insert(
+            checkpoint_path("results", checkpoint, "xdr.gz"),
+            gzip_bytes(&[]),
+        );
+
+        // Data-checkpoint ledger data: correct on A, divergent on B.
+        fixtures.insert(
+            checkpoint_path("ledger", data_checkpoint, "xdr.gz"),
+            gzip_bytes(if good {
+                &headers_xdr_good
+            } else {
+                &headers_xdr_divergent
+            }),
+        );
+        fixtures.insert(
+            checkpoint_path("transactions", data_checkpoint, "xdr.gz"),
+            gzip_bytes(&tx_history_xdr),
+        );
+        fixtures.insert(
+            checkpoint_path("results", data_checkpoint, "xdr.gz"),
+            gzip_bytes(&tx_result_xdr),
+        );
+
+        // Gate HAS at the target's covering checkpoint — only archive A serves
+        // it. Archive B 404s, forcing `download_has` rotation to pick A as the
+        // gate archive.
+        if good {
+            register_published_target_has(&mut fixtures, target);
+        }
+        fixtures
+    };
+
+    async fn serve(
+        fixtures: HashMap<String, Vec<u8>>,
+    ) -> Option<(String, tokio::task::JoinHandle<()>)> {
+        let fixtures = Arc::new(fixtures);
+        let app = Router::new()
+            .route(
+                "/*path",
+                get(
+                    |Path(path): Path<String>,
+                     State(state): State<Arc<HashMap<String, Vec<u8>>>>| async move {
+                        let key = path.trim_start_matches('/');
+                        if let Some(body) = state.get(key) {
+                            (StatusCode::OK, body.clone())
+                        } else {
+                            (StatusCode::NOT_FOUND, Vec::new())
+                        }
+                    },
+                ),
+            )
+            .with_state(Arc::clone(&fixtures));
+        let listener = match TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => return None,
+            Err(err) => panic!("bind: {err}"),
+        };
+        let addr = listener.local_addr().expect("addr");
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Some((format!("http://{}/", addr), handle))
+    }
+
+    // Archive A (good) and archive B (divergent).
+    let (url_a, _h_a) = match serve(build_fixtures(true)).await {
+        Some(v) => v,
+        None => {
+            eprintln!("skipping test: tcp bind not permitted in this environment");
+            return;
+        }
+    };
+    let (url_b, _h_b) = match serve(build_fixtures(false)).await {
+        Some(v) => v,
+        None => {
+            eprintln!("skipping test: tcp bind not permitted in this environment");
+            return;
+        }
+    };
+
+    let archive_a = HistoryArchive::new(&url_a).expect("archive A");
+    let archive_b = HistoryArchive::new(&url_b).expect("archive B");
+
+    let bucket_dir = tempfile::tempdir().expect("bucket dir");
+    let bucket_manager =
+        henyey_bucket::BucketManager::new(bucket_dir.path().to_path_buf()).expect("bucket manager");
+    let db = Database::open_in_memory().expect("db");
+
+    let ledger_manager = henyey_ledger::LedgerManager::new(
+        "Test SDF Network ; September 2015".to_string(),
+        henyey_ledger::LedgerManagerConfig {
+            validate_bucket_hash: false,
+            ..Default::default()
+        },
+    );
+
+    // Order [B, A]: B is tried first for ledger data under the old fixed-order
+    // rotation, so an unpinned attempt would consume B's divergent bytes.
+    let mut manager = CatchupManagerBuilder::new()
+        .add_archive(archive_b)
+        .add_archive(archive_a)
+        .bucket_manager(bucket_manager)
+        .database(db)
+        .options(CatchupOptions {
+            verify_buckets: false,
+            verify_headers: false,
+        })
+        .build()
+        .expect("catchup manager");
+
+    manager.set_replay_config(henyey_history::ReplayConfig {
+        verify_bucket_list: false,
+        verify_header_chain: false,
+        verify_tx_set: false,
+        verify_tx_results: false,
+        verify_header_hash: false,
+        ..Default::default()
+    });
+
+    // Catchup must SUCCEED. The publication gate selects archive A (the only
+    // archive serving the gate HAS). With the #2940 pin, the LCL header and
+    // checkpoint payload are fetched from A only — A's header64 knits to LCL
+    // and replays cleanly. Without the pin, fixed-order rotation would fetch
+    // archive B's divergent header64 first (B is index 0), whose mismatched
+    // previous_ledger_hash fails the unconditional §11.2 knit-to-LCL check
+    // with a fatal KnitCurrentLedgerPrevHashMismatch → catchup fails. So a
+    // successful catchup proves B's divergent ledger data was never consumed.
+    let output = manager
+        .catchup_to_ledger(target, &ledger_manager)
+        .await
+        .expect("catchup must succeed using the gate archive's ledger data only");
+
+    assert_eq!(output.ledger_seq, target);
+    assert_eq!(output.ledgers_applied, 1);
+    let final_header = ledger_manager.current_header();
+    assert_eq!(final_header.ledger_seq, target);
+}


### PR DESCRIPTION
Closes #2940

## Summary

A gated catchup replay attempt now downloads ledger data **only** from the archive that served `target_has` and passed the #2937 publication gate. `download_verify_and_replay_once` captures that `Arc<HistoryArchive>` and threads it as `Option<&Arc<HistoryArchive>>` into `download_ledger_data` → `download_checkpoint_header` + `download_checkpoint_ledger_data`. When the pin is `Some`, those downloads target the gate archive with no rotation/fallback; when `None` (bucket-apply phase, SCP/bucket downloads, all other non-gated callers) the existing fixed-order rotation over `&self.archives` is preserved.

This closes the cross-archive bypass where a second stale-but-serving archive could supply ledger data that never satisfied the gate — reopening the #2931 knit-to-LCL mismatch / state-wipe path under archive asymmetry. The pin is re-derived per replay attempt (never cached across retries), so a down archive is still rotated at the attempt boundary while intra-attempt consistency (gate archive == data archive) is guaranteed.

`download_has` now returns the serving `Arc<HistoryArchive>` (the bare name `String` is derived via `archive.name()` at the metric call sites).

## Parity

Matches stellar-core's **offline** `mArchive` pinning discipline (`CatchupWork` stores a single `mArchive` threaded to all child works; `doReset()` never clears it). This is **stronger** than stellar-core's online catchup, which passes `nullptr` and uses uncoordinated per-request random archive selection. Never weaker than online behaviour.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2940#issuecomment-4604133158)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-history — all pass (528 lib + integration/doctests, 0 failures)

## Regression test

- **Test:** `crates/history/tests/replay_integration.rs::test_catchup_pins_downloads_to_gate_archive`
- **Setup:** two archives ordered [B, A]. A serves the gate HAS + correct data-checkpoint ledger; B 404s the gate HAS and serves a divergent header64 (mismatched `previous_ledger_hash`). `download_has` rotation picks A as the gate archive (B 404s the gate HAS); under the old unpinned behaviour fixed-order rotation would fetch B's divergent ledger first.
- **Pre-fix (verified):** with the pin set to `None`, catchup fails with `KnitCurrentLedgerPrevHashMismatch { ledger: 64, actual: "abab…" }` — B's divergent bytes are consumed.
- **Post-fix:** with the pin, catchup succeeds using A's data only.
- **Unit:** `crates/history/src/catchup/download.rs::test_download_has_returns_serving_archive` and `::test_download_checkpoint_header_pin_targets_only_pinned` (pin targets only the pinned archive; `None` preserves rotation; pinned-to-dead fails without fallback).

## Deviations from plan

- The plan listed an optional `download_checkpoint_ledger_data` pin unit test that would require extending `test_utils` to serve transactions/results. That exact pin path (`download_ledger_data` → `download_checkpoint_ledger_data`) is fully exercised end-to-end by the integration regression test, so the additional unit test was not added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)