### PR TITLE
Enforce ~/data workspace contract across /do and reviewer/critic sub-agents

### DIFF
--- a/.github/skills/do/SKILL.md
+++ b/.github/skills/do/SKILL.md
@@ -72,26 +72,48 @@ If neither exists, post `## Do: Missing Plan` and route the issue back to `ready
 
 ### A.2 Set up the worktree
 
+ALL scratch — the worktree, the cargo target, and the `.session-id` marker —
+lives under `~/data/<session>/do-$ISSUE/`, **never inside the repo tree**. Derive
+the paths from the shared contract helper (`do_bootstrap`), which validates them
+against the passwd-anchored `~/data` boundary and the per-session prefix.
+
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-WORKTREE="$REPO_ROOT/data/do-$ISSUE/worktree"
 BRANCH="do/issue-$ISSUE"
-SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d-%H%M%S)}"
-export CARGO_TARGET_DIR="$HOME/data/$SESSION_ID/do-$ISSUE/cargo-target"
 
-mkdir -p "$REPO_ROOT/data" "$HOME/data/$SESSION_ID/do-$ISSUE"
+# Derive + validate the workspace. Exports WORKTREE_BASE, CARGO_TARGET_DIR, and
+# DO_WORKTREE, all under ~/data/$SESSION_ID/do-$ISSUE. Fails closed on any path
+# that escapes ~/data — the `|| exit 1` guard prevents the mkdir below from
+# running on a rejected (hostile/stale) path.
+source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+do_bootstrap "$ISSUE" || exit 1
+export CARGO_TARGET_DIR
 
-# Persist the session ID alongside the worktree so /review-pr can clean up
-# the cargo target dir on merge (avoids accumulating multi-GB stale caches).
-echo "$SESSION_ID" > "$REPO_ROOT/data/do-$ISSUE/.session-id"
+mkdir -p "$WORKTREE_BASE"
 
-# Fresh worktree off origin/main.
+# Persist the session ID alongside the workspace (under ~/data, NOT in the repo)
+# so /review-pr can clean up the cargo target dir on merge.
+echo "${CLAUDE_SESSION_ID:-$SESSION_ID}" > "$WORKTREE_BASE/.session-id"
+
+# Fresh worktree off origin/main, under ~/data (DO_WORKTREE).
 git fetch origin main
-git -C "$REPO_ROOT" worktree add -B "$BRANCH" "$WORKTREE" origin/main
-cd "$WORKTREE"
+git -C "$REPO_ROOT" worktree add -B "$BRANCH" "$DO_WORKTREE" origin/main
+cd "$DO_WORKTREE"
 ```
 
-`/data/` is gitignored in the repo. `~/data/` is the shared volume per CLAUDE.md.
+The worktree, cargo target, and review-comments scratch (B.1) all live under
+`~/data` — the shared volume per CLAUDE.md. **Forbidden scratch locations** (these
+are the observed disk-leak patterns from #2843 — never create any of them, whether
+in the repo tree, as a `<repo>-pr<N>` sibling, or under `/tmp`):
+`.review-data/`, `.review-worktrees/`, `.worktrees/`, `.copilot-tmp/`,
+`.opencode/worktrees/`, and any path under `/tmp`. After the build (A.4) and on
+every failure/`blocked` exit, assert the repo tree is clean:
+
+```bash
+assert_no_repo_tree_scratch "$REPO_ROOT" || {
+  echo "Scratch leak detected — clean it before exiting." >&2
+}
+```
 
 ### A.2.5 Write the failing test FIRST (TDD)
 
@@ -148,10 +170,16 @@ Then run tests with scope chosen from the plan:
 - **Plan touches a single crate** → `cargo test -p henyey-<crate>` (faster).
 - **Plan touches multiple crates or shared types** → `cargo test --all`.
 
+After the build, assert no scratch leaked into the repo tree:
+
+```bash
+assert_no_repo_tree_scratch "$REPO_ROOT" || exit 1
+```
+
 If anything fails:
 
 - Fix attempts: up to 3.
-- After 3 failed fixes, post `## Do: Local Verification Failed` with the relevant error output, move to `blocked`, unassign, exit.
+- After 3 failed fixes, post `## Do: Local Verification Failed` with the relevant error output, move to `blocked`, unassign, **reap your own workspace** (`git -C "$REPO_ROOT" worktree remove --force "$DO_WORKTREE" 2>/dev/null; rm -rf "$WORKTREE_BASE"`), exit.
 
 ### A.5 Commit and push
 
@@ -236,14 +264,22 @@ LAST_PUSH=$(gh pr view $PR_NUM --repo stellar-experimental/henyey \
   --json commits --jq '.commits | sort_by(.committedDate) | last | .committedDate')
 ```
 
-Fetch inline review-comments WITH IDs (you'll need these to reply):
+Fetch inline review-comments WITH IDs (you'll need these to reply). Write the
+scratch JSON under the `~/data` workspace — **never under `/tmp`** (see #2843):
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+do_bootstrap "$ISSUE" || exit 1
+export CARGO_TARGET_DIR
+mkdir -p "$WORKTREE_BASE"
+COMMENTS_JSON="$WORKTREE_BASE/review-comments-$PR_NUM.json"
+
 gh api "repos/stellar-experimental/henyey/pulls/$PR_NUM/comments" --paginate \
   --jq --arg cutoff "$LAST_PUSH" '
     [.[] | select(.created_at > $cutoff) |
      {id, path, line, body, in_reply_to: .in_reply_to_id, url: .html_url}]' \
-  > /tmp/review-comments-$PR_NUM.json
+  > "$COMMENTS_JSON"
 ```
 
 Also fetch PR-level reviews (the structured `## 🔍 Reviewer:` comments from /review-pr are issue-level, NOT review-comments):
@@ -255,7 +291,7 @@ gh api "repos/stellar-experimental/henyey/issues/$PR_NUM/comments" --paginate \
      {id, body, url: .html_url}]'
 ```
 
-Items in `/tmp/review-comments-$PR_NUM.json` are the inline ones with `.id` you'll iterate over in B.6 to post replies. Items not in `in_reply_to` chains (i.e. `in_reply_to: null`) are top-level thread comments; replying to those creates a follow-up in the same thread.
+Items in `$COMMENTS_JSON` (under `~/data`) are the inline ones with `.id` you'll iterate over in B.6 to post replies. Items not in `in_reply_to` chains (i.e. `in_reply_to: null`) are top-level thread comments; replying to those creates a follow-up in the same thread.
 
 ### B.2 Group the feedback
 
@@ -267,22 +303,28 @@ For each comment, classify:
 
 ### B.3 Re-enter the worktree
 
+The worktree lives under `~/data` (`DO_WORKTREE`), **never in the repo tree**.
+If B.1 already ran `do_bootstrap` in this shell, `DO_WORKTREE`/`WORKTREE_BASE`/
+`CARGO_TARGET_DIR` are set; otherwise derive them now via the helper.
+
 ```bash
-WORKTREE="$REPO_ROOT/data/do-$ISSUE/worktree"
-export CARGO_TARGET_DIR="$HOME/data/$SESSION_ID/do-$ISSUE/cargo-target"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+do_bootstrap "$ISSUE" || exit 1
+export CARGO_TARGET_DIR
 BRANCH="do/issue-$ISSUE"
 
 # Re-enter or re-create the worktree. The worktree may have been cleaned up
 # by /review-pr after a previous merge attempt, or never existed if this is
 # the first Mode B run on a re-bounced issue.
-if [ ! -d "$WORKTREE/.git" ] && [ ! -f "$WORKTREE/.git" ]; then
-  # No worktree — recreate from origin/$BRANCH (PR head).
+if [ ! -d "$DO_WORKTREE/.git" ] && [ ! -f "$DO_WORKTREE/.git" ]; then
+  # No worktree — recreate from origin/$BRANCH (PR head), under ~/data.
   git -C "$REPO_ROOT" fetch origin "$BRANCH"
-  mkdir -p "$(dirname "$WORKTREE")"
-  git -C "$REPO_ROOT" worktree add -B "$BRANCH" "$WORKTREE" "origin/$BRANCH"
+  mkdir -p "$WORKTREE_BASE"
+  git -C "$REPO_ROOT" worktree add -B "$BRANCH" "$DO_WORKTREE" "origin/$BRANCH"
 fi
 
-cd "$WORKTREE"
+cd "$DO_WORKTREE"
 git fetch origin
 git rebase origin/main  # In case main moved during review.
 ```
@@ -299,12 +341,12 @@ Same as Mode A.5.
 
 ### B.6 Reply inline and push
 
-Iterate over every inline comment in `/tmp/review-comments-$PR_NUM.json` and reply within the same thread. The endpoint `POST /repos/.../pulls/{pr}/comments/{comment_id}/replies` creates a reply IN the thread containing `{comment_id}`, which is what `/review-pr`'s "addressed" heuristic looks for (it scans `reviewThreads { comments }` for `Addressed in` / `Fixed in` / `Done in`).
+Iterate over every inline comment in `$COMMENTS_JSON` (under `~/data`, from B.1) and reply within the same thread. The endpoint `POST /repos/.../pulls/{pr}/comments/{comment_id}/replies` creates a reply IN the thread containing `{comment_id}`, which is what `/review-pr`'s "addressed" heuristic looks for (it scans `reviewThreads { comments }` for `Addressed in` / `Fixed in` / `Done in`).
 
 ```bash
 FIX_SHA=$(git rev-parse HEAD)   # captured AFTER the fix commit in B.5/B.7
 
-jq -r '.[] | .id' /tmp/review-comments-$PR_NUM.json | while read CID; do
+jq -r '.[] | .id' "$COMMENTS_JSON" | while read CID; do
   # classify: actionable / question / disagree (per B.2)
   # then reply with the appropriate template:
   gh api -X POST \
@@ -382,6 +424,10 @@ Exit.
 
 ## Cleanup
 
-- **Worktree at `$REPO_ROOT/data/do-$ISSUE/worktree`:** cleaned up by `/review-pr` after merge.
-- **Build cache at `~/data/$SESSION_ID/do-$ISSUE/cargo-target`:** also cleaned up by `/review-pr` after merge.
-- If you `blocked` mid-flow, leave both in place — the operator may want to inspect.
+The entire workspace — worktree, cargo cache, scratch JSON — lives under
+`$WORKTREE_BASE` (= `~/data/$SESSION_ID/do-$ISSUE`), **never inside the repo tree**.
+
+- **Worktree at `$DO_WORKTREE` (under `~/data`):** cleaned up by `/review-pr` after merge.
+- **Build cache at `$CARGO_TARGET_DIR` (under `~/data`):** also cleaned up by `/review-pr` after merge.
+- On `blocked` mid-flow, leave the workspace in place for operator inspection — **except** the local-verification-failed and unrecoverable failure exits, which reap their own `$WORKTREE_BASE` (the leak this skill exists to prevent: orphaned in-bounds workspaces that never produced a merged artifact).
+- The repo tree must stay clean: no `.review-data/`, `.review-worktrees/`, `.worktrees/`, `.copilot-tmp/`, `.opencode/worktrees/`, `<repo>-pr<N>` siblings, or `/tmp` scratch. `assert_no_repo_tree_scratch "$REPO_ROOT"` (from the contract helper) asserts this.

--- a/.github/skills/plan/SKILL.md
+++ b/.github/skills/plan/SKILL.md
@@ -106,6 +106,17 @@ mkdir -p "$CRITIC_WORKTREE"
 
 Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those only if they resolve under the real `~/data` AND under the expected session/issue prefix (`~/data/$SESSION_ID/plan-$ISSUE/...`); otherwise the bootstrap rejects the value and exits non-zero — the `|| exit 1` guard ensures no subsequent commands run with stale env vars. Hostile overrides (paths outside `~/data`, traversal like `~/data/../escape`, HOME-poisoned paths, or cross-session shared directories) are rejected before any `mkdir`, `git clone`, or cargo command runs.
 
+**Forbidden scratch patterns (issue #2843 — hard requirement).** Every critic prompt must bind the sub-agent to `$CRITIC_WORKTREE` and explicitly forbid the observed disk-leak patterns — not in the repo tree, not as a `<repo>-pr<N>` sibling, not under `/tmp`:
+
+- `.review-data/`
+- `.review-worktrees/`
+- `.worktrees/`
+- `.copilot-tmp/`
+- `.opencode/worktrees/`
+- any path under `/tmp`
+
+These are the exact out-of-`~/data` scratch dirs that prior pipeline runs leaked and that repeatedly filled the root FS. A critic that needs a checkout uses `$CRITIC_WORKTREE` and nothing else.
+
 Launch three `general-purpose` agents in parallel — do not wait between them. **Each critic must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity is the whole point of the critic step. Each gets the issue number, the plan-draft comment ID, and a focused brief:
 
 ### Critic A — Correctness

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -286,6 +286,10 @@ Otherwise, the PR is **non-parity** — Reviewer B uses risk lens.
 
 Launch both as `general-purpose` foreground sub-agents. Do not wait between them. **Each reviewer must be spawned with `--model gpt-5.4`** (or equivalent model parameter) explicitly — do not inherit from the parent. Cross-model diversity catches issues a same-model pipeline would miss.
 
+**Workspace binding (issue #2843 — pass into every reviewer prompt).** Before spawning, run the Workspace-contract bootstrap to derive `$REVIEWER_WORKTREE` (under `~/data/$SESSION_ID/review-pr-$ISSUE/reviewer`). Pass that exact path into each reviewer prompt and require it as the ONLY scratch location:
+
+> Your working directory and any checkout/build scratch MUST be `$REVIEWER_WORKTREE` (`<resolved-path>`). If you need a git worktree, run `git worktree add "$REVIEWER_WORKTREE/<sub>"`; if you build, set `CARGO_TARGET_DIR="$REVIEWER_WORKTREE/cargo-target"`. You are FORBIDDEN from creating `.review-data/`, `.review-worktrees/`, `.worktrees/`, `.copilot-tmp/`, `.opencode/worktrees/`, any `<repo>-pr<N>` sibling, or any path under `/tmp`. These are the disk-leak patterns from #2843 and have repeatedly filled the root FS.
+
 **Why structured comments, not `gh pr review --approve`:** the authenticated GH user is the PR author (the same user opened the PR via `/do` and now reviews it). GitHub disallows author self-approval, so `gh pr review --approve` is silently downgraded to a comment by `gh`. Instead, each reviewer posts a structured comment with a verdict marker that `/review-pr` parses in Step 6.
 
 **Verdict comment format** — each reviewer MUST post exactly one comment with this exact shape:
@@ -990,6 +994,28 @@ resolve under `~/data` and within the session prefix.
 
 **Never create worktrees at the repo root or outside `~/data`.** All worktrees
 must be under `~/data/$SESSION_ID/` to avoid polluting the shared checkout.
+
+**Forbidden scratch patterns (issue #2843 — hard requirement).** Every reviewer
+sub-agent (and any `/review`, `/spec-adhere`, `/review-fix` it invokes) is bound
+to `$REVIEWER_WORKTREE` and must NEVER create any of these observed disk-leak
+patterns — not in the repo tree, not as a `<repo>-pr<N>` sibling, not under `/tmp`:
+
+- `.review-data/`
+- `.review-worktrees/`
+- `.worktrees/`
+- `.copilot-tmp/`
+- `.opencode/worktrees/`
+- any path under `/tmp` (e.g. `/tmp/pr<N>-review`)
+
+These are the exact paths prior review cycles leaked (an 11 GB `/tmp/pr2797-review`
+near-OOM'd the root FS). On every exit path — including the Step 7 cleanup of
+`WORKTREE_BASE` — assert the repo tree is clean:
+
+```bash
+assert_no_repo_tree_scratch "$REPO_ROOT" || {
+  echo "Reviewer scratch leaked into the repo tree or a sibling — clean it now." >&2
+}
+```
 
 ## Branch protection
 

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -232,3 +232,121 @@ review_pr_bootstrap() {
   fi
   export REVIEWER_WORKTREE
 }
+
+# do_bootstrap <issue>
+# Derives and validates the full workspace layout for a /do implementation run.
+# Exports: WORKTREE_BASE, CARGO_TARGET_DIR, DO_WORKTREE
+# DO_WORKTREE is the implementation worktree (under ~/data, NOT in the repo tree).
+# Validates pre-seeded env vars against both ~/data boundary AND session prefix.
+# On failure, clears all derived vars to prevent stale-env escape.
+do_bootstrap() {
+  local issue="$1"
+  local session_id="${CLAUDE_SESSION_ID:-${SESSION_ID:-$(date +%Y%m%d-%H%M%S)}}"
+  local real_home
+  real_home="$(_contract_real_home)"
+
+  # The expected session prefix for do operations
+  local expected_prefix="$real_home/data/$session_id/do-$issue"
+
+  # Capture incoming overrides before clearing, so we can validate them.
+  local incoming_base="${WORKTREE_BASE:-}"
+  local incoming_cargo="${CARGO_TARGET_DIR:-}"
+
+  # Clear derived vars on entry to prevent stale values from surviving a failure.
+  unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+
+  # Derive or validate WORKTREE_BASE
+  local candidate_base="${incoming_base:-$real_home/data/$session_id/do-$issue}"
+  if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+    return 1
+  fi
+  # Enforce session-prefix isolation for pre-seeded overrides
+  if [[ -n "$incoming_base" ]]; then
+    if ! require_session_prefix "$WORKTREE_BASE" "$expected_prefix" "WORKTREE_BASE"; then
+      unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+      return 1
+    fi
+  fi
+  export WORKTREE_BASE
+
+  # Derive or validate CARGO_TARGET_DIR
+  local candidate_cargo="${incoming_cargo:-$WORKTREE_BASE/cargo-target}"
+  if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+    return 1
+  fi
+  # Enforce session-prefix isolation for pre-seeded overrides
+  if [[ -n "$incoming_cargo" ]]; then
+    if ! require_session_prefix "$CARGO_TARGET_DIR" "$expected_prefix" "CARGO_TARGET_DIR"; then
+      unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+      return 1
+    fi
+  fi
+  export CARGO_TARGET_DIR
+
+  # Derive the implementation worktree (under ~/data, never inside the repo).
+  DO_WORKTREE="$WORKTREE_BASE/worktree"
+  if ! DO_WORKTREE="$(require_home_data_path "$DO_WORKTREE" "DO_WORKTREE")"; then
+    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+    return 1
+  fi
+  export DO_WORKTREE
+}
+
+# assert_no_repo_tree_scratch <repo_root>
+# Detection-only guard (NO deletion, NO recursive sweeps) that fails fast if any
+# of the fixed, enumerated agent-scratch leak patterns (issue #2843) exists in
+# the repo working tree or as a "<basename>-pr<N>" sibling of the repo parent.
+# Prints each offender to stderr and returns non-zero if any are found.
+#
+# This is a fixed enumeration of the OBSERVED leak patterns — intentionally not
+# a generalized filesystem janitor. Skills invoke it as a pre/post assertion so a
+# leak is caught while still on disk; CI exercises it via a planted fixture.
+assert_no_repo_tree_scratch() {
+  local repo_root="$1"
+  if [[ -z "$repo_root" ]]; then
+    echo "ERROR: assert_no_repo_tree_scratch: repo_root argument is required" >&2
+    return 2
+  fi
+
+  # Fixed enumeration of observed out-of-~/data scratch directory names.
+  local leak_dirs=(
+    ".review-data"
+    ".review-worktrees"
+    ".worktrees"
+    ".copilot-tmp"
+    ".opencode/worktrees"
+  )
+
+  local found=0
+  local d
+  for d in "${leak_dirs[@]}"; do
+    if [[ -e "$repo_root/$d" ]]; then
+      echo "ERROR: agent scratch leak detected in repo tree: $repo_root/$d (see #2843)" >&2
+      found=1
+    fi
+  done
+
+  # Sibling worktrees named "<basename>-pr<N>" alongside the repo (e.g. a
+  # /tmp/henyey-pr2797 sibling, or <repo>-pr42). Match only the parent dir.
+  # Enumerate via `find` (depth 1) rather than a shell glob: a bare glob is
+  # not portable across shells — zsh's default `nomatch` makes an unmatched
+  # pattern a hard error, while bash leaves the literal string. `find` is
+  # immune to both and to the no-match case.
+  local parent base sib
+  parent="$(dirname "$repo_root")"
+  base="$(basename "$repo_root")"
+  if [[ -d "$parent" ]]; then
+    while IFS= read -r sib; do
+      [[ -n "$sib" ]] || continue
+      echo "ERROR: agent scratch leak detected as repo sibling: $sib (see #2843)" >&2
+      found=1
+    done < <(find "$parent" -mindepth 1 -maxdepth 1 -name "$base-pr*" 2>/dev/null)
+  fi
+
+  if [[ "$found" -ne 0 ]]; then
+    return 1
+  fi
+  return 0
+}

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -17,7 +17,20 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 REVIEW_PR_SKILL="$REPO_ROOT/.github/skills/review-pr/SKILL.md"
 PLAN_SKILL="$REPO_ROOT/.github/skills/plan/SKILL.md"
+DO_SKILL="$REPO_ROOT/.github/skills/do/SKILL.md"
 CONTRACT_HELPER="$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+
+# Observed disk-leak scratch patterns (issue #2843). These are out-of-~/data
+# scratch dirs that prior /do, /review-pr, and /plan runs created. Every skill
+# that spawns sub-agents must explicitly forbid these, and the detection guard
+# (assert_no_repo_tree_scratch) must recognize them as leaks.
+LEAK_PATTERNS=(
+  ".review-data"
+  ".review-worktrees"
+  ".worktrees"
+  ".copilot-tmp"
+  ".opencode/worktrees"
+)
 
 PASS=0
 FAIL=0
@@ -1091,6 +1104,229 @@ STUB
 }
 
 # --------------------------------------------------------------------------
+# Test: do_bootstrap rejects hostile WORKTREE_BASE/CARGO_TARGET_DIR, sibling
+# prefixes, and cross-session bases; clears stale DO_WORKTREE on failure.
+# --------------------------------------------------------------------------
+test_do_bootstrap_rejects_hostile_and_sibling_paths() {
+  local desc="do_bootstrap rejects hostile and sibling paths"
+
+  local real_home
+  real_home="$(_test_real_home)"
+
+  # Hostile absolute WORKTREE_BASE outside ~/data
+  local output
+  if output=$(WORKTREE_BASE="/tmp/evil" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && do_bootstrap 999" 2>&1); then
+    tap_not_ok "$desc (hostile base)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Traversal escaping ~/data
+  if output=$(WORKTREE_BASE="$HOME/data/../escape" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && do_bootstrap 999" 2>&1); then
+    tap_not_ok "$desc (traversal)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Sibling-prefix ~/data-evil
+  if output=$(WORKTREE_BASE="$HOME/data-evil/do-999" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && do_bootstrap 999" 2>&1); then
+    tap_not_ok "$desc (sibling prefix)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Hostile CARGO_TARGET_DIR with valid base
+  if output=$(WORKTREE_BASE="$real_home/data/test-session/do-999" \
+    CARGO_TARGET_DIR="/tmp/evil-cargo" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && do_bootstrap 999" 2>&1); then
+    tap_not_ok "$desc (hostile cargo)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Cross-session base under ~/data but wrong session prefix
+  if output=$(WORKTREE_BASE="$real_home/data/other-session/do-999" \
+    CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="test-session" \
+    bash -c "source '$CONTRACT_HELPER' && do_bootstrap 999" 2>&1); then
+    tap_not_ok "$desc (cross-session)" "Should have failed but succeeded: $output"
+    return
+  fi
+
+  # Stale-env escape: stale DO_WORKTREE must be cleared after a rejection
+  output=$(DO_WORKTREE="/tmp/stale-do" \
+    WORKTREE_BASE="/tmp/evil-base" \
+    CARGO_TARGET_DIR="" \
+    CLAUDE_SESSION_ID="test-session" \
+    bash -c '
+      source "'"$CONTRACT_HELPER"'"
+      do_bootstrap 999
+      rc=$?
+      echo "rc=$rc"
+      echo "DO_WORKTREE=${DO_WORKTREE:-EMPTY}"
+    ' 2>&1)
+  if ! echo "$output" | grep -q "rc=1"; then
+    tap_not_ok "$desc (stale-clear rc)" "Expected rc=1, got: $output"
+    return
+  fi
+  if echo "$output" | grep -q "DO_WORKTREE=/tmp/stale-do"; then
+    tap_not_ok "$desc (stale-clear)" "DO_WORKTREE retained stale value: $output"
+    return
+  fi
+  if ! echo "$output" | grep -q "DO_WORKTREE=EMPTY"; then
+    tap_not_ok "$desc (stale-clear empty)" "DO_WORKTREE not cleared: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: do_bootstrap default layout resolves under ~/data/<session>/do-<issue>
+# --------------------------------------------------------------------------
+test_do_bootstrap_default_under_home_data() {
+  local desc="do_bootstrap default layout under HOME/data/<session>/do-<issue>"
+
+  local output
+  if ! output=$(WORKTREE_BASE="" CARGO_TARGET_DIR="" CLAUDE_SESSION_ID="default-test" \
+    bash -c "source '$CONTRACT_HELPER' && do_bootstrap 55 && echo \$WORKTREE_BASE && echo \$CARGO_TARGET_DIR && echo \$DO_WORKTREE" 2>&1); then
+    tap_not_ok "$desc" "Default do_bootstrap failed: $output"
+    return
+  fi
+
+  local home_data
+  home_data="$(source "$CONTRACT_HELPER" && canonicalize_contract_path "$HOME/data")"
+  local line
+  while IFS= read -r line; do
+    if [[ -n "$line" && "$line" != "$home_data" && "$line" != "$home_data/"* ]]; then
+      tap_not_ok "$desc" "Path escapes \$HOME/data: $line"
+      return
+    fi
+  done <<< "$output"
+
+  if ! echo "$output" | grep -q "data/default-test/do-55"; then
+    tap_not_ok "$desc" "Layout missing expected session/do structure: $output"
+    return
+  fi
+  # DO_WORKTREE must be the worktree subdir, not the bare base.
+  if ! echo "$output" | grep -q "data/default-test/do-55/worktree"; then
+    tap_not_ok "$desc" "DO_WORKTREE missing worktree subdir: $output"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: /do uses the shared contract helper, not an in-repo worktree
+# --------------------------------------------------------------------------
+test_do_skill_uses_contract_helper_not_repo_tree() {
+  local desc="do/SKILL.md uses do_bootstrap and no in-repo worktree"
+
+  if [[ ! -f "$DO_SKILL" ]]; then
+    tap_not_ok "$desc" "do/SKILL.md not found at $DO_SKILL"
+    return
+  fi
+
+  # Must reference the shared helper bootstrap.
+  if ! grep -q 'do_bootstrap' "$DO_SKILL"; then
+    tap_not_ok "$desc" "do/SKILL.md does not reference do_bootstrap"
+    return
+  fi
+  if ! grep -q 'agent-worktree-contract.sh' "$DO_SKILL"; then
+    tap_not_ok "$desc" "do/SKILL.md does not source the contract helper"
+    return
+  fi
+
+  # Must NOT create a worktree inside the repo tree ($REPO_ROOT/data/do-...).
+  if grep -Eq 'REPO_ROOT/data/do-' "$DO_SKILL"; then
+    tap_not_ok "$desc" "do/SKILL.md still references in-repo \$REPO_ROOT/data/do- worktree"
+    return
+  fi
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: every spawning skill enumerates the observed forbidden leak patterns
+# --------------------------------------------------------------------------
+test_skill_prompts_forbid_known_leak_patterns() {
+  local desc="skill prompts forbid all observed leak patterns"
+
+  local skill_file pat missing
+  for skill_file in "$DO_SKILL" "$PLAN_SKILL" "$REVIEW_PR_SKILL"; do
+    if [[ ! -f "$skill_file" ]]; then
+      tap_not_ok "$desc" "Skill file not found: $skill_file"
+      return
+    fi
+    for pat in "${LEAK_PATTERNS[@]}"; do
+      if ! grep -qF "$pat" "$skill_file"; then
+        tap_not_ok "$desc" "$skill_file does not forbid leak pattern '$pat'"
+        return
+      fi
+    done
+    # Also require an explicit /tmp prohibition.
+    if ! grep -qF '/tmp' "$skill_file"; then
+      tap_not_ok "$desc" "$skill_file does not mention forbidden /tmp scratch"
+      return
+    fi
+    missing=""
+  done
+  : "${missing:-}"
+
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: assert_no_repo_tree_scratch detects planted leak dirs, passes clean tree
+# --------------------------------------------------------------------------
+test_assert_no_repo_tree_scratch_detects_leak_dirs() {
+  local desc="assert_no_repo_tree_scratch detects leak dirs and passes clean tree"
+
+  local fixture
+  fixture="$(mktemp -d)"
+  # Build a fake repo tree.
+  mkdir -p "$fixture/repo/crates/foo"
+  touch "$fixture/repo/crates/foo/lib.rs"
+
+  # Clean tree → guard must return 0.
+  local output
+  if ! output=$(source "$CONTRACT_HELPER" && assert_no_repo_tree_scratch "$fixture/repo" 2>&1); then
+    rm -rf "$fixture"
+    tap_not_ok "$desc (clean)" "Guard failed on clean tree: $output"
+    return
+  fi
+
+  # Plant a leak dir → guard must return non-zero AND name the offender.
+  mkdir -p "$fixture/repo/.review-data/pr1/target"
+  if output=$(source "$CONTRACT_HELPER" && assert_no_repo_tree_scratch "$fixture/repo" 2>&1); then
+    rm -rf "$fixture"
+    tap_not_ok "$desc (planted)" "Guard passed despite planted .review-data: $output"
+    return
+  fi
+  if ! echo "$output" | grep -qF ".review-data"; then
+    rm -rf "$fixture"
+    tap_not_ok "$desc (names offender)" "Guard did not name the offender: $output"
+    return
+  fi
+
+  # Remove the leak, plant a sibling-prefixed worktree (<basename>-pr<N>).
+  rm -rf "$fixture/repo/.review-data"
+  mkdir -p "$fixture/repo-pr42/target"
+  if output=$(source "$CONTRACT_HELPER" && assert_no_repo_tree_scratch "$fixture/repo" 2>&1); then
+    rm -rf "$fixture"
+    tap_not_ok "$desc (sibling)" "Guard passed despite sibling repo-pr42: $output"
+    return
+  fi
+  if ! echo "$output" | grep -qF "repo-pr42"; then
+    rm -rf "$fixture"
+    tap_not_ok "$desc (names sibling)" "Guard did not name the sibling offender: $output"
+    return
+  fi
+
+  rm -rf "$fixture"
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
 # Run all tests
 # --------------------------------------------------------------------------
 echo "TAP version 13"
@@ -1118,6 +1354,11 @@ test_bootstraps_fallback_when_realpath_is_missing
 test_bootstraps_fallback_when_realpath_rejects_dash_m
 test_symlinked_home_alias_overrides_are_accepted
 test_poisoned_python_on_path_ignored
+test_do_bootstrap_rejects_hostile_and_sibling_paths
+test_do_bootstrap_default_under_home_data
+test_do_skill_uses_contract_helper_not_repo_tree
+test_skill_prompts_forbid_known_leak_patterns
+test_assert_no_repo_tree_scratch_detects_leak_dirs
 
 echo "1..$TEST_NUM"
 echo "# pass: $PASS"


### PR DESCRIPTION
Closes #2843

## Summary

Closes the recurring high-priority disk leak where pipeline sub-agents created scratch (worktrees, cargo targets, review/plan/do data) outside the `~/data` shared volume and filled the root FS (an 11 GB `/tmp/pr2797-review` near-OOM'd it). `/do` was the dominant offender: it placed its worktree inside the repo tree (`$REPO_ROOT/data/do-$ISSUE/worktree`). The reviewer/critic sub-agents weren't bound to the helper-derived dir, so each cycle invented a fresh out-of-`~/data` path.

Changes:
- **`scripts/lib/agent-worktree-contract.sh`** — adds `do_bootstrap` (symmetric to the existing `plan_critic_bootstrap`/`review_pr_bootstrap`; exports `WORKTREE_BASE`/`CARGO_TARGET_DIR`/`DO_WORKTREE` under `~/data/$SESSION_ID/do-$ISSUE` with the same boundary, session-prefix, and stale-env-clear logic), and `assert_no_repo_tree_scratch` — a detection-only (no `rm`, no recursive sweep) guard over a fixed enumeration of observed leak patterns plus `<repo>-pr<N>` siblings. Sibling scan uses `find`, not a bare glob, so it is safe under both zsh (`nomatch`) and bash.
- **`.github/skills/do/SKILL.md`** — A.2/B.1/B.3/B.6 move the worktree, cargo target, `.session-id` marker, and review-comments scratch off the in-repo path onto the helper-derived `~/data` paths; invokes the guard post-build; reaps the workspace on local-verification-failed exits.
- **`.github/skills/review-pr/SKILL.md`, `.github/skills/plan/SKILL.md`** — bind every spawned sub-agent to the helper-derived worktree and enumerate the forbidden leak patterns.

Folds in closed #2837 (operator-override validation — already satisfied by `require_home_data_path` + `require_session_prefix`).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2843#issuecomment-4613576517)

## What the guard enforces

`assert_no_repo_tree_scratch <repo_root>` returns non-zero (and names each offender) if any of these exist in the repo tree or as a `<repo>-pr<N>` sibling — detection only, no deletion:
`.review-data/`, `.review-worktrees/`, `.worktrees/`, `.copilot-tmp/`, `.opencode/worktrees/`. Skills additionally forbid any path under `/tmp`. It is exercised in CI via a planted fixture and invoked by the skills as a runtime pre/post assertion.

## Test plan

- [x] `bash scripts/test-agent-worktree-contract.sh` — 28/28 pass (23 pre-existing + 5 new)
- [x] `bash scripts/test-review-pr-skill-snippets.sh` — 49/49 pass
- [x] `shellcheck scripts/lib/agent-worktree-contract.sh` — clean
- [x] Guard verified safe + correct under both zsh and bash

## Regression tests (kind: bug-fix)

Committed as `2915aecf` (fails on main), passing after `1dc36092`:
- `test_do_bootstrap_rejects_hostile_and_sibling_paths` — pre-fix: `do_bootstrap: command not found`
- `test_do_bootstrap_default_under_home_data` — pre-fix: function absent
- `test_do_skill_uses_contract_helper_not_repo_tree` — pre-fix: `/do` used in-repo worktree
- `test_skill_prompts_forbid_known_leak_patterns` — pre-fix: no skill enumerated the patterns
- `test_assert_no_repo_tree_scratch_detects_leak_dirs` — pre-fix: function absent

## Deviations from plan

- Sibling-scan implemented with `find` instead of a shell glob — a bare glob is a hard error under zsh's default `nomatch` (the repo's shell per CLAUDE.md). Caught by a zsh sanity run; behavior is identical, just shell-portable.
- Opened on a fresh branch (`do/issue-2843-v2`); the prior stale PR #2846 (abandoned at the lifetime bounce cap on an earlier plan) was closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)