### PR TITLE
Count SAC native-XLM ContractData balances in ConservationOfLumens

### DIFF
--- a/crates/invariant/Cargo.toml
+++ b/crates/invariant/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+henyey-common.workspace = true
 stellar-xdr.workspace = true
 tracing.workspace = true
 metrics.workspace = true
@@ -13,3 +14,4 @@ serde_json.workspace = true
 regex = "1"
 
 [dev-dependencies]
+henyey-common.workspace = true

--- a/crates/invariant/src/conservation.rs
+++ b/crates/invariant/src/conservation.rs
@@ -20,13 +20,11 @@
 //! - `LiquidityPool` constant-product `reserveA`/`reserveB` — for whichever leg
 //!   is the native asset.
 //!
-//! `ContractData` (Stellar Asset Contract native balances) is NOT counted in
-//! this implementation. An Account↔Contract native SAC transfer would show a
-//! non-zero Account-side delta with the offsetting `ContractData` credit
-//! uncounted, producing a spurious violation (a **false alarm**, not a missed
-//! imbalance). Because this invariant is non-strict, that is log noise rather
-//! than a crash. Counting SAC `ContractData` native balances is tracked as a
-//! follow-up in #2987.
+//! - `ContractData` (Stellar Asset Contract native balances) — only the native
+//!   SAC's `Balance` entries, mirroring core's `getAssetBalance` CONTRACT_DATA
+//!   branch (see [`native_balance`]). The native SAC contract id is derived
+//!   per-op from `delta.network_id` (a pure function of the network passphrase,
+//!   identical to core's precomputed `mLumenContractInfo`).
 //!
 //! # Parity
 //!
@@ -36,8 +34,9 @@
 //! hook). Strictness: non-strict (`Invariant(false)`).
 
 use stellar_xdr::curr::{
-    Asset, ContractEvent, LedgerEntry, LedgerEntryData, LiquidityPoolEntryBody, Operation,
-    OperationResult, OperationResultTr,
+    Asset, ContractEvent, ContractId, ContractIdPreimage, Hash, HashIdPreimage,
+    HashIdPreimageContractId, LedgerEntry, LedgerEntryData, LiquidityPoolEntryBody, Operation,
+    OperationResult, OperationResultTr, ScAddress, ScVal,
 };
 
 use crate::{Invariant, OperationDelta};
@@ -57,46 +56,149 @@ impl Default for ConservationOfLumens {
     }
 }
 
-/// Returns the native-XLM balance held by a single ledger entry, or `None` if
-/// the entry holds no native balance (the asset doesn't match / not a
-/// balance-bearing type).
+/// Outcome of inspecting one ledger entry for a native-XLM balance.
+///
+/// Mirrors the relevant part of stellar-core's `AssetBalanceResult`
+/// (`{overflowed, assetMatched, balance}`): an entry either holds no native
+/// balance (`None` → contributes 0), holds a representable native balance
+/// (`Balance(i64)`), or — only in the SAC `ContractData` case — holds an i128
+/// amount outside the `i64` range (`Overflow`), which fails the invariant.
+enum NativeBalance {
+    /// No native balance (asset mismatch, non-balance-bearing type, or a
+    /// matched-but-malformed SAC entry). Contributes 0, never an error.
+    None,
+    /// A representable native balance.
+    Balance(i64),
+    /// SAC i128 amount out of `i64` range (`hi > 0 || lo > i64::MAX`).
+    Overflow,
+}
+
+/// Derives the native-XLM Stellar-Asset-Contract id for `network_id`, mirroring
+/// stellar-core's `getAssetContractID(networkID, Asset(ASSET_TYPE_NATIVE))`.
+///
+/// This is a pure function of the network passphrase, so deriving it per-op is
+/// behaviorally identical to core's precomputed `mLumenContractInfo`.
+fn native_sac_contract_id(network_id: &[u8; 32]) -> ContractId {
+    let preimage = HashIdPreimage::ContractId(HashIdPreimageContractId {
+        network_id: Hash(*network_id),
+        contract_id_preimage: ContractIdPreimage::Asset(Asset::Native),
+    });
+    let hash = henyey_common::Hash256::hash_xdr(&preimage);
+    ContractId(Hash(hash.0))
+}
+
+/// Returns the native-XLM balance held by a single ledger entry.
 ///
 /// Mirrors `getAssetBalance(le, Asset(ASSET_TYPE_NATIVE), lumenContractInfo)`
-/// for the native asset, excluding the SAC `ContractData` case (see module
-/// docs / #2987).
-fn native_balance(entry: &LedgerEntry) -> Option<i64> {
+/// for the native asset, including the SAC `ContractData` branch
+/// (`TransactionUtils.cpp` `getAssetBalance`): an entry is the native SAC
+/// balance iff its `contract` is `Contract(native_sac_id)`, its `key` is a
+/// non-empty `Vec` whose first element is `Symbol("Balance")`, and its `val` is
+/// a non-empty `Map` whose first entry is keyed `Symbol("amount")` with an
+/// `I128` value. A matched-contract-but-malformed entry contributes 0 (not an
+/// error); only an in-range-failing i128 (`hi > 0 || lo > i64::MAX`) is an
+/// [`NativeBalance::Overflow`].
+fn native_balance(entry: &LedgerEntry, native_sac_id: &ContractId) -> NativeBalance {
     match &entry.data {
-        LedgerEntryData::Account(acc) => Some(acc.balance),
-        LedgerEntryData::ClaimableBalance(cb) => {
-            matches!(cb.asset, Asset::Native).then_some(cb.amount)
-        }
+        LedgerEntryData::Account(acc) => NativeBalance::Balance(acc.balance),
+        LedgerEntryData::ClaimableBalance(cb) => match cb.asset {
+            Asset::Native => NativeBalance::Balance(cb.amount),
+            _ => NativeBalance::None,
+        },
         LedgerEntryData::LiquidityPool(lp) => {
             let LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) = &lp.body;
             if matches!(cp.params.asset_a, Asset::Native) {
-                Some(cp.reserve_a)
+                NativeBalance::Balance(cp.reserve_a)
             } else if matches!(cp.params.asset_b, Asset::Native) {
-                Some(cp.reserve_b)
+                NativeBalance::Balance(cp.reserve_b)
             } else {
-                None
+                NativeBalance::None
             }
         }
+        LedgerEntryData::ContractData(cd) => sac_native_balance(cd, native_sac_id),
         // Trustlines never hold the native asset; offers/data/contract code/
-        // config/TTL hold no asset balance. ContractData (SAC) deferred to #2987.
-        _ => None,
+        // config/TTL hold no asset balance.
+        _ => NativeBalance::None,
     }
+}
+
+/// Extracts the native-XLM balance from a `ContractData` entry, mirroring the
+/// CONTRACT_DATA branch of stellar-core's `getAssetBalance`.
+fn sac_native_balance(
+    cd: &stellar_xdr::curr::ContractDataEntry,
+    native_sac_id: &ContractId,
+) -> NativeBalance {
+    // The entry must be stored under the native SAC contract address.
+    let ScAddress::Contract(contract_id) = &cd.contract else {
+        return NativeBalance::None;
+    };
+    if contract_id != native_sac_id {
+        return NativeBalance::None;
+    }
+    // key == Vec(Some(v)), non-empty, v[0] == Symbol("Balance").
+    let ScVal::Vec(Some(key_vec)) = &cd.key else {
+        return NativeBalance::None;
+    };
+    match key_vec.first() {
+        Some(ScVal::Symbol(sym)) if sym.0.as_slice() == b"Balance" => {}
+        _ => return NativeBalance::None,
+    }
+    // val == Map(Some(m)), non-empty, m[0].key == Symbol("amount"),
+    // m[0].val == I128(parts).
+    let ScVal::Map(Some(val_map)) = &cd.val else {
+        return NativeBalance::None;
+    };
+    let Some(amount_entry) = val_map.first() else {
+        return NativeBalance::None;
+    };
+    match &amount_entry.key {
+        ScVal::Symbol(sym) if sym.0.as_slice() == b"amount" => {}
+        _ => return NativeBalance::None,
+    }
+    let ScVal::I128(parts) = &amount_entry.val else {
+        return NativeBalance::None;
+    };
+    // Out of i64 range (`hi > 0 || lo > i64::MAX`) → overflow; mirror core's
+    // `hi > 0` (not `hi != 0`) exactly. `hi` is `i64` in this XDR version, so
+    // `hi > 0` is byte-for-byte equivalent to core's unsigned check for the
+    // representable cases (any high word means out of range).
+    if parts.hi > 0 || parts.lo > i64::MAX as u64 {
+        return NativeBalance::Overflow;
+    }
+    NativeBalance::Balance(parts.lo as i64)
 }
 
 /// Computes the native-balance delta for a single changed entry:
 /// `native_balance(current) - native_balance(previous)`, treating a missing
-/// entry as contributing 0.
+/// entry (or a non-balance-bearing one) as contributing 0.
 ///
-/// Mirrors stellar-core's `calculateDeltaBalance`. Both inputs cannot be
-/// `None` (every changed entry has at least one side); the caller guarantees
-/// this.
-fn calculate_delta_balance(current: Option<&LedgerEntry>, previous: Option<&LedgerEntry>) -> i64 {
-    let cur = current.and_then(native_balance).unwrap_or(0);
-    let prev = previous.and_then(native_balance).unwrap_or(0);
-    cur - prev
+/// Mirrors stellar-core's `calculateDeltaBalance`: if either side reports an
+/// i128 overflow, the delta cannot be computed and the invariant fails with
+/// core's verbatim error string. Both inputs cannot be `None` (every changed
+/// entry has at least one side); the caller guarantees this.
+fn calculate_delta_balance(
+    current: Option<&LedgerEntry>,
+    previous: Option<&LedgerEntry>,
+    native_sac_id: &ContractId,
+) -> Result<i64, String> {
+    let cur = current.map_or(NativeBalance::Balance(0), |e| {
+        native_balance(e, native_sac_id)
+    });
+    let prev = previous.map_or(NativeBalance::Balance(0), |e| {
+        native_balance(e, native_sac_id)
+    });
+    if matches!(cur, NativeBalance::Overflow) || matches!(prev, NativeBalance::Overflow) {
+        return Err("Could not calculate lumen balance delta for an entry".to_string());
+    }
+    let cur = match cur {
+        NativeBalance::Balance(b) => b,
+        NativeBalance::None | NativeBalance::Overflow => 0,
+    };
+    let prev = match prev {
+        NativeBalance::Balance(b) => b,
+        NativeBalance::None | NativeBalance::Overflow => 0,
+    };
+    Ok(cur - prev)
 }
 
 impl Invariant for ConservationOfLumens {
@@ -120,6 +222,10 @@ impl Invariant for ConservationOfLumens {
         // underflow guards.
         let mut delta_balances: i64 = 0;
 
+        // The native SAC contract id is a pure function of the network id;
+        // derive it once per op (core precomputes it as `mLumenContractInfo`).
+        let native_sac_id = native_sac_contract_id(delta.network_id);
+
         let mut accumulate = |d: i64| -> Result<(), String> {
             // Overflow: positive d pushing past i64::MAX.
             if d > 0 && delta_balances > i64::MAX - d {
@@ -135,7 +241,7 @@ impl Invariant for ConservationOfLumens {
 
         // Created: (current = Some, previous = None).
         for entry in delta.created {
-            accumulate(calculate_delta_balance(Some(entry), None))?;
+            accumulate(calculate_delta_balance(Some(entry), None, &native_sac_id)?)?;
         }
         // Updated: (current, previous) pairs. `updated` and `update_states` are
         // documented as parallel slices; a length divergence is a caller bug.
@@ -150,11 +256,19 @@ impl Invariant for ConservationOfLumens {
             ));
         }
         for (current, previous) in delta.updated.iter().zip(delta.update_states.iter()) {
-            accumulate(calculate_delta_balance(Some(current), Some(previous)))?;
+            accumulate(calculate_delta_balance(
+                Some(current),
+                Some(previous),
+                &native_sac_id,
+            )?)?;
         }
         // Deleted: (current = None, previous = Some).
         for previous in delta.delete_states {
-            accumulate(calculate_delta_balance(None, Some(previous)))?;
+            accumulate(calculate_delta_balance(
+                None,
+                Some(previous),
+                &native_sac_id,
+            )?)?;
         }
 
         // Header deltas. If either header is missing, skip the header-delta
@@ -187,7 +301,18 @@ impl Invariant for ConservationOfLumens {
                     let mut sum: i64 = 0;
                     for p in payouts.iter() {
                         sum = sum.checked_add(p.amount).ok_or_else(|| {
-                            "Overflow detected when summing inflation payouts".to_string()
+                            // `checked_add` returns `None` on both overflow
+                            // (positive addend) and underflow (negative addend);
+                            // distinguish so the message reports the actual
+                            // condition rather than always saying "Overflow"
+                            // (#3007). Inflation payouts are non-negative in
+                            // practice, but a corrupt/unexpected meta could carry
+                            // a negative amount.
+                            if p.amount >= 0 {
+                                "Overflow detected when summing inflation payouts".to_string()
+                            } else {
+                                "Underflow detected when summing inflation payouts".to_string()
+                            }
                         })?;
                     }
                     sum

--- a/crates/invariant/tests/conservation.rs
+++ b/crates/invariant/tests/conservation.rs
@@ -12,11 +12,13 @@ use henyey_invariant::{ConservationOfLumens, Invariant, InvariantManager, Operat
 use stellar_xdr::curr::{
     AccountEntry, AccountEntryExt, AccountId, AlphaNum4, Asset, AssetCode4, ClaimPredicate,
     ClaimableBalanceEntry, ClaimableBalanceEntryExt, ClaimableBalanceId, Claimant, ClaimantV0,
-    Hash, InflationResult, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerHeader,
-    LedgerHeaderExt, LiquidityPoolConstantProductParameters, LiquidityPoolEntry,
-    LiquidityPoolEntryBody, LiquidityPoolEntryConstantProduct, Operation, OperationBody,
-    OperationResult, OperationResultTr, PoolId, PublicKey, SequenceNumber, StellarValue,
-    StellarValueExt, String32, Thresholds, TimePoint, Uint256, VecM,
+    ContractDataDurability, ContractDataEntry, ContractId, ContractIdPreimage, ExtensionPoint,
+    Hash, HashIdPreimage, HashIdPreimageContractId, InflationResult, Int128Parts, LedgerEntry,
+    LedgerEntryData, LedgerEntryExt, LedgerHeader, LedgerHeaderExt,
+    LiquidityPoolConstantProductParameters, LiquidityPoolEntry, LiquidityPoolEntryBody,
+    LiquidityPoolEntryConstantProduct, Operation, OperationBody, OperationResult,
+    OperationResultTr, PoolId, PublicKey, ScAddress, ScMap, ScMapEntry, ScSymbol, ScVal, ScVec,
+    SequenceNumber, StellarValue, StellarValueExt, String32, Thresholds, TimePoint, Uint256, VecM,
 };
 
 // ---------------------------------------------------------------------------
@@ -99,6 +101,63 @@ fn liquidity_pool_entry(
             ),
         }),
         ext: LedgerEntryExt::V0,
+    }
+}
+
+/// Derives the native-XLM Stellar-Asset-Contract id for a given network id,
+/// mirroring stellar-core's `getAssetContractID(networkID, Asset::Native)`.
+fn native_sac_contract_id(network_id: &[u8; 32]) -> ContractId {
+    let preimage = HashIdPreimage::ContractId(HashIdPreimageContractId {
+        network_id: Hash(*network_id),
+        contract_id_preimage: ContractIdPreimage::Asset(Asset::Native),
+    });
+    let hash = henyey_common::Hash256::hash_xdr(&preimage);
+    ContractId(Hash(hash.0))
+}
+
+fn symbol_scval(s: &str) -> ScVal {
+    ScVal::Symbol(ScSymbol(s.as_bytes().to_vec().try_into().unwrap()))
+}
+
+/// Builds a SAC native-balance `ContractData` entry for `network_id` holding
+/// `amount`, keyed as core's `getAssetBalance` CONTRACT_DATA branch expects:
+/// `contract == Contract(nativeSacId)`, `key == Vec[Symbol("Balance"), Account(holder)]`,
+/// `val == Map{ "amount" => I128(parts) }`.
+fn sac_native_balance_entry(network_id: &[u8; 32], holder: u8, parts: Int128Parts) -> LedgerEntry {
+    let key = ScVal::Vec(Some(ScVec(
+        vec![
+            symbol_scval("Balance"),
+            ScVal::Address(ScAddress::Account(account_id(holder))),
+        ]
+        .try_into()
+        .unwrap(),
+    )));
+    let val = ScVal::Map(Some(ScMap(
+        vec![ScMapEntry {
+            key: symbol_scval("amount"),
+            val: ScVal::I128(parts),
+        }]
+        .try_into()
+        .unwrap(),
+    )));
+    LedgerEntry {
+        last_modified_ledger_seq: 1,
+        data: LedgerEntryData::ContractData(ContractDataEntry {
+            ext: ExtensionPoint::V0,
+            contract: ScAddress::Contract(native_sac_contract_id(network_id)),
+            key,
+            durability: ContractDataDurability::Persistent,
+            val,
+        }),
+        ext: LedgerEntryExt::V0,
+    }
+}
+
+/// `Int128Parts` for a non-negative `i64` amount (hi = 0).
+fn i128_amount(amount: i64) -> Int128Parts {
+    Int128Parts {
+        hi: 0,
+        lo: amount as u64,
     }
 }
 
@@ -335,6 +394,156 @@ fn test_conservation_liquidity_pool_native_leg() {
         )
         .check(&inv, &payment_result(), Some(&h), Some(&h));
     assert!(bad.is_err(), "unmatched LP native-leg change should fail");
+}
+
+// ---------------------------------------------------------------------------
+// SAC ContractData native balances (#2987)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_conservation_sac_native_transfer_account_to_contract() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    let net = [0u8; 32]; // matches DeltaBuilder::check's network_id
+                         // Account debited 500; an offsetting SAC native-balance ContractData entry
+                         // of 500 is created → net delta 0. (On origin/main the ContractData credit
+                         // is uncounted → delta -500 → false-alarm violation.)
+    let ok = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 500))
+        .created(sac_native_balance_entry(&net, 2, i128_amount(500)))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        ok.is_ok(),
+        "balanced Account→Contract SAC transfer should hold: {ok:?}"
+    );
+
+    // Unbalanced: account debited 500, SAC credited only 300 → delta -200.
+    let bad = DeltaBuilder::new()
+        .updated(account_entry(2, 1000), account_entry(2, 500))
+        .created(sac_native_balance_entry(&net, 2, i128_amount(300)))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(bad.is_err(), "unbalanced SAC transfer should fail");
+}
+
+#[test]
+fn test_conservation_sac_native_transfer_contract_to_account() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    let net = [0u8; 32];
+    // SAC balance drops 1000 → 400 (−600); account credited +600 → net 0.
+    let ok = DeltaBuilder::new()
+        .updated(
+            sac_native_balance_entry(&net, 2, i128_amount(1000)),
+            sac_native_balance_entry(&net, 2, i128_amount(400)),
+        )
+        .updated(account_entry(3, 2000), account_entry(3, 2600))
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        ok.is_ok(),
+        "balanced Contract→Account SAC transfer should hold: {ok:?}"
+    );
+}
+
+#[test]
+fn test_conservation_sac_unrelated_contract_id_ignored() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    let net = [0u8; 32];
+    // A ContractData entry under a WRONG contract id (not the native SAC id)
+    // contributes 0, so a standalone create does not perturb conservation.
+    let mut entry = sac_native_balance_entry(&net, 2, i128_amount(500));
+    if let LedgerEntryData::ContractData(cd) = &mut entry.data {
+        cd.contract = ScAddress::Contract(ContractId(Hash([0x42; 32])));
+    }
+    let ok = DeltaBuilder::new()
+        .created(entry)
+        .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        ok.is_ok(),
+        "ContractData under non-native contract id must contribute 0: {ok:?}"
+    );
+}
+
+#[test]
+fn test_conservation_sac_malformed_key_or_val_ignored() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    let net = [0u8; 32];
+
+    // Correct native contract id but wrong key first symbol ("NotBalance").
+    let mut bad_key = sac_native_balance_entry(&net, 2, i128_amount(500));
+    if let LedgerEntryData::ContractData(cd) = &mut bad_key.data {
+        cd.key = ScVal::Vec(Some(ScVec(
+            vec![symbol_scval("NotBalance")].try_into().unwrap(),
+        )));
+    }
+    let ok_key =
+        DeltaBuilder::new()
+            .created(bad_key)
+            .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        ok_key.is_ok(),
+        "wrong key symbol must contribute 0: {ok_key:?}"
+    );
+
+    // Correct native contract id and key, but the amount is not an I128.
+    let mut bad_val = sac_native_balance_entry(&net, 2, i128_amount(500));
+    if let LedgerEntryData::ContractData(cd) = &mut bad_val.data {
+        cd.val = ScVal::Map(Some(ScMap(
+            vec![ScMapEntry {
+                key: symbol_scval("amount"),
+                val: ScVal::U32(500),
+            }]
+            .try_into()
+            .unwrap(),
+        )));
+    }
+    let ok_val =
+        DeltaBuilder::new()
+            .created(bad_val)
+            .check(&inv, &payment_result(), Some(&h), Some(&h));
+    assert!(
+        ok_val.is_ok(),
+        "non-i128 amount must contribute 0 (not an error): {ok_val:?}"
+    );
+}
+
+#[test]
+fn test_conservation_sac_i128_overflow_detected() {
+    let inv = ConservationOfLumens::new();
+    let h = header(1_000_000, 0);
+    let net = [0u8; 32];
+
+    // hi > 0 → out of i64 range → distinct overflow error.
+    let hi_overflow = sac_native_balance_entry(&net, 2, Int128Parts { hi: 1, lo: 0 });
+    let res_hi =
+        DeltaBuilder::new()
+            .created(hi_overflow)
+            .check(&inv, &payment_result(), Some(&h), Some(&h));
+    let err_hi = res_hi.expect_err("hi>0 SAC amount must fail the invariant");
+    assert_eq!(
+        err_hi, "Could not calculate lumen balance delta for an entry",
+        "unexpected message: {err_hi}"
+    );
+
+    // lo > i64::MAX (hi == 0) → also out of range.
+    let lo_overflow = sac_native_balance_entry(
+        &net,
+        2,
+        Int128Parts {
+            hi: 0,
+            lo: i64::MAX as u64 + 1,
+        },
+    );
+    let res_lo =
+        DeltaBuilder::new()
+            .created(lo_overflow)
+            .check(&inv, &payment_result(), Some(&h), Some(&h));
+    let err_lo = res_lo.expect_err("lo>i64::MAX SAC amount must fail the invariant");
+    assert_eq!(
+        err_lo, "Could not calculate lumen balance delta for an entry",
+        "unexpected message: {err_lo}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #2987
Closes #3007

## Summary

Extends `ConservationOfLumens::native_balance` to recognize the native Stellar-Asset-Contract's `Balance` `ContractData` entries, mirroring stellar-core's `getAssetBalance` CONTRACT_DATA branch (`TransactionUtils.cpp`). An entry is the native SAC balance iff its `contract` is `Contract(native_sac_id)` (id derived per-op from `delta.network_id` via `HashIdPreimage::ContractId` / `ContractIdPreimage::Asset(Native)` — identical to core's precomputed `mLumenContractInfo`), its `key` is a non-empty `Vec` with `v[0] == Symbol("Balance")`, and its `val` is a non-empty `Map` with `m[0].key == Symbol("amount")` and an `I128` value. An i128 amount out of `i64` range (`hi > 0 || lo > i64::MAX`) fails the invariant with core's verbatim `"Could not calculate lumen balance delta for an entry"`; any other structural mismatch contributes 0. This lets Account↔Contract native SAC transfers net to zero instead of firing false-alarm violations.

Also folds in sibling nit #3007 (same file): the inflation-payout sum guard now reports `"Underflow"` for a negative addend instead of always saying `"Overflow"` (`checked_add` returns `None` for both directions).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/2987#issuecomment-4617226288)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-invariant --all-targets -- -D warnings
- [x] cargo test -p henyey-invariant — 16/16 pass (5 new SAC tests + all existing)

## New coverage (feature)

Five SAC tests in `crates/invariant/tests/conservation.rs` (committed first as `c7afa048`, verified 3 FAILED on `origin/main`: the two transfer tests saw uncounted ContractData → false-alarm violation, and the i128-overflow test went undetected). All pass after the implementation commit `c8753084`:
- `test_conservation_sac_native_transfer_account_to_contract`
- `test_conservation_sac_native_transfer_contract_to_account`
- `test_conservation_sac_unrelated_contract_id_ignored`
- `test_conservation_sac_malformed_key_or_val_ignored`
- `test_conservation_sac_i128_overflow_detected`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)