### PR TITLE
Strengthen CheckpointNotYetPublished test with distinct field values

### DIFF
--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -738,9 +738,14 @@ mod tests {
         // It must NOT be classified as a fatal catchup failure (which would
         // trigger a state-wipe) nor as a typed hash mismatch (which would
         // force a full bucket-apply reset).
+        // Use DISTINCT values for every field so each assertion below
+        // independently proves that its own field is rendered. If `target` and
+        // `covering_checkpoint` shared a value, a message that only printed
+        // `target` would still satisfy the covering-checkpoint assertion by
+        // coincidence (#2953).
         let err = HistoryError::CheckpointNotYetPublished {
             target: 62845439,
-            covering_checkpoint: 62845439,
+            covering_checkpoint: 62845280,
             has_current: 62845375,
         };
         assert!(
@@ -751,11 +756,15 @@ mod tests {
             !err.is_hash_mismatch(),
             "CheckpointNotYetPublished must not be treated as a hash mismatch"
         );
-        // The covering checkpoint value must appear in the rendered message so
+        // Each distinct field value must appear in the rendered message so
         // on-call debugging needn't recompute checkpoint math from the log line.
         let msg = err.to_string();
         assert!(
             msg.contains("62845439"),
+            "message must include the target ledger value: {msg}"
+        );
+        assert!(
+            msg.contains("62845280"),
             "message must include the covering checkpoint value: {msg}"
         );
         assert!(


### PR DESCRIPTION
Closes #2953

## Summary

The `test_checkpoint_not_yet_published_is_transient` unit test in
`crates/history/src/error.rs` set `target` and `covering_checkpoint` to the
same value (62845439), so the assertion that the covering checkpoint appears
in the rendered message could pass even if the message only printed `target`.
This change uses distinct values for `target` (62845439), `covering_checkpoint`
(62845280), and `has_current` (62845375), and asserts each distinct value
appears independently in the rendered message — giving an independent guarantee
that the `covering_checkpoint` field is actually printed.

## Plan reference

Trivial short-circuit (Implementation Notes in the Triage Report on #2953).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-history --lib error:: passes (15 tests)

## Deviations from plan

None. (Triage referenced lines 740-763; the actual test is at lines 734-765 of
the current origin/main — same test, identical change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)