### PR TITLE
Persist resolved workspace path as single source of truth for /do→/review-pr reap

### DIFF
--- a/.github/skills/do/SKILL.md
+++ b/.github/skills/do/SKILL.md
@@ -81,19 +81,31 @@ against the passwd-anchored `~/data` boundary and the per-session prefix.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 BRANCH="do/issue-$ISSUE"
 
-# Derive + validate the workspace. Exports WORKTREE_BASE, CARGO_TARGET_DIR, and
-# DO_WORKTREE, all under ~/data/$SESSION_ID/do-$ISSUE. Fails closed on any path
-# that escapes ~/data — the `|| exit 1` guard prevents the mkdir below from
-# running on a rejected (hostile/stale) path.
+# Derive + validate the workspace. Exports WORKTREE_BASE, CARGO_TARGET_DIR,
+# DO_WORKTREE, and DO_WORKSPACE, all under ~/data/$SESSION_ID/do-$ISSUE. Fails
+# closed on any path that escapes ~/data — the `|| exit 1` guard prevents the
+# mkdir and marker write below from running on a rejected (hostile/stale) path.
 source "$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
 do_bootstrap "$ISSUE" || exit 1
 export CARGO_TARGET_DIR
 
 mkdir -p "$WORKTREE_BASE"
 
-# Persist the session ID alongside the workspace (under ~/data, NOT in the repo)
-# so /review-pr can clean up the cargo target dir on merge.
-echo "${CLAUDE_SESSION_ID:-$SESSION_ID}" > "$WORKTREE_BASE/.session-id"
+# Persist the fully-resolved ABSOLUTE workspace path so /review-pr reaps EXACTLY
+# the directory we created on merge. DO_WORKSPACE is the single source of truth
+# (== WORKTREE_BASE, canonicalized + ~/data-validated by do_bootstrap); we write
+# it verbatim and /review-pr reads it verbatim, so the write and read paths can
+# never diverge regardless of CLAUDE_SESSION_ID state or $HOME poisoning (#2979,
+# #2978). The marker is a flat, per-issue, session-INDEPENDENT file directly
+# under <real-home>/data — so /review-pr (a different session) can locate it
+# without knowing /do's session id, while keeping ALL scratch under ~/data and
+# OUT of the repo tree (the #2843 contract). Its CONTENTS are the ~/data
+# absolute workspace path. Use the passwd-derived home (NOT $HOME, which may be
+# poisoned). Written ONLY after do_bootstrap succeeds.
+PW_HOME="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6)"
+[ -z "$PW_HOME" ] && PW_HOME="$(eval echo "~$(id -un)")"
+mkdir -p "$PW_HOME/data"
+printf '%s\n' "$DO_WORKSPACE" > "$PW_HOME/data/do-$ISSUE.workspace"
 
 # Fresh worktree off origin/main, under ~/data (DO_WORKTREE).
 git fetch origin main

--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -744,17 +744,44 @@ gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Recover session ID from the sidecar /do persisted (see do/SKILL.md A.2).
-# Build cache lives at $HOME/data/<session-id>/do-$ISSUE/cargo-target/ — can be
-# 25-50 GB per issue. Clean it up here; otherwise nothing else will.
-if [ -f "$REPO_ROOT/data/do-$ISSUE/.session-id" ]; then
+# Reap the /do session workspace (worktree + cargo target — 25-50 GB per issue).
+# /do persists the fully-resolved ABSOLUTE workspace path in a flat, per-issue,
+# session-independent marker under <real-home>/data/do-$ISSUE.workspace (see
+# do/SKILL.md A.2). We reap that exact string verbatim — no recombination from a
+# session id or $HOME — so the write path and the read path cannot diverge
+# (#2979, #2978).
+#
+# Boundary guard: only `rm -rf` paths under <real-home>/data, where <real-home>
+# is the PASSWD-derived home (NOT $HOME — $HOME may be poisoned). This fails
+# closed if a marker ever contains a path outside the contract boundary.
+PW_HOME="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6)"
+[ -z "$PW_HOME" ] && PW_HOME="$(eval echo "~$(id -un)")"
+
+reap_workspace() {  # $1 = absolute dir to remove
+  local ws="$1"
+  [ -z "$ws" ] && return 0
+  case "$ws" in
+    "$PW_HOME"/data/*) [ -d "$ws" ] && rm -rf "$ws" ;;
+    *) echo "WARN: refusing to reap '$ws' — outside $PW_HOME/data" >&2 ;;
+  esac
+}
+
+WORKSPACE_MARKER="$PW_HOME/data/do-$ISSUE.workspace"
+if [ -f "$WORKSPACE_MARKER" ]; then
+  # Current marker: contents are the resolved absolute workspace dir. Reap it
+  # verbatim, then remove the marker itself.
+  reap_workspace "$(cat "$WORKSPACE_MARKER")"
+  rm -f "$WORKSPACE_MARKER"
+elif [ -f "$REPO_ROOT/data/do-$ISSUE/.session-id" ]; then
+  # Legacy marker (pre-#2979 /do wrote a bare session id into the repo tree).
+  # Reconstruct <real-home>/data/<id>/do-$ISSUE using the SAME passwd-home
+  # boundary guard (NOT $HOME) before any rm -rf. Handles in-flight PRs opened
+  # by the pre-fix /do.
   SESSION_ID=$(cat "$REPO_ROOT/data/do-$ISSUE/.session-id")
-  if [ -n "$SESSION_ID" ] && [ -d "$HOME/data/$SESSION_ID/do-$ISSUE" ]; then
-    rm -rf "$HOME/data/$SESSION_ID/do-$ISSUE"
-  fi
+  [ -n "$SESSION_ID" ] && reap_workspace "$PW_HOME/data/$SESSION_ID/do-$ISSUE"
 fi
 
-# Worktree dir cleanup.
+# Repo-tree cleanup: legacy marker dir (if any) + any pruned worktree refs.
 rm -rf "$REPO_ROOT/data/do-$ISSUE"
 git worktree prune
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify agent workspace contract
         run: bash scripts/test-agent-worktree-contract.sh
+      - name: Verify do_bootstrap workspace persist/reap contract
+        run: bash scripts/lib/tests/test-do-bootstrap.bats
 
   quickstart-harness:
     name: Quickstart Harness

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -235,8 +235,14 @@ review_pr_bootstrap() {
 
 # do_bootstrap <issue>
 # Derives and validates the full workspace layout for a /do implementation run.
-# Exports: WORKTREE_BASE, CARGO_TARGET_DIR, DO_WORKTREE
+# Exports: WORKTREE_BASE, CARGO_TARGET_DIR, DO_WORKTREE, DO_WORKSPACE
 # DO_WORKTREE is the implementation worktree (under ~/data, NOT in the repo tree).
+# DO_WORKSPACE is the canonical, fully-resolved absolute session-workspace dir
+# (== WORKTREE_BASE) — the SINGLE source of truth for the directory /review-pr
+# reaps on merge (issue #2979/#2978). /do persists this exact string to a
+# session-independent marker; /review-pr reads and `rm -rf`s it verbatim, with no
+# downstream recombination of the session id or $HOME, so the write path and the
+# read path cannot diverge regardless of CLAUDE_SESSION_ID state or $HOME value.
 # Validates pre-seeded env vars against both ~/data boundary AND session prefix.
 # On failure, clears all derived vars to prevent stale-env escape.
 do_bootstrap() {
@@ -253,18 +259,18 @@ do_bootstrap() {
   local incoming_cargo="${CARGO_TARGET_DIR:-}"
 
   # Clear derived vars on entry to prevent stale values from surviving a failure.
-  unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+  unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE DO_WORKSPACE
 
   # Derive or validate WORKTREE_BASE
   local candidate_base="${incoming_base:-$real_home/data/$session_id/do-$issue}"
   if ! WORKTREE_BASE="$(require_home_data_path "$candidate_base" "WORKTREE_BASE")"; then
-    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE DO_WORKSPACE
     return 1
   fi
   # Enforce session-prefix isolation for pre-seeded overrides
   if [[ -n "$incoming_base" ]]; then
     if ! require_session_prefix "$WORKTREE_BASE" "$expected_prefix" "WORKTREE_BASE"; then
-      unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+      unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE DO_WORKSPACE
       return 1
     fi
   fi
@@ -273,13 +279,13 @@ do_bootstrap() {
   # Derive or validate CARGO_TARGET_DIR
   local candidate_cargo="${incoming_cargo:-$WORKTREE_BASE/cargo-target}"
   if ! CARGO_TARGET_DIR="$(require_home_data_path "$candidate_cargo" "CARGO_TARGET_DIR")"; then
-    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE DO_WORKSPACE
     return 1
   fi
   # Enforce session-prefix isolation for pre-seeded overrides
   if [[ -n "$incoming_cargo" ]]; then
     if ! require_session_prefix "$CARGO_TARGET_DIR" "$expected_prefix" "CARGO_TARGET_DIR"; then
-      unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+      unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE DO_WORKSPACE
       return 1
     fi
   fi
@@ -288,10 +294,17 @@ do_bootstrap() {
   # Derive the implementation worktree (under ~/data, never inside the repo).
   DO_WORKTREE="$WORKTREE_BASE/worktree"
   if ! DO_WORKTREE="$(require_home_data_path "$DO_WORKTREE" "DO_WORKTREE")"; then
-    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE
+    unset WORKTREE_BASE CARGO_TARGET_DIR DO_WORKTREE DO_WORKSPACE
     return 1
   fi
   export DO_WORKTREE
+
+  # DO_WORKSPACE is the canonical session-workspace dir to reap on merge. It is
+  # exactly the validated, canonicalized WORKTREE_BASE — a stable alias so the
+  # persist/reap contract refers to one named, fully-resolved absolute path
+  # rather than re-deriving it from the session id downstream.
+  DO_WORKSPACE="$WORKTREE_BASE"
+  export DO_WORKSPACE
 }
 
 # assert_no_repo_tree_scratch <repo_root>

--- a/scripts/lib/tests/test-do-bootstrap.bats
+++ b/scripts/lib/tests/test-do-bootstrap.bats
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Tests for do_bootstrap in scripts/lib/agent-worktree-contract.sh (issue #2979/#2978).
+#
+# Written in a BATS-compatible style (each test is a function named test_*) but
+# also runs as a plain-bash TAP-style runner, matching the convention used by
+# .github/skills/shared/tests/bounce-cap-check.bats. We default to the plain-bash
+# fallback since BATS isn't part of the project's required toolchain.
+#
+# What we assert:
+#   1. With CLAUDE_SESSION_ID unset, do_bootstrap exports DO_WORKSPACE (the
+#      canonical absolute workspace dir) and a write->read round-trip of the
+#      persisted marker targets the IDENTICAL absolute path — i.e. /review-pr
+#      reads exactly the dir /do created, with no date/$HOME recombination.
+#   2. do_bootstrap rejects hostile pre-seeded WORKTREE_BASE / CARGO_TARGET_DIR
+#      overrides (outside ~/data, ../ traversal, cross-session prefix), and on
+#      rejection writes no marker.
+#
+# Usage:
+#   bash scripts/lib/tests/test-do-bootstrap.bats     # plain
+#   bats scripts/lib/tests/test-do-bootstrap.bats     # BATS
+#
+# Output: TAP. Exit: 0 if all tests pass, non-zero otherwise.
+
+set -uo pipefail
+
+# ── Locate the library under test ────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LIB_UNDER_TEST="$REPO_ROOT/scripts/lib/agent-worktree-contract.sh"
+
+# Passwd-derived real home — the trust anchor the contract uses. We compute it
+# here independently so tests stage their fixtures under the SAME root the
+# helper will validate against (immune to $HOME poisoning in the test env).
+REAL_HOME="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6)"
+[[ -z "$REAL_HOME" ]] && REAL_HOME="$(eval echo "~$(id -un)")"
+
+# ── TAP state ────────────────────────────────────────────────────────────────
+TAP_CURRENT=0
+TAP_FAILURES=0
+TAP_OUTPUT=()
+
+tap_ok() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  TAP_OUTPUT+=("ok $TAP_CURRENT - $1")
+}
+
+tap_fail() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  TAP_FAILURES=$((TAP_FAILURES + 1))
+  TAP_OUTPUT+=("not ok $TAP_CURRENT - $1")
+  if [ -n "${2:-}" ]; then
+    TAP_OUTPUT+=("  ---")
+    TAP_OUTPUT+=("  $2")
+    TAP_OUTPUT+=("  ...")
+  fi
+}
+
+# Run a callback in a clean subshell with the library sourced and the relevant
+# env vars cleared, so each test is independent.
+# Usage: run_in_clean_env "<bash code>"; result in $LAST_STDOUT / $LAST_EXIT.
+run_in_clean_env() {
+  local code="$1"
+  LAST_STDOUT="$(
+    env -u CLAUDE_SESSION_ID -u SESSION_ID -u WORKTREE_BASE -u CARGO_TARGET_DIR -u DO_WORKSPACE \
+      bash -c '
+        set -uo pipefail
+        source "'"$LIB_UNDER_TEST"'"
+        '"$code"'
+      ' 2>&1
+  )"
+  LAST_EXIT=$?
+}
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+# Test 1: write->read round-trip is identical with CLAUDE_SESSION_ID unset.
+# do_bootstrap must export DO_WORKSPACE and the persisted marker must read back
+# to the IDENTICAL absolute path with no date/$HOME recombination on read.
+test_do_bootstrap_roundtrip_identical_unset_session() {
+  local marker
+  marker="$(mktemp)"
+  run_in_clean_env '
+    do_bootstrap 2979 || { echo "BOOTSTRAP_FAILED"; exit 1; }
+    # /do persists the resolved absolute path (A.2).
+    printf "%s" "$DO_WORKSPACE" > "'"$marker"'"
+    # /review-pr reads it back verbatim (Step 7.4) — no recombination.
+    read_back="$(cat "'"$marker"'")"
+    if [ "$read_back" = "$DO_WORKSPACE" ] && [ -n "$DO_WORKSPACE" ]; then
+      echo "ROUNDTRIP_OK:$DO_WORKSPACE"
+    else
+      echo "ROUNDTRIP_MISMATCH:write=$DO_WORKSPACE:read=$read_back"
+    fi
+  '
+  rm -f "$marker"
+  if [ "$LAST_EXIT" -eq 0 ] && echo "$LAST_STDOUT" | grep -q "ROUNDTRIP_OK:"; then
+    tap_ok "do_bootstrap roundtrip identical with CLAUDE_SESSION_ID unset"
+  else
+    tap_fail "do_bootstrap roundtrip identical with CLAUDE_SESSION_ID unset" "exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 2: DO_WORKSPACE lives under <real-home>/data and ends in do-<issue>.
+test_do_bootstrap_workspace_under_home_data() {
+  run_in_clean_env '
+    do_bootstrap 2979 || { echo "BOOTSTRAP_FAILED"; exit 1; }
+    echo "WS:$DO_WORKSPACE"
+  '
+  if [ "$LAST_EXIT" -eq 0 ] \
+     && echo "$LAST_STDOUT" | grep -q "WS:$REAL_HOME/data/" \
+     && echo "$LAST_STDOUT" | grep -q "/do-2979"; then
+    tap_ok "do_bootstrap DO_WORKSPACE is under <real-home>/data/.../do-2979"
+  else
+    tap_fail "do_bootstrap DO_WORKSPACE is under <real-home>/data/.../do-2979" "exit=$LAST_EXIT stdout=$LAST_STDOUT real_home=$REAL_HOME"
+  fi
+}
+
+# Test 3: also exports CARGO_TARGET_DIR under the workspace.
+test_do_bootstrap_exports_cargo_target() {
+  run_in_clean_env '
+    do_bootstrap 2979 || { echo "BOOTSTRAP_FAILED"; exit 1; }
+    echo "CT:$CARGO_TARGET_DIR"
+  '
+  if [ "$LAST_EXIT" -eq 0 ] && echo "$LAST_STDOUT" | grep -q "CT:$REAL_HOME/data/" \
+     && echo "$LAST_STDOUT" | grep -q "/do-2979/cargo-target"; then
+    tap_ok "do_bootstrap exports CARGO_TARGET_DIR under workspace"
+  else
+    tap_fail "do_bootstrap exports CARGO_TARGET_DIR under workspace" "exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 4: hostile WORKTREE_BASE outside ~/data is rejected (return 1, no DO_WORKSPACE).
+test_do_bootstrap_rejects_outside_home_data() {
+  run_in_clean_env '
+    type do_bootstrap >/dev/null 2>&1 || { echo "NO_FUNC"; exit 1; }
+    WORKTREE_BASE="/tmp/evil-do-2979"
+    if do_bootstrap 2979; then
+      echo "ACCEPTED_BAD:$DO_WORKSPACE"
+    else
+      echo "REJECTED:DO_WORKSPACE=[${DO_WORKSPACE:-}]"
+    fi
+  '
+  if echo "$LAST_STDOUT" | grep -q "REJECTED:DO_WORKSPACE=\[\]"; then
+    tap_ok "do_bootstrap rejects WORKTREE_BASE outside ~/data and clears DO_WORKSPACE"
+  else
+    tap_fail "do_bootstrap rejects WORKTREE_BASE outside ~/data" "exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 5: hostile ../ traversal escaping ~/data is rejected.
+test_do_bootstrap_rejects_dotdot_traversal() {
+  run_in_clean_env '
+    type do_bootstrap >/dev/null 2>&1 || { echo "NO_FUNC"; exit 1; }
+    WORKTREE_BASE="'"$REAL_HOME"'/data/../../etc/do-2979"
+    if do_bootstrap 2979; then
+      echo "ACCEPTED_BAD:$DO_WORKSPACE"
+    else
+      echo "REJECTED:DO_WORKSPACE=[${DO_WORKSPACE:-}]"
+    fi
+  '
+  if echo "$LAST_STDOUT" | grep -q "REJECTED:DO_WORKSPACE=\[\]"; then
+    tap_ok "do_bootstrap rejects ../ traversal escaping ~/data"
+  else
+    tap_fail "do_bootstrap rejects ../ traversal escaping ~/data" "exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 6: cross-session prefix override (under ~/data but wrong session/issue
+# dir) is rejected by the session-prefix guard.
+test_do_bootstrap_rejects_cross_session_prefix() {
+  run_in_clean_env '
+    type do_bootstrap >/dev/null 2>&1 || { echo "NO_FUNC"; exit 1; }
+    SESSION_ID="sess-a"
+    # Override points under ~/data but at a DIFFERENT session/issue dir.
+    WORKTREE_BASE="'"$REAL_HOME"'/data/sess-b/do-9999"
+    if do_bootstrap 2979; then
+      echo "ACCEPTED_BAD:$DO_WORKSPACE"
+    else
+      echo "REJECTED:DO_WORKSPACE=[${DO_WORKSPACE:-}]"
+    fi
+  '
+  if echo "$LAST_STDOUT" | grep -q "REJECTED:DO_WORKSPACE=\[\]"; then
+    tap_ok "do_bootstrap rejects cross-session prefix override"
+  else
+    tap_fail "do_bootstrap rejects cross-session prefix override" "exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# Test 7: hostile CARGO_TARGET_DIR outside ~/data is rejected.
+test_do_bootstrap_rejects_bad_cargo_target() {
+  run_in_clean_env '
+    type do_bootstrap >/dev/null 2>&1 || { echo "NO_FUNC"; exit 1; }
+    CARGO_TARGET_DIR="/tmp/evil-cargo"
+    if do_bootstrap 2979; then
+      echo "ACCEPTED_BAD:$CARGO_TARGET_DIR"
+    else
+      echo "REJECTED:DO_WORKSPACE=[${DO_WORKSPACE:-}]"
+    fi
+  '
+  if echo "$LAST_STDOUT" | grep -q "REJECTED:DO_WORKSPACE=\[\]"; then
+    tap_ok "do_bootstrap rejects CARGO_TARGET_DIR outside ~/data"
+  else
+    tap_fail "do_bootstrap rejects CARGO_TARGET_DIR outside ~/data" "exit=$LAST_EXIT stdout=$LAST_STDOUT"
+  fi
+}
+
+# ── Runner ───────────────────────────────────────────────────────────────────
+main() {
+  test_do_bootstrap_roundtrip_identical_unset_session
+  test_do_bootstrap_workspace_under_home_data
+  test_do_bootstrap_exports_cargo_target
+  test_do_bootstrap_rejects_outside_home_data
+  test_do_bootstrap_rejects_dotdot_traversal
+  test_do_bootstrap_rejects_cross_session_prefix
+  test_do_bootstrap_rejects_bad_cargo_target
+
+  echo "1..$TAP_CURRENT"
+  for line in "${TAP_OUTPUT[@]}"; do
+    echo "$line"
+  done
+  echo "# tests: $TAP_CURRENT  failures: $TAP_FAILURES"
+  if [ "$TAP_FAILURES" -ne 0 ]; then
+    exit 1
+  fi
+  exit 0
+}
+
+main "$@"

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -1216,6 +1216,93 @@ test_do_bootstrap_default_under_home_data() {
 }
 
 # --------------------------------------------------------------------------
+# Test: do_bootstrap exports DO_WORKSPACE == WORKTREE_BASE (the canonical,
+# ~/data-validated session-workspace dir /review-pr reaps on merge — #2979/#2978)
+# --------------------------------------------------------------------------
+test_do_bootstrap_exports_workspace_alias() {
+  local desc="do_bootstrap exports DO_WORKSPACE == WORKTREE_BASE"
+
+  local output
+  if ! output=$(WORKTREE_BASE="" CARGO_TARGET_DIR="" DO_WORKSPACE="" CLAUDE_SESSION_ID="ws-test" \
+    bash -c "source '$CONTRACT_HELPER' && do_bootstrap 42 && echo \$DO_WORKSPACE && echo \$WORKTREE_BASE" 2>&1); then
+    tap_not_ok "$desc" "do_bootstrap failed: $output"
+    return
+  fi
+  local ws base
+  ws=$(echo "$output" | sed -n '1p')
+  base=$(echo "$output" | sed -n '2p')
+  if [[ -z "$ws" ]]; then
+    tap_not_ok "$desc" "DO_WORKSPACE empty: $output"
+    return
+  fi
+  if [[ "$ws" != "$base" ]]; then
+    tap_not_ok "$desc" "DO_WORKSPACE ('$ws') != WORKTREE_BASE ('$base')"
+    return
+  fi
+  if ! echo "$ws" | grep -q "data/ws-test/do-42"; then
+    tap_not_ok "$desc" "DO_WORKSPACE not under expected session/do dir: $ws"
+    return
+  fi
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: do_bootstrap clears DO_WORKSPACE on a rejected hostile override (no
+# stale workspace path survives to be reaped)
+# --------------------------------------------------------------------------
+test_do_bootstrap_clears_workspace_on_failure() {
+  local desc="do_bootstrap clears DO_WORKSPACE on rejection"
+  local output
+  output=$(WORKTREE_BASE="/tmp/evil-do" DO_WORKSPACE="/tmp/stale-ws" \
+    bash -c "source '$CONTRACT_HELPER'; do_bootstrap 999; echo \"DO_WORKSPACE=\${DO_WORKSPACE:-EMPTY}\"" 2>&1)
+  if echo "$output" | grep -q "DO_WORKSPACE=/tmp/stale-ws"; then
+    tap_not_ok "$desc" "DO_WORKSPACE retained stale value: $output"
+    return
+  fi
+  if ! echo "$output" | grep -q "DO_WORKSPACE=EMPTY"; then
+    tap_not_ok "$desc" "DO_WORKSPACE not cleared on failure: $output"
+    return
+  fi
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: the /do persist + /review-pr reap docs form a single-source-of-truth
+# contract — /do writes the flat ~/data marker from $DO_WORKSPACE, /review-pr
+# reads do-$ISSUE.workspace behind a passwd-home guard, with a legacy fallback.
+# --------------------------------------------------------------------------
+test_workspace_marker_persist_reap_contract() {
+  local desc="do persists DO_WORKSPACE marker; review-pr reaps it under passwd-home guard"
+
+  # /do A.2 must write the flat per-issue marker from the resolved DO_WORKSPACE.
+  if ! grep -q 'DO_WORKSPACE' "$DO_SKILL"; then
+    tap_not_ok "$desc" "do/SKILL.md does not reference DO_WORKSPACE"
+    return
+  fi
+  if ! grep -q 'do-\$ISSUE\.workspace' "$DO_SKILL"; then
+    tap_not_ok "$desc" "do/SKILL.md does not write the flat do-\$ISSUE.workspace marker"
+    return
+  fi
+
+  # /review-pr Step 7.4 must read the same flat marker and guard rm -rf with the
+  # passwd-derived home (getent), NOT $HOME.
+  if ! grep -q 'do-\$ISSUE\.workspace' "$REVIEW_PR_SKILL"; then
+    tap_not_ok "$desc" "review-pr/SKILL.md does not read the flat do-\$ISSUE.workspace marker"
+    return
+  fi
+  if ! grep -q 'getent passwd' "$REVIEW_PR_SKILL"; then
+    tap_not_ok "$desc" "review-pr/SKILL.md reap path does not use passwd-derived home guard"
+    return
+  fi
+  # Legacy fallback for pre-fix /do markers must remain.
+  if ! grep -q '\.session-id' "$REVIEW_PR_SKILL"; then
+    tap_not_ok "$desc" "review-pr/SKILL.md dropped the legacy .session-id fallback"
+    return
+  fi
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
 # Test: /do uses the shared contract helper, not an in-repo worktree
 # --------------------------------------------------------------------------
 test_do_skill_uses_contract_helper_not_repo_tree() {
@@ -1356,6 +1443,9 @@ test_symlinked_home_alias_overrides_are_accepted
 test_poisoned_python_on_path_ignored
 test_do_bootstrap_rejects_hostile_and_sibling_paths
 test_do_bootstrap_default_under_home_data
+test_do_bootstrap_exports_workspace_alias
+test_do_bootstrap_clears_workspace_on_failure
+test_workspace_marker_persist_reap_contract
 test_do_skill_uses_contract_helper_not_repo_tree
 test_skill_prompts_forbid_known_leak_patterns
 test_assert_no_repo_tree_scratch_detects_leak_dirs


### PR DESCRIPTION
Closes #2979
Closes #2978

## Summary

Collapses the three independent session-workspace path derivations (`/do` A.2, the contract helper, `/review-pr` Step 7.4) into one producer. `do_bootstrap` now exports `DO_WORKSPACE` — the canonical, `~/data`-validated, canonicalized absolute session-workspace dir (`== WORKTREE_BASE`). `/do` persists that exact string; `/review-pr` reads and `rm -rf`s it verbatim. No component is recombined downstream, so the write path and the read path can no longer diverge regardless of `CLAUDE_SESSION_ID` state or `$HOME` poisoning — closing both #2979 (write divergence) and #2978 (stale read-path) at their shared root.

- `scripts/lib/agent-worktree-contract.sh` — `do_bootstrap` exports `DO_WORKSPACE` (alias of the validated `WORKTREE_BASE`); cleared on any rejection alongside the other derived vars.
- `.github/skills/do/SKILL.md` (A.2) — after `do_bootstrap` succeeds, persists `$DO_WORKSPACE` to a flat, session-independent marker `<real-home>/data/do-$ISSUE.workspace` (passwd-derived home, written only on success).
- `.github/skills/review-pr/SKILL.md` (Step 7.4) — reads that marker and reaps it verbatim behind a passwd-home (`getent`, not `$HOME`) `~/data` boundary guard, with a legacy `.session-id` fallback for in-flight PRs opened by the pre-fix `/do`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2979#issuecomment-4614482293)

## Test plan

- [x] `scripts/test-agent-worktree-contract.sh` — 31/31 pass (adds DO_WORKSPACE export, clear-on-failure, and persist/reap-contract doc assertions)
- [x] `scripts/lib/tests/test-do-bootstrap.bats` — 7/7 pass (new; wired into the `agent-worktree-contract` CI job)
- [x] `shellcheck` clean on the contract helper and harness (only pre-existing SC1090 + intentional SC2016 info)
- [x] pre-commit fmt + clippy green

## Regression test

- **Test:** `scripts/lib/tests/test-do-bootstrap.bats::do_bootstrap roundtrip identical with CLAUDE_SESSION_ID unset` (+ `DO_WORKSPACE under ~/data`)
- **Pre-fix:** committed as `784bcde5` — verified FAILED on `origin/main` with `DO_WORKSPACE: unbound variable` (helper exported no workspace alias, so the write→read round-trip could target a divergent dir).
- **Post-fix:** verified PASSES after `c7f52983`.

## Deviations from plan

- **Marker location.** The plan specified writing the marker at `$REPO_ROOT/data/do-$ISSUE/.session-id-path` (repo tree). Since the plan was drafted, #2843 landed a CI guard (`scripts/test-agent-worktree-contract.sh`) that forbids any `$REPO_ROOT/data/do-` reference in `do/SKILL.md` — all `/do` scratch must live under `~/data`. To honor both that contract and the plan's single-source-of-truth intent, the marker is instead a flat, session-independent file `<real-home>/data/do-$ISSUE.workspace` under `~/data`. This is session-independent (so `/review-pr`, a different session, can locate it) and keeps the plan's core guarantee — persist the fully-resolved absolute path, read it verbatim — fully intact. The legacy `.session-id` fallback is preserved as the plan requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)