### PR TITLE
Fix quickstart.yml comment overclaiming validate-contract coverage

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -57,8 +57,11 @@ permissions:
 # `github.run_attempt * timeout_multiplier`. We reproduce the same multiplier
 # here so the in-repo orchestration preserves upstream timeout semantics (4 min
 # on attempt 1, escalating on manual re-runs) instead of diverging silently.
-# Pinned in scripts/ci/upstream-quickstart-contract.yml (timeout_multiplier: 4)
-# so multiplier drift is caught by validate-contract and the harness (#2920).
+# Pinned in scripts/ci/upstream-quickstart-contract.yml (timeout_multiplier: 4).
+# Note: the validate-contract job only fetches/validates upstream build.yml and
+# internal-build.yml, not internal-test.yml (where the multiplier lives), so it
+# does NOT catch multiplier drift. Drift is caught by the harness/text
+# assertions in scripts/test-quickstart-harness.sh instead (#2920).
 env:
   timeout_multiplier: 4
 


### PR DESCRIPTION
Closes #2944

## Summary

The comment above `timeout_multiplier` in `.github/workflows/quickstart.yml` claimed that multiplier drift is caught by `validate-contract`. That job only fetches/validates upstream `build.yml` and `internal-build.yml`, not `internal-test.yml` (where the multiplier lives), so it does not actually catch multiplier drift. Reworded to state that drift is caught by the harness/text assertions in `scripts/test-quickstart-harness.sh` instead.

Comment-only change; no behavior impact.

## Plan reference

Trivial short-circuit — `## Implementation Notes` in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2944).

## Test plan

- [x] actionlint on quickstart.yml (only a pre-existing SC2012 info at line 372, unrelated; exit 0)
- [x] cargo fmt --check (pre-commit hook)
- [x] cargo clippy --all (pre-commit hook)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)