### PR TITLE
Implement ConservationOfLumens invariant

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -1199,6 +1199,9 @@ impl App {
             inv_mgr.register(std::sync::Arc::new(
                 henyey_invariant::SponsorshipCountIsValid,
             ));
+            inv_mgr.register(std::sync::Arc::new(
+                henyey_invariant::ConservationOfLumens::new(),
+            ));
             // Enable invariants matching configured patterns.
             for pattern in &config.invariants.checks {
                 inv_mgr.enable(pattern).unwrap_or_else(|e| {

--- a/crates/invariant/PARITY_STATUS.md
+++ b/crates/invariant/PARITY_STATUS.md
@@ -22,7 +22,7 @@ integrity checks during ledger close.
 | AccountSubEntriesCountIsValid | ✅ | ✅ | No | Pool share trustlines count as 2 |
 | LedgerEntryIsValid | ✅ | ⚠️ Partial | No | Missing: Soroban entries, asset validity, claim predicates |
 | SponsorshipCountIsValid | ✅ | ✅ | No | Full sponsorship accounting |
-| ConservationOfLumens | ✅ | ❌ | No | Deferred (needs header access) |
+| ConservationOfLumens | ✅ | ⚠️ Partial | No | Per-op native-XLM conservation; SAC ContractData balances not counted (#2987); `checkSnapshot` bucket-scan out of scope |
 | LiabilitiesMatchOffers | ✅ | ❌ | No | Deferred |
 | BucketListIsConsistentWithDatabase | ✅ | ❌ | Yes | Deferred (bucket-apply hook) |
 | BucketListStateConsistency | ✅ | ❌ | Yes | Deferred (snapshot hook) |

--- a/crates/invariant/src/conservation.rs
+++ b/crates/invariant/src/conservation.rs
@@ -1,0 +1,211 @@
+//! ConservationOfLumens invariant.
+//!
+//! Verifies that native XLM is conserved across each operation apply: the sum
+//! of per-entry native-balance deltas (`deltaBalances`), the change in the
+//! ledger header's `totalCoins` (`deltaTotalCoins`), and the change in `feePool`
+//! (`deltaFeePool`) must satisfy the conservation equation.
+//!
+//! In the no-inflation case (the only live case for protocol 24+, where
+//! inflation is removed and always returns `NotTime`/empty payouts) all three
+//! deltas must be zero. The inflation branch is retained for parity with
+//! stellar-core but is dead in henyey.
+//!
+//! # Native-balance-bearing entry types
+//!
+//! Per stellar-core's `getAssetBalance(le, ASSET_TYPE_NATIVE, ...)`
+//! (`TransactionUtils.cpp:2032`) / `canHoldAsset(type, NATIVE)`:
+//!
+//! - `Account.balance` — always native.
+//! - `ClaimableBalance.amount` — only when its `asset` is native.
+//! - `LiquidityPool` constant-product `reserveA`/`reserveB` — for whichever leg
+//!   is the native asset.
+//!
+//! `ContractData` (Stellar Asset Contract native balances) is NOT counted in
+//! this implementation. An Account↔Contract native SAC transfer would show a
+//! non-zero Account-side delta with the offsetting `ContractData` credit
+//! uncounted, producing a spurious violation (a **false alarm**, not a missed
+//! imbalance). Because this invariant is non-strict, that is log noise rather
+//! than a crash. Counting SAC `ContractData` native balances is tracked as a
+//! follow-up in #2987.
+//!
+//! # Parity
+//!
+//! stellar-core reference: `src/invariant/ConservationOfLumens.cpp`
+//! (per-operation `checkOnOperationApply`; the bucket-list `checkSnapshot`
+//! scan is out of scope — henyey's `Invariant` trait only exposes the per-op
+//! hook). Strictness: non-strict (`Invariant(false)`).
+
+use stellar_xdr::curr::{
+    Asset, ContractEvent, LedgerEntry, LedgerEntryData, LiquidityPoolEntryBody, Operation,
+    OperationResult, OperationResultTr,
+};
+
+use crate::{Invariant, OperationDelta};
+
+/// The `ConservationOfLumens` invariant.
+pub struct ConservationOfLumens;
+
+impl ConservationOfLumens {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ConservationOfLumens {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns the native-XLM balance held by a single ledger entry, or `None` if
+/// the entry holds no native balance (the asset doesn't match / not a
+/// balance-bearing type).
+///
+/// Mirrors `getAssetBalance(le, Asset(ASSET_TYPE_NATIVE), lumenContractInfo)`
+/// for the native asset, excluding the SAC `ContractData` case (see module
+/// docs / #2987).
+fn native_balance(entry: &LedgerEntry) -> Option<i64> {
+    match &entry.data {
+        LedgerEntryData::Account(acc) => Some(acc.balance),
+        LedgerEntryData::ClaimableBalance(cb) => {
+            matches!(cb.asset, Asset::Native).then_some(cb.amount)
+        }
+        LedgerEntryData::LiquidityPool(lp) => {
+            let LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) = &lp.body;
+            if matches!(cp.params.asset_a, Asset::Native) {
+                Some(cp.reserve_a)
+            } else if matches!(cp.params.asset_b, Asset::Native) {
+                Some(cp.reserve_b)
+            } else {
+                None
+            }
+        }
+        // Trustlines never hold the native asset; offers/data/contract code/
+        // config/TTL hold no asset balance. ContractData (SAC) deferred to #2987.
+        _ => None,
+    }
+}
+
+/// Computes the native-balance delta for a single changed entry:
+/// `native_balance(current) - native_balance(previous)`, treating a missing
+/// entry as contributing 0.
+///
+/// Mirrors stellar-core's `calculateDeltaBalance`. Both inputs cannot be
+/// `None` (every changed entry has at least one side); the caller guarantees
+/// this.
+fn calculate_delta_balance(current: Option<&LedgerEntry>, previous: Option<&LedgerEntry>) -> i64 {
+    let cur = current.and_then(native_balance).unwrap_or(0);
+    let prev = previous.and_then(native_balance).unwrap_or(0);
+    cur - prev
+}
+
+impl Invariant for ConservationOfLumens {
+    fn name(&self) -> &str {
+        "ConservationOfLumens"
+    }
+
+    fn is_strict(&self) -> bool {
+        false
+    }
+
+    fn check_on_operation_apply(
+        &self,
+        _operation: &Operation,
+        op_result: &OperationResult,
+        delta: &OperationDelta<'_>,
+        _events: &[ContractEvent],
+    ) -> Result<(), String> {
+        // Accumulate the native-balance delta across every changed entry, with
+        // checked arithmetic mirroring stellar-core's explicit overflow /
+        // underflow guards.
+        let mut delta_balances: i64 = 0;
+
+        let mut accumulate = |d: i64| -> Result<(), String> {
+            // Overflow: positive d pushing past i64::MAX.
+            if d > 0 && delta_balances > i64::MAX - d {
+                return Err("Overflow detected when adding to deltaBalances".to_string());
+            }
+            // Underflow: negative d pushing past i64::MIN.
+            if d < 0 && delta_balances < i64::MIN - d {
+                return Err("Underflow detected when adding to deltaBalances".to_string());
+            }
+            delta_balances += d;
+            Ok(())
+        };
+
+        // Created: (current = Some, previous = None).
+        for entry in delta.created {
+            accumulate(calculate_delta_balance(Some(entry), None))?;
+        }
+        // Updated: (current, previous) pairs.
+        for (current, previous) in delta.updated.iter().zip(delta.update_states.iter()) {
+            accumulate(calculate_delta_balance(Some(current), Some(previous)))?;
+        }
+        // Deleted: (current = None, previous = Some).
+        for previous in delta.delete_states {
+            accumulate(calculate_delta_balance(None, Some(previous)))?;
+        }
+
+        // Header deltas. If either header is missing, skip the header-delta
+        // checks and treat both as 0 (see module docs / OperationDelta).
+        let (delta_total_coins, delta_fee_pool, headers_present) =
+            match (delta.header_current, delta.header_previous) {
+                (Some(curr), Some(prev)) => (
+                    curr.total_coins - prev.total_coins,
+                    curr.fee_pool - prev.fee_pool,
+                    true,
+                ),
+                _ => (0, 0, false),
+            };
+
+        let is_inflation = matches!(
+            op_result,
+            OperationResult::OpInner(OperationResultTr::Inflation(_))
+        );
+
+        if is_inflation {
+            // Retained for parity; dead in 24+ (inflation always NotTime/empty).
+            let inflation_payouts: i64 = match op_result {
+                OperationResult::OpInner(OperationResultTr::Inflation(
+                    stellar_xdr::curr::InflationResult::Success(payouts),
+                )) => payouts.iter().map(|p| p.amount).sum(),
+                _ => 0,
+            };
+
+            if headers_present && delta_total_coins != inflation_payouts + delta_fee_pool {
+                return Err(format!(
+                    "LedgerHeader totalCoins change ({}) did not match feePool change ({}) \
+                     plus inflation payouts ({})",
+                    delta_total_coins, delta_fee_pool, inflation_payouts
+                ));
+            }
+            if delta_balances != inflation_payouts {
+                return Err(format!(
+                    "LedgerEntry account balances change ({}) did not match inflation payouts ({})",
+                    delta_balances, inflation_payouts
+                ));
+            }
+        } else {
+            if headers_present && delta_total_coins != 0 {
+                return Err(format!(
+                    "LedgerHeader totalCoins changed by {} without inflation",
+                    delta_total_coins
+                ));
+            }
+            if headers_present && delta_fee_pool != 0 {
+                return Err(format!(
+                    "LedgerHeader feePool changed by {} without inflation",
+                    delta_fee_pool
+                ));
+            }
+            if delta_balances != 0 {
+                return Err(format!(
+                    "LedgerEntry account balances changed by {} without inflation",
+                    delta_balances
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/invariant/src/lib.rs
+++ b/crates/invariant/src/lib.rs
@@ -11,10 +11,12 @@
 //! - All invariants use `Invariant(false)` (non-strict) unless otherwise noted.
 //! - Strict invariants panic on failure; non-strict invariants log and continue.
 
+mod conservation;
 mod entry_valid;
 mod sponsorship;
 mod sub_entries;
 
+pub use conservation::ConservationOfLumens;
 pub use entry_valid::LedgerEntryIsValid;
 pub use sponsorship::SponsorshipCountIsValid;
 pub use sub_entries::AccountSubEntriesCountIsValid;
@@ -52,10 +54,12 @@ pub struct OperationDelta<'a> {
     /// Current protocol version.
     pub ledger_version: u32,
     /// Current ledger header (after this operation's header mutations).
-    /// `None` until ConservationOfLumens invariant is implemented.
+    /// Consumed by [`ConservationOfLumens`] for the `totalCoins`/`feePool`
+    /// delta checks. `None` callers skip those header-delta checks (the
+    /// `deltaBalances` portion is still evaluated).
     pub header_current: Option<&'a LedgerHeader>,
     /// Previous ledger header (before this ledger's transactions).
-    /// `None` until ConservationOfLumens invariant is implemented.
+    /// See [`Self::header_current`]; `None` skips the header-delta checks.
     pub header_previous: Option<&'a LedgerHeader>,
     /// Network ID (SHA-256 of passphrase).
     pub network_id: &'a [u8; 32],

--- a/crates/invariant/tests/conservation.rs
+++ b/crates/invariant/tests/conservation.rs
@@ -1,0 +1,387 @@
+//! Integration tests for the `ConservationOfLumens` invariant.
+//!
+//! Verifies the per-operation native-XLM conservation equation:
+//! `deltaBalances == 0` (no-inflation branch, the only live branch in 24+),
+//! and the header-delta checks (`deltaTotalCoins == 0`, `deltaFeePool == 0`).
+//!
+//! Parity: `src/invariant/ConservationOfLumens.cpp` no-inflation branch.
+
+use std::sync::Arc;
+
+use henyey_invariant::{ConservationOfLumens, Invariant, InvariantManager, OperationDelta};
+use stellar_xdr::curr::{
+    AccountEntry, AccountEntryExt, AccountId, AlphaNum4, Asset, AssetCode4, ClaimPredicate,
+    ClaimableBalanceEntry, ClaimableBalanceEntryExt, ClaimableBalanceId, Claimant, ClaimantV0,
+    Hash, InflationResult, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerHeader,
+    LedgerHeaderExt, LiquidityPoolConstantProductParameters, LiquidityPoolEntry,
+    LiquidityPoolEntryBody, LiquidityPoolEntryConstantProduct, Operation, OperationBody,
+    OperationResult, OperationResultTr, PoolId, PublicKey, SequenceNumber, StellarValue,
+    StellarValueExt, String32, Thresholds, TimePoint, Uint256, VecM,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn account_id(seed: u8) -> AccountId {
+    AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([seed; 32])))
+}
+
+fn account_entry(seed: u8, balance: i64) -> LedgerEntry {
+    LedgerEntry {
+        last_modified_ledger_seq: 1,
+        data: LedgerEntryData::Account(AccountEntry {
+            account_id: account_id(seed),
+            balance,
+            seq_num: SequenceNumber(0),
+            num_sub_entries: 0,
+            inflation_dest: None,
+            flags: 0,
+            home_domain: String32::default(),
+            thresholds: Thresholds([1, 0, 0, 0]),
+            signers: VecM::default(),
+            ext: AccountEntryExt::V0,
+        }),
+        ext: LedgerEntryExt::V0,
+    }
+}
+
+fn claimable_balance_entry(seed: u8, asset: Asset, amount: i64) -> LedgerEntry {
+    LedgerEntry {
+        last_modified_ledger_seq: 1,
+        data: LedgerEntryData::ClaimableBalance(ClaimableBalanceEntry {
+            balance_id: ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash([seed; 32])),
+            claimants: vec![Claimant::ClaimantTypeV0(ClaimantV0 {
+                destination: account_id(99),
+                predicate: ClaimPredicate::Unconditional,
+            })]
+            .try_into()
+            .unwrap(),
+            asset,
+            amount,
+            ext: ClaimableBalanceEntryExt::V0,
+        }),
+        ext: LedgerEntryExt::V0,
+    }
+}
+
+fn liquidity_pool_entry(
+    seed: u8,
+    native_leg_a: bool,
+    reserve_a: i64,
+    reserve_b: i64,
+) -> LedgerEntry {
+    let usd = Asset::CreditAlphanum4(AlphaNum4 {
+        asset_code: AssetCode4(*b"USD\0"),
+        issuer: account_id(1),
+    });
+    let (asset_a, asset_b) = if native_leg_a {
+        (Asset::Native, usd)
+    } else {
+        (usd, Asset::Native)
+    };
+    LedgerEntry {
+        last_modified_ledger_seq: 1,
+        data: LedgerEntryData::LiquidityPool(LiquidityPoolEntry {
+            liquidity_pool_id: PoolId(Hash([seed; 32])),
+            body: LiquidityPoolEntryBody::LiquidityPoolConstantProduct(
+                LiquidityPoolEntryConstantProduct {
+                    params: LiquidityPoolConstantProductParameters {
+                        asset_a,
+                        asset_b,
+                        fee: 30,
+                    },
+                    reserve_a,
+                    reserve_b,
+                    total_pool_shares: 1000,
+                    pool_shares_trust_line_count: 1,
+                },
+            ),
+        }),
+        ext: LedgerEntryExt::V0,
+    }
+}
+
+fn header(total_coins: i64, fee_pool: i64) -> LedgerHeader {
+    LedgerHeader {
+        ledger_version: 24,
+        previous_ledger_hash: Hash([0; 32]),
+        scp_value: StellarValue {
+            tx_set_hash: Hash([0; 32]),
+            close_time: TimePoint(0),
+            upgrades: VecM::default(),
+            ext: StellarValueExt::Basic,
+        },
+        tx_set_result_hash: Hash([0; 32]),
+        bucket_list_hash: Hash([0; 32]),
+        ledger_seq: 100,
+        total_coins,
+        fee_pool,
+        inflation_seq: 0,
+        id_pool: 0,
+        base_fee: 100,
+        base_reserve: 5_000_000,
+        max_tx_set_size: 1000,
+        skip_list: [Hash([0; 32]), Hash([0; 32]), Hash([0; 32]), Hash([0; 32])],
+        ext: LedgerHeaderExt::V0,
+    }
+}
+
+fn dummy_op() -> Operation {
+    Operation {
+        source_account: None,
+        body: OperationBody::Inflation,
+    }
+}
+
+/// A non-inflation op result (Payment success) so the no-inflation branch runs.
+fn payment_result() -> OperationResult {
+    use stellar_xdr::curr::PaymentResult;
+    OperationResult::OpInner(OperationResultTr::Payment(PaymentResult::Success))
+}
+
+fn inflation_result(payouts: Vec<(u8, i64)>) -> OperationResult {
+    use stellar_xdr::curr::InflationPayout;
+    let payouts: VecM<InflationPayout> = payouts
+        .into_iter()
+        .map(|(seed, amount)| InflationPayout {
+            destination: account_id(seed),
+            amount,
+        })
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    OperationResult::OpInner(OperationResultTr::Inflation(InflationResult::Success(
+        payouts,
+    )))
+}
+
+struct DeltaBuilder {
+    created: Vec<LedgerEntry>,
+    updated: Vec<LedgerEntry>,
+    update_states: Vec<LedgerEntry>,
+    delete_states: Vec<LedgerEntry>,
+}
+
+impl DeltaBuilder {
+    fn new() -> Self {
+        Self {
+            created: vec![],
+            updated: vec![],
+            update_states: vec![],
+            delete_states: vec![],
+        }
+    }
+    fn created(mut self, e: LedgerEntry) -> Self {
+        self.created.push(e);
+        self
+    }
+    fn updated(mut self, prev: LedgerEntry, cur: LedgerEntry) -> Self {
+        self.update_states.push(prev);
+        self.updated.push(cur);
+        self
+    }
+    fn deleted(mut self, prev: LedgerEntry) -> Self {
+        self.delete_states.push(prev);
+        self
+    }
+
+    fn check(
+        &self,
+        inv: &ConservationOfLumens,
+        op_result: &OperationResult,
+        header_current: Option<&LedgerHeader>,
+        header_previous: Option<&LedgerHeader>,
+    ) -> Result<(), String> {
+        let network_id = [0u8; 32];
+        let deleted_keys: Vec<stellar_xdr::curr::LedgerKey> = vec![]; // not read by invariant
+        let delta = OperationDelta {
+            created: &self.created,
+            updated: &self.updated,
+            update_states: &self.update_states,
+            deleted: &deleted_keys,
+            delete_states: &self.delete_states,
+            ledger_seq: 100,
+            ledger_version: 24,
+            header_current,
+            header_previous,
+            network_id: &network_id,
+        };
+        inv.check_on_operation_apply(&dummy_op(), op_result, &delta, &[])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Regression canary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_conservation_fails_on_minted_lumens() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    // Single account whose native balance grows by 500 with no offset → minted lumens.
+    let res = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 1500))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    let err = res.expect_err("minted lumens must violate ConservationOfLumens");
+    assert!(
+        err.contains("balances changed"),
+        "unexpected message: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// New coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_conservation_holds_on_balanced_transfer() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    // Account 2 loses 500, account 3 gains 500 → net zero.
+    let res = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 500))
+        .updated(account_entry(3, 2000), account_entry(3, 2500))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(res.is_ok(), "balanced transfer should hold: {res:?}");
+}
+
+#[test]
+fn test_conservation_claimable_balance_native() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    // Balanced: account debited 700, native claimable balance created with 700.
+    let ok = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 300))
+        .created(claimable_balance_entry(5, Asset::Native, 700))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(ok.is_ok(), "balanced CB create should hold: {ok:?}");
+
+    // Unbalanced: CB created with 700 but account only debited 100.
+    let bad = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 900))
+        .created(claimable_balance_entry(5, Asset::Native, 700))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(bad.is_err(), "unbalanced CB create should fail");
+
+    // Non-native claimable balance must be ignored (only the account debit counts → fails).
+    let usd = Asset::CreditAlphanum4(AlphaNum4 {
+        asset_code: AssetCode4(*b"USD\0"),
+        issuer: account_id(1),
+    });
+    let non_native = DeltaBuilder::new()
+        .created(claimable_balance_entry(5, usd, 700))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        non_native.is_ok(),
+        "non-native CB carries no native delta: {non_native:?}"
+    );
+}
+
+#[test]
+fn test_conservation_liquidity_pool_native_leg() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    // LP native reserve (leg A) grows by 400, matched by an account debit of 400.
+    let ok = DeltaBuilder::new()
+        .updated(
+            liquidity_pool_entry(7, true, 1000, 2000),
+            liquidity_pool_entry(7, true, 1400, 2000),
+        )
+        .updated(account_entry(2, 1000), account_entry(2, 600))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        ok.is_ok(),
+        "balanced LP native-leg change should hold: {ok:?}"
+    );
+
+    // Native leg B variant: change in reserve_b counts when asset_b is native.
+    let ok_b = DeltaBuilder::new()
+        .updated(
+            liquidity_pool_entry(8, false, 2000, 1000),
+            liquidity_pool_entry(8, false, 2000, 1400),
+        )
+        .updated(account_entry(2, 1000), account_entry(2, 600))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        ok_b.is_ok(),
+        "balanced LP native-leg-B change should hold: {ok_b:?}"
+    );
+
+    // Unbalanced LP change → fails.
+    let bad = DeltaBuilder::new()
+        .updated(
+            liquidity_pool_entry(7, true, 1000, 2000),
+            liquidity_pool_entry(7, true, 1400, 2000),
+        )
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(bad.is_err(), "unmatched LP native-leg change should fail");
+}
+
+#[test]
+fn test_conservation_overflow_detected() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    // Two created native balances each near i64::MAX → overflow accumulating positive deltas.
+    let res = DeltaBuilder::new()
+        .created(account_entry(2, i64::MAX))
+        .created(account_entry(3, i64::MAX))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    let err = res.expect_err("overflowing deltaBalances must fail");
+    assert!(err.contains("Overflow"), "unexpected message: {err}");
+}
+
+#[test]
+fn test_conservation_none_header_skips_header_checks() {
+    let inv = ConservationOfLumens::new();
+    // header_current = None: header-delta checks skipped, only deltaBalances evaluated.
+    // Balanced balances → Ok despite missing headers.
+    let res = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 500))
+        .updated(account_entry(3, 2000), account_entry(3, 2500))
+        .check(&inv, &payment_result(), None, None);
+    assert!(
+        res.is_ok(),
+        "None headers + balanced balances should hold: {res:?}"
+    );
+
+    // But an imbalance still fires even with None headers.
+    let bad = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 1500))
+        .check(&inv, &payment_result(), None, None);
+    assert!(
+        bad.is_err(),
+        "None headers must not suppress balance imbalance"
+    );
+}
+
+#[test]
+fn test_conservation_inflation_branch_balanced() {
+    // Dead-but-retained inflation branch: totalCoins grows by exactly the payout sum,
+    // feePool unchanged, and account balances grow by the same payout sum.
+    let inv = ConservationOfLumens::new();
+    let prev = header(1_000_000, 0);
+    let curr = header(1_000_300, 0); // +300 total coins
+    let res = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 1300)) // +300 balance
+        .check(
+            &inv,
+            &inflation_result(vec![(2, 300)]),
+            Some(&curr),
+            Some(&prev),
+        );
+    assert!(res.is_ok(), "balanced inflation should hold: {res:?}");
+}
+
+#[test]
+fn test_conservation_manager_registers_and_enables() {
+    let mut mgr = InvariantManager::new();
+    mgr.register(Arc::new(ConservationOfLumens::new()));
+    mgr.enable("ConservationOfLumens").unwrap();
+    assert_eq!(mgr.get_enabled_invariants(), vec!["ConservationOfLumens"]);
+
+    let mut mgr2 = InvariantManager::new();
+    mgr2.register(Arc::new(ConservationOfLumens::new()));
+    mgr2.enable(".*").unwrap();
+    assert_eq!(mgr2.get_enabled_invariants(), vec!["ConservationOfLumens"]);
+}

--- a/crates/invariant/tests/conservation.rs
+++ b/crates/invariant/tests/conservation.rs
@@ -235,6 +235,25 @@ fn test_conservation_fails_on_minted_lumens() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_conservation_holds_on_balanced_delete_and_credit() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    // A native claimable balance of 700 is deleted (claimed); the destination
+    // account is credited 700 → net zero.
+    let res = DeltaBuilder::new()
+        .deleted(claimable_balance_entry(5, Asset::Native, 700))
+        .updated(account_entry(3, 1000), account_entry(3, 1700))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(res.is_ok(), "balanced delete+credit should hold: {res:?}");
+
+    // Deleting the native CB without crediting anyone → lumens vanish → fails.
+    let bad = DeltaBuilder::new()
+        .deleted(claimable_balance_entry(5, Asset::Native, 700))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(bad.is_err(), "unmatched CB delete should fail");
+}
+
+#[test]
 fn test_conservation_holds_on_balanced_transfer() {
     let inv = ConservationOfLumens::new();
     let h = header(1_000_000, 0);

--- a/crates/ledger/src/execution/apply.rs
+++ b/crates/ledger/src/execution/apply.rs
@@ -444,6 +444,45 @@ pub(super) fn collect_soroban_restored_entries(
 }
 
 impl TransactionExecutor {
+    /// Build an op-scoped [`stellar_xdr::curr::LedgerHeader`] used as both the
+    /// `current` and `previous` header for `ConservationOfLumens`.
+    ///
+    /// Only `total_coins`/`fee_pool` are read by the invariant, and it reads
+    /// only their *delta* between current and previous. Because the same header
+    /// value is passed for both sides, that delta is always 0 — which is correct
+    /// for henyey: no operation mutates `totalCoins`/`feePool` within op scope
+    /// (inflation is unsupported in 24+ and always returns `NotTime`/empty
+    /// payouts; fee-pool changes are applied at tx-set level via
+    /// `record_fee_pool_delta`, outside the per-op delta). The concrete field
+    /// values are therefore irrelevant; we emit a minimal header.
+    fn op_scoped_header(&self) -> stellar_xdr::curr::LedgerHeader {
+        use stellar_xdr::curr::{
+            Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint,
+        };
+        LedgerHeader {
+            ledger_version: self.protocol_version,
+            previous_ledger_hash: Hash([0; 32]),
+            scp_value: StellarValue {
+                tx_set_hash: Hash([0; 32]),
+                close_time: TimePoint(self.close_time),
+                upgrades: Default::default(),
+                ext: StellarValueExt::Basic,
+            },
+            tx_set_result_hash: Hash([0; 32]),
+            bucket_list_hash: Hash([0; 32]),
+            ledger_seq: self.ledger_seq,
+            total_coins: 0,
+            fee_pool: 0,
+            inflation_seq: 0,
+            id_pool: 0,
+            base_fee: 0,
+            base_reserve: self.base_reserve,
+            max_tx_set_size: 0,
+            skip_list: [Hash([0; 32]), Hash([0; 32]), Hash([0; 32]), Hash([0; 32])],
+            ext: LedgerHeaderExt::V0,
+        }
+    }
+
     /// Apply phase: execute operations, build meta, handle rollback on failure.
     ///
     /// This is the second half of transaction execution, consuming the
@@ -804,6 +843,15 @@ impl TransactionExecutor {
 
                         // Run invariant checks on the operation delta.
                         if let Some(ref invariant_mgr) = self.invariant_manager {
+                            // Op-scoped header pair for ConservationOfLumens. No
+                            // henyey operation mutates totalCoins/feePool within
+                            // op scope (inflation always returns NotTime/empty
+                            // payouts — operations/execute/inflation.rs; fee
+                            // charging is tx-set-level via record_fee_pool_delta),
+                            // so current == previous yields
+                            // deltaTotalCoins = deltaFeePool = 0. The shared
+                            // values are irrelevant since only the delta is read.
+                            let op_scoped_header = self.op_scoped_header();
                             let inv_delta = henyey_invariant::OperationDelta {
                                 created: delta_slice.created(),
                                 updated: delta_slice.updated(),
@@ -812,8 +860,8 @@ impl TransactionExecutor {
                                 delete_states: delta_slice.delete_states(),
                                 ledger_seq: self.ledger_seq,
                                 ledger_version: self.protocol_version,
-                                header_current: None,
-                                header_previous: None,
+                                header_current: Some(&op_scoped_header),
+                                header_previous: Some(&op_scoped_header),
                                 network_id: &self.network_id.0 .0,
                             };
                             invariant_mgr.check_on_operation_apply(


### PR DESCRIPTION
Closes #2804

## Summary

Adds a non-strict `ConservationOfLumens` invariant to `henyey-invariant` that asserts native-XLM conservation per operation apply: the sum of per-entry native-balance deltas (`deltaBalances`) plus the header `totalCoins`/`feePool` deltas must net to zero. This is the no-inflation branch — the only live branch for protocol 24+, where inflation is removed. The inflation branch is ported for parity with `ConservationOfLumens.cpp` but is dead in henyey. Native-balance-bearing entry types mirror stellar-core's `getAssetBalance(le, NATIVE)`: `Account.balance`, native `ClaimableBalance.amount`, and the native leg of a constant-product `LiquidityPool`. Per-op `header_current`/`header_previous` are wired at `apply.rs` via an op-scoped header pair (current == previous → zero header deltas; correct because no henyey op mutates `totalCoins`/`feePool` within op scope), and the invariant is registered in `app/mod.rs`.

SAC `ContractData` native balances are not counted (would produce false alarms, not missed imbalances — and non-strict, so log noise only); deferred to #2987.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2804#issuecomment-4614775869)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (CI-equivalent; clean)
- [x] cargo test -p henyey-invariant — 19 pass (incl. 9 new conservation tests)
- [x] cargo test -p henyey-ledger — all pass (453 + others), header wiring intact
- [x] cargo build -p henyey-app — registration compiles

## Regression test

- **Test:** `crates/invariant/tests/conservation.rs::test_conservation_fails_on_minted_lumens`
- **Pre-fix:** committed as `7a8de8c0` — verified FAILED: `unresolved import henyey_invariant::ConservationOfLumens` (type does not exist on main)
- **Post-fix:** verified PASSES after `10340c52` — unmatched native-balance increase returns `Err` containing "balances changed"

## Deviations from plan

None. (Added one extra coverage test `test_conservation_holds_on_balanced_delete_and_credit` exercising the deleted-entry path and the dead inflation branch `test_conservation_inflation_branch_balanced`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)