### PR TITLE
Document --timeout default in run-quickstart-test.sh usage

### DIFF
--- a/scripts/ci/run-quickstart-test.sh
+++ b/scripts/ci/run-quickstart-test.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   run-quickstart-test.sh --network <net> --enable <services> --probe <name> \
-#       --timeout <seconds> --diagnostics-dir <dir> -- <probe_command...>
+#       --timeout <seconds> (default: 600) --diagnostics-dir <dir> -- <probe_command...>
 #
 # Exit codes:
 #   0 — probe passed (possibly after one retry)


### PR DESCRIPTION
Closes #2946

## Summary

The usage comment in `scripts/ci/run-quickstart-test.sh` implied `--timeout` was caller-required, but the script defaults `TIMEOUT=600`. This adds `(default: 600)` to the usage doc so the documentation matches the actual behavior.

## Plan reference

Trivial short-circuit via the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2946#issuecomment) (Implementation Notes section).

## Test plan

- [x] `bash -n scripts/ci/run-quickstart-test.sh` — syntax OK
- [x] shellcheck — no new findings (pre-existing SC2086 info on line 105 untouched)
- Docs-only change; no test impact.

## Deviations from plan

None. (Triage note referenced line 7; the usage line is 8 — same comment block, change applied as intended.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)