### PR TITLE
Canonicalize reap marker path before boundary check; fix bats usage comment

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -760,9 +760,34 @@ PW_HOME="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6)"
 reap_workspace() {  # $1 = absolute dir to remove
   local ws="$1"
   [ -z "$ws" ] && return 0
-  case "$ws" in
-    "$PW_HOME"/data/*) [ -d "$ws" ] && rm -rf "$ws" ;;
-    *) echo "WARN: refusing to reap '$ws' — outside $PW_HOME/data" >&2 ;;
+  # Canonicalize BEFORE the boundary prefix check (defense-in-depth, #2990).
+  # A raw string-prefix `case` would accept a marker like "$PW_HOME/data/../etc"
+  # — it begins with "$PW_HOME/data/" yet resolves outside the boundary. We
+  # resolve `..`/symlinks first (realpath -m, then a Python fallback at known
+  # absolute paths so PATH poisoning can't substitute realpath), and compare the
+  # RESOLVED path against the RESOLVED boundary so the read side is independently
+  # safe even if a malformed marker is ever introduced.
+  local canon home_data
+  canon="$(realpath -m "$ws" 2>/dev/null)" || canon=""
+  home_data="$(realpath -m "$PW_HOME/data" 2>/dev/null)" || home_data=""
+  if [ -z "$canon" ] || [ -z "$home_data" ]; then
+    local py
+    for py in /usr/bin/python3 /usr/local/bin/python3 /bin/python3; do
+      [ -x "$py" ] || continue
+      canon="$("$py" -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$ws" 2>/dev/null)"
+      home_data="$("$py" -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$PW_HOME/data" 2>/dev/null)"
+      break
+    done
+  fi
+  if [ -z "$canon" ] || [ -z "$home_data" ]; then
+    echo "WARN: refusing to reap '$ws' — could not canonicalize for boundary check" >&2
+    return 0
+  fi
+  # Directory-boundary check on the RESOLVED paths: accept exact <home>/data or
+  # paths strictly under it. Rejects siblings like ~/data-evil and ../ escapes.
+  case "$canon" in
+    "$home_data" | "$home_data"/*) [ -d "$canon" ] && rm -rf "$canon" ;;
+    *) echo "WARN: refusing to reap '$ws' — resolves to '$canon', outside '$home_data'" >&2 ;;
   esac
 }
 

--- a/scripts/lib/tests/test-do-bootstrap.bats
+++ b/scripts/lib/tests/test-do-bootstrap.bats
@@ -2,10 +2,12 @@
 #
 # Tests for do_bootstrap in scripts/lib/agent-worktree-contract.sh (issue #2979/#2978).
 #
-# Written in a BATS-compatible style (each test is a function named test_*) but
-# also runs as a plain-bash TAP-style runner, matching the convention used by
-# .github/skills/shared/tests/bounce-cap-check.bats. We default to the plain-bash
-# fallback since BATS isn't part of the project's required toolchain.
+# Despite the .bats extension, this file does NOT use BATS @test blocks: each
+# test is a plain bash function named test_*, and the file ships its own
+# TAP-style runner (see main() at the bottom). It is invoked with `bash`, not
+# the BATS runner — running it under real `bats` would execute 0 @test blocks.
+# This matches the convention used by .github/skills/shared/tests/bounce-cap-check.bats;
+# BATS is not part of the project's required toolchain.
 #
 # What we assert:
 #   1. With CLAUDE_SESSION_ID unset, do_bootstrap exports DO_WORKSPACE (the
@@ -17,8 +19,7 @@
 #      rejection writes no marker.
 #
 # Usage:
-#   bash scripts/lib/tests/test-do-bootstrap.bats     # plain
-#   bats scripts/lib/tests/test-do-bootstrap.bats     # BATS
+#   bash scripts/lib/tests/test-do-bootstrap.bats     # the only supported runner
 #
 # Output: TAP. Exit: 0 if all tests pass, non-zero otherwise.
 

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -1303,6 +1303,92 @@ test_workspace_marker_persist_reap_contract() {
 }
 
 # --------------------------------------------------------------------------
+# Test: review-pr reap guard canonicalizes the marker path BEFORE the
+# boundary prefix check (issue #2990 — defense-in-depth against a malformed
+# marker containing ../ that string-prefix-matches $PW_HOME/data but resolves
+# outside it). We extract the real reap_workspace function from the skill doc
+# and feed it a hostile escape path; the guard must REFUSE to rm -rf it.
+# --------------------------------------------------------------------------
+test_reap_guard_canonicalizes_before_prefix_check() {
+  local desc="review-pr reap guard canonicalizes marker before boundary check (#2990)"
+
+  # Extract the reap_workspace function body verbatim from the skill doc:
+  # everything from the `reap_workspace() {` line up to the closing `}` at
+  # column 0. The skill defines it exactly once.
+  local reap_fn
+  reap_fn=$(awk '
+    /^reap_workspace\(\) \{/ { capture = 1 }
+    capture { print }
+    capture && /^\}/ { exit }
+  ' "$REVIEW_PR_SKILL")
+
+  if [[ -z "$reap_fn" ]] || ! grep -q 'rm -rf' <<< "$reap_fn"; then
+    tap_not_ok "$desc" "could not extract reap_workspace() from $REVIEW_PR_SKILL"
+    return
+  fi
+
+  local real_home
+  real_home="$(_test_real_home)"
+
+  # Stage a real directory OUTSIDE the contract boundary, then a hostile path
+  # that string-prefix-matches "$PW_HOME/data/" but canonicalizes to that
+  # outside directory via a ../ traversal. The pre-fix raw `case` glob accepts
+  # this (it begins with "$PW_HOME/data/"); a canonicalize-first guard rejects it.
+  local victim
+  victim="$(mktemp -d)"
+  local sentinel="$victim/SHOULD_NOT_BE_REAPED"
+  : > "$sentinel"
+
+  # Build the escape: $PW_HOME/data/../<...>/<victim-tail> resolving to $victim.
+  # Walk up from $PW_HOME/data to filesystem root, then back down to $victim.
+  local up_count escape
+  up_count=$(awk -F/ '{print NF-1}' <<< "$real_home/data")
+  escape="$real_home/data"
+  local i
+  for ((i = 0; i < up_count; i++)); do escape="$escape/.."; done
+  # $escape now resolves to "/"; append the absolute victim path (sans leading /).
+  escape="$escape${victim}"
+
+  local output
+  output=$(PW_HOME="$real_home" bash -c '
+    set -uo pipefail
+    '"$reap_fn"'
+    reap_workspace "'"$escape"'"
+    echo "REAP_RETURNED:$?"
+  ' 2>&1) || true
+
+  if [[ ! -f "$sentinel" ]]; then
+    rm -rf "$victim"
+    tap_not_ok "$desc" "reap_workspace DELETED an outside-boundary path via ../ escape: $output"
+    return
+  fi
+
+  if ! grep -q 'refusing to reap' <<< "$output"; then
+    rm -rf "$victim"
+    tap_not_ok "$desc" "reap_workspace did not refuse the ../ escape path: $output"
+    return
+  fi
+
+  # Sanity: the guard must still reap a legitimate in-boundary directory.
+  local legit
+  legit="$real_home/data/.reap-guard-test-$$"
+  mkdir -p "$legit"
+  PW_HOME="$real_home" bash -c '
+    set -uo pipefail
+    '"$reap_fn"'
+    reap_workspace "'"$legit"'"
+  ' >/dev/null 2>&1 || true
+  if [[ -d "$legit" ]]; then
+    rm -rf "$victim" "$legit"
+    tap_not_ok "$desc" "reap_workspace refused a legitimate in-boundary path: $legit"
+    return
+  fi
+
+  rm -rf "$victim" "$legit"
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
 # Test: /do uses the shared contract helper, not an in-repo worktree
 # --------------------------------------------------------------------------
 test_do_skill_uses_contract_helper_not_repo_tree() {
@@ -1446,6 +1532,7 @@ test_do_bootstrap_default_under_home_data
 test_do_bootstrap_exports_workspace_alias
 test_do_bootstrap_clears_workspace_on_failure
 test_workspace_marker_persist_reap_contract
+test_reap_guard_canonicalizes_before_prefix_check
 test_do_skill_uses_contract_helper_not_repo_tree
 test_skill_prompts_forbid_known_leak_patterns
 test_assert_no_repo_tree_scratch_detects_leak_dirs


### PR DESCRIPTION
Closes #2990
Closes #2991

## Summary

Two pipeline-script follow-ups from PR #2983 (issue #2979), fixed together.

**#2990 — harden the /review-pr reap guard (defense-in-depth).** The reap boundary guard in `review-pr/SKILL.md` Step 7.4 (`reap_workspace`) previously did a raw string-prefix `case "$ws" in "$PW_HOME"/data/*)` check on the marker value. A marker containing `..` (e.g. `$PW_HOME/data/../<path>`) string-prefix-matches the boundary yet resolves outside it — the raw glob would `rm -rf` an out-of-boundary path. The guard now canonicalizes the marker (`realpath -m`, with a Python fallback at known absolute paths so PATH poisoning can't substitute `realpath`) and compares the RESOLVED path against the RESOLVED `$PW_HOME/data` boundary before deciding to delete. Not exploitable today (the marker is always written from `do_bootstrap`'s canonicalized, ~/data-validated `DO_WORKSPACE`) — this makes the read side independently safe.

**#2991 — fix misleading bats usage comment.** `scripts/lib/tests/test-do-bootstrap.bats` advertised a `bats <file>` invocation in its header, but the file uses plain `test_*` bash functions with its own TAP runner and is invoked via `bash` in CI (real `bats` would execute 0 `@test` blocks). Replaced the misleading usage line and clarified the header.

## Plan reference

Both issues were trivial short-circuits — see the [Triage Report on #2990](https://github.com/stellar-experimental/henyey/issues/2990#issuecomment-4615629031) and the Triage Report on #2991.

## Test plan

- [x] `bash scripts/test-agent-worktree-contract.sh` — 32/32 pass (was 31 tests + 1 new)
- [x] `bash scripts/lib/tests/test-do-bootstrap.bats` — 7/7 pass
- [x] shellcheck clean on touched files (no new findings vs main; added test code has zero findings)
- [x] pre-commit fmt + clippy pass

## Regression test

- **Test:** `scripts/test-agent-worktree-contract.sh::test_reap_guard_canonicalizes_before_prefix_check`
- It extracts the real `reap_workspace` function from `review-pr/SKILL.md` and feeds it a marker that string-prefix-matches `$PW_HOME/data/` but resolves outside via `..`.
- **Pre-fix:** committed as `e914f7d8` — verified FAILED: `reap_workspace DELETED an outside-boundary path via ../ escape: REAP_RETURNED:0`.
- **Post-fix:** verified PASSES after `8544ae4d` (guard refuses the escape; still reaps a legitimate in-boundary dir).

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)