### PR TITLE
Derive quickstart negative-case fixtures from contract values

### DIFF
--- a/scripts/test-quickstart-harness.sh
+++ b/scripts/test-quickstart-harness.sh
@@ -449,23 +449,35 @@ test_upstream_contract_validation() {
     # --- Negative cases: incompatible suffixes must be REJECTED ---
     # A future relaxation of the anchored regexes to a substring match would
     # let these through and turn these assertions red — that is the point.
-    if [[ -n "$artifact_regex" ]] && ! echo "image-quickstart-testing-with-pr-amd64.zip" | grep -Eq "$artifact_regex"; then
+    # Derive the negative fixtures from the contract's expected values so they
+    # track the contract as it evolves: if expected_artifact_name /
+    # expected_image_tag ever change, these still exercise genuine suffix
+    # rejection (rather than passing because a stale hard-coded tag/arch no
+    # longer matches the regex for an unrelated reason).
+    #   - .zip      : swap the trailing .tar for .zip
+    #   - .tar.gz   : append .gz to the full .tar artifact name
+    #   - -debug    : append -debug to the full image tag
+    local negative_artifact_zip negative_artifact_double_ext negative_tag_debug
+    negative_artifact_zip="${expected_artifact%.tar}.zip"
+    negative_artifact_double_ext="${expected_artifact}.gz"
+    negative_tag_debug="${expected_tag}-debug"
+    if [[ -n "$artifact_regex" ]] && ! echo "$negative_artifact_zip" | grep -Eq "$artifact_regex"; then
         tap_ok "workflow_artifact_regex_rejects_zip"
     else
         tap_not_ok "workflow_artifact_regex_rejects_zip" \
-            "anchored artifact regex must reject the .zip suffix"
+            "anchored artifact regex must reject the .zip suffix ($negative_artifact_zip)"
     fi
-    if [[ -n "$artifact_regex" ]] && ! echo "image-quickstart-testing-with-pr-amd64.tar.gz" | grep -Eq "$artifact_regex"; then
+    if [[ -n "$artifact_regex" ]] && ! echo "$negative_artifact_double_ext" | grep -Eq "$artifact_regex"; then
         tap_ok "workflow_artifact_regex_rejects_double_ext"
     else
         tap_not_ok "workflow_artifact_regex_rejects_double_ext" \
-            "anchored artifact regex must reject the .tar.gz double extension"
+            "anchored artifact regex must reject the .tar.gz double extension ($negative_artifact_double_ext)"
     fi
-    if [[ -n "$image_tag_regex" ]] && ! echo "quickstart:testing-with-pr-amd64-debug" | grep -Eq "$image_tag_regex"; then
+    if [[ -n "$image_tag_regex" ]] && ! echo "$negative_tag_debug" | grep -Eq "$image_tag_regex"; then
         tap_ok "workflow_image_tag_regex_rejects_debug_suffix"
     else
         tap_not_ok "workflow_image_tag_regex_rejects_debug_suffix" \
-            "anchored image-tag regex must reject the -debug suffix"
+            "anchored image-tag regex must reject the -debug suffix ($negative_tag_debug)"
     fi
 
     # --- Workflow consumer-side checks use anchored grep -Eq (not bare prefix) ---


### PR DESCRIPTION
Closes #2973

## Summary

The `.zip` / `.tar.gz` / `-debug` suffix-rejection assertions in `test_upstream_contract_validation()` (in `scripts/test-quickstart-harness.sh`) hard-coded the `testing-with-pr`/`amd64` tag+arch. If the contract's `expected_artifact_name` / `expected_image_tag` ever change, those fixtures would no longer match the anchored regex for an unrelated reason — so the tests could pass without actually exercising suffix rejection. This derives the negative fixtures from `$expected_artifact` / `$expected_tag` (swap `.tar`→`.zip`, append `.gz`, append `-debug`) so they track the contract as it evolves.

The derived strings are byte-identical to the previous hard-coded values for the current contract, so this is a pure refactor of the test inputs with no change in coverage.

## Plan reference

Trivial short-circuit — Implementation Notes in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2973) on #2973.

## Test plan

- [x] `bash scripts/test-quickstart-harness.sh` — 48/48 pass (negative-case assertions 28/29/30 included)
- [x] cargo fmt --check (pre-commit hook)
- [x] cargo clippy --all -- -D warnings (pre-commit hook)
- [x] shellcheck introduces no new warnings (pre-existing SC2016/SC2034 only)

## Deviations from plan

The triage notes referenced line 469 and `artifact_name_pattern`/`image_tag_pattern` against the pre-merge state of PR #2971. On current `origin/main` (post-#2971 merge, 8b238238) the equivalent assertions live in the "Negative cases" block at lines 449-468 and use `$artifact_regex` / `$image_tag_regex`. Applied the same contract-derivation intent to that block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)