### PR TITLE
Close 3 residual OVERLAY_SPEC parity gaps (§7.3 assert, §10.4 promote-inbound, §12.3 drain)

### DIFF
--- a/crates/overlay/SPEC_ADHERENCE.md
+++ b/crates/overlay/SPEC_ADHERENCE.md
@@ -2,11 +2,11 @@
 
 **Spec version:** 26 (Overlay Protocol v38–v39)
 **Crate:** crates/overlay
-**Last updated:** 2026-05-28
-**Overall adherence:** 79%
+**Last updated:** 2026-06-03
+**Overall adherence:** 83%
 
 Counts (excluding Drift and N/A from denominator):
-**Full 78 | Partial 18 | Absent 3 | Drift 2 | N/A 2**
+**Full 82 | Partial 17 | Absent 0 | Drift 2 | N/A 2**
 
 ## Summary table
 
@@ -36,7 +36,7 @@ Counts (excluding Drift and N/A from denominator):
 | §7.1 | Dual-axis (msg+byte) flow control | Full | `flow_control.rs:308-439` |
 | §7.2 | `getFlowControlBytesTotal` auto-compute | Full | `flow_control.rs:119-135` |
 | §7.3 | begin/endMessageProcessing capacity bookkeeping | Full | `flow_control.rs:1021-1065` |
-| §7.3 | `releaseAssert(processed <= batch_size)` | Absent | Not enforced; release counter can drift |
+| §7.3 | `releaseAssert(processed <= batch_size)` | Full | `flow_control.rs:1045-1056` hard `assert!(flood_data_processed <= batch_size)` after the counter increment; message send-more uses `==` (bytes `>=`), mirroring `FlowControl.cpp:303-311` |
 | §7.4 | Reading throttling on total capacity | Full | `flow_control.rs:1068-1071, 1084-1094` |
 | §7.5 | Outbound priority queues (SCP/TX/Demand/Advert) | Full | `flow_control.rs:236-281,516-534` |
 | §7.5 | SCP queue trimming (slot floor + nomination/ballot replace) | Full | `flow_control.rs:826-927` |
@@ -68,7 +68,7 @@ Counts (excluding Drift and N/A from denominator):
 | §10.4 | Tick period 3 s (`PEER_AUTHENTICATION_TIMEOUT + 1`) | Full | `manager/tick.rs:26` |
 | §10.4 | DNS resolution every 600 s w/ linear backoff | Full | `manager/tick.rs:31-40,176-198` |
 | §10.4 | Random out-of-sync drop after 60 s | Partial | `manager/tick.rs:589-670` `maybe_drop_random_peer()` with `OUT_OF_SYNC_RECONNECT_DELAY = 60s`; tested via `test_maybe_drop_random_peer_drops_after_cooldown` et al. See §10.4 detailed note for remaining divergences. |
-| §10.4 | Promote inbound (open parallel outbound) | Absent | No promote-inbound logic found in `tick.rs` |
+| §10.4 | Promote inbound (open parallel outbound) | Full | `manager/tick.rs` `promote_inbound_peers()` runs last in the tick, dialing authenticated inbound peers' advertised listening addresses; `fill_outbound_slots` reserves `RESERVED_FOR_PROMOTION = 1` pending slot when promotable inbound peers exist, mirroring `OverlayManagerImpl.cpp:782-794` |
 | §10.5 | IPv6 silently ignored | Full | `lib.rs:530-535`, `manager/mod.rs:1398-1400` |
 | §10.5 | Private/localhost addresses ignored | Full | `lib.rs:457-483`, `manager/mod.rs:1431-1433` |
 | §10.6 | `PEERS` sample size 50 | Full | `manager/mod.rs:85` defines `MAX_PEERS_PER_MESSAGE = 50`; enforced at `mod.rs:1386` |
@@ -85,7 +85,7 @@ Counts (excluding Drift and N/A from denominator):
 | §12.1 | ERROR_MSG drops connection | Full | `manager/peer_loop.rs:1046-1064` |
 | §12.2 | ERR_MISC/ERR_DATA/ERR_CONF/ERR_AUTH/ERR_LOAD usage | Full | `peer.rs:557-576`, `manager/connection.rs:224`, `manager/peer_loop.rs:1079-1082` |
 | §12.3 | Drop-once idempotence (INV-O19) | Partial | No `mDropStarted`-style atomic flag in `peer.rs::close`; instead state machine + tokio drop semantics. Idempotence relies on `state != PeerState::Disconnected` guard (`peer.rs:932-939`), which is single-threaded per peer. |
-| §12.3 | 5-second drain delay before socket close | Absent | Connection close is immediate (`connection.rs:285-290`); no 5 s deferred shutdown |
+| §12.3 | 5-second drain delay before socket close | Full | `manager/peer_loop.rs` `OutboundMessage::ShutdownAfterError` + `wait_error_drop_drain()`: error-drop path flushes the queued `ERROR_MSG`, then defers the close by `ERROR_DROP_DRAIN_DELAY = 5s` (interruptible by node shutdown), mirroring `TCPPeer.cpp:835-862`. Plain teardown (`Shutdown`) stays immediate |
 | §13.4 | Pre-auth payload limit 4 KiB | Full | `codec.rs:194-206` |
 | §13.4 | Pending connection caps | Full | `connection.rs:473-529` |
 | §13.4 | Handshake timeout 2 s | Full | `lib.rs:225-232,315` |
@@ -111,7 +111,7 @@ Counts (excluding Drift and N/A from denominator):
 | INV-O8 (Initial credit precedence) | Full | `peer.rs:460-477` — SEND_MORE_EXTENDED sent before `set_authenticated()` enables flood reads; first flood-controlled traffic only after this. |
 | INV-O9 (Capacity non-overshoot) | Full | `flow_control.rs:1021-1033`, `manager/peer_loop.rs:1069-1089` |
 | INV-O10 (SEND_MORE_EXTENDED validation) | Full | `flow_control.rs:979-1010` (numBytes!=0 + overflow guards) |
-| INV-O11 (Recv-side batch grants) | Partial | `flow_control.rs:1038-1065` emits SEND_MORE_EXTENDED on batch threshold, but the spec's `releaseAssert(mFloodDataProcessed <= BATCH_SIZE)` upper bound is not asserted |
+| INV-O11 (Recv-side batch grants) | Full | `flow_control.rs:1038-1065` emits SEND_MORE_EXTENDED on the batch threshold and now enforces the spec's `releaseAssert(mFloodDataProcessed <= BATCH_SIZE)` upper bound via a hard `assert!` (`flow_control.rs:1045-1056`) |
 | INV-O12 (One PEERS per connection) | Full | `manager/peer_loop.rs:512-531,712-717` |
 | INV-O13 (Inbound role rejects PEERS) | Full | `manager/peer_loop.rs:522-524` rejects PEERS from **Inbound** direction peers (`REMOTE_CALLED_US`); spec says "an inbound role peer MUST NOT receive `PEERS`" — Rust enforces the same. |
 | INV-O14 (No flood while not synced) | Full | `manager/peer_loop.rs:693-697` |
@@ -123,7 +123,7 @@ Counts (excluding Drift and N/A from denominator):
 
 Re-evaluation: INV-O13 — code is correct. Spec says "An inbound role peer (`REMOTE_CALLED_US`) MUST NOT receive `PEERS`"; the Rust code `if direction == ConnectionDirection::Inbound { return RejectWrongDirection }` matches that exactly. The invariant name is corrected to "Inbound role rejects PEERS" to align with the spec language. Reclassified to **Full** in the summary count.
 
-Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
+Corrected invariant tally: **Full 18 | Partial 1 | Absent 0**.
 
 ## Detailed findings
 
@@ -156,10 +156,10 @@ Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
   5. `crates/app/src/app/survey_impl.rs:786-793` decrypts response bodies via `henyey_crypto::open_from_curve25519_secret_key`.
   6. Rate limiting is enforced via `survey.rs:268-356` (`SurveyMessageLimiter`) in the overlay crate.
 
-### §12.3 — Drop-to-close 5 s delay (Absent)
+### §12.3 — Drop-to-close 5 s delay (Full)
 - **Claim**: Drop schedules `TCPPeer::shutdown` 5 s later to drain the final `ERROR_MSG`.
-- **Rust**: `connection.rs:285-290` closes immediately on drop; `peer.rs:932-939` likewise.
-- **Notes**: Wire-observable difference: an `ERR_LOAD` or `ERR_CONF` sent immediately before close may not reach the peer because the socket is RST'd. Possible operational impact: peers don't know why we rejected them. Not consensus-affecting.
+- **Rust**: `send_error_and_drop` (`manager/peer_loop.rs`) queues `Send(err)` then `OutboundMessage::ShutdownAfterError` on the same outbound channel. The loop flushes `Send(err)` to the socket first (FIFO), then the `ShutdownAfterError` arm calls `wait_error_drop_drain()`, which sleeps `ERROR_DROP_DRAIN_DELAY = 5s` before breaking. Plain `Shutdown` (idle/normal teardown) stays immediate. Mirrors `TCPPeer.cpp:835-862`.
+- **Notes**: The 5 s sleep is per-peer-task and interruptible by node shutdown (`state.running` going false, polled every 100 ms), so overlay teardown is never delayed 5 s per peer. Covered by `test_error_drop_drains_before_close` and `test_error_drop_drain_interrupted_by_shutdown`.
 
 ### §13.4 — Crypto-error → ERR_DATA (Partial)
 - **Claim**: any `xdr_runtime_error` or `CryptoError` during message receive triggers `ERR_DATA` and drop.
@@ -172,9 +172,10 @@ Corrected invariant tally: **Full 17 | Partial 2 | Absent 0**.
 - **Send side (divergence)**: Post-auth ERROR_MSG goes through `send_error_and_drop` (`peer_loop.rs:306-314`) → `OutboundMessage::Send` → `peer.send()` (`peer.rs:738-751`) → `auth.wrap_message()`, which applies normal MAC/sequence. Stellar-core exempts outbound ERROR_MSG from MAC in `Hmac.cpp:72-79`. Pre-auth errors use `send_raw` (`peer.rs:573`) which is correct (no MAC before keys).
 - **Notes**: Partial because receive-side matches but outbound path diverges. The divergence is benign (peers accept MACed ERROR_MSG) but not spec-identical.
 
-### §10.4 — Tick promote-inbound (Absent)
+### §10.4 — Tick promote-inbound (Full)
 - **Claim**: Step 8: "Promote inbound peers (open a parallel outbound connection to their address) to fill any leftover pending slots."
-- **Rust**: `tick.rs:1-200` covers DNS, preferred peers, random drop; no code opens a parallel outbound to an existing inbound peer.
+- **Rust**: `promote_inbound_peers()` (`manager/tick.rs`) runs strictly last in the tick loop. It enumerates authenticated inbound peers via `enumerate_promotable_inbound_peers()` — skipping those we already have an outbound to or under a dial cooldown — shuffles them, and dials their advertised listening address (rewritten into `PeerInfo.address` at Hello, `peer.rs:687-691`) via `connect_to_explicit_peer`. To keep promotion reachable under outbound saturation, `fill_outbound_slots` leaves `RESERVED_FOR_PROMOTION = 1` pending slot free when promotable inbound peers exist. Mirrors `OverlayManagerImpl.cpp:782-794`.
+- **Notes**: Covered by `test_promote_inbound_dials_inbound_peer_address`, `test_promote_inbound_skips_existing_outbound`, `test_promote_inbound_respects_pending_budget`, `test_fill_outbound_reserves_promotion_slot`, `test_enumerate_promotable_excludes_outbound_only`.
 
 ### §10.4 — Random out-of-sync drop (Partial)
 - **Claim**: Step 6: when `availableAuthSlots == 0` and out-of-sync ≥ 60 s, drop one random non-preferred outbound.
@@ -205,9 +206,8 @@ No dangling anchors. (Older codebase comments cite §5.4 as well — also valid.
 
 ## Recommendations
 
-1. **Medium — §12.3 drop-to-close delay**: Add a 5 s deferred socket shutdown so peers receive the final `ERROR_MSG` before RST. Helps operational debugging.
-2. **Medium — §5.4.4 `GET_SCP_STATE` min-ledger seq**: Add app callback or local state to compute `getMinLedgerSeqToAskPeers()`; currently sends 0.
-3. **Medium — §10.4 promote-inbound**: Implement step 8 of the tick algorithm (open parallel outbound to existing inbound peers). Important for connection diversity under load.
-4. **Low — §5.4.2 cert refresh**: Currently one cert per `AuthContext`; could move to a process-lifetime shared cert with 30-min refresh, but functionally equivalent and not consensus-affecting.
-5. **Low — §13.4 explicit `ERR_DATA` on crypto failure**: Emit an outbound `ERROR_MSG(ERR_DATA, ...)` before dropping on XDR/HMAC decode errors, instead of silent close.
-6. **Cosmetic — INV-O11 assert**: Add `debug_assert!(state.flood_data_processed <= self.config.flow_control_send_more_batch_size)` after each batch increment in `flow_control.rs::end_message_processing`.
+1. **Medium — §5.4.4 `GET_SCP_STATE` min-ledger seq**: Add app callback or local state to compute `getMinLedgerSeqToAskPeers()`; currently sends 0.
+2. **Low — §5.4.2 cert refresh**: Currently one cert per `AuthContext`; could move to a process-lifetime shared cert with 30-min refresh, but functionally equivalent and not consensus-affecting.
+3. **Low — §13.4 explicit `ERR_DATA` on crypto failure**: Emit an outbound `ERROR_MSG(ERR_DATA, ...)` before dropping on XDR/HMAC decode errors, instead of silent close.
+
+Resolved in #2802: §7.3 `releaseAssert(processed <= batch_size)` (hard `assert!`), §10.4 promote-inbound, §12.3 5 s drop-to-close drain, INV-O11 recv-side assert.

--- a/crates/overlay/src/flow_control.rs
+++ b/crates/overlay/src/flow_control.rs
@@ -1042,8 +1042,22 @@ impl FlowControl {
         state.flood_data_processed_bytes += state.byte_capacity.release_local_capacity(msg);
         state.total_msgs_processed += 1;
 
+        // Parity: FlowControl.cpp:303-310. The message-capacity counter rises
+        // by exactly 1 per flood message and resets to 0 on each send-more
+        // grant, so it can never exceed the batch size. Mirror stellar-core's
+        // `releaseAssert` with a hard `assert!` (not `debug_assert!`) — the
+        // invariant is load-bearing for the `==` send-more check below.
+        assert!(
+            state.flood_data_processed <= self.config.flow_control_send_more_batch_size,
+            "flood_data_processed ({}) exceeded send-more batch size ({})",
+            state.flood_data_processed,
+            self.config.flow_control_send_more_batch_size
+        );
+
+        // Messages: grant exactly at the batch boundary (`==`); bytes: at or
+        // past the byte batch (`>=`). Matches FlowControl.cpp:305-311.
         let should_send_more = state.flood_data_processed
-            >= self.config.flow_control_send_more_batch_size
+            == self.config.flow_control_send_more_batch_size
             || state.flood_data_processed_bytes >= self.config.flow_control_bytes_batch_size;
 
         let mut result = SendMoreCapacity::default();
@@ -1841,6 +1855,49 @@ mod tests {
                 assert!(cap.num_flood_messages > 0);
             }
         }
+    }
+
+    #[test]
+    fn test_should_send_more_exact_batch_equality() {
+        // §7.3 / FlowControl.cpp:303-311: the message-capacity counter rises by
+        // exactly 1 per flood message and the send-more grant fires at the
+        // exact batch boundary (`==`), resetting the counter to 0. The hard
+        // `assert!(flood_data_processed <= batch_size)` is exercised on every
+        // increment along the way (it can never trip on the legitimate path —
+        // the counter cannot exceed the batch by construction).
+        let mut config = FlowControlConfig::default();
+        // Use a large byte batch so only the message counter drives send-more.
+        config.flow_control_send_more_batch_size = 3;
+        config.flow_control_bytes_batch_size = u64::MAX;
+        config.peer_reading_capacity = 1000;
+        config.peer_flood_reading_capacity = 1000;
+        let fc = Arc::new(FlowControl::new(config));
+        let tx = make_tx_message();
+
+        // Messages 1 and 2: below the batch boundary, no grant.
+        for i in 1..3u64 {
+            assert!(fc.begin_message_processing(&tx));
+            let res = fc.end_message_processing(&tx);
+            assert!(
+                res.num_flood_messages == 0,
+                "no grant expected at count {i} (< batch)"
+            );
+            // Counter is strictly below the batch and never exceeds it.
+            assert_eq!(fc.state.lock().unwrap().flood_data_processed, i);
+        }
+
+        // Message 3: hits the batch boundary exactly ⇒ grant, counter resets.
+        assert!(fc.begin_message_processing(&tx));
+        let res = fc.end_message_processing(&tx);
+        assert_eq!(
+            res.num_flood_messages, 3,
+            "grant must fire at exactly batch_size, not batch_size-1"
+        );
+        assert_eq!(
+            fc.state.lock().unwrap().flood_data_processed,
+            0,
+            "counter resets to 0 after the grant"
+        );
     }
 
     #[test]

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -402,8 +402,15 @@ pub(super) enum OutboundMessage {
     Send(StellarMessage),
     /// Flood message (goes through FlowControl outbound queue).
     Flood(StellarMessage),
-    /// Close the connection.
+    /// Close the connection immediately (idle/normal teardown).
     Shutdown,
+    /// Close the connection after a 5 s drain delay (error-drop path).
+    ///
+    /// §12.3 / TCPPeer.cpp:835-862: after the final `ERROR_MSG` has been
+    /// flushed to the socket, defer the actual close by 5 s so the peer
+    /// receives the error rather than an RST. Only the error-drop path uses
+    /// this; plain teardown stays immediate (`Shutdown`).
+    ShutdownAfterError,
 }
 
 /// Bundled connection parameters for the tick-loop helpers

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -1960,7 +1960,7 @@ impl TestPeerReceiver {
     pub async fn recv(&mut self) -> Option<StellarMessage> {
         match self.rx.recv().await? {
             OutboundMessage::Send(msg) | OutboundMessage::Flood(msg) => Some(msg),
-            OutboundMessage::Shutdown => None,
+            OutboundMessage::Shutdown | OutboundMessage::ShutdownAfterError => None,
         }
     }
 
@@ -1968,7 +1968,7 @@ impl TestPeerReceiver {
     pub fn try_recv(&mut self) -> Option<StellarMessage> {
         match self.rx.try_recv().ok()? {
             OutboundMessage::Send(msg) | OutboundMessage::Flood(msg) => Some(msg),
-            OutboundMessage::Shutdown => None,
+            OutboundMessage::Shutdown | OutboundMessage::ShutdownAfterError => None,
         }
     }
 }

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -14,7 +14,7 @@ use crate::{
     PeerId,
 };
 use sha2::Digest;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use stellar_xdr::curr::{ErrorCode, SError, StellarMessage, StringM, Uint256};
@@ -270,6 +270,16 @@ impl PeerRateLimiter {
 /// Matches stellar-core `RECURRENT_TIMER_PERIOD` (5 seconds).
 const PING_INTERVAL_TICKS: u32 = 5;
 
+/// Delay before closing the socket on the error-drop path, after the final
+/// `ERROR_MSG` has been flushed.
+///
+/// §12.3 / TCPPeer.cpp:849: `expires_from_now(std::chrono::seconds(5))`.
+const ERROR_DROP_DRAIN_DELAY: Duration = Duration::from_secs(5);
+
+/// Poll interval used to make the error-drop drain delay interruptible by
+/// node shutdown without depending on a per-peer shutdown channel.
+const ERROR_DROP_DRAIN_POLL: Duration = Duration::from_millis(100);
+
 /// Truncate an error message to fit within the XDR `string msg<100>` limit.
 ///
 /// If the message exceeds 100 bytes it is truncated at a valid UTF-8 boundary
@@ -311,7 +321,12 @@ pub(super) fn send_error_and_drop(
 ) -> bool {
     let err_msg = make_error_msg(code, message);
     let _ = outbound_tx.try_send(OutboundMessage::Send(err_msg));
-    let shutdown_queued = match outbound_tx.try_send(OutboundMessage::Shutdown) {
+    // §12.3 / TCPPeer.cpp:835-862: use the deferred-shutdown variant so the
+    // loop flushes the queued ERROR_MSG and then waits 5 s before closing the
+    // socket, letting the peer actually receive the error. The `Send(err)` is
+    // dequeued and flushed before `ShutdownAfterError` (same channel, FIFO),
+    // so the drain delay is guaranteed to run post-flush.
+    let shutdown_queued = match outbound_tx.try_send(OutboundMessage::ShutdownAfterError) {
         Ok(()) | Err(TrySendError::Closed(_)) => true,
         Err(TrySendError::Full(_)) => false,
     };
@@ -848,6 +863,23 @@ impl OverlayManager {
     /// The peer is owned by this task (no mutex). Outbound messages arrive
     /// via `outbound_rx`. The `tokio::select!` multiplexes between network
     /// recv, outbound channel, and periodic timers without blocking.
+    /// Sleep for `ERROR_DROP_DRAIN_DELAY`, returning early if the overlay is
+    /// shutting down (`running` flips to false).
+    ///
+    /// §12.3 / TCPPeer.cpp:835-862: the per-peer 5 s deferred-close timer. The
+    /// poll loop keeps node-wide shutdown responsive (≤100 ms) instead of
+    /// blocking each peer task for a full 5 s.
+    async fn wait_error_drop_drain(running: &AtomicBool) {
+        let deadline = Instant::now() + ERROR_DROP_DRAIN_DELAY;
+        while Instant::now() < deadline {
+            if !running.load(Ordering::Relaxed) {
+                return;
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            tokio::time::sleep(remaining.min(ERROR_DROP_DRAIN_POLL)).await;
+        }
+    }
+
     pub(super) async fn run_peer_loop(
         peer_id: PeerId,
         mut peer: Peer,
@@ -927,6 +959,21 @@ impl OverlayManager {
                         }
                         Some(OutboundMessage::Shutdown) => {
                             info!("Peer {} loop exiting: shutdown requested", peer_id);
+                            break;
+                        }
+                        Some(OutboundMessage::ShutdownAfterError) => {
+                            // §12.3 / TCPPeer.cpp:835-862: the preceding
+                            // `Send(err)` has already been flushed to the socket
+                            // (same channel, FIFO). Defer the close by 5 s so the
+                            // ERROR_MSG drains rather than being RST'd. The sleep
+                            // is per-peer-task and interruptible by node shutdown
+                            // (`state.running` going false), so it never delays
+                            // overlay teardown by 5 s per peer.
+                            info!(
+                                "Peer {} loop exiting: error drop, draining for {:?}",
+                                peer_id, ERROR_DROP_DRAIN_DELAY
+                            );
+                            Self::wait_error_drop_drain(running).await;
                             break;
                         }
                         None => {
@@ -1376,14 +1423,43 @@ mod tests {
             ),
         }
 
-        // Second message should be shutdown
+        // Second message should be the deferred (error-drop) shutdown so the
+        // loop drains the ERROR_MSG for 5 s before closing the socket.
         match rx.recv().await.unwrap() {
-            OutboundMessage::Shutdown => {}
+            OutboundMessage::ShutdownAfterError => {}
             other => panic!(
-                "expected Shutdown, got {:?}",
+                "expected ShutdownAfterError, got {:?}",
                 std::mem::discriminant(&other)
             ),
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_error_drop_drains_before_close() {
+        // §12.3: on the error-drop path the loop waits the full 5 s drain
+        // before returning, when the node stays up.
+        let running = AtomicBool::new(true);
+        let start = tokio::time::Instant::now();
+        OverlayManager::wait_error_drop_drain(&running).await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= ERROR_DROP_DRAIN_DELAY,
+            "error-drop drain must wait the full {ERROR_DROP_DRAIN_DELAY:?}, waited {elapsed:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_error_drop_drain_interrupted_by_shutdown() {
+        // Node shutdown (`running` → false) cuts the 5 s drain short so overlay
+        // teardown is never blocked 5 s per peer.
+        let running = AtomicBool::new(false);
+        let start = tokio::time::Instant::now();
+        OverlayManager::wait_error_drop_drain(&running).await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < ERROR_DROP_DRAIN_DELAY,
+            "shutdown must interrupt the drain well before {ERROR_DROP_DRAIN_DELAY:?}, waited {elapsed:?}"
+        );
     }
 
     #[test]

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -870,12 +870,17 @@ impl OverlayManager {
     /// poll loop keeps node-wide shutdown responsive (≤100 ms) instead of
     /// blocking each peer task for a full 5 s.
     async fn wait_error_drop_drain(running: &AtomicBool) {
-        let deadline = Instant::now() + ERROR_DROP_DRAIN_DELAY;
-        while Instant::now() < deadline {
+        // Use `tokio::time::Instant` (not `std::time::Instant`) for both the
+        // deadline and the elapsed check so the delay is driven by Tokio's
+        // clock. Under paused/advanced time in tests this stays deterministic
+        // and fast; mixing std `Instant` with `tokio::time::sleep` would tie
+        // the loop to wall-clock and busy-loop for ~5 real seconds.
+        let deadline = tokio::time::Instant::now() + ERROR_DROP_DRAIN_DELAY;
+        while tokio::time::Instant::now() < deadline {
             if !running.load(Ordering::Relaxed) {
                 return;
             }
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             tokio::time::sleep(remaining.min(ERROR_DROP_DRAIN_POLL)).await;
         }
     }

--- a/crates/overlay/src/manager/tick.rs
+++ b/crates/overlay/src/manager/tick.rs
@@ -9,8 +9,8 @@ use crate::{connection::ConnectionPool, peer::PeerInfo, DialKey, PeerAddress, Pe
 use dashmap::DashMap;
 use parking_lot::RwLock;
 use rand::seq::SliceRandom;
-use std::collections::HashMap;
-use std::net::IpAddr;
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -612,6 +612,36 @@ impl OverlayManager {
     /// dials (OverlayManagerImpl.cpp:790-794).
     fn enumerate_promotable_inbound_peers(shared: &SharedPeerState) -> Vec<PeerAddress> {
         let now = std::time::Instant::now();
+
+        // Precompute the outbound peers' match keys in a single pass so the
+        // per-candidate "already have an outbound connection?" check is O(1)
+        // instead of re-scanning `peer_info_cache` for every inbound peer
+        // (which made the whole enumeration O(n²) per tick). The two sets
+        // mirror `peer_info_matches_address` exactly: `orig` is the
+        // advertised host:port, `resolved` is the connected IP:port.
+        let mut outbound_orig: HashSet<(String, u16)> = HashSet::new();
+        let mut outbound_resolved: HashSet<SocketAddr> = HashSet::new();
+        for entry in shared.peer_info_cache.iter() {
+            let info = entry.value();
+            if !info.direction.we_called_remote() {
+                continue;
+            }
+            if let Some(ref orig) = info.original_address {
+                outbound_orig.insert((orig.host.clone(), orig.port));
+            }
+            outbound_resolved.insert(info.address);
+        }
+        // Mirrors `peer_info_matches_address` against the precomputed sets.
+        let has_outbound = |addr: &PeerAddress| -> bool {
+            if outbound_orig.contains(&(addr.host.clone(), addr.port)) {
+                return true;
+            }
+            addr.host
+                .parse::<IpAddr>()
+                .map(|ip| outbound_resolved.contains(&SocketAddr::new(ip, addr.port)))
+                .unwrap_or(false)
+        };
+
         let mut out = Vec::new();
         for entry in shared.peer_info_cache.iter() {
             let info = entry.value();
@@ -621,7 +651,7 @@ impl OverlayManager {
             }
             let addr = PeerAddress::from(info.address);
             // Skip if we already have an outbound connection to this address.
-            if Self::has_outbound_connection_to(&shared.peer_info_cache, &addr) {
+            if has_outbound(&addr) {
                 continue;
             }
             // Skip if within reconnection cooldown (mutual-dial oscillation guard).

--- a/crates/overlay/src/manager/tick.rs
+++ b/crates/overlay/src/manager/tick.rs
@@ -342,20 +342,46 @@ impl OverlayManager {
                 let outbound_count = Self::count_outbound_peers(&shared.peer_info_cache);
                 let remaining = max_outbound.saturating_sub(outbound_count);
                 if remaining == 0 || outbound_count >= ctx.target_outbound {
+                    // No outbound budget left for either known-peer fill or
+                    // promotion — skip both. Still sweep cooldowns below.
+                    let now = std::time::Instant::now();
+                    shared.dial_cooldowns.retain(|_, expiry| now < *expiry);
                     continue;
                 }
 
+                // §10.4 / OverlayManagerImpl.cpp:782-787: if there are inbound
+                // peers we could promote to outbound, leave RESERVED_FOR_PROMOTION
+                // slots free so the promote-inbound step below can actually fire
+                // under outbound saturation. Otherwise use the full budget.
+                let promotable = Self::enumerate_promotable_inbound_peers(&shared);
+                let fill_budget = if !promotable.is_empty() {
+                    remaining.saturating_sub(Self::RESERVED_FOR_PROMOTION)
+                } else {
+                    remaining
+                };
+
                 // Fill remaining outbound slots from known peers.
-                Self::fill_outbound_slots(
-                    &known_peers,
-                    &mut retry_after,
-                    now,
-                    remaining,
-                    &pool,
-                    &shared,
-                    &ctx,
-                )
-                .await;
+                if fill_budget > 0 {
+                    Self::fill_outbound_slots(
+                        &known_peers,
+                        &mut retry_after,
+                        now,
+                        fill_budget,
+                        &pool,
+                        &shared,
+                        &ctx,
+                    )
+                    .await;
+                }
+
+                // §10.4 / OverlayManagerImpl.cpp:790-794: finally, attempt to
+                // promote some inbound connections to outbound. Runs strictly
+                // last so it consumes only the leftover (reserved) budget.
+                let outbound_count = Self::count_outbound_peers(&shared.peer_info_cache);
+                let promote_budget = max_outbound.saturating_sub(outbound_count);
+                if promote_budget > 0 {
+                    Self::promote_inbound_peers(promote_budget, &pool, &shared, &ctx).await;
+                }
 
                 // Sweep expired dial cooldowns to avoid unbounded growth.
                 let now = std::time::Instant::now();
@@ -566,6 +592,110 @@ impl OverlayManager {
         }
     }
 
+    /// Number of pending outbound slots reserved for inbound-peer promotion.
+    ///
+    /// Matches stellar-core `RESERVED_FOR_PROMOTION` (OverlayManagerImpl.cpp:784).
+    /// When promotable inbound peers exist, `fill_outbound_slots` leaves this
+    /// many slots free so the promote-inbound step can fire under saturation.
+    const RESERVED_FOR_PROMOTION: usize = 1;
+
+    /// Enumerate authenticated Inbound peers that are candidates for promotion
+    /// to an outbound connection.
+    ///
+    /// A peer is promotable if we have an inbound connection to it, we do not
+    /// already have an outbound connection to its advertised listening address,
+    /// and it is not under a dial cooldown. The returned addresses are the
+    /// peers' advertised listening IP:port (rewritten into `PeerInfo.address`
+    /// at Hello, peer.rs:687-691), so they are directly dialable.
+    ///
+    /// Mirrors the candidate set stellar-core's `connectTo(.., PeerType::INBOUND)`
+    /// dials (OverlayManagerImpl.cpp:790-794).
+    fn enumerate_promotable_inbound_peers(shared: &SharedPeerState) -> Vec<PeerAddress> {
+        let now = std::time::Instant::now();
+        let mut out = Vec::new();
+        for entry in shared.peer_info_cache.iter() {
+            let info = entry.value();
+            // Only inbound peers are promotion candidates.
+            if info.direction.we_called_remote() {
+                continue;
+            }
+            let addr = PeerAddress::from(info.address);
+            // Skip if we already have an outbound connection to this address.
+            if Self::has_outbound_connection_to(&shared.peer_info_cache, &addr) {
+                continue;
+            }
+            // Skip if within reconnection cooldown (mutual-dial oscillation guard).
+            if let DialKey::Resolved(resolved) = addr.dial_key() {
+                if let Some(expiry) = shared.dial_cooldowns.get(&resolved) {
+                    if now < *expiry.value() {
+                        continue;
+                    }
+                }
+            }
+            out.push(addr);
+        }
+        out
+    }
+
+    /// Attempt to promote inbound connections to outbound by dialing their
+    /// advertised listening addresses, up to `budget` slots.
+    ///
+    /// Matches stellar-core `connectTo(availablePendingSlots, PeerType::INBOUND)`
+    /// (OverlayManagerImpl.cpp:790-794) — the final step of `tick()`. The
+    /// candidate set is shuffled so promotion is not biased toward any peer.
+    async fn promote_inbound_peers(
+        budget: usize,
+        pool: &Arc<ConnectionPool>,
+        shared: &SharedPeerState,
+        ctx: &TickConnectCtx,
+    ) {
+        if budget == 0 {
+            return;
+        }
+        let mut candidates = Self::enumerate_promotable_inbound_peers(shared);
+        if candidates.is_empty() {
+            return;
+        }
+        candidates.shuffle(&mut rand::thread_rng());
+
+        let mut remaining = budget;
+        for addr in &candidates {
+            if remaining == 0 {
+                break;
+            }
+
+            // Re-check under the loop: an earlier promotion in this tick may
+            // have created the outbound connection we're about to dial.
+            if Self::has_outbound_connection_to(&shared.peer_info_cache, addr) {
+                continue;
+            }
+
+            if !pool.try_reserve() {
+                debug!("Outbound peer pending limit reached during promotion");
+                break;
+            }
+
+            match super::connection::connect_to_explicit_peer(
+                addr,
+                ctx.local_node.clone(),
+                ctx.timeouts,
+                Arc::clone(pool),
+                shared.clone(),
+                Arc::clone(&ctx.connection_factory),
+            )
+            .await
+            {
+                Ok(_) => {
+                    debug!("Promoting inbound peer {} to outbound", addr);
+                    remaining = remaining.saturating_sub(1);
+                }
+                Err(e) => {
+                    debug!("Failed to promote inbound peer {}: {}", addr, e);
+                }
+            }
+        }
+    }
+
     /// Delay (seconds) before we drop a random peer when out of sync.
     ///
     /// Matches stellar-core `OUT_OF_SYNC_RECONNECT_DELAY` (60s).
@@ -759,6 +889,187 @@ mod tests {
                 "bind not used in test".to_string(),
             ))
         }
+    }
+
+    /// A connection factory that records every address it is asked to dial,
+    /// then fails the connect (so no handshake is needed). Used to assert
+    /// which peers the promote-inbound step dials.
+    #[derive(Debug, Default)]
+    struct RecordingConnectionFactory {
+        dialed: std::sync::Mutex<Vec<SocketAddr>>,
+    }
+
+    impl RecordingConnectionFactory {
+        fn dialed(&self) -> Vec<SocketAddr> {
+            self.dialed.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl ConnectionFactory for RecordingConnectionFactory {
+        async fn connect(&self, addr: SocketAddr, _timeout_secs: u64) -> Result<Connection> {
+            self.dialed.lock().unwrap().push(addr);
+            Err(OverlayError::ConnectionFailed(format!(
+                "recorded dial to {addr}"
+            )))
+        }
+
+        async fn bind(&self, _port: u16) -> Result<Listener> {
+            Err(OverlayError::ConnectionFailed(
+                "bind not used in test".to_string(),
+            ))
+        }
+    }
+
+    fn promote_ctx(factory: Arc<dyn ConnectionFactory>) -> TickConnectCtx {
+        TickConnectCtx {
+            local_node: LocalNode::new_testnet(SecretKey::generate()),
+            timeouts: crate::OutboundTimeouts {
+                connect_secs: 1,
+                auth_secs: 1,
+            },
+            target_outbound: 8,
+            connection_factory: factory,
+        }
+    }
+
+    // ---- §10.4 promote-inbound tests ----
+
+    #[tokio::test]
+    async fn test_promote_inbound_dials_inbound_peer_address() {
+        let factory = Arc::new(RecordingConnectionFactory::default());
+        let manager = OverlayManager::new_with_connection_factory(
+            OverlayConfig::default(),
+            LocalNode::new_testnet(SecretKey::generate()),
+            factory.clone(),
+        )
+        .unwrap();
+        let shared = manager.shared_state();
+
+        // An authenticated inbound peer whose advertised listening address is
+        // 10.0.0.5:11625 (rewritten into PeerInfo.address at Hello).
+        let mut info = make_peer_info(ConnectionDirection::Inbound, 11625);
+        info.address = "10.0.0.5:11625".parse().unwrap();
+        register_fake_peer(&shared.peers, &shared.peer_info_cache, info);
+
+        // A free pending slot exists for promotion.
+        let ctx = promote_ctx(factory.clone());
+        OverlayManager::promote_inbound_peers(1, &manager.outbound_pool, &shared, &ctx).await;
+
+        let dialed = factory.dialed();
+        assert_eq!(dialed.len(), 1, "should dial exactly the one inbound peer");
+        assert_eq!(
+            dialed[0],
+            "10.0.0.5:11625".parse::<SocketAddr>().unwrap(),
+            "should dial the inbound peer's advertised listening address"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_promote_inbound_skips_existing_outbound() {
+        let factory = Arc::new(RecordingConnectionFactory::default());
+        let manager = OverlayManager::new_with_connection_factory(
+            OverlayConfig::default(),
+            LocalNode::new_testnet(SecretKey::generate()),
+            factory.clone(),
+        )
+        .unwrap();
+        let shared = manager.shared_state();
+
+        // Inbound peer advertising 10.0.0.7:11625 ...
+        let mut inbound = make_peer_info(ConnectionDirection::Inbound, 11625);
+        inbound.address = "10.0.0.7:11625".parse().unwrap();
+        register_fake_peer(&shared.peers, &shared.peer_info_cache, inbound);
+
+        // ... and an existing outbound connection to the same address.
+        let mut outbound = make_peer_info(ConnectionDirection::Outbound, 22000);
+        outbound.address = "10.0.0.7:11625".parse().unwrap();
+        register_fake_peer(&shared.peers, &shared.peer_info_cache, outbound);
+
+        let ctx = promote_ctx(factory.clone());
+        OverlayManager::promote_inbound_peers(4, &manager.outbound_pool, &shared, &ctx).await;
+
+        assert!(
+            factory.dialed().is_empty(),
+            "must not redial a peer we already have an outbound connection to"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_promote_inbound_respects_pending_budget() {
+        let factory = Arc::new(RecordingConnectionFactory::default());
+        let manager = OverlayManager::new_with_connection_factory(
+            OverlayConfig::default(),
+            LocalNode::new_testnet(SecretKey::generate()),
+            factory.clone(),
+        )
+        .unwrap();
+        let shared = manager.shared_state();
+
+        let mut info = make_peer_info(ConnectionDirection::Inbound, 11625);
+        info.address = "10.0.0.9:11625".parse().unwrap();
+        register_fake_peer(&shared.peers, &shared.peer_info_cache, info);
+
+        // Zero budget ⇒ no dial.
+        let ctx = promote_ctx(factory.clone());
+        OverlayManager::promote_inbound_peers(0, &manager.outbound_pool, &shared, &ctx).await;
+        assert!(
+            factory.dialed().is_empty(),
+            "no dial should occur with zero promotion budget"
+        );
+    }
+
+    #[test]
+    fn test_fill_outbound_reserves_promotion_slot() {
+        // With a promotable inbound peer present, the fill budget must be
+        // reduced by RESERVED_FOR_PROMOTION so the promote step can fire.
+        let manager = OverlayManager::new_with_connection_factory(
+            OverlayConfig::default(),
+            LocalNode::new_testnet(SecretKey::generate()),
+            Arc::new(FailingConnectionFactory),
+        )
+        .unwrap();
+        let shared = manager.shared_state();
+
+        let mut info = make_peer_info(ConnectionDirection::Inbound, 11625);
+        info.address = "10.0.0.11:11625".parse().unwrap();
+        register_fake_peer(&shared.peers, &shared.peer_info_cache, info);
+
+        let promotable = OverlayManager::enumerate_promotable_inbound_peers(&shared);
+        assert_eq!(promotable.len(), 1, "the inbound peer should be promotable");
+
+        // Mirror the tick-loop budget computation.
+        let remaining = 8usize;
+        let fill_budget = if !promotable.is_empty() {
+            remaining.saturating_sub(OverlayManager::RESERVED_FOR_PROMOTION)
+        } else {
+            remaining
+        };
+        assert_eq!(
+            fill_budget, 7,
+            "one slot must be reserved for promotion when promotable peers exist"
+        );
+    }
+
+    #[test]
+    fn test_enumerate_promotable_excludes_outbound_only() {
+        // An outbound-only peer is never a promotion candidate.
+        let manager = OverlayManager::new_with_connection_factory(
+            OverlayConfig::default(),
+            LocalNode::new_testnet(SecretKey::generate()),
+            Arc::new(FailingConnectionFactory),
+        )
+        .unwrap();
+        let shared = manager.shared_state();
+
+        let mut info = make_peer_info(ConnectionDirection::Outbound, 11625);
+        info.address = "10.0.0.13:11625".parse().unwrap();
+        register_fake_peer(&shared.peers, &shared.peer_info_cache, info);
+
+        assert!(
+            OverlayManager::enumerate_promotable_inbound_peers(&shared).is_empty(),
+            "outbound peers are not promotion candidates"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #2802

## Summary

Implements the 3 genuine residual OVERLAY_SPEC parity gaps in `henyey-overlay`, parity-faithful to stellar-core:

- **§7.3 / `FlowControl.cpp:303-311`** — receive-side `end_message_processing` now has a hard `assert!(flood_data_processed <= batch_size)` after the counter increment (mirrors `releaseAssert`, not `debug_assert!`), and the message half of `should_send_more` switched from `>=` to `==` (bytes stay `>=`). Closes INV-O11.
- **§10.4 / `OverlayManagerImpl.cpp:782-794`** — `promote_inbound_peers()` runs strictly last in the tick, dialing authenticated inbound peers' advertised listening addresses; `fill_outbound_slots` reserves `RESERVED_FOR_PROMOTION = 1` pending slot when promotable inbound peers exist so promotion is reachable under saturation.
- **§12.3 / `TCPPeer.cpp:835-862`** — new `OutboundMessage::ShutdownAfterError` + `wait_error_drop_drain()`: the error-drop path flushes the queued `ERROR_MSG` then defers the socket close by 5 s (interruptible by node shutdown, polled every 100 ms). Plain `Shutdown` (idle/normal teardown) stays immediate.

Also flips the 4 corresponding `crates/overlay/SPEC_ADHERENCE.md` rows to Full (§7.3 assert, §10.4 promote-inbound, §12.3 drain, INV-O11) and updates the summary counts to **Full 82 | Partial 17 | Absent 0 | Drift 2 | N/A 2**.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2802#issuecomment-4614452889)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (CI's invocation; pre-commit hook also green)
- [x] `cargo test -p henyey-overlay` — 453 + new tests pass, 0 failed

New coverage:
- `flow_control.rs::test_should_send_more_exact_batch_equality`
- `tick.rs::test_promote_inbound_dials_inbound_peer_address`, `test_promote_inbound_skips_existing_outbound`, `test_promote_inbound_respects_pending_budget`, `test_fill_outbound_reserves_promotion_slot`, `test_enumerate_promotable_excludes_outbound_only`
- `peer_loop.rs::test_error_drop_drains_before_close`, `test_error_drop_drain_interrupted_by_shutdown`
- Updated `peer_loop.rs::test_send_error_and_drop_sends_error_then_shutdown` to expect `ShutdownAfterError`

## Deviations from plan

- The plan suggested `tokio::time::sleep` raced against `shutdown_rx`, but the peer loop has no per-peer shutdown channel — only `state.running: Arc<AtomicBool>`. The drain is made interruptible by polling `running` every 100 ms, which keeps node-wide teardown responsive without adding a new channel. Functionally equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)