### PR TITLE
Add §7 Ledger Apply Manager drift threshold and pure decision logic

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -1697,17 +1697,12 @@ impl App {
     /// Returns `None` if no trimming should occur (last_buffered <= 1 and is a
     /// checkpoint start). Otherwise returns `Some(trim_before)` — entries below
     /// this value should be removed.
+    ///
+    /// Delegates to the spec §7.4 pure boundary logic in
+    /// `henyey_history::ledger_apply_manager` (parity:
+    /// `LedgerApplyManagerImpl::trimSyncingLedgers`).
     pub(super) fn trim_boundary_for_last_buffered(last_buffered: u32) -> Option<u32> {
-        if is_checkpoint_start(last_buffered) {
-            if last_buffered <= 1 {
-                None
-            } else {
-                let prev = last_buffered - 1;
-                Some(checkpoint_start(prev))
-            }
-        } else {
-            Some(checkpoint_start(last_buffered))
-        }
+        henyey_history::trim_boundary_for_last_buffered(last_buffered)
     }
 
     /// Ensure a slot is in the syncing_ledgers buffer with the best
@@ -1883,6 +1878,23 @@ impl App {
 
         let current_ledger = self.get_current_ledger().await.ok()?;
         let next_seq = current_ledger.saturating_add(1);
+
+        // CATCHUP_SPEC §7.3 sequential-apply drift stop-condition
+        // (parity: LedgerApplyManagerImpl.cpp:516). If the next ledger to apply
+        // is too far ahead of the last-closed ledger, stop scheduling and let
+        // the node gracefully fall into catchup. Henyey applies inline, so
+        // `next_seq == current_ledger + 1` always and this gate is
+        // faithful-but-dormant — exactly as in stellar-core, where it only
+        // fires under parallel-close queue depth. `next_seq` is the
+        // `nextToApply` (= last-queued + 1) that core compares against `lcl`.
+        if henyey_history::apply_drift_exceeded(next_seq, current_ledger) {
+            tracing::info!(
+                next_to_apply = next_seq,
+                lcl = current_ledger,
+                "Next ledger to apply is too far ahead of LCL; waiting (drift gate)"
+            );
+            return None;
+        }
 
         let close_info = {
             let mut buffer =

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -71,7 +71,7 @@ use henyey_herder::{
     HerderStats, TxQueueConfig, TxSetValidationContext,
 };
 use henyey_history::{
-    build_history_archive_state, checkpoint_containing, checkpoint_frequency, checkpoint_start,
+    build_history_archive_state, checkpoint_containing, checkpoint_frequency,
     first_ledger_after_checkpoint_containing, is_checkpoint_ledger, is_checkpoint_start,
     last_ledger_before_checkpoint_containing, latest_checkpoint_before_or_at, CatchupConfiguration,
     CatchupManager, CatchupMode, CatchupResult as HistoryCatchupResult, CatchupRunMode,

--- a/crates/history/src/ledger_apply_manager.rs
+++ b/crates/history/src/ledger_apply_manager.rs
@@ -1,0 +1,232 @@
+//! Pure §7 Ledger Apply Manager decision logic.
+//!
+//! Spec: `stellar-specs/CATCHUP_SPEC.md` §7 ("Ledger Apply Manager"). Parity:
+//! `stellar-core/src/catchup/LedgerApplyManagerImpl.{h,cpp}`.
+//!
+//! In henyey the §7 Ledger Apply Manager is collapsed into `App` (which owns the
+//! `RwLock<BTreeMap>` syncing-ledger buffer, the herder, and the async ledger
+//! close). This module extracts only the **pure decision logic** — the drift
+//! threshold constant, the §7.3 drift stop-predicate, the §7.4 trim, and the
+//! §7.2 process-ledger classifier — so that the normative §7 architecture is
+//! visible from `crates/history` and the spec threshold is real and enforced.
+//! The async/lock machinery stays correctly App-owned.
+//!
+//! ## Faithful-but-dormant drift gate
+//!
+//! Henyey applies ledgers **inline**: there is no `lastQueuedToApply` distinct
+//! from the last-closed ledger (LCL) and no parallel-close queue. Under inline
+//! apply `next_to_apply - lcl == 1` always, so [`apply_drift_exceeded`] never
+//! fires — exactly as in stellar-core, where the check only fires under
+//! parallel-close queue depth. We deliberately do NOT repurpose the threshold
+//! to gate the catchup trigger (stellar-core's drift check gates ONLY
+//! sequential-apply scheduling, never the catchup trigger — that is §7.2
+//! step-8's distinct "first ledger of checkpoint" rule).
+
+use std::collections::BTreeMap;
+
+use crate::checkpoint::{checkpoint_frequency, checkpoint_start, is_checkpoint_start};
+
+/// Maximum allowed drift, in ledgers, between the next ledger queued for
+/// sequential apply and the last-closed ledger (LCL) before the node stops
+/// scheduling sequential applies and lets itself fall into catchup.
+///
+/// Parity: `LedgerApplyManagerImpl.cpp:28` (`= 12`). Spec: CATCHUP_SPEC §7.3.
+pub const MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT: u32 = 12;
+
+/// §7.3 sequential-apply drift stop-condition.
+///
+/// Returns `true` when the drift between the next ledger to apply and the
+/// last-closed ledger has reached [`MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT`], at
+/// which point sequential-apply scheduling must stop so the node can gracefully
+/// transition to catchup.
+///
+/// `next_to_apply` is the sequence of the ledger about to be scheduled — i.e.
+/// `last_queued_to_apply + 1` — to be byte-identical to the stellar-core check
+/// `nextToApply - lcl >= MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT`
+/// (`LedgerApplyManagerImpl.cpp:516`, with `nextToApply = *mLastQueuedToApply + 1`).
+///
+/// `saturating_sub` is used so the port cannot panic where core relies on
+/// `releaseAssert(mLastQueuedToApply >= lcl)` (`.cpp:515`); under inline apply
+/// `next_to_apply == lcl + 1 > lcl`, so the assertion holds trivially.
+///
+/// # Examples
+///
+/// ```
+/// use henyey_history::ledger_apply_manager::{apply_drift_exceeded, MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT};
+///
+/// // Inline apply: next_to_apply is always lcl + 1 → never fires.
+/// assert!(!apply_drift_exceeded(101, 100));
+/// // At the threshold (drift == 12) → fires.
+/// assert!(apply_drift_exceeded(100 + MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT, 100));
+/// ```
+#[inline]
+pub fn apply_drift_exceeded(next_to_apply: u32, lcl: u32) -> bool {
+    next_to_apply.saturating_sub(lcl) >= MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT
+}
+
+/// The §7.2 process-ledger decision for a newly received externalized ledger.
+///
+/// This captures the spec's decision tree (§7.2 steps 3/5/6) as a pure
+/// classification over the relevant scalar inputs, independent of the buffer
+/// storage and lock machinery (which stay App-owned).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessLedgerDecision {
+    /// §7.2 step 3 — `S <= last_queued_to_apply`: the ledger is stale and is
+    /// silently dropped.
+    SkipStale,
+    /// §7.2 step 5 — `S == last_queued_to_apply + 1` and no catchup running:
+    /// the ledger is contiguous with the apply stream and is applied
+    /// sequentially (via §7.3).
+    SequentialApply,
+    /// §7.2 step 6/8 — the ledger is buffered and the node waits (either a gap
+    /// exists, or a catchup is currently running so even a contiguous ledger is
+    /// buffered rather than applied).
+    BufferAndWait,
+}
+
+/// Classify a newly received externalized ledger with sequence `s` per §7.2.
+///
+/// `last_queued_to_apply` is the highest ledger sequence already queued for
+/// apply (in henyey's inline model, the last-closed ledger). `catchup_running`
+/// is whether a `CatchupWork` is currently in flight.
+///
+/// Parity: mirrors the early branches of
+/// `LedgerApplyManagerImpl::processLedger` — skip-stale (`S <= lastQueued`),
+/// sequential (`S == lastQueued + 1` with no catchup), otherwise buffer-and-wait.
+///
+/// # Examples
+///
+/// ```
+/// use henyey_history::ledger_apply_manager::{classify_process_ledger, ProcessLedgerDecision};
+///
+/// assert_eq!(classify_process_ledger(100, 100, false), ProcessLedgerDecision::SkipStale);
+/// assert_eq!(classify_process_ledger(101, 100, false), ProcessLedgerDecision::SequentialApply);
+/// assert_eq!(classify_process_ledger(105, 100, false), ProcessLedgerDecision::BufferAndWait);
+/// assert_eq!(classify_process_ledger(101, 100, true), ProcessLedgerDecision::BufferAndWait);
+/// ```
+#[inline]
+pub fn classify_process_ledger(
+    s: u32,
+    last_queued_to_apply: u32,
+    catchup_running: bool,
+) -> ProcessLedgerDecision {
+    if s <= last_queued_to_apply {
+        ProcessLedgerDecision::SkipStale
+    } else if !catchup_running && s == last_queued_to_apply + 1 {
+        ProcessLedgerDecision::SequentialApply
+    } else {
+        ProcessLedgerDecision::BufferAndWait
+    }
+}
+
+/// §7.4 buffer trimming — discard ledgers that cannot contribute to a future
+/// catchup operation.
+///
+/// Operating on a generic `BTreeMap<u32, V>` keyed by ledger sequence (so it is
+/// independent of the `LedgerCloseInfo` value type, which lives in the herder
+/// crate), this performs the spec's trim:
+///
+/// 1. Remove all entries with `ledgerSeq < last_queued_to_apply + 1` (stale).
+/// 2. Let `last_buffered` be the largest remaining key. If it is the first
+///    ledger of a checkpoint, retain only `last_buffered` plus the entire prior
+///    checkpoint (i.e. entries `>= checkpoint_start(last_buffered - 1)`).
+/// 3. Otherwise retain only entries with sequence
+///    `>= firstLedgerInCheckpointContaining(last_buffered)`.
+///
+/// The result satisfies the §7.1(c) invariant: at most `CHECKPOINT_FREQUENCY+1`
+/// entries spanning one full checkpoint plus the following checkpoint's first
+/// ledger.
+///
+/// Parity: `LedgerApplyManagerImpl::trimSyncingLedgers`.
+pub fn trim_syncing_buffer<V>(buffer: &mut BTreeMap<u32, V>, last_queued_to_apply: u32) {
+    // Step 1: drop stale entries (already queued / applied).
+    let min_keep = last_queued_to_apply.saturating_add(1);
+    buffer.retain(|seq, _| *seq >= min_keep);
+    if buffer.is_empty() {
+        return;
+    }
+
+    // Steps 2/3: trim to the checkpoint boundary implied by the last buffered
+    // ledger.
+    let last_buffered = *buffer
+        .keys()
+        .next_back()
+        .expect("buffer checked non-empty above");
+    let trim_before = match trim_boundary_for_last_buffered(last_buffered) {
+        Some(b) => b,
+        None => return,
+    };
+    buffer.retain(|seq, _| *seq >= trim_before);
+}
+
+/// Compute the §7.4 trim boundary for the given `last_buffered` slot.
+///
+/// Returns `None` when no checkpoint-boundary trim should occur (the degenerate
+/// `last_buffered <= 1` checkpoint-start case). Otherwise returns
+/// `Some(trim_before)` — entries with sequence `< trim_before` should be
+/// removed.
+///
+/// - If `last_buffered` is the first ledger of a checkpoint, its checkpoint has
+///   not yet been published, so retain it plus the entire prior checkpoint:
+///   boundary is `checkpoint_start(last_buffered - 1)`.
+/// - Otherwise its checkpoint has begun publishing, so retain only
+///   `>= checkpoint_start(last_buffered)`.
+///
+/// Parity: the boundary arithmetic in `trimSyncingLedgers`.
+pub fn trim_boundary_for_last_buffered(last_buffered: u32) -> Option<u32> {
+    if is_checkpoint_start(last_buffered) {
+        if last_buffered <= 1 {
+            None
+        } else {
+            Some(checkpoint_start(last_buffered - 1))
+        }
+    } else {
+        Some(checkpoint_start(last_buffered))
+    }
+}
+
+/// The §7.1(c) buffer-size invariant bound: at most one full checkpoint plus the
+/// following checkpoint's first ledger.
+#[inline]
+pub fn max_buffer_invariant_entries() -> usize {
+    (checkpoint_frequency() + 1) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drift_predicate_pins_constant() {
+        assert_eq!(MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT, 12);
+        for drift in 0..=11u32 {
+            assert!(!apply_drift_exceeded(1000 + drift, 1000));
+        }
+        for drift in 12..=24u32 {
+            assert!(apply_drift_exceeded(1000 + drift, 1000));
+        }
+    }
+
+    #[test]
+    fn drift_predicate_saturates() {
+        assert!(!apply_drift_exceeded(0, 1000));
+    }
+
+    #[test]
+    fn trim_boundary_checkpoint_start_retains_prior_checkpoint() {
+        // freq 64: last_buffered = 192 (checkpoint start) → retain from 128.
+        assert_eq!(trim_boundary_for_last_buffered(192), Some(128));
+        // mid-checkpoint last_buffered = 200 → retain from 192.
+        assert_eq!(trim_boundary_for_last_buffered(200), Some(192));
+        // degenerate ledger 1 → no trim.
+        assert_eq!(trim_boundary_for_last_buffered(1), None);
+    }
+
+    #[test]
+    fn trim_buffer_respects_invariant() {
+        let mut buf: BTreeMap<u32, ()> = (10u32..=192).map(|s| (s, ())).collect();
+        trim_syncing_buffer(&mut buf, 9);
+        assert!(buf.len() <= max_buffer_invariant_entries());
+        assert_eq!(*buf.keys().next().unwrap(), 128);
+    }
+}

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -106,6 +106,7 @@ pub mod paths;
 pub mod catchup;
 pub mod catchup_range;
 pub mod checkpoint;
+pub mod ledger_apply_manager;
 pub mod replay;
 pub mod verify;
 
@@ -160,6 +161,11 @@ pub use checkpoint_builder::write_record_marked_xdr;
 pub use compare::{compare_checkpoint, Category, CheckpointComparison, Mismatch};
 pub use download::DownloadConfig;
 pub use error::{HistoryError, TxSetHashMismatchInfo, VerifyHashKind, VerifyHashMismatchInfo};
+pub use ledger_apply_manager::{
+    apply_drift_exceeded, classify_process_ledger, max_buffer_invariant_entries,
+    trim_boundary_for_last_buffered, trim_syncing_buffer, ProcessLedgerDecision,
+    MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT,
+};
 pub use paths::{
     bucket_path, checkpoint_path, checkpoint_path_dirty, dirty_to_final_path, final_to_dirty_path,
     is_dirty_path,

--- a/crates/history/tests/ledger_apply_manager.rs
+++ b/crates/history/tests/ledger_apply_manager.rs
@@ -74,11 +74,21 @@ fn test_trim_retains_last_checkpoint_plus_boundary() {
 }
 
 /// §7.4 step 1: stale ledgers (`< last_queued_to_apply + 1`) are always removed.
+/// After stale removal the §7.4 checkpoint-boundary trim still applies, so for a
+/// mid-checkpoint `last_buffered = 70` (checkpoint_start = 64) the surviving
+/// floor is the larger of the stale floor (61) and the checkpoint floor (64).
 #[test]
 fn test_trim_removes_stale() {
+    // Stale floor 61 is below the checkpoint floor 64 → checkpoint floor wins.
     let mut buf: BTreeMap<u32, ()> = (50u32..=70).map(|s| (s, ())).collect();
     trim_syncing_buffer(&mut buf, /* last_queued_to_apply */ 60);
-    assert_eq!(*buf.keys().next().unwrap(), 61);
+    assert_eq!(*buf.keys().next().unwrap(), 64);
+
+    // Stale floor 100 is above the checkpoint floor (64) → stale removal alone
+    // governs; entry 99 and below are gone, last_buffered 120 keeps from 100.
+    let mut buf2: BTreeMap<u32, ()> = (90u32..=120).map(|s| (s, ())).collect();
+    trim_syncing_buffer(&mut buf2, /* last_queued_to_apply */ 99);
+    assert_eq!(*buf2.keys().next().unwrap(), 100);
 }
 
 /// §7.2 step 3: `S <= last_queued_to_apply` ⇒ the ledger is silently dropped.

--- a/crates/history/tests/ledger_apply_manager.rs
+++ b/crates/history/tests/ledger_apply_manager.rs
@@ -1,0 +1,120 @@
+//! Integration tests for the pure §7 Ledger Apply Manager decision logic.
+//!
+//! These exercise the spec CATCHUP_SPEC §7.2/§7.3/§7.4 pure functions extracted
+//! into `henyey_history::ledger_apply_manager`. They mirror the parity-relevant
+//! behavior of stellar-core `LedgerApplyManagerImpl.{h,cpp}` without the
+//! async/lock machinery (which stays App-owned).
+
+use std::collections::BTreeMap;
+
+use henyey_history::ledger_apply_manager::{
+    apply_drift_exceeded, classify_process_ledger, trim_syncing_buffer, ProcessLedgerDecision,
+    MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT,
+};
+
+/// §7.3 drift stop-condition: parity with `LedgerApplyManagerImpl.cpp:516`
+/// (`nextToApply - lcl >= MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT`). The predicate
+/// is parameterized on `next_to_apply` (= last-queued + 1) to be byte-identical
+/// to core. False for drift 0..=11, true at 12 and above. Pins the constant.
+#[test]
+fn test_apply_drift_exceeded_threshold() {
+    assert_eq!(MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT, 12);
+
+    let lcl = 1_000u32;
+    // next_to_apply - lcl in 0..=11 → not exceeded.
+    for drift in 0..=11u32 {
+        let next_to_apply = lcl + drift;
+        assert!(
+            !apply_drift_exceeded(next_to_apply, lcl),
+            "drift {drift} (next_to_apply={next_to_apply}) must NOT exceed threshold"
+        );
+    }
+    // 12 and above → exceeded.
+    for drift in 12..=20u32 {
+        let next_to_apply = lcl + drift;
+        assert!(
+            apply_drift_exceeded(next_to_apply, lcl),
+            "drift {drift} (next_to_apply={next_to_apply}) MUST exceed threshold"
+        );
+    }
+}
+
+/// `apply_drift_exceeded` must not panic when `next_to_apply < lcl`
+/// (saturating_sub yields 0, well under the threshold). Core relies on
+/// `releaseAssert(mLastQueuedToApply >= lcl)`; the Rust port saturates instead
+/// of asserting, which holds trivially under inline apply.
+#[test]
+fn test_apply_drift_exceeded_saturates_below_lcl() {
+    assert!(!apply_drift_exceeded(5, 100));
+}
+
+/// §7.4 trim: when `last_buffered` is the first ledger of a checkpoint, retain
+/// that ledger plus the entire prior checkpoint; the §7.1(c) ≤ 65-entry
+/// invariant must hold. When `last_buffered` is mid-checkpoint, retain only
+/// entries `>= firstLedgerInCheckpointContaining(last_buffered)`.
+#[test]
+fn test_trim_retains_last_checkpoint_plus_boundary() {
+    // Mid-checkpoint last_buffered (default freq 64): last = 200 lives in the
+    // checkpoint [192, 255]; retain only entries >= 192.
+    let mut buf: BTreeMap<u32, ()> = (100u32..=200).map(|s| (s, ())).collect();
+    trim_syncing_buffer(&mut buf, /* last_queued_to_apply */ 99);
+    assert_eq!(*buf.keys().next().unwrap(), 192);
+    assert_eq!(*buf.keys().next_back().unwrap(), 200);
+
+    // last_buffered at a checkpoint start (192): retain 192 + the entire prior
+    // checkpoint [128, 191]. First retained key is 128; ≤ 65 entries.
+    let mut buf2: BTreeMap<u32, ()> = (10u32..=192).map(|s| (s, ())).collect();
+    trim_syncing_buffer(&mut buf2, /* last_queued_to_apply */ 9);
+    assert_eq!(*buf2.keys().next().unwrap(), 128);
+    assert_eq!(*buf2.keys().next_back().unwrap(), 192);
+    assert!(
+        buf2.len() <= (henyey_history::checkpoint_frequency() + 1) as usize,
+        "§7.1(c): at most CHECKPOINT_FREQUENCY+1 entries"
+    );
+}
+
+/// §7.4 step 1: stale ledgers (`< last_queued_to_apply + 1`) are always removed.
+#[test]
+fn test_trim_removes_stale() {
+    let mut buf: BTreeMap<u32, ()> = (50u32..=70).map(|s| (s, ())).collect();
+    trim_syncing_buffer(&mut buf, /* last_queued_to_apply */ 60);
+    assert_eq!(*buf.keys().next().unwrap(), 61);
+}
+
+/// §7.2 step 3: `S <= last_queued_to_apply` ⇒ the ledger is silently dropped.
+#[test]
+fn test_process_ledger_decision_skip_stale() {
+    assert_eq!(
+        classify_process_ledger(/* s */ 100, /* last_queued_to_apply */ 100, false),
+        ProcessLedgerDecision::SkipStale
+    );
+    assert_eq!(
+        classify_process_ledger(/* s */ 99, /* last_queued_to_apply */ 100, false),
+        ProcessLedgerDecision::SkipStale
+    );
+}
+
+/// §7.2 step 5: `S == last_queued_to_apply + 1` and no catchup running ⇒
+/// sequential apply.
+#[test]
+fn test_process_ledger_decision_sequential() {
+    assert_eq!(
+        classify_process_ledger(/* s */ 101, /* last_queued_to_apply */ 100, false),
+        ProcessLedgerDecision::SequentialApply
+    );
+}
+
+/// §7.2: a ledger beyond `last_queued_to_apply + 1` (gap) buffers and waits;
+/// likewise any new ledger while catchup is running buffers and waits.
+#[test]
+fn test_process_ledger_decision_buffer_and_wait() {
+    assert_eq!(
+        classify_process_ledger(/* s */ 105, /* last_queued_to_apply */ 100, false),
+        ProcessLedgerDecision::BufferAndWait
+    );
+    // Catchup running: even a contiguous ledger is buffered, not applied.
+    assert_eq!(
+        classify_process_ledger(/* s */ 101, /* last_queued_to_apply */ 100, true),
+        ProcessLedgerDecision::BufferAndWait
+    );
+}


### PR DESCRIPTION
Closes #3038

## Summary

Makes the CATCHUP_SPEC §7 Ledger Apply Manager threshold real and history-visible. Adds `crates/history/src/ledger_apply_manager.rs` exposing `MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT = 12`, the §7.3 drift stop-predicate `apply_drift_exceeded(next_to_apply, lcl)` (byte-identical to `LedgerApplyManagerImpl.cpp:516`), the §7.4 `trim_syncing_buffer` / `trim_boundary_for_last_buffered` helpers, and the §7.2 `classify_process_ledger` decision classifier — pure functions only. App's lock/async machinery stays App-owned. The drift gate is wired at App's sequential-apply site (`try_start_ledger_close`); App's `trim_boundary_for_last_buffered` now delegates to the history pure function.

Henyey applies ledgers inline (`next_seq == current_ledger + 1` always), so the drift gate is **faithful-but-dormant** — exactly as in stellar-core, where it only fires under parallel-close queue depth. The catchup trigger is deliberately NOT gated on this threshold (that is §7.2 step-8's distinct "first ledger of checkpoint" rule).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3038#issuecomment-4618651832)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-history (29 passed incl. doctests; new ledger_apply_manager suite green)
- [x] cargo test -p henyey-app --lib (983 passed; existing trim/apply/start batteries preserved)

## New coverage

- `crates/history/tests/ledger_apply_manager.rs` — drift threshold (false 0..=11, true ≥12, pins constant to 12), saturation below lcl, §7.4 trim retaining last-checkpoint-plus-boundary and §7.1(c) ≤65-entry invariant, stale removal, and the §7.2 skip-stale / sequential / buffer-and-wait classifier.

## Deviations from plan

- The §7.4 `trim_syncing_buffer` history function is the spec-pure version. App's existing `trim_syncing_ledgers` (with its `gap >= checkpoint_frequency()` closeable-entry guard and `MAX_BUFFER_SIZE = 100` cap) is preserved unchanged as a behavioral superset — only the identical `trim_boundary_for_last_buffered` boundary logic is routed through the history crate. Replacing App's trim wholesale would change observable apply behavior and break the existing `test_trim_syncing_ledgers_*` battery, which the plan requires to stay green.
- §7.2 classifier extracted as a pure history function but not yet wired into App's `maybe_start_buffered_catchup` (that lock-sensitive delegation is deferred to #3122 per the plan's scope narrowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)