### PR TITLE
Harden reap_workspace canonicalization and fix boundary-refusal message

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -763,13 +763,20 @@ reap_workspace() {  # $1 = absolute dir to remove
   # Canonicalize BEFORE the boundary prefix check (defense-in-depth, #2990).
   # A raw string-prefix `case` would accept a marker like "$PW_HOME/data/../etc"
   # — it begins with "$PW_HOME/data/" yet resolves outside the boundary. We
-  # resolve `..`/symlinks first (realpath -m, then a Python fallback at known
-  # absolute paths so PATH poisoning can't substitute realpath), and compare the
-  # RESOLVED path against the RESOLVED boundary so the read side is independently
-  # safe even if a malformed marker is ever introduced.
-  local canon home_data
-  canon="$(realpath -m "$ws" 2>/dev/null)" || canon=""
-  home_data="$(realpath -m "$PW_HOME/data" 2>/dev/null)" || home_data=""
+  # resolve `..`/symlinks first (realpath -m at a KNOWN ABSOLUTE PATH — never a
+  # bare PATH lookup — then a Python fallback at known absolute paths so PATH
+  # poisoning can't substitute realpath/python3), and compare the RESOLVED path
+  # against the RESOLVED boundary so the read side is independently safe even if
+  # a malformed marker is ever introduced. A bare `realpath` on the fast path
+  # would defeat the hardening, since the Python fallback only runs when the
+  # fast path returns empty (matches the #3005 fix in agent-worktree-contract.sh).
+  local canon home_data rp
+  for rp in /usr/bin/realpath /bin/realpath /usr/local/bin/realpath; do
+    [ -x "$rp" ] || continue
+    canon="$("$rp" -m "$ws" 2>/dev/null)" || canon=""
+    home_data="$("$rp" -m "$PW_HOME/data" 2>/dev/null)" || home_data=""
+    [ -n "$canon" ] && [ -n "$home_data" ] && break
+  done
   if [ -z "$canon" ] || [ -z "$home_data" ]; then
     local py
     for py in /usr/bin/python3 /usr/local/bin/python3 /bin/python3; do
@@ -790,7 +797,7 @@ reap_workspace() {  # $1 = absolute dir to remove
   # against a canon that begins with a dash being parsed as an rm option.
   case "$canon" in
     "$home_data"/*) [ -d "$canon" ] && rm -rf -- "$canon" ;;
-    *) echo "WARN: refusing to reap '$ws' — resolves to '$canon', outside '$home_data/'" >&2 ;;
+    *) echo "WARN: refusing to reap '$ws' — resolves to '$canon', not strictly under '$home_data/' (the bare data root and any path outside it are both rejected)" >&2 ;;
   esac
 }
 


### PR DESCRIPTION
Closes #3008
Closes #3009

## Summary

Two defense-in-depth follow-ups from #3004/PR #3006, both in the `reap_workspace` guard in `.github/skills/review-pr/SKILL.md`:

- **#3008** — the fast-path canonicalization called bare-PATH `realpath`, which a poisoned PATH stub could subvert (the Python fallback only runs when the fast path returns empty, so a malicious `realpath` would never trigger it). Now iterates over known absolute paths (`/usr/bin/realpath`, `/bin/realpath`, `/usr/local/bin/realpath`), matching the #3005 fix in `scripts/lib/agent-worktree-contract.sh`, so the PATH-poisoning protection holds on the reap path too.
- **#3009** — the boundary-refusal `WARN` said the path resolved "outside '<home>/data/'" even when it resolved to exactly the data root (rejected intentionally by #3004). Reworded to "not strictly under" with a parenthetical clarifying that both the bare data root and any path outside it are rejected.

`.claude/skills/review-pr` is a symlink to `.github/skills/review-pr`, so the single edit keeps the two copies in sync (sync test passes).

## Test plan

- [x] shellcheck clean on the edited `reap_workspace` function (the one pre-existing SC1010 elsewhere in the block is unrelated and untouched)
- [x] `bash scripts/test-agent-worktree-contract.sh` — 34/34 pass (incl. #30 data-root rejection, #31 poisoned-realpath ignored)
- [x] Behavioral check of the edited function under a poisoned PATH: legit descendant reaped, data-root preserved, outside path preserved, with the corrected message
- [x] pre-commit `cargo fmt` + `cargo clippy` passed on push

## Deviations from plan

The issue text pointed at `scripts/lib/agent-worktree-contract.sh` as the possible home of `reap_workspace`; the function actually lives in `.github/skills/review-pr/SKILL.md` (the contract helper's analogous `canonicalize_contract_path` was already fixed by #3005). Edited the real location. No converged-plan comment existed — these are trivial follow-up nits, so the change tracks the issue bodies and the #3005 pattern directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)