### PR TITLE
Harden ConservationOfLumens: zip-length fail-fast and checked payout sum

### DIFF
--- a/crates/invariant/src/conservation.rs
+++ b/crates/invariant/src/conservation.rs
@@ -137,7 +137,18 @@ impl Invariant for ConservationOfLumens {
         for entry in delta.created {
             accumulate(calculate_delta_balance(Some(entry), None))?;
         }
-        // Updated: (current, previous) pairs.
+        // Updated: (current, previous) pairs. `updated` and `update_states` are
+        // documented as parallel slices; a length divergence is a caller bug.
+        // Fail fast instead of letting `zip` silently truncate to the shorter
+        // slice (which would drop trailing entries and could mask a real
+        // imbalance). See #2997.
+        if delta.updated.len() != delta.update_states.len() {
+            return Err(format!(
+                "OperationDelta updated ({}) and update_states ({}) lengths diverge",
+                delta.updated.len(),
+                delta.update_states.len()
+            ));
+        }
         for (current, previous) in delta.updated.iter().zip(delta.update_states.iter()) {
             accumulate(calculate_delta_balance(Some(current), Some(previous)))?;
         }
@@ -165,10 +176,22 @@ impl Invariant for ConservationOfLumens {
 
         if is_inflation {
             // Retained for parity; dead in 24+ (inflation always NotTime/empty).
+            // Use checked accumulation so a pathological payout set (only
+            // reachable via tests / unexpected result variants) surfaces a
+            // detectable error rather than wrapping silently and producing a
+            // misleading invariant message. See #2998.
             let inflation_payouts: i64 = match op_result {
                 OperationResult::OpInner(OperationResultTr::Inflation(
                     stellar_xdr::curr::InflationResult::Success(payouts),
-                )) => payouts.iter().map(|p| p.amount).sum(),
+                )) => {
+                    let mut sum: i64 = 0;
+                    for p in payouts.iter() {
+                        sum = sum.checked_add(p.amount).ok_or_else(|| {
+                            "Overflow detected when summing inflation payouts".to_string()
+                        })?;
+                    }
+                    sum
+                }
                 _ => 0,
             };
 
@@ -180,6 +203,14 @@ impl Invariant for ConservationOfLumens {
                 ));
             }
             if delta_balances != inflation_payouts {
+                // #2999: "LedgerEntry account balances" is upstream-verbatim by
+                // design. `delta_balances` also covers native claimable-balance
+                // and the native leg of liquidity-pool reserves, but the wording
+                // is a byte-for-byte match to stellar-core's
+                // ConservationOfLumens.cpp error string (FMT_STRING at
+                // "LedgerEntry account balances change ({:d}) did not match
+                // inflation payouts ({:d})"). Rewording would deviate from
+                // message parity, so we keep the upstream phrasing intentionally.
                 return Err(format!(
                     "LedgerEntry account balances change ({}) did not match inflation payouts ({})",
                     delta_balances, inflation_payouts
@@ -199,6 +230,12 @@ impl Invariant for ConservationOfLumens {
                 ));
             }
             if delta_balances != 0 {
+                // #2999: "LedgerEntry account balances" is upstream-verbatim by
+                // design (covers native CB amounts and native LP reserve legs in
+                // addition to account balances). Byte-for-byte match to
+                // stellar-core's ConservationOfLumens.cpp FMT_STRING
+                // "LedgerEntry account balances changed by {:d} without
+                // inflation"; kept unchanged for message parity.
                 return Err(format!(
                     "LedgerEntry account balances changed by {} without inflation",
                     delta_balances

--- a/crates/invariant/tests/conservation.rs
+++ b/crates/invariant/tests/conservation.rs
@@ -393,6 +393,63 @@ fn test_conservation_inflation_branch_balanced() {
 }
 
 #[test]
+fn test_conservation_mismatched_update_lengths_fail_fast() {
+    // #2997: `updated` and `update_states` must be parallel. If their lengths
+    // diverge, the invariant must error early rather than silently truncating
+    // the longer slice via `zip` (which would skip the trailing entries and
+    // could mask a real imbalance). Build a divergent delta directly, bypassing
+    // the lockstep `DeltaBuilder` helper.
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    let network_id = [0u8; 32];
+    let deleted_keys: Vec<stellar_xdr::curr::LedgerKey> = vec![];
+
+    // Two post-states but only one pre-state → length divergence.
+    let updated = vec![account_entry(2, 500), account_entry(3, 2500)];
+    let update_states = vec![account_entry(2, 1000)];
+
+    let delta = OperationDelta {
+        created: &[],
+        updated: &updated,
+        update_states: &update_states,
+        deleted: &deleted_keys,
+        delete_states: &[],
+        ledger_seq: 100,
+        ledger_version: 24,
+        header_current: Some(&h),
+        header_previous: Some(&h),
+        network_id: &network_id,
+    };
+    let res = inv.check_on_operation_apply(&dummy_op(), &payment_result(), &delta, &[]);
+    let err = res.expect_err("mismatched updated/update_states lengths must fail fast");
+    assert!(
+        err.contains("updated") && err.contains("update_states"),
+        "unexpected message: {err}"
+    );
+}
+
+#[test]
+fn test_conservation_inflation_payout_sum_overflow_detected() {
+    // #2998: the inflation-payout sum must use checked accumulation. Two payouts
+    // each near i64::MAX overflow the sum; this must surface a detectable error
+    // rather than silently wrapping to a misleading value.
+    let inv = ConservationOfLumens::new();
+    let prev = header(1_000_000, 0);
+    let curr = header(1_000_000, 0);
+    let res = DeltaBuilder::new().check(
+        &inv,
+        &inflation_result(vec![(2, i64::MAX), (3, i64::MAX)]),
+        Some(&curr),
+        Some(&prev),
+    );
+    let err = res.expect_err("overflowing inflation payout sum must fail");
+    assert!(
+        err.contains("Overflow") && err.contains("inflation payouts"),
+        "unexpected message: {err}"
+    );
+}
+
+#[test]
 fn test_conservation_manager_registers_and_enables() {
     let mut mgr = InvariantManager::new();
     mgr.register(Arc::new(ConservationOfLumens::new()));


### PR DESCRIPTION
Closes #2997
Closes #2998
Closes #2999

## Summary

Three follow-ups from PR #2989 (issue #2804), all in `crates/invariant/src/conservation.rs`:

- **#2997** — Fail fast if `OperationDelta.updated` and `update_states` slice lengths diverge. Previously `zip` silently truncated to the shorter slice, dropping trailing entries and potentially masking a real imbalance. Now returns an error before the accumulation loop.
- **#2998** — Sum inflation payouts with `checked_add` instead of `Iterator::sum()`. The inflation branch is dead in protocol 24+ (always `NotTime`/empty), but is reachable via tests / unexpected result variants, where an unchecked sum would wrap silently (release) or panic (debug). Now surfaces a detectable "Overflow detected when summing inflation payouts" error.
- **#2999** — Documented as parity-intentional, **not reworded**. The "LedgerEntry account balances" wording is a byte-for-byte match to stellar-core's `ConservationOfLumens.cpp` error strings (the `change (...) did not match inflation payouts (...)` and `changed by (...) without inflation` FMT_STRINGs). Per CLAUDE.md determinism/parity rules, rewording would deviate from upstream message parity, so the verbatim phrasing is kept and a code comment explains why.

## Plan reference

Trivial short-circuit — implemented from the `## Triage Report` / `## Implementation Notes` on #2997.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-invariant --all-targets -- -D warnings
- [x] cargo test -p henyey-invariant — all pass (11 conservation tests + 10 unit tests)

## Regression tests

Two new tests in `crates/invariant/tests/conservation.rs`, committed as the failing-first commit `a2f202e6` (verified to FAIL on current main), passing after fix commit `2c46f1b2`:

- `test_conservation_mismatched_update_lengths_fail_fast` — pre-fix: zip truncated, produced wrong `-500` balance message instead of erroring; post-fix: errors on length divergence.
- `test_conservation_inflation_payout_sum_overflow_detected` — pre-fix: `attempt to add with overflow` panic from unchecked `.sum()`; post-fix: returns checked-overflow error.

#2999 is documentation-only (no behavior change), so no test.

## Deviations from plan

None. #2999 resolved as parity-documentation rather than a reword, exactly as the issue's parity note and the task framing directed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)