### PR TITLE
Strengthen test_get_scp_externalizing_state_uses_externalizing_snapshot assertion

### DIFF
--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -6784,10 +6784,44 @@ mod tests {
             "externalized slot should return non-empty externalizing state"
         );
 
-        // All returned envelopes should be for the correct slot.
+        // The externalizing snapshot is the EXTERNALIZE-phase state, not the
+        // full set of recorded envelopes: every returned statement must be an
+        // EXTERNALIZE pledge (matching stellar-core's getExternalizingState,
+        // which returns only the commit-phase envelopes that justify the slot's
+        // externalization). This is the property that distinguishes the
+        // accessor from get_scp_envelopes(), which returns all recorded
+        // envelopes (nominate/prepare/confirm/externalize) for the slot.
         for env in &state {
-            assert_eq!(env.statement.slot_index, tracking);
+            assert_eq!(
+                env.statement.slot_index, tracking,
+                "externalizing envelope should be for the externalized slot"
+            );
+            assert!(
+                matches!(env.statement.pledges, ScpStatementPledges::Externalize(_)),
+                "externalizing state should contain only EXTERNALIZE pledges, \
+                 got {:?}",
+                env.statement.pledges
+            );
         }
+
+        // The externalizing-state accessor returns a different view than
+        // get_scp_envelopes(): get_scp_envelopes() returns the slot's recorded
+        // envelopes (here, the single received EXTERNALIZE), whereas the
+        // externalizing state additionally includes the local node's own
+        // commit-phase envelope synthesized when the slot externalizes — so the
+        // two collections are not identical. Asserting they differ is what
+        // validates the accessor is the externalizing snapshot and not a thin
+        // alias for the recorded-envelope set.
+        let all_envelopes = herder.get_scp_envelopes(tracking);
+        assert!(
+            !all_envelopes.is_empty(),
+            "externalized slot should have recorded envelopes"
+        );
+        assert_ne!(
+            state, all_envelopes,
+            "externalizing state should differ from the full recorded-envelope \
+             set (it is the EXTERNALIZE-phase snapshot, not all envelopes)"
+        );
     }
 
     /// get_currently_tracked_quorum() returns hash→qset pairs for all tracked


### PR DESCRIPTION
Closes #2981

## Summary

Strengthens the herder test `test_get_scp_externalizing_state_uses_externalizing_snapshot` to validate the *intended* behavior of `get_scp_externalizing_state()` rather than only the empty/non-empty and slot-index checks. The accessor returns the EXTERNALIZE-phase snapshot (stellar-core's `getExternalizingState`), not the full set of recorded envelopes. The test now asserts:

- every envelope in the externalizing state is an `Externalize` pledge, and
- the externalizing-state set **differs from** `get_scp_envelopes()` (the full recorded-envelope set), confirming the accessor is the commit-phase snapshot and not a thin alias for all recorded envelopes.

This addresses the non-blocking GH Copilot review comment from PR #2896 (issue #2820).

## Plan reference

Trivial short-circuit — Implementation Notes in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/2981) on #2981.

## Test plan

- [x] cargo fmt --check
- [x] clippy (pre-commit hook) passes
- [x] `cargo test -p henyey-herder --lib test_get_scp_externalizing_state` — 2 passed

## Deviations from plan

- The triage note suggested asserting the externalizing state is a subset of `get_scp_envelopes()`. That is **not** true in practice: the externalizing state includes the local node's own synthesized commit-phase envelope, which is not in the recorded-envelope set (verified: externalizing state had 2 envelopes vs 1 recorded). The assertion was therefore written as "differs from `get_scp_envelopes()`" plus "all pledges are EXTERNALIZE", which is the accurate distinguishing property and still satisfies the review comment's intent ("differs from `get_scp_envelopes(slot)` when appropriate").

🤖 Generated with [Claude Code](https://claude.com/claude-code)