### PR TITLE
Remove unused nonblocking trigger-timer handle methods

### DIFF
--- a/crates/herder/src/timer_manager.rs
+++ b/crates/herder/src/timer_manager.rs
@@ -268,33 +268,6 @@ impl TimerManagerHandle {
         }
     }
 
-    /// Schedule the consensus trigger timer (non-blocking). Used from the
-    /// synchronous post-close / cold-start arming paths (#2702).
-    pub fn schedule_trigger_next_ledger_nonblocking(&self, slot: SlotIndex, duration: Duration) {
-        if self
-            .sender
-            .send(TimerCommand::ScheduleTriggerNextLedger {
-                slot,
-                duration,
-                epoch: None,
-            })
-            .is_err()
-        {
-            tracing::warn!(slot, "timer channel closed: schedule trigger dropped");
-        }
-    }
-
-    /// Cancel the consensus trigger timer for a slot (non-blocking) (#2702).
-    pub fn cancel_trigger_next_ledger_nonblocking(&self, slot: SlotIndex) {
-        if self
-            .sender
-            .send(TimerCommand::CancelTriggerNextLedger { slot })
-            .is_err()
-        {
-            tracing::warn!(slot, "timer channel closed: cancel trigger dropped");
-        }
-    }
-
     /// Cancel all timers for a slot (non-blocking).
     pub fn cancel_slot_timers_nonblocking(&self, slot: SlotIndex) {
         if self


### PR DESCRIPTION
Closes #3012

## Summary

`schedule_trigger_next_ledger_nonblocking` and `cancel_trigger_next_ledger_nonblocking` on `TimerManagerHandle` were added in PR #2773 (issue #2702) but have zero callers across the workspace. The async `schedule_trigger_next_ledger`/`cancel_trigger_next_ledger` variants are what the arming paths actually use. Because the unused methods are `pub`, they evaded the dead-code lint. This removes both. The underlying `TimerCommand::ScheduleTriggerNextLedger`/`CancelTriggerNextLedger` variants remain in use by the async variants and are untouched.

## Plan reference

Trivial short-circuit — Implementation Notes in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3012#issuecomment-list) on #3012.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (clean; confirms no remaining references)
- [x] cargo test -p henyey-herder passes (1176+ tests, 0 failures)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)