### PR TITLE
Enforce eviction-scan validity on background reuse path (BUCKETLISTDB §12.6)

### DIFF
--- a/crates/bucket/PARITY_STATUS.md
+++ b/crates/bucket/PARITY_STATUS.md
@@ -232,6 +232,7 @@ Corresponds to: `LiveBucketIndex.h`, `DiskIndex.h`, `InMemoryIndex.h`, `BucketIn
 | `LedgerEntryIdCmp` / `BucketEntryIdCmp` | `compare_keys()` / `compare_entries()` | Full |
 | `MergeCounters` / `BucketEntryCounters` | Same-named Rust structs | Full |
 | `EvictionResultEntry` / `EvictionResultCandidates` / `EvictedStateVectors` | `EvictionCandidate` / `EvictionResult` / `ResolvedEviction` | Full |
+| `EvictionResultCandidates::isValid()` (BUCKETLISTDB §12.5/§12.6 scan-validity check) | `EvictionResult::is_valid()` (V23-crossing + ledger_seq + 3 archival-settings fields), enforced on the background-scan reuse path in `henyey-ledger` `manager.rs` | Full |
 | `EvictionMetrics` / `EvictionStatistics::recordEvictedEntry()` | `EvictionCounters` / eviction stats | Full |
 | `EvictionStatistics::submitMetricsAndRestartCycle()` | Simplified eviction statistics only | Partial |
 | Binary fuse filter and random-eviction cache | `BucketBloomFilter` / `RandomEvictionCache` | Full |

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -3320,10 +3320,15 @@ impl BucketList {
     /// - Returns evicted entries (archived persistent + deleted temporary)
     ///
     /// The scan automatically advances through buckets when reaching the end of one.
+    ///
+    /// `ledger_version` is the protocol version the scan is based on; it is
+    /// captured on the result so a stale background scan can be invalidated at
+    /// resolve time via [`EvictionResult::is_valid`] (BUCKETLISTDB §12.5/§12.6).
     pub fn scan_for_eviction_incremental(
         &self,
         mut iter: EvictionIterator,
         current_ledger: u32,
+        ledger_version: u32,
         settings: &StateArchivalSettings,
     ) -> Result<EvictionResult> {
         let mut result = EvictionResult {
@@ -3331,6 +3336,12 @@ impl BucketList {
             end_iterator: iter.clone(),
             bytes_scanned: 0,
             scan_complete: false,
+            // Capture the network state this scan is based on so a stale
+            // background scan can be invalidated at resolve time
+            // (EvictionResult::is_valid). Spec: BUCKETLISTDB §12.5/§12.6.
+            initial_ledger_seq: current_ledger,
+            initial_ledger_version: ledger_version,
+            initial_archival_settings: settings.clone(),
         };
 
         // Update iterator based on spills (reset offset if bucket received new data)
@@ -5127,7 +5138,7 @@ mod tests {
         };
 
         // Should panic: persistent entry lookup returns None (DEAD tombstone)
-        let _ = bl.scan_for_eviction_incremental(iter, current_ledger, &settings);
+        let _ = bl.scan_for_eviction_incremental(iter, current_ledger, 23, &settings);
     }
 
     // ============ hash assertion tests ============

--- a/crates/bucket/src/eviction.rs
+++ b/crates/bucket/src/eviction.rs
@@ -65,7 +65,7 @@
 //! update_starting_eviction_iterator(&mut iter, 6, current_ledger);
 //!
 //! // Perform the scan (handled by BucketList::scan_for_eviction_incremental)
-//! let result = bucket_list.scan_for_eviction_incremental(iter, current_ledger, &settings)?;
+//! let result = bucket_list.scan_for_eviction_incremental(iter, current_ledger, ledger_version, &settings)?;
 //!
 //! // Update iterator for next ledger
 //! iter = result.end_iterator;
@@ -257,6 +257,24 @@ pub struct EvictionResult {
     pub bytes_scanned: u64,
     /// Whether the scan completed its byte quota (vs hitting bucket end early).
     pub scan_complete: bool,
+    /// Ledger sequence the scan was based on (captured at scan start).
+    ///
+    /// Used by [`EvictionResult::is_valid`] to reject a stale background scan
+    /// whose ledger no longer matches the resolve-time ledger.
+    pub initial_ledger_seq: u32,
+    /// Protocol version the scan was based on (captured at scan start).
+    ///
+    /// A background scan for ledger N is started immediately after N-1 closes,
+    /// so this is the *just-closed* ledger's protocol version. At resolve time
+    /// it is compared against the resolve ledger's pre-transaction version
+    /// (post any upgrade) to detect a crossing into the first protocol that
+    /// supports persistent eviction (V23).
+    pub initial_ledger_version: u32,
+    /// State archival settings the scan was based on (captured at scan start).
+    ///
+    /// Used by [`EvictionResult::is_valid`] to reject a scan whose eviction
+    /// parameters changed via a config upgrade before resolve.
+    pub initial_archival_settings: StateArchivalSettings,
 }
 
 /// Result of resolving eviction candidates.
@@ -295,6 +313,58 @@ impl ResolvedEviction {
 }
 
 impl EvictionResult {
+    /// Returns true if this scan is still a valid basis for eviction at the
+    /// given current ledger / protocol version / archival settings.
+    ///
+    /// Mirrors stellar-core `EvictionResultCandidates::isValid`
+    /// (`src/bucket/BucketUtils.cpp`, v26.0.1). A background eviction scan for
+    /// ledger N is started immediately after N-1 closes, but ledger N may apply
+    /// a network upgrade that changes eviction behavior. Such a scan must be
+    /// discarded and restarted with the post-upgrade state.
+    ///
+    /// Invalid (returns false) when ANY of:
+    /// - The protocol crosses *into* V23 (the first protocol supporting
+    ///   persistent eviction) between scan start and resolve. Other protocol
+    ///   upgrades do not affect eviction scans.
+    /// - The resolve ledger_seq differs from the scan's captured ledger_seq.
+    /// - Any of the three eviction-relevant archival-settings fields changed:
+    ///   `max_entries_to_archive`, `eviction_scan_size`,
+    ///   `starting_eviction_scan_level`.
+    ///
+    /// Parity: compares ONLY those three settings fields — NOT the full
+    /// `StateArchivalSettings` struct. stellar-core deliberately ignores
+    /// TTL/rent fields (e.g. `min_temporary_ttl`) here; a full-struct equality
+    /// check would be over-strict and diverge from core.
+    ///
+    /// Version mapping: `curr_ledger_seq` / `curr_ledger_vers` / `curr_sas`
+    /// are the resolve ledger's pre-transaction values (core's `currLedger*`),
+    /// while `initial_*` were captured at scan start (the just-closed ledger).
+    pub fn is_valid(
+        &self,
+        curr_ledger_seq: u32,
+        curr_ledger_vers: u32,
+        curr_sas: &StateArchivalSettings,
+    ) -> bool {
+        use henyey_common::protocol::{
+            protocol_version_is_before, protocol_version_starts_from, ProtocolVersion,
+        };
+
+        // If the scan started before V23 and the resolve ledger crosses into
+        // V23, eviction behavior changed mid-scan — restart.
+        if protocol_version_is_before(self.initial_ledger_version, ProtocolVersion::V23)
+            && protocol_version_starts_from(curr_ledger_vers, ProtocolVersion::V23)
+        {
+            return false;
+        }
+
+        self.initial_ledger_seq == curr_ledger_seq
+            && self.initial_archival_settings.max_entries_to_archive
+                == curr_sas.max_entries_to_archive
+            && self.initial_archival_settings.eviction_scan_size == curr_sas.eviction_scan_size
+            && self.initial_archival_settings.starting_eviction_scan_level
+                == curr_sas.starting_eviction_scan_level
+    }
+
     /// Resolve eviction candidates by applying TTL filtering and max_entries limit.
     ///
     /// This matches stellar-core's `resolveBackgroundEvictionScan`:
@@ -1032,6 +1102,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 1000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let mut modified = std::collections::HashSet::new();
@@ -1053,6 +1124,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 1000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let modified = std::collections::HashSet::new(); // empty
@@ -1078,6 +1150,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 1000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let mut modified = std::collections::HashSet::new();
@@ -1107,6 +1180,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 1000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let mut modified = std::collections::HashSet::new();
@@ -1131,6 +1205,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 3000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let modified = std::collections::HashSet::new();
@@ -1153,6 +1228,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 1000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let modified = std::collections::HashSet::new();
@@ -1204,6 +1280,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 4000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let modified = std::collections::HashSet::new();
@@ -1249,6 +1326,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 3000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let modified = std::collections::HashSet::new();
@@ -1282,6 +1360,7 @@ mod tests {
             end_iterator: EvictionIterator::with_default_level(),
             bytes_scanned: 2000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let modified = std::collections::HashSet::new();
@@ -1370,6 +1449,7 @@ mod tests {
             end_iterator: scan_end.clone(),
             bytes_scanned: 1000,
             scan_complete: true,
+            ..Default::default()
         };
 
         let modified = std::collections::HashSet::new();
@@ -1398,6 +1478,7 @@ mod tests {
             end_iterator: scan_end.clone(),
             bytes_scanned: 2000,
             scan_complete: true,
+            ..Default::default()
         };
 
         // All TTL keys are modified — all candidates filtered out
@@ -1520,6 +1601,7 @@ mod tests {
             end_iterator: scan_end.clone(),
             bytes_scanned: 3000,
             scan_complete: true,
+            ..Default::default()
         };
 
         // Only c1's TTL is modified — c1 filtered, c2 and c3 are evicted

--- a/crates/bucket/src/eviction.rs
+++ b/crates/bucket/src/eviction.rs
@@ -1412,6 +1412,93 @@ mod tests {
         assert_eq!(resolved.end_iterator, scan_end);
     }
 
+    // --- EvictionResult::is_valid() tests (BUCKETLISTDB §12.5/§12.6) ---
+
+    fn make_eviction_result_with_initial(
+        initial_ledger_seq: u32,
+        initial_ledger_version: u32,
+        initial_archival_settings: StateArchivalSettings,
+    ) -> EvictionResult {
+        EvictionResult {
+            candidates: Vec::new(),
+            end_iterator: EvictionIterator::with_default_level(),
+            bytes_scanned: 0,
+            scan_complete: true,
+            initial_ledger_seq,
+            initial_ledger_version,
+            initial_archival_settings,
+        }
+    }
+
+    #[test]
+    fn test_eviction_result_is_valid_rejects_ledger_seq_change() {
+        let sas = default_state_archival_settings();
+        let result = make_eviction_result_with_initial(100, 23, sas.clone());
+
+        // Same ledger_seq → valid.
+        assert!(result.is_valid(100, 23, &sas));
+        // Different ledger_seq → invalid (scan was based on a different ledger).
+        assert!(!result.is_valid(150, 23, &sas));
+    }
+
+    #[test]
+    fn test_eviction_result_is_valid_rejects_v23_crossing() {
+        let sas = default_state_archival_settings();
+
+        // Scan started pre-V23 (22), resolve ledger crosses into V23 → invalid.
+        let pre_v23 = make_eviction_result_with_initial(100, 22, sas.clone());
+        assert!(!pre_v23.is_valid(100, 23, &sas));
+
+        // Scan started at V23, resolve at V24 → no crossing into V23 → valid.
+        let at_v23 = make_eviction_result_with_initial(100, 23, sas.clone());
+        assert!(at_v23.is_valid(100, 24, &sas));
+    }
+
+    #[test]
+    fn test_eviction_result_is_valid_rejects_archival_setting_change() {
+        let base = default_state_archival_settings();
+        let result = make_eviction_result_with_initial(100, 23, base.clone());
+
+        // Each of the three relevant fields changing → invalid.
+        let mut changed_max = base.clone();
+        changed_max.max_entries_to_archive += 1;
+        assert!(!result.is_valid(100, 23, &changed_max));
+
+        let mut changed_scan_size = base.clone();
+        changed_scan_size.eviction_scan_size += 1;
+        assert!(!result.is_valid(100, 23, &changed_scan_size));
+
+        let mut changed_level = base.clone();
+        changed_level.starting_eviction_scan_level += 1;
+        assert!(!result.is_valid(100, 23, &changed_level));
+
+        // Changing an unrelated field (min_temporary_ttl) → still valid.
+        // Parity: stellar-core's isValid compares only the three eviction fields.
+        let mut changed_unrelated = base.clone();
+        changed_unrelated.min_temporary_ttl += 1;
+        assert!(result.is_valid(100, 23, &changed_unrelated));
+    }
+
+    #[test]
+    fn test_eviction_result_captures_initial_state() {
+        // New coverage: scan_for_eviction_incremental must populate the three
+        // initial_* fields from its inputs so is_valid can be enforced later.
+        use crate::bucket_list::BucketList;
+
+        let bl = BucketList::new();
+        let mut settings = default_state_archival_settings();
+        settings.max_entries_to_archive = 7;
+        let iter = EvictionIterator::with_default_level();
+
+        let result = bl
+            .scan_for_eviction_incremental(iter, 42, 23, &settings)
+            .expect("scan should succeed on empty bucket list");
+
+        assert_eq!(result.initial_ledger_seq, 42);
+        assert_eq!(result.initial_ledger_version, 23);
+        assert_eq!(result.initial_archival_settings.max_entries_to_archive, 7);
+    }
+
     #[test]
     fn test_resolve_filtered_before_limit_uses_last_evicted_position() {
         // Candidates: [filtered, kept, kept] with max_entries=2

--- a/crates/bucket/src/snapshot.rs
+++ b/crates/bucket/src/snapshot.rs
@@ -509,10 +509,17 @@ impl BucketListSnapshot {
     /// Used by the background eviction scan: a snapshot is taken after committing ledger N,
     /// and the scan runs on a background thread targeting ledger N+1. When N+1 arrives,
     /// the result is resolved with that ledger's modified TTL keys.
+    ///
+    /// `ledger_version` is the protocol version the scan is based on (the
+    /// just-closed ledger's version when launched as a background scan for the
+    /// next ledger). It is captured on the result so a stale scan can be
+    /// invalidated at resolve time via [`EvictionResult::is_valid`]
+    /// (BUCKETLISTDB §12.5/§12.6).
     pub fn scan_for_eviction_incremental(
         &self,
         mut iter: EvictionIterator,
         current_ledger: u32,
+        ledger_version: u32,
         settings: &StateArchivalSettings,
     ) -> crate::Result<EvictionResult> {
         let mut result = EvictionResult {
@@ -520,6 +527,9 @@ impl BucketListSnapshot {
             end_iterator: iter.clone(),
             bytes_scanned: 0,
             scan_complete: false,
+            initial_ledger_seq: current_ledger,
+            initial_ledger_version: ledger_version,
+            initial_archival_settings: settings.clone(),
         };
 
         // Update iterator based on spills (reset offset if bucket received new data)

--- a/crates/bucket/tests/bucket_list_integration.rs
+++ b/crates/bucket/tests/bucket_list_integration.rs
@@ -964,7 +964,7 @@ async fn test_eviction_scan_incremental() {
 
     // Perform incremental scan at ledger 5 (after expiration)
     let result = bl
-        .scan_for_eviction_incremental(iter, 5, &settings)
+        .scan_for_eviction_incremental(iter, 5, 23, &settings)
         .unwrap();
 
     // Should have scanned some bytes
@@ -1040,7 +1040,7 @@ async fn test_snapshot_eviction_scan_matches_bucket_list() {
 
     // Run scan on the bucket list directly
     let bl_result = bl
-        .scan_for_eviction_incremental(iter.clone(), scan_ledger, &settings)
+        .scan_for_eviction_incremental(iter.clone(), scan_ledger, 23, &settings)
         .unwrap();
 
     // Take a snapshot and run the same scan on it
@@ -1068,7 +1068,7 @@ async fn test_snapshot_eviction_scan_matches_bucket_list() {
     };
     let snapshot = BucketListSnapshot::new(&bl, header);
     let snap_result = snapshot
-        .scan_for_eviction_incremental(iter, scan_ledger, &settings)
+        .scan_for_eviction_incremental(iter, scan_ledger, 23, &settings)
         .unwrap();
 
     // Results must be identical
@@ -1196,7 +1196,7 @@ async fn test_snapshot_eviction_scan_on_background_thread() {
     let snapshot = BucketListSnapshot::new(&bl, header);
 
     let handle = std::thread::spawn(move || {
-        snapshot.scan_for_eviction_incremental(iter, target_ledger, &settings)
+        snapshot.scan_for_eviction_incremental(iter, target_ledger, 23, &settings)
     });
 
     let result = handle.join().expect("thread should not panic").unwrap();
@@ -1307,7 +1307,7 @@ async fn test_snapshot_eviction_scan_respects_extended_ttl() {
 
     // Scan at ledger 10: after original TTL (4) but before extended TTL (20)
     let result = snapshot
-        .scan_for_eviction_incremental(iter.clone(), 10, &settings)
+        .scan_for_eviction_incremental(iter.clone(), 10, 23, &settings)
         .unwrap();
 
     // Entry should NOT be evicted because the snapshot sees the extended TTL
@@ -1319,7 +1319,7 @@ async fn test_snapshot_eviction_scan_respects_extended_ttl() {
 
     // Now scan at ledger 25: after the extended TTL
     let result2 = snapshot
-        .scan_for_eviction_incremental(iter, 25, &settings)
+        .scan_for_eviction_incremental(iter, 25, 23, &settings)
         .unwrap();
 
     // Entry SHOULD be evicted now
@@ -1408,7 +1408,7 @@ async fn test_snapshot_eviction_scan_temporary_entries() {
     };
 
     let result = snapshot
-        .scan_for_eviction_incremental(iter, 5, &settings)
+        .scan_for_eviction_incremental(iter, 5, 23, &settings)
         .unwrap();
 
     // Should find all 5 expired entries (3 temporary + 2 persistent)
@@ -2046,7 +2046,7 @@ async fn test_eviction_scan_zero_budget_does_not_advance_iterator() {
 
     // Scan at a ledger past expiration
     let result = bl
-        .scan_for_eviction_incremental(start_iter.clone(), 100, &settings)
+        .scan_for_eviction_incremental(start_iter.clone(), 100, 23, &settings)
         .unwrap();
 
     // stellar-core returns immediately with no work when bytesToScan == 0
@@ -2136,7 +2136,7 @@ fn test_audit_156_incremental_eviction_panics_on_dead_persistent_entry() {
     };
 
     // Should panic: persistent entry lookup returns None (DEAD tombstone)
-    let _ = bl.scan_for_eviction_incremental(iter, 100, &settings);
+    let _ = bl.scan_for_eviction_incremental(iter, 100, 23, &settings);
 }
 
 /// Same as above but exercises the BucketListSnapshot path.
@@ -2222,5 +2222,5 @@ fn test_audit_156_snapshot_incremental_eviction_panics_on_dead_persistent_entry(
     };
 
     // Should panic: snapshot lookup also returns None for DEAD-shadowed key
-    let _ = snapshot.scan_for_eviction_incremental(iter, 100, &settings);
+    let _ = snapshot.scan_for_eviction_incremental(iter, 100, 23, &settings);
 }

--- a/crates/history/src/replay/execution.rs
+++ b/crates/history/src/replay/execution.rs
@@ -82,7 +82,12 @@ fn run_eviction_scan(
         EvictionIterator::new(context.eviction_settings.starting_eviction_scan_level)
     });
     let eviction_result = bucket_list
-        .scan_for_eviction_incremental(iter, context.header.ledger_seq, context.eviction_settings)
+        .scan_for_eviction_incremental(
+            iter,
+            context.header.ledger_seq,
+            context.header.ledger_version,
+            context.eviction_settings,
+        )
         .map_err(HistoryError::Bucket)?;
 
     tracing::info!(

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -151,7 +151,6 @@ pub fn prepend_fee_event(
 struct PendingEvictionScan {
     handle: std::thread::JoinHandle<henyey_bucket::Result<EvictionResult>>,
     target_ledger_seq: u32,
-    settings: StateArchivalSettings,
 }
 
 /// Pre-computed cache data from a bucket list scan.
@@ -5017,6 +5016,10 @@ impl LedgerCloseContext<'_> {
                     let eviction_result = {
                         let pending = self.manager.pending_eviction_scan.lock().take();
                         let background_result = pending.and_then(|scan| {
+                            // Cheap pre-filter: a scan launched for a different
+                            // target ledger can't be reused (and lets us skip
+                            // joining the thread). The authoritative validity
+                            // check is `EvictionResult::is_valid` below.
                             if scan.target_ledger_seq != self.close_data.ledger_seq {
                                 tracing::debug!(
                                     ledger_seq = self.close_data.ledger_seq,
@@ -5025,15 +5028,28 @@ impl LedgerCloseContext<'_> {
                                 );
                                 return None;
                             }
-                            if scan.settings != eviction_settings {
-                                tracing::debug!(
-                                    ledger_seq = self.close_data.ledger_seq,
-                                    "Discarding background eviction scan: settings changed"
-                                );
-                                return None;
-                            }
                             match scan.handle.join() {
                                 Ok(Ok(result)) => {
+                                    // Authoritative spec check (BUCKETLISTDB
+                                    // §12.5/§12.6): discard a stale scan whose
+                                    // ledger_seq / eviction settings changed, or
+                                    // that crossed into V23 before resolve.
+                                    // `prev_version` is the resolve ledger's
+                                    // pre-transaction version (core's
+                                    // `currLedgerVers`). On invalid, fall through
+                                    // to the inline rescan with current state.
+                                    if !result.is_valid(
+                                        self.close_data.ledger_seq,
+                                        prev_version,
+                                        &eviction_settings,
+                                    ) {
+                                        tracing::debug!(
+                                            ledger_seq = self.close_data.ledger_seq,
+                                            "Discarding background eviction scan: \
+                                             invalid (ledger/version/settings changed)"
+                                        );
+                                        return None;
+                                    }
                                     tracing::debug!(
                                         ledger_seq = self.close_data.ledger_seq,
                                         candidates = result.candidates.len(),
@@ -5069,6 +5085,7 @@ impl LedgerCloseContext<'_> {
                                     .scan_for_eviction_incremental(
                                         iter,
                                         self.close_data.ledger_seq,
+                                        prev_version,
                                         &eviction_settings,
                                     )
                                     .map_err(LedgerError::Bucket)?
@@ -5512,7 +5529,11 @@ impl LedgerCloseContext<'_> {
                         let snapshot =
                             BucketListSnapshot::new(&bucket_list, self.prev_header.clone());
                         let iter = load_eviction_iterator_from_bucket_list(&bucket_list)?;
-                        Some((snapshot, iter, settings))
+                        // The scan for ledger N+1 runs on the just-closed
+                        // ledger's protocol version (`prev_version`); that value
+                        // becomes the result's `initial_ledger_version` so a
+                        // V23 crossing at N+1 invalidates it (is_valid).
+                        Some((snapshot, iter, prev_version, settings))
                     } else {
                         None
                     }
@@ -5537,16 +5558,19 @@ impl LedgerCloseContext<'_> {
         // Start background eviction scan for the next ledger.
         // The scan runs on a snapshot of the bucket list (taken above while the write
         // lock was held), so it doesn't interfere with subsequent operations.
-        if let Some((snapshot, iter, settings)) = bg_eviction_data {
+        if let Some((snapshot, iter, scan_version, settings)) = bg_eviction_data {
             let target_ledger_seq = self.close_data.ledger_seq + 1;
-            let settings_clone = settings.clone();
             let handle = std::thread::spawn(move || {
-                snapshot.scan_for_eviction_incremental(iter, target_ledger_seq, &settings_clone)
+                snapshot.scan_for_eviction_incremental(
+                    iter,
+                    target_ledger_seq,
+                    scan_version,
+                    &settings,
+                )
             });
             *self.manager.pending_eviction_scan.lock() = Some(PendingEvictionScan {
                 handle,
                 target_ledger_seq,
-                settings,
             });
         }
 
@@ -7639,14 +7663,12 @@ mod tests {
         let snapshot = BucketListSnapshot::new(&BucketList::default(), create_genesis_header());
         let settings = StateArchivalSettings::default();
         let iter = EvictionIterator::new(settings.starting_eviction_scan_level);
-        let settings_clone = settings.clone();
         let handle = std::thread::spawn(move || {
-            snapshot.scan_for_eviction_incremental(iter, 2, &settings_clone)
+            snapshot.scan_for_eviction_incremental(iter, 2, 23, &settings)
         });
         *manager.pending_eviction_scan.lock() = Some(PendingEvictionScan {
             handle,
             target_ledger_seq: 2,
-            settings,
         });
 
         assert!(manager.pending_eviction_scan.lock().is_some());
@@ -7729,8 +7751,9 @@ mod tests {
             bucket_file_offset: 0,
         };
 
-        let handle =
-            std::thread::spawn(move || snapshot.scan_for_eviction_incremental(iter, 5, &settings));
+        let handle = std::thread::spawn(move || {
+            snapshot.scan_for_eviction_incremental(iter, 5, 23, &settings)
+        });
 
         let result = handle.join().expect("thread should not panic").unwrap();
         assert_eq!(result.candidates.len(), 3, "Should find 3 expired entries");


### PR DESCRIPTION
Closes #3019

## Summary

Adds `initial_ledger_seq`, `initial_ledger_version`, and `initial_archival_settings` to `EvictionResult` plus `EvictionResult::is_valid(curr_seq, curr_vers, curr_sas)`, mirroring stellar-core `EvictionResultCandidates::isValid` (v26.0.1): a V23-crossing check via `protocol_version_is_before(initial_vers, V23) && protocol_version_starts_from(curr_vers, V23)`, equality on `ledger_seq`, and equality on the **three** eviction archival-settings fields only (`max_entries_to_archive`, `eviction_scan_size`, `starting_eviction_scan_level`) — NOT full-SAS equality. `ledger_version` is threaded through `scan_for_eviction_incremental` so the scan captures the network state it is based on.

The behavioral fix is in `henyey-ledger` `manager.rs`: the background-scan reuse path previously discarded on full-`settings` inequality (over-strict on benign TTL/rent upgrades, and silent on a V23 crossing). It now keeps the cheap `target_ledger_seq` pre-filter, then calls `result.is_valid(self.close_data.ledger_seq, prev_version, &eviction_settings)`; on `false` it falls through to the existing inline rescan — exactly core's §12.6 "restart the scan". The now-redundant `PendingEvictionScan.settings` field is removed.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3019#issuecomment-4618651938)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-bucket (523 tests) passes
- [x] cargo test -p henyey-ledger -p henyey-history passes

## Regression test (kind: bug-fix)

- **Tests:** `crates/bucket/src/eviction.rs` — `test_eviction_result_is_valid_rejects_ledger_seq_change`, `test_eviction_result_is_valid_rejects_v23_crossing`, `test_eviction_result_is_valid_rejects_archival_setting_change`, `test_eviction_result_captures_initial_state`
- **Pre-fix:** committed as `f5a211fd` — verified FAILED to compile (no `initial_*` fields / `is_valid` method, scan signature lacked `ledger_version`)
- **Post-fix:** verified PASSES after `bed6c739`

## Deviations from plan

- The README parity-column cell is a single aggregate percentage; left unchanged rather than guess a recomputed value. The §12.6 validity-check parity is recorded in `crates/bucket/PARITY_STATUS.md` (new row) as the plan intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)