### PR TITLE
Address §5.4 trigger/herder follow-up nits from #2816/#2981

### DIFF
--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -258,17 +258,16 @@ impl App {
                 return;
             }
 
-            // Parity: stellar-core HerderImpl.cpp:1281-1282
-            // triggerOffset = triggerTime - now (always >= 0 because triggerTime
-            // was clamped to max(lastBallotStart + expectedClose, now) above).
-            // This is the *remaining* time until trigger, not elapsed time.
-            let trigger_offset_secs = trigger_time
-                .saturating_duration_since(now_instant)
-                .as_secs();
-            let ct_offset = self.herder.ct_validity_offset(
-                self.herder.lcl_close_time().saturating_add(1),
-                trigger_offset_secs,
-            );
+            // Parity: stellar-core HerderImpl.cpp:1281-1282 passes
+            // `triggerTime - now` as the trigger offset. In this poller, we only
+            // reach this point once `trigger_time <= now_instant` (the
+            // early-return above bails out otherwise), so that offset is always
+            // 0 — the trigger fires at or after its scheduled time, never ahead.
+            // Pass 0 directly rather than computing a value that is provably
+            // zero on this path.
+            let ct_offset = self
+                .herder
+                .ct_validity_offset(self.herder.lcl_close_time().saturating_add(1), 0);
             if ct_offset > 0 {
                 tracing::debug!(
                     next_slot,

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1308,7 +1308,9 @@ impl Herder {
     }
 
     /// Get the ballot-start instant for the given slot.
-    /// Parity: stellar-core `mLastTrigger` (HerderImpl.cpp), exposed as "prepare start".
+    /// Parity: stellar-core `getPrepareStart(slot)` / `mPrepareStart`
+    /// (HerderSCPDriver), as consumed by `setupTriggerNextLedger`
+    /// (HerderImpl.cpp:1266). Exposed here as "prepare start".
     pub fn prepare_start(&self, slot: SlotIndex) -> Option<std::time::Instant> {
         self.scp_driver.prepare_start(slot)
     }
@@ -7323,21 +7325,52 @@ mod tests {
 
         // The externalizing-state accessor returns a different view than
         // get_scp_envelopes(): get_scp_envelopes() returns the slot's recorded
-        // envelopes (here, the single received EXTERNALIZE), whereas the
-        // externalizing state additionally includes the local node's own
-        // commit-phase envelope synthesized when the slot externalizes — so the
-        // two collections are not identical. Asserting they differ is what
-        // validates the accessor is the externalizing snapshot and not a thin
-        // alias for the recorded-envelope set.
+        // (peer-received) envelopes — here, the single received EXTERNALIZE from
+        // `other_node` — whereas the externalizing state additionally includes
+        // the local node's own commit-phase envelope synthesized when the slot
+        // externalizes. We assert this as a *semantic*, order-insensitive
+        // difference rather than `assert_ne!` on the Vecs (which would pass even
+        // if both accessors returned the same set in a different order): the
+        // local node's synthesized EXTERNALIZE must be present in the
+        // externalizing snapshot and absent from the recorded-envelope set.
         let all_envelopes = herder.get_scp_envelopes(tracking);
         assert!(
             !all_envelopes.is_empty(),
             "externalized slot should have recorded envelopes"
         );
+
+        let local_in_state = state
+            .iter()
+            .any(|env| env.statement.node_id == local_node_id);
+        let local_in_recorded = all_envelopes
+            .iter()
+            .any(|env| env.statement.node_id == local_node_id);
+        assert!(
+            local_in_state,
+            "externalizing state must include the local node's synthesized \
+             EXTERNALIZE envelope"
+        );
+        assert!(
+            !local_in_recorded,
+            "recorded-envelope set must NOT include the local node's \
+             synthesized EXTERNALIZE (it holds only peer-received envelopes)"
+        );
+
+        // As a backstop, compare the two views as node-id sets so the check
+        // stays order-insensitive: the externalizing snapshot adds the local
+        // node, so the sets must differ.
+        let state_nodes: std::collections::BTreeSet<_> = state
+            .iter()
+            .map(|env| env.statement.node_id.clone())
+            .collect();
+        let recorded_nodes: std::collections::BTreeSet<_> = all_envelopes
+            .iter()
+            .map(|env| env.statement.node_id.clone())
+            .collect();
         assert_ne!(
-            state, all_envelopes,
-            "externalizing state should differ from the full recorded-envelope \
-             set (it is the EXTERNALIZE-phase snapshot, not all envelopes)"
+            state_nodes, recorded_nodes,
+            "externalizing state and recorded-envelope set should differ as \
+             node-id sets (the externalizing snapshot adds the local node)"
         );
     }
 


### PR DESCRIPTION
Closes #2992
Closes #2993
Closes #2994
Closes #2995
Closes #2996
Closes #2988

## Summary

Bundles six small, localized follow-up nits filed off the merged #2835 (issue #2816) and #2985 (issue #2981) reviews. All touch the §5.4 trigger / herder code that those PRs landed.

Three required code/doc/test changes against current `origin/main`:

- **#2994** (`crates/app/src/app/consensus.rs`): past the `trigger_time > now_instant` early-return, `trigger_time <= now_instant`, so `trigger_offset_secs = trigger_time.saturating_duration_since(now_instant)` is provably 0. Removed the dead computation and pass `0` directly to `ct_validity_offset`, with a comment explaining the invariant. Matches stellar-core HerderImpl.cpp:1281-1282 semantics (offset is remaining-time-until-trigger, which is 0 once we're at/after the trigger time).
- **#2996** (`crates/herder/src/herder.rs`): aligned the `prepare_start` doc citation from the stale `mLastTrigger` to `getPrepareStart`/`mPrepareStart` — the value `setupTriggerNextLedger` (HerderImpl.cpp:1266) actually consumes, consistent with `ScpDriver::prepare_start`. Doc-only.
- **#2988** (`crates/herder/src/herder.rs`): tightened `test_get_scp_externalizing_state_uses_externalizing_snapshot` from an order-sensitive `assert_ne!` on `Vec`s to a semantic, order-insensitive check — the local node's synthesized EXTERNALIZE is asserted present in the externalizing snapshot and absent from the recorded-envelope set, plus a node-id-set backstop.

Three were already incorporated into the merged code and verified to be in the requested state on current `origin/main` (no change needed):

- **#2992**: `lcl_close_time()` already returns `u64` (not `Option<u64>`).
- **#2993**: `close_time_offset` already uses `checked_sub` with an explicit abort when `close_time <= lcl_close_time`.
- **#2995**: `test_prepare_start_purged_with_slot_trim` already uses the public `purge_slots_below()` API instead of mutating the private `slot_timing` map.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-herder -p henyey-app -- -D warnings (clean)
- [x] cargo test -p henyey-herder — 1172 passed, 0 failed
- [x] cargo test -p henyey-app — all passed, 0 failed

## Deviations from plan

No /plan stage — operator-directed trivial bundle. Three of the six issues turned out already-satisfied on current main; they are kept in the Closes list since the code is now in the exact state each issue requested, with verification noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)