### PR TITLE
Restore NotStarted guard to request_scp_state

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -12457,6 +12457,10 @@ mod tests {
         let mut rx1 = overlay.inject_test_peer(peer1, 64);
         let mut rx2 = overlay.inject_test_peer(peer2, 64);
         let mut rx3 = overlay.inject_test_peer(peer3, 64);
+        // Mark the manager started so request_scp_state passes the NotStarted
+        // guard restored in #2980; otherwise the bounded pull bails early and
+        // no peers receive GetScpState.
+        overlay.set_running_for_test();
         *app.overlay.write().await = Some(Arc::new(overlay));
 
         // Record timestamp before the request.

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -4349,6 +4349,28 @@ mod tests {
 
     // ──────── request_scp_state §15.3 parity tests ────────
 
+    /// Regression test for #2980: request_scp_state must return
+    /// Err(NotStarted) when the overlay has not been started, matching the
+    /// guard on broadcast()/connect() and stellar-core's shutdown guard,
+    /// instead of silently returning Ok(0) (which is indistinguishable from
+    /// "started, no peers").
+    #[test]
+    fn test_request_scp_state_returns_not_started_when_not_started() {
+        let config = OverlayConfig::default();
+        let secret = SecretKey::generate();
+        let local_node = LocalNode::new_testnet(secret);
+
+        // new() leaves running=false; the manager is never started.
+        let manager = OverlayManager::new(config, local_node).unwrap();
+
+        let result = manager.request_scp_state(42);
+        assert!(
+            matches!(result, Err(OverlayError::NotStarted)),
+            "request_scp_state should return Err(NotStarted) before start, got {:?}",
+            result
+        );
+    }
+
     #[tokio::test]
     async fn test_request_scp_state_with_single_peer_sends_once() {
         let config = OverlayConfig::default();

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -1733,6 +1733,10 @@ impl OverlayManager {
     pub fn request_scp_state(&self, ledger_seq: u32) -> Result<usize> {
         use rand::seq::SliceRandom;
 
+        if !self.running.load(Ordering::Relaxed) {
+            return Err(OverlayError::NotStarted);
+        }
+
         let message = StellarMessage::GetScpState(ledger_seq);
         let peers = self.connected_peers();
         if peers.is_empty() {
@@ -4378,6 +4382,9 @@ mod tests {
         let local_node = LocalNode::new_testnet(secret);
 
         let manager = OverlayManager::new(config, local_node).unwrap();
+        // Mark the manager started so request_scp_state passes the NotStarted
+        // guard (see #2980).
+        manager.running.store(true, Ordering::Relaxed);
 
         let peer_id = PeerId::from_bytes([42u8; 32]);
         let mut rx = insert_peer_with_capacity(&manager, peer_id, 16);
@@ -4401,6 +4408,9 @@ mod tests {
         let local_node = LocalNode::new_testnet(secret);
 
         let manager = OverlayManager::new(config, local_node).unwrap();
+        // Mark the manager started; started-but-no-peers must still yield 0
+        // (distinct from the NotStarted error path, see #2980).
+        manager.running.store(true, Ordering::Relaxed);
 
         let sent = manager.request_scp_state(100).unwrap();
         assert_eq!(sent, 0, "should return 0 when no peers connected");


### PR DESCRIPTION
Closes #2980

## Summary

`OverlayManager::request_scp_state()` was missing the `self.running` guard that every sibling send/connect API (`broadcast()`, `connect()`) opens with, so it silently returned `Ok(0)` when the overlay was not started or shutting down — indistinguishable from "started, no peers." This prepends the same guard, returning `Err(OverlayError::NotStarted)` in those states, restoring parity with stellar-core's shutdown guard and henyey's own overlay APIs.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2980#issuecomment-4614586475)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-overlay passes (462 tests, 0 failures)

## Regression test (kind: bug-fix)

- **Test:** `crates/overlay/src/manager/mod.rs::test_request_scp_state_returns_not_started_when_not_started`
- **Pre-fix:** committed as `68b9ac89` — verified FAILED with: `request_scp_state should return Err(NotStarted) before start, got Ok(0)`
- **Post-fix:** verified PASSES after `62a20d7c`

Two existing tests (`test_request_scp_state_with_single_peer_sends_once`, `test_request_scp_state_with_zero_peers_returns_zero`) build an unstarted manager and were implicitly relying on the missing guard; both updated to mark the manager started before the call and still assert `Ok(1)`/`Ok(0)`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)