### PR TITLE
Harden reap-guard boundary and realpath canonicalization

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -783,11 +783,14 @@ reap_workspace() {  # $1 = absolute dir to remove
     echo "WARN: refusing to reap '$ws' — could not canonicalize for boundary check" >&2
     return 0
   fi
-  # Directory-boundary check on the RESOLVED paths: accept exact <home>/data or
-  # paths strictly under it. Rejects siblings like ~/data-evil and ../ escapes.
+  # Directory-boundary check on the RESOLVED paths: accept ONLY paths strictly
+  # under <home>/data. The bare <home>/data root is rejected — a marker that
+  # resolved to exactly the data root would otherwise `rm -rf` every workspace.
+  # Also rejects siblings like ~/data-evil and ../ escapes. The `--` guards
+  # against a canon that begins with a dash being parsed as an rm option.
   case "$canon" in
-    "$home_data" | "$home_data"/*) [ -d "$canon" ] && rm -rf "$canon" ;;
-    *) echo "WARN: refusing to reap '$ws' — resolves to '$canon', outside '$home_data'" >&2 ;;
+    "$home_data"/*) [ -d "$canon" ] && rm -rf -- "$canon" ;;
+    *) echo "WARN: refusing to reap '$ws' — resolves to '$canon', outside '$home_data/'" >&2 ;;
   esac
 }
 

--- a/scripts/lib/agent-worktree-contract.sh
+++ b/scripts/lib/agent-worktree-contract.sh
@@ -35,18 +35,28 @@ _contract_real_home() {
 # Tries GNU realpath -m first, falls back to Python os.path.realpath at a known
 # absolute path, then fails closed (returns non-zero) if neither backend is available.
 #
-# SECURITY: The Python fallback uses absolute paths (/usr/bin/python3, /usr/bin/python)
-# rather than PATH lookup. This prevents PATH-poisoning attacks where a malicious
-# python3 stub could feed arbitrary output into the canonicalization trust chain.
+# SECURITY: Both backends are invoked via absolute paths (/usr/bin/realpath,
+# /usr/bin/python3, ...) rather than a bare PATH lookup. This prevents
+# PATH-poisoning attacks where a malicious `realpath`/`python3` stub on PATH
+# could feed arbitrary output into the canonicalization trust chain. A bare
+# `realpath` on the fast path would have defeated this, since the Python
+# fallback only runs when the fast path returns empty.
 canonicalize_contract_path() {
   local path="$1"
   local result
 
-  # Fast path: GNU realpath -m (works on Linux with coreutils)
-  if result="$(realpath -m "$path" 2>/dev/null)" && [[ -n "$result" ]]; then
-    echo "$result"
-    return 0
-  fi
+  # Fast path: GNU realpath -m (works on Linux with coreutils). Invoked via a
+  # known absolute path (never a PATH lookup) so a poisoned `realpath` on PATH
+  # cannot subvert the trust chain — see the SECURITY note above.
+  local rp
+  for rp in /usr/bin/realpath /bin/realpath /usr/local/bin/realpath; do
+    if [[ -x "$rp" ]]; then
+      if result="$("$rp" -m "$path" 2>/dev/null)" && [[ -n "$result" ]]; then
+        echo "$result"
+        return 0
+      fi
+    fi
+  done
 
   # Fallback: Python os.path.realpath at known absolute paths (immune to PATH poisoning)
   local py

--- a/scripts/test-agent-worktree-contract.sh
+++ b/scripts/test-agent-worktree-contract.sh
@@ -1389,6 +1389,137 @@ test_reap_guard_canonicalizes_before_prefix_check() {
 }
 
 # --------------------------------------------------------------------------
+# Test: review-pr reap guard rejects the bare <home>/data root but reaps a
+# strict descendant (issue #3004 — defense-in-depth). A marker that resolved
+# to exactly <home>/data must NOT be reaped (it would `rm -rf` every other
+# agent's workspace); only paths strictly under <home>/data/ are reapable.
+# We extract the real reap_workspace function from the skill doc and exercise
+# both the exact-root and strict-descendant cases against a sandbox home.
+# --------------------------------------------------------------------------
+test_reap_guard_rejects_exact_data_root_allows_descendant() {
+  local desc="review-pr reap guard rejects exact <home>/data, reaps strict descendant (#3004)"
+
+  local reap_fn
+  reap_fn=$(awk '
+    /^reap_workspace\(\) \{/ { capture = 1 }
+    capture { print }
+    capture && /^\}/ { exit }
+  ' "$REVIEW_PR_SKILL")
+
+  if [[ -z "$reap_fn" ]] || ! grep -q 'rm -rf' <<< "$reap_fn"; then
+    tap_not_ok "$desc" "could not extract reap_workspace() from $REVIEW_PR_SKILL"
+    return
+  fi
+
+  # Sandbox home so the data root we point the guard at is disposable — we must
+  # never risk reaping a real ~/data during the test.
+  local sandbox sandbox_data
+  sandbox="$(mktemp -d)"
+  sandbox_data="$sandbox/data"
+  mkdir -p "$sandbox_data"
+  local sentinel="$sandbox_data/SHOULD_NOT_BE_REAPED"
+  : > "$sentinel"
+
+  # Case 1: feed the guard the bare data root itself — it must REFUSE and the
+  # data root (and its sentinel) must survive.
+  local output
+  output=$(PW_HOME="$sandbox" bash -c '
+    set -uo pipefail
+    '"$reap_fn"'
+    reap_workspace "'"$sandbox_data"'"
+    echo "REAP_RETURNED:$?"
+  ' 2>&1) || true
+
+  if [[ ! -d "$sandbox_data" || ! -f "$sentinel" ]]; then
+    rm -rf "$sandbox"
+    tap_not_ok "$desc" "reap_workspace DELETED the bare data root: $output"
+    return
+  fi
+  if ! grep -q 'refusing to reap' <<< "$output"; then
+    rm -rf "$sandbox"
+    tap_not_ok "$desc" "reap_workspace did not refuse the exact data root: $output"
+    return
+  fi
+
+  # Case 2: a strict descendant under the data root must be reaped.
+  local descendant="$sandbox_data/do-3004/worktree"
+  mkdir -p "$descendant"
+  PW_HOME="$sandbox" bash -c '
+    set -uo pipefail
+    '"$reap_fn"'
+    reap_workspace "'"$descendant"'"
+  ' >/dev/null 2>&1 || true
+  if [[ -d "$descendant" ]]; then
+    rm -rf "$sandbox"
+    tap_not_ok "$desc" "reap_workspace refused a legitimate strict descendant: $descendant"
+    return
+  fi
+  # The data root must still be intact after reaping the descendant.
+  if [[ ! -d "$sandbox_data" || ! -f "$sentinel" ]]; then
+    rm -rf "$sandbox"
+    tap_not_ok "$desc" "reaping a descendant clobbered the data root"
+    return
+  fi
+
+  rm -rf "$sandbox"
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
+# Test: a PATH-poisoned `realpath` is ignored by the contract canonicalizer
+# (issue #3005). canonicalize_contract_path invokes realpath via an absolute
+# path, so a malicious `realpath` stub earlier on PATH that prints attacker-
+# controlled output (/etc) must NOT be trusted — the helper either uses the
+# real absolute-path realpath (correct output) or fails closed, but never
+# returns the poisoned value.
+# --------------------------------------------------------------------------
+test_poisoned_realpath_on_path_ignored() {
+  local desc="poisoned realpath on PATH is ignored (uses absolute path only) (#3005)"
+
+  local real_home
+  real_home="$(_test_real_home)"
+
+  local stub_dir
+  stub_dir="$(mktemp -d)"
+  cat > "$stub_dir/realpath" << 'STUB'
+#!/usr/bin/env bash
+# Malicious: always outputs /etc regardless of input
+echo "/etc"
+STUB
+  chmod +x "$stub_dir/realpath"
+
+  # Resolve a known in-boundary path through the helper with the poisoned PATH.
+  local probe="$real_home/data/poison-realpath-probe-$$"
+  local output rc
+  output=$(PATH="$stub_dir:$PATH" \
+    bash -c "source '$CONTRACT_HELPER' && canonicalize_contract_path '$probe'" 2>&1) && rc=0 || rc=$?
+
+  if [[ $rc -eq 0 ]]; then
+    # Succeeded — the result must be the real resolution, never the poisoned /etc.
+    if [[ "$output" == "/etc" || "$output" == "/etc/"* ]]; then
+      rm -rf "$stub_dir"
+      tap_not_ok "$desc" "PATH-poisoned realpath was trusted! Got: $output"
+      return
+    fi
+    if [[ "$output" != "$real_home/data/"* ]]; then
+      rm -rf "$stub_dir"
+      tap_not_ok "$desc" "Unexpected resolution: '$output' (expected under $real_home/data/)"
+      return
+    fi
+  else
+    # Fail-closed is acceptable, as long as it never echoed the poisoned value.
+    if [[ "$output" == "/etc"* ]]; then
+      rm -rf "$stub_dir"
+      tap_not_ok "$desc" "canonicalizer emitted poisoned /etc before failing: $output"
+      return
+    fi
+  fi
+
+  rm -rf "$stub_dir"
+  tap_ok "$desc"
+}
+
+# --------------------------------------------------------------------------
 # Test: /do uses the shared contract helper, not an in-repo worktree
 # --------------------------------------------------------------------------
 test_do_skill_uses_contract_helper_not_repo_tree() {
@@ -1533,6 +1664,8 @@ test_do_bootstrap_exports_workspace_alias
 test_do_bootstrap_clears_workspace_on_failure
 test_workspace_marker_persist_reap_contract
 test_reap_guard_canonicalizes_before_prefix_check
+test_reap_guard_rejects_exact_data_root_allows_descendant
+test_poisoned_realpath_on_path_ignored
 test_do_skill_uses_contract_helper_not_repo_tree
 test_skill_prompts_forbid_known_leak_patterns
 test_assert_no_repo_tree_scratch_detects_leak_dirs


### PR DESCRIPTION
Closes #3004
Closes #3005

## Summary

Two defense-in-depth pipeline-hardening nits carried over from PR #3001 (issue #2990), fixed together:

- **#3004** — `.github/skills/review-pr/SKILL.md` reap guard: the boundary `case` previously accepted `canon == $home_data` (the bare `<home>/data` root). A marker that ever resolved to exactly the data root would `rm -rf` every other agent's workspace. The guard now accepts **only strict descendants** under `$home_data/` and passes `--` to `rm -rf` so a dash-prefixed `canon` can't be parsed as an option. Comment updated to match.
- **#3005** — `scripts/lib/agent-worktree-contract.sh` `canonicalize_contract_path`: the fast path invoked `realpath -m` via a bare PATH lookup, so a poisoned `realpath` on PATH could feed attacker-controlled output into the trust chain (the Python fallback only runs when `realpath` returns empty, so it never engaged). The fast path now iterates known **absolute** realpath locations (`/usr/bin/realpath`, `/bin/realpath`, `/usr/local/bin/realpath`), never a PATH lookup — so the SECURITY note the function already carried now actually holds for both backends.

## Plan reference

Trivial short-circuit — both issues were ACCEPTed in triage with implementation notes (no separate `/plan` stage). See the Triage Report on #3004 and #3005.

## Test plan

- [x] `scripts/test-agent-worktree-contract.sh` — 34/34 pass (was 32 + 2 new)
- [x] `scripts/lib/tests/test-do-bootstrap.bats` — 7/7 pass
- [x] `scripts/test-review-pr-skill-snippets.sh` — 49/49 pass
- [x] `shellcheck scripts/lib/agent-worktree-contract.sh` — clean
- [x] pre-commit `cargo fmt --check` + `cargo clippy` — clean

## Regression tests

Both new tests were committed first (commit `34e7a1ba`) and verified to **FAIL on current main**, then pass after the fix (commit `1792f5d9`):

- **`test_reap_guard_rejects_exact_data_root_allows_descendant` (#3004)** — extracts the real `reap_workspace` from the skill doc; asserts the bare `<home>/data` root is refused (sentinel survives) and a strict descendant is reaped. Pre-fix failure: guard DELETED the bare data root.
- **`test_poisoned_realpath_on_path_ignored` (#3005)** — puts a malicious `realpath` (prints `/etc`) earlier on PATH; asserts `canonicalize_contract_path` never returns the poisoned value. Pre-fix failure: poisoned `realpath` was trusted.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)