### PR TITLE
Clarify timeout_multiplier comment does not imply validate-contract coverage

### DIFF
--- a/scripts/ci/upstream-quickstart-contract.yml
+++ b/scripts/ci/upstream-quickstart-contract.yml
@@ -57,9 +57,11 @@ probe_naming:
 # `timeout-minutes` as `github.run_attempt * timeout_multiplier`. Our
 # quickstart.yml mirrors this multiplier and computes
 # `PROBE_TIMEOUT = github.run_attempt * timeout_multiplier * 60` seconds for
-# GNU `timeout`. Pinning the multiplier here means a future upstream bump
-# (e.g. 4 -> 5) surfaces as a contract mismatch in the harness/validate-contract
-# rather than silently diverging again (#2920).
+# GNU `timeout`. This value is documented here as a tracked expectation; note
+# that `validate-contract` only fetches build.yml/internal-build.yml, not
+# internal-test.yml, so a future upstream bump (e.g. 4 -> 5) is NOT caught by
+# validate-contract — it must be reconciled manually against this file when
+# upstream changes (#2920).
 timeout_multiplier: 4
 timeout_formula: "github.run_attempt * timeout_multiplier minutes per probe (x 60 for GNU timeout seconds)"
 


### PR DESCRIPTION
Closes #2945

## Summary

The `timeout_multiplier` comment in `scripts/ci/upstream-quickstart-contract.yml` claimed that a future upstream multiplier bump would "surface as a contract mismatch in the harness/validate-contract". That overstated coverage: `validate-contract` only fetches and validates `build.yml`/`internal-build.yml`, not `internal-test.yml` (where `timeout_multiplier` actually lives), so it cannot detect such a drift. The wording is corrected to state the value is a manually-reconciled tracked expectation that `validate-contract` does NOT catch.

Comment/docs only — no code or behavior change.

## Plan reference

Trivial short-circuit (Implementation Notes in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2945)).

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [x] No code touched — fmt/clippy/cargo tests N/A (CI data file)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)