### PR TITLE
Anchor quickstart upstream-contract artifact and tag checks

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -289,6 +289,43 @@ jobs:
 
           echo ""
 
+          # --- 2b. Validate OUR consumer-side artifact/tag shape (anchored) ---
+          # The checks above validate the UPSTREAM template (internal-build.yml).
+          # This block validates the EXACT, concrete artifact filename and image
+          # tag that *this* workflow consumes — the download-artifact `name:` and
+          # the `docker run ... <tag>` line — against anchored ERE regexes stored
+          # in the contract file (single source of truth, also used by
+          # scripts/test-quickstart-harness.sh). Anchoring rejects incompatible
+          # suffixes (.zip, .tar.gz, -debug) that a bare substring `grep -q`
+          # would silently accept (#2932). The contract stores the regex body
+          # verbatim (raw grep|sed extraction, no YAML unescaping).
+          echo "--- consumer-side artifact/tag shape (this workflow) ---"
+          ARTIFACT_NAME_REGEX=$(grep '^artifact_name_regex:' "$CONTRACT" | sed 's/^artifact_name_regex: *"\(.*\)"$/\1/')
+          IMAGE_TAG_REGEX=$(grep '^image_tag_regex:' "$CONTRACT" | sed 's/^image_tag_regex: *"\(.*\)"$/\1/')
+          WORKFLOW_SELF=".github/workflows/quickstart.yml"
+
+          if [[ -z "$ARTIFACT_NAME_REGEX" || -z "$IMAGE_TAG_REGEX" ]]; then
+            echo "✗ contract missing artifact_name_regex/image_tag_regex (anchored ERE)"
+            ERRORS=$((ERRORS + 1))
+          else
+            if grep -Eq "$ARTIFACT_NAME_REGEX" "$WORKFLOW_SELF"; then
+              echo "✓ workflow downloads the exact artifact shape (anchored)"
+            else
+              echo "✗ workflow has no line matching the anchored artifact regex"
+              echo "  Regex: $ARTIFACT_NAME_REGEX"
+              ERRORS=$((ERRORS + 1))
+            fi
+            if grep -Eq "$IMAGE_TAG_REGEX" "$WORKFLOW_SELF"; then
+              echo "✓ workflow runs the exact image tag shape (anchored)"
+            else
+              echo "✗ workflow has no line matching the anchored image-tag regex"
+              echo "  Regex: $IMAGE_TAG_REGEX"
+              ERRORS=$((ERRORS + 1))
+            fi
+          fi
+
+          echo ""
+
           # --- 3. Summary ---
           if [[ $ERRORS -gt 0 ]]; then
             echo "=== FAILED: $ERRORS contract violation(s) detected ==="

--- a/scripts/ci/upstream-quickstart-contract.yml
+++ b/scripts/ci/upstream-quickstart-contract.yml
@@ -27,6 +27,27 @@ image_tag_pattern: "quickstart:{tag}-{arch}"
 expected_artifact_name: "image-quickstart-testing-with-pr-amd64.tar"
 expected_image_tag: "quickstart:testing-with-pr-amd64"
 
+# Anchored ERE patterns — the single source of truth for the consumer-side
+# shape, shared by the validate-contract workflow job and the local harness
+# (scripts/test-quickstart-harness.sh). These enforce the EXACT artifact
+# filename / image-tag shape that our quickstart.yml consumes (the
+# download-artifact `name:` line and the `docker run ... <tag>` line), so a
+# future drift to an incompatible suffix is rejected rather than silently
+# accepted by a substring match:
+#   - image-quickstart-testing-with-pr-amd64.zip      -> REJECTED (not .tar)
+#   - image-quickstart-testing-with-pr-amd64.tar.gz   -> REJECTED (double ext)
+#   - quickstart:testing-with-pr-amd64-debug          -> REJECTED (tag suffix)
+# The leading/trailing character classes anchor the token at word-ish
+# boundaries (start/end of line or a non-identifier char) without requiring the
+# token to occupy the whole line, so they still match inside the real workflow
+# lines (`name: image-quickstart-...`, `docker run ... quickstart:... \`). The
+# trailing class excludes `.` so `.tar.gz` cannot slip past the `.tar` anchor.
+# Used with `grep -Eq`; keep these ERE-compatible (no PCRE constructs). NOTE:
+# both consumers extract the value with a raw `grep | sed` (no YAML parser), so
+# the quoted body is used verbatim — write a single backslash before `.` here.
+artifact_name_regex: "(^|[^[:alnum:]_-])image-quickstart-testing-with-pr-amd64\.tar([^[:alnum:]_.-]|$)"
+image_tag_regex: "(^|[^[:alnum:]_-])quickstart:testing-with-pr-amd64($|[^[:alnum:]_.-])"
+
 # The artifact contains a docker image tarball inside an `image` directory
 # or as a top-level .tar file.
 artifact_layout: "image/ directory or top-level .tar"

--- a/scripts/test-quickstart-harness.sh
+++ b/scripts/test-quickstart-harness.sh
@@ -380,6 +380,13 @@ test_upstream_contract_validation() {
         tap_not_ok "contract_documents_delegated_artifact" "skipped (no contract)"
         tap_not_ok "workflow_enforces_exact_artifact_pattern" "skipped (no contract)"
         tap_not_ok "workflow_enforces_exact_image_tag_pattern" "skipped (no contract)"
+        tap_not_ok "contract_defines_anchored_regexes" "skipped (no contract)"
+        tap_not_ok "workflow_artifact_regex_accepts_exact_tar" "skipped (no contract)"
+        tap_not_ok "workflow_image_tag_regex_accepts_exact_tag" "skipped (no contract)"
+        tap_not_ok "workflow_artifact_regex_rejects_zip" "skipped (no contract)"
+        tap_not_ok "workflow_artifact_regex_rejects_double_ext" "skipped (no contract)"
+        tap_not_ok "workflow_image_tag_regex_rejects_debug_suffix" "skipped (no contract)"
+        tap_not_ok "workflow_uses_anchored_grep" "skipped (no contract)"
         return
     fi
 
@@ -387,22 +394,87 @@ test_upstream_contract_validation() {
 
     # Extract expected values from contract (simple grep — no YAML parser needed)
     local expected_artifact expected_tag artifact_pattern
+    local artifact_regex image_tag_regex
     expected_artifact=$(grep '^expected_artifact_name:' "$CONTRACT" | sed 's/.*: *"\(.*\)"/\1/')
     expected_tag=$(grep '^expected_image_tag:' "$CONTRACT" | sed 's/.*: *"\(.*\)"/\1/')
     artifact_pattern=$(grep '^artifact_name_pattern:' "$CONTRACT" | sed 's/.*: *"\(.*\)"/\1/')
+    # Anchored ERE patterns — the single source of truth shared with the
+    # validate-contract workflow job. These enforce the EXACT consumer-facing
+    # shape (image-quickstart-{tag}-{arch}.tar / quickstart:{tag}-{arch}) so a
+    # suffix drift like .zip / .tar.gz / -debug is rejected, not silently
+    # accepted by a substring match.
+    # `|| true` so a missing field yields an empty string (reported as a failed
+    # assertion below) rather than aborting under `set -euo pipefail`.
+    artifact_regex=$(grep '^artifact_name_regex:' "$CONTRACT" | sed 's/^artifact_name_regex: *"\(.*\)"$/\1/' || true)
+    image_tag_regex=$(grep '^image_tag_regex:' "$CONTRACT" | sed 's/^image_tag_regex: *"\(.*\)"$/\1/' || true)
 
-    # Validate artifact name in workflow matches contract
-    if grep -q "$expected_artifact" "$WORKFLOW"; then
+    # Validate artifact name in workflow matches contract (anchored to the exact
+    # image-quickstart-{tag}-{arch}.tar shape, not a substring).
+    if [[ -n "$artifact_regex" ]] && grep -Eq "$artifact_regex" "$WORKFLOW"; then
         tap_ok "workflow_artifact_matches_contract"
     else
-        tap_not_ok "workflow_artifact_matches_contract" "expected '$expected_artifact' in workflow"
+        tap_not_ok "workflow_artifact_matches_contract" "expected exact '$expected_artifact' (regex: $artifact_regex) in workflow"
     fi
 
-    # Validate image tag in workflow matches contract
-    if grep -q "$expected_tag" "$WORKFLOW"; then
+    # Validate image tag in workflow matches contract (anchored to the exact
+    # quickstart:{tag}-{arch} shape, not a substring).
+    if [[ -n "$image_tag_regex" ]] && grep -Eq "$image_tag_regex" "$WORKFLOW"; then
         tap_ok "workflow_image_tag_matches_contract"
     else
-        tap_not_ok "workflow_image_tag_matches_contract" "expected '$expected_tag' in workflow"
+        tap_not_ok "workflow_image_tag_matches_contract" "expected exact '$expected_tag' (regex: $image_tag_regex) in workflow"
+    fi
+
+    # --- Contract defines the anchored ERE regexes (single source of truth) ---
+    if [[ -n "$artifact_regex" && -n "$image_tag_regex" ]]; then
+        tap_ok "contract_defines_anchored_regexes"
+    else
+        tap_not_ok "contract_defines_anchored_regexes" \
+            "contract must define artifact_name_regex: and image_tag_regex: anchored ERE strings"
+    fi
+
+    # --- Positive controls: anchored regexes accept the exact expected strings ---
+    if [[ -n "$artifact_regex" ]] && echo "$expected_artifact" | grep -Eq "$artifact_regex"; then
+        tap_ok "workflow_artifact_regex_accepts_exact_tar"
+    else
+        tap_not_ok "workflow_artifact_regex_accepts_exact_tar" \
+            "anchored artifact regex must accept '$expected_artifact'"
+    fi
+    if [[ -n "$image_tag_regex" ]] && echo "$expected_tag" | grep -Eq "$image_tag_regex"; then
+        tap_ok "workflow_image_tag_regex_accepts_exact_tag"
+    else
+        tap_not_ok "workflow_image_tag_regex_accepts_exact_tag" \
+            "anchored image-tag regex must accept '$expected_tag'"
+    fi
+
+    # --- Negative cases: incompatible suffixes must be REJECTED ---
+    # A future relaxation of the anchored regexes to a substring match would
+    # let these through and turn these assertions red — that is the point.
+    if [[ -n "$artifact_regex" ]] && ! echo "image-quickstart-testing-with-pr-amd64.zip" | grep -Eq "$artifact_regex"; then
+        tap_ok "workflow_artifact_regex_rejects_zip"
+    else
+        tap_not_ok "workflow_artifact_regex_rejects_zip" \
+            "anchored artifact regex must reject the .zip suffix"
+    fi
+    if [[ -n "$artifact_regex" ]] && ! echo "image-quickstart-testing-with-pr-amd64.tar.gz" | grep -Eq "$artifact_regex"; then
+        tap_ok "workflow_artifact_regex_rejects_double_ext"
+    else
+        tap_not_ok "workflow_artifact_regex_rejects_double_ext" \
+            "anchored artifact regex must reject the .tar.gz double extension"
+    fi
+    if [[ -n "$image_tag_regex" ]] && ! echo "quickstart:testing-with-pr-amd64-debug" | grep -Eq "$image_tag_regex"; then
+        tap_ok "workflow_image_tag_regex_rejects_debug_suffix"
+    else
+        tap_not_ok "workflow_image_tag_regex_rejects_debug_suffix" \
+            "anchored image-tag regex must reject the -debug suffix"
+    fi
+
+    # --- Workflow consumer-side checks use anchored grep -Eq (not bare prefix) ---
+    if grep -q 'grep -Eq "\$ARTIFACT_NAME_REGEX"' "$WORKFLOW" && \
+       grep -q 'grep -Eq "\$IMAGE_TAG_REGEX"' "$WORKFLOW"; then
+        tap_ok "workflow_uses_anchored_grep"
+    else
+        tap_not_ok "workflow_uses_anchored_grep" \
+            "validate-contract must read the anchored regexes and check the consumer lines with grep -Eq"
     fi
 
     # Validate workflow passes test: false (matches contract's build_inputs)
@@ -671,7 +743,7 @@ EOF
 }
 
 # --- Run all tests ---
-tap_plan 41
+tap_plan 48
 
 test_timeout_retry_on_targeted_shard
 test_non_timeout_failure_no_retry


### PR DESCRIPTION
Closes #2932

## Summary

The quickstart upstream-contract gate validated the consumer-facing artifact filename and image tag with unanchored substring matches, so an upstream/local drift to an incompatible suffix (`image-quickstart-{tag}-{arch}.zip`, `.tar.gz`, or `quickstart:{tag}-{arch}-debug`) would pass validation while breaking the `download-artifact name:` and `docker run … <tag>` lines this workflow depends on.

This change stores anchored ERE regexes (`artifact_name_regex` / `image_tag_regex`) in `scripts/ci/upstream-quickstart-contract.yml` as the single source of truth, and enforces them with `grep -Eq` in both the workflow `validate-contract` job (new consumer-side block) and `scripts/test-quickstart-harness.sh`. The regexes pin the literal `image-quickstart-…-amd64.tar` prefix+suffix and `quickstart:…-amd64` tag, with trailing character classes that exclude `.` so double extensions (`.tar.gz`) are rejected.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2932#issuecomment-4603710767)

## Test plan

- [x] `bash scripts/test-quickstart-harness.sh` — 48/48 pass (was 41; +7 new assertions)
- [x] `actionlint .github/workflows/quickstart.yml` — no new findings (the single pre-existing SC2012 on the unrelated `ls /tmp/quickstart-image` docker-load step also exists on `origin/main`)
- [x] `cargo fmt --check` / `cargo clippy --all` — pass (pre-commit hook)

## New coverage (`scripts/test-quickstart-harness.sh::test_upstream_contract_validation`)

- `contract_defines_anchored_regexes` — contract has `artifact_name_regex:` / `image_tag_regex:`
- `workflow_artifact_regex_accepts_exact_tar` / `workflow_image_tag_regex_accepts_exact_tag` — positive controls
- `workflow_artifact_regex_rejects_zip` — `.zip` rejected
- `workflow_artifact_regex_rejects_double_ext` — `.tar.gz` rejected
- `workflow_image_tag_regex_rejects_debug_suffix` — `-debug` rejected
- `workflow_uses_anchored_grep` — workflow reads the regexes and checks the consumer lines with `grep -Eq`
- The two existing `workflow_artifact_matches_contract` / `workflow_image_tag_matches_contract` checks were tightened from substring `grep -q` to anchored `grep -Eq`.

These 9 assertions were committed first (`9535fbf`) and verified FAILING on the unmodified tree, then pass after the fix (`54fea7a`) — confirming they capture the latent false-green.

## Deviations from plan

- Plan referenced HEAD using bare `grep -q 'image-quickstart'` prefix checks; the workflow had since been refactored (post-#2967) to already have upstream-template `ARTIFACT_REGEX`/`TAG_REGEX` checks. Those validate the *upstream* `internal-build.yml` template. This PR adds the missing *consumer-side* anchored check (our own `quickstart.yml` download/run lines) — the same false-green the reviewer flagged — rather than replacing the upstream-template checks.
- The contract stores the regex body with a single backslash (`\.tar`) because both consumers extract it via raw `grep | sed` with no YAML unescaping; documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)