### PR TITLE
Send responder HELLO before version/network/port validation (#3067)

### DIFF
--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -464,11 +464,19 @@ impl AuthContext {
     /// malformed, too old, or too new; `NetworkMismatch` if the network IDs
     /// differ.
     pub fn validate_hello_post_send(&self, hello: &Hello) -> Result<()> {
-        // Check overlay version range compatibility (matching stellar-core Peer::recvHello)
-        // Three conditions that cause version rejection:
-        // 1. Peer's range is malformed (min > max)
-        // 2. Peer's max version is below our minimum (peer too old)
-        // 3. Peer's min version is above our maximum (peer too new)
+        // Auth-level phase-2 checks, version before network (matching the
+        // stellar-core ordering). The peer-level self-connection check is
+        // interposed between these two by the responder caller (peer.rs).
+        self.validate_overlay_version(hello)?;
+        self.validate_network_id(hello)
+    }
+
+    /// Overlay-version range check (auth-level phase-2).
+    ///
+    /// Returns `VersionMismatch` if the peer's advertised overlay version range
+    /// is malformed (min > max), too old (max below our minimum), or too new
+    /// (min above our maximum). Matches stellar-core `Peer::recvHello`.
+    pub fn validate_overlay_version(&self, hello: &Hello) -> Result<()> {
         if hello.overlay_min_version > hello.overlay_version {
             return Err(OverlayError::VersionMismatch(format!(
                 "peer overlay version range malformed: min {} > max {}",
@@ -487,13 +495,17 @@ impl AuthContext {
                 hello.overlay_min_version, self.local_node.overlay_version
             )));
         }
+        Ok(())
+    }
 
-        // Check network ID
+    /// Network-ID check (auth-level phase-2).
+    ///
+    /// Returns `NetworkMismatch` if the peer is on a different network.
+    pub fn validate_network_id(&self, hello: &Hello) -> Result<()> {
         let network_id_bytes = hello.network_id.0;
         if network_id_bytes != *self.local_node.network_id.as_bytes() {
             return Err(OverlayError::NetworkMismatch);
         }
-
         Ok(())
     }
 

--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -367,6 +367,33 @@ impl AuthContext {
     /// - Auth certificate signature is invalid or expired
     /// - Key derivation fails
     pub fn process_hello(&mut self, hello: &Hello) -> Result<()> {
+        // Combined wrapper preserving the original semantics for the initiator
+        // path and tests: phase-1 (cert + keys + state) followed by phase-2
+        // (overlay-version + network-ID checks).
+        //
+        // The responder path (peer.rs) runs these phases separately so it can
+        // echo its own HELLO between phase-1 and phase-2 — OVERLAY §4.4.2-6.
+        self.process_hello_phase1(hello)?;
+        self.validate_hello_post_send(hello)
+    }
+
+    /// Phase-1 of HELLO processing: AuthCert verification, X25519 key exchange,
+    /// MAC-key derivation, and the `HelloReceived` state transition.
+    ///
+    /// This MUST run before the responder echoes its own HELLO so that the
+    /// MAC keys exist (and a duplicate HELLO is rejected) — but it deliberately
+    /// does NOT run the overlay-version or network-ID checks. Those are deferred
+    /// to [`validate_hello_post_send`] (phase-2), matching stellar-core
+    /// `Peer::recvHello` which sends HELLO before those checks (OVERLAY §4.4.2-6).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Called in an invalid state (not `Initial`/`HelloSent`) — INV-O3/INV-O4
+    /// - The peer's public key is malformed
+    /// - The auth certificate signature is invalid or expired
+    /// - Key derivation fails (including a small-order shared secret)
+    pub fn process_hello_phase1(&mut self, hello: &Hello) -> Result<()> {
         // State guard: process_hello is only valid in Initial or HelloSent states.
         // Rejecting other states prevents MAC key clobbering from a duplicate HELLO
         // (INV-O3) and enforces the handshake state machine (INV-O4).
@@ -374,36 +401,6 @@ impl AuthContext {
             return Err(OverlayError::AuthenticationFailed(format!(
                 "process_hello called in invalid state {:?} (expected Initial or HelloSent)",
                 self.state
-            )));
-        }
-
-        // Check network ID
-        let network_id_bytes = hello.network_id.0;
-        if network_id_bytes != *self.local_node.network_id.as_bytes() {
-            return Err(OverlayError::NetworkMismatch);
-        }
-
-        // Check overlay version range compatibility (matching stellar-core Peer::recvHello)
-        // Three conditions that cause version rejection:
-        // 1. Peer's range is malformed (min > max)
-        // 2. Peer's max version is below our minimum (peer too old)
-        // 3. Peer's min version is above our maximum (peer too new)
-        if hello.overlay_min_version > hello.overlay_version {
-            return Err(OverlayError::VersionMismatch(format!(
-                "peer overlay version range malformed: min {} > max {}",
-                hello.overlay_min_version, hello.overlay_version
-            )));
-        }
-        if hello.overlay_version < self.local_node.overlay_min_version {
-            return Err(OverlayError::VersionMismatch(format!(
-                "peer overlay version {} below minimum {}",
-                hello.overlay_version, self.local_node.overlay_min_version
-            )));
-        }
-        if hello.overlay_min_version > self.local_node.overlay_version {
-            return Err(OverlayError::VersionMismatch(format!(
-                "peer overlay min version {} above our maximum {}",
-                hello.overlay_min_version, self.local_node.overlay_version
             )));
         }
 
@@ -449,6 +446,53 @@ impl AuthContext {
         self.send_mac_key = Some(send_key);
         self.recv_mac_key = Some(recv_key);
         self.state = AuthState::HelloReceived;
+
+        Ok(())
+    }
+
+    /// Phase-2 of HELLO processing: overlay-version-range and network-ID checks.
+    ///
+    /// On the responder path this runs AFTER the local HELLO has been sent, so a
+    /// failure here is reported to the peer via an (unauthenticated) ERR_CONF
+    /// that the peer can decode now that it has consumed our HELLO
+    /// (OVERLAY §4.4.2-6). On the initiator path it runs immediately after
+    /// phase-1 (the initiator already sent its HELLO first).
+    ///
+    /// # Errors
+    ///
+    /// Returns `VersionMismatch` if the peer's overlay version range is
+    /// malformed, too old, or too new; `NetworkMismatch` if the network IDs
+    /// differ.
+    pub fn validate_hello_post_send(&self, hello: &Hello) -> Result<()> {
+        // Check overlay version range compatibility (matching stellar-core Peer::recvHello)
+        // Three conditions that cause version rejection:
+        // 1. Peer's range is malformed (min > max)
+        // 2. Peer's max version is below our minimum (peer too old)
+        // 3. Peer's min version is above our maximum (peer too new)
+        if hello.overlay_min_version > hello.overlay_version {
+            return Err(OverlayError::VersionMismatch(format!(
+                "peer overlay version range malformed: min {} > max {}",
+                hello.overlay_min_version, hello.overlay_version
+            )));
+        }
+        if hello.overlay_version < self.local_node.overlay_min_version {
+            return Err(OverlayError::VersionMismatch(format!(
+                "peer overlay version {} below minimum {}",
+                hello.overlay_version, self.local_node.overlay_min_version
+            )));
+        }
+        if hello.overlay_min_version > self.local_node.overlay_version {
+            return Err(OverlayError::VersionMismatch(format!(
+                "peer overlay min version {} above our maximum {}",
+                hello.overlay_min_version, self.local_node.overlay_version
+            )));
+        }
+
+        // Check network ID
+        let network_id_bytes = hello.network_id.0;
+        if network_id_bytes != *self.local_node.network_id.as_bytes() {
+            return Err(OverlayError::NetworkMismatch);
+        }
 
         Ok(())
     }
@@ -1469,5 +1513,112 @@ mod tests {
 
         let result = ctx_b.process_auth();
         assert!(result.is_err(), "duplicate process_auth must be rejected");
+    }
+
+    // ── OVERLAY §4.4.2-6: handshake ordering — phase split ─────────────
+
+    #[test]
+    fn test_process_hello_phase1_succeeds_before_version_check() {
+        // Regression for #3067: phase-1 (cert verify + key derivation +
+        // HelloReceived) MUST succeed even when the peer advertises an
+        // incompatible overlay version. The version check is deferred to
+        // phase-2 so the responder can echo HELLO before any ERROR_MSG.
+        //
+        // Before the split, process_hello() ran the version check first and
+        // returned Err, so no keys were derived and state stayed Initial —
+        // this test FAILS on main (no phase-1 method exists / version rejected).
+        let secret = SecretKey::generate();
+        let local_node = LocalNode::new_testnet(secret);
+        let mut ctx = AuthContext::new(local_node.clone(), false); // responder
+        ctx.hello_sent();
+
+        // Peer is "too old" (overlay_version 37 < our minimum 38), which would
+        // be rejected by the version check.
+        let hello = make_hello_with_versions(37, 35, &local_node);
+
+        let result = ctx.process_hello_phase1(&hello);
+        assert!(
+            result.is_ok(),
+            "phase-1 must succeed despite incompatible version: {:?}",
+            result
+        );
+        assert_eq!(
+            ctx.state(),
+            AuthState::HelloReceived,
+            "phase-1 must transition to HelloReceived"
+        );
+        assert!(
+            ctx.recv_mac_key.is_some() && ctx.send_mac_key.is_some(),
+            "phase-1 must derive MAC keys"
+        );
+        assert!(ctx.peer_id().is_some(), "phase-1 must record peer id");
+    }
+
+    #[test]
+    fn test_validate_hello_post_send_rejects_version_and_network() {
+        // New coverage for #3067: phase-2 (validate_hello_post_send) returns
+        // the same VersionMismatch / NetworkMismatch errors the old
+        // process_hello produced.
+        let secret = SecretKey::generate();
+        let local_node = LocalNode::new_testnet(secret);
+
+        // Peer too old.
+        let mut ctx = AuthContext::new(local_node.clone(), false);
+        ctx.hello_sent();
+        let hello = make_hello_with_versions(37, 35, &local_node);
+        ctx.process_hello_phase1(&hello).unwrap();
+        let r = ctx.validate_hello_post_send(&hello);
+        assert!(
+            matches!(&r, Err(OverlayError::VersionMismatch(m)) if m.contains("below minimum")),
+            "expected VersionMismatch(below minimum), got {:?}",
+            r
+        );
+
+        // Peer too new.
+        let mut ctx = AuthContext::new(local_node.clone(), false);
+        ctx.hello_sent();
+        let hello = make_hello_with_versions(43, 41, &local_node);
+        ctx.process_hello_phase1(&hello).unwrap();
+        let r = ctx.validate_hello_post_send(&hello);
+        assert!(
+            matches!(&r, Err(OverlayError::VersionMismatch(m)) if m.contains("above our maximum")),
+            "expected VersionMismatch(above our maximum), got {:?}",
+            r
+        );
+
+        // Malformed range.
+        let mut ctx = AuthContext::new(local_node.clone(), false);
+        ctx.hello_sent();
+        let hello = make_hello_with_versions(38, 40, &local_node);
+        ctx.process_hello_phase1(&hello).unwrap();
+        let r = ctx.validate_hello_post_send(&hello);
+        assert!(
+            matches!(&r, Err(OverlayError::VersionMismatch(m)) if m.contains("malformed")),
+            "expected VersionMismatch(malformed), got {:?}",
+            r
+        );
+
+        // Network mismatch (compatible version, wrong network id).
+        let mut ctx = AuthContext::new(local_node.clone(), false);
+        ctx.hello_sent();
+        let mut hello = make_hello_with_versions(39, 38, &local_node);
+        hello.network_id = xdr::Hash([0xAB; 32]);
+        ctx.process_hello_phase1(&hello).unwrap();
+        let r = ctx.validate_hello_post_send(&hello);
+        assert!(
+            matches!(r, Err(OverlayError::NetworkMismatch)),
+            "expected NetworkMismatch, got {:?}",
+            r
+        );
+
+        // Fully compatible: phase-2 returns Ok.
+        let mut ctx = AuthContext::new(local_node.clone(), false);
+        ctx.hello_sent();
+        let hello = make_hello_with_versions(39, 38, &local_node);
+        ctx.process_hello_phase1(&hello).unwrap();
+        assert!(
+            ctx.validate_hello_post_send(&hello).is_ok(),
+            "compatible peer must pass phase-2"
+        );
     }
 }

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -343,8 +343,16 @@ impl Peer {
 
         if self.connection.we_called_remote() {
             // --- Initiator (outbound): Send HELLO first, then receive ---
+            // The initiator already sent its HELLO, so it runs both phases of
+            // HELLO processing back-to-back: recv_hello (phase-1) then phase-2
+            // (version → self → network → port). On a phase-2 failure it sends
+            // ERR_CONF then drops — observably identical to the prior behavior.
             self.send_hello().await?;
-            self.recv_hello(auth_timeout_secs).await?;
+            let peer_hello = self.recv_hello(auth_timeout_secs).await?;
+            if let Err(e) = self.validate_hello_phase2(&peer_hello) {
+                self.try_send_err_conf(&e).await;
+                return Err(e);
+            }
 
             // Reserve pending peer_id after learning remote identity.
             // Matches stellar-core Peer::recvHello() duplicate check.
@@ -384,7 +392,12 @@ impl Peer {
             }
         } else {
             // --- Responder (inbound): Receive HELLO first, then reply ---
-            self.recv_hello(auth_timeout_secs).await?;
+            // OVERLAY §4.4.2-6: HELLO must be echoed BEFORE the
+            // overlay-version / self-connection / network-ID / port checks, so
+            // the remote (still awaiting an unauthenticated HELLO) can decode
+            // the subsequent seq-0 / zero-MAC ERROR_MSG. recv_hello runs only
+            // phase-1 here (cert + keys + state); phase-2 runs after send_hello.
+            let peer_hello = self.recv_hello(auth_timeout_secs).await?;
 
             // Check ban status immediately after learning peer identity,
             // before sending any response. Mirrors stellar-core's
@@ -440,8 +453,17 @@ impl Peer {
             // Remaining handshake steps after peer_id reservation.
             // If any step fails, clean up the pending peer_id reservation
             // only if we own it.
+            //
+            // Ordering (OVERLAY §4.4.2-6): send_hello FIRST, then phase-2
+            // validation. On a phase-2 failure we send an (unauthenticated)
+            // ERR_CONF and drop — but the HELLO was already on the wire, so the
+            // remote can decode the ERROR_MSG.
             let result: Result<()> = async {
                 self.send_hello().await?;
+                if let Err(e) = self.validate_hello_phase2(&peer_hello) {
+                    self.try_send_err_conf(&e).await;
+                    return Err(e);
+                }
                 self.recv_auth(auth_timeout_secs).await?;
                 self.send_auth_msg().await?;
                 Ok(())
@@ -502,8 +524,17 @@ impl Peer {
         Ok(())
     }
 
-    /// Receive and process the peer's HELLO message.
-    async fn recv_hello(&mut self, timeout_secs: u64) -> Result<()> {
+    /// Receive the peer's HELLO message and run phase-1 processing.
+    ///
+    /// Phase-1 = AuthCert verification + X25519 key derivation + the
+    /// `HelloReceived` state transition (and peer-identity bookkeeping). It does
+    /// NOT run the overlay-version / self-connection / network-ID / port checks —
+    /// those are phase-2 ([`validate_hello_phase2`]). On the responder path the
+    /// caller echoes its own HELLO between phase-1 and phase-2 so that HELLO
+    /// always precedes any ERROR_MSG (OVERLAY §4.4.2-6).
+    ///
+    /// Returns the received `Hello` so the caller can run phase-2 against it.
+    async fn recv_hello(&mut self, timeout_secs: u64) -> Result<Hello> {
         let start = Instant::now();
         let result = self.recv_hello_inner(timeout_secs).await;
 
@@ -518,7 +549,7 @@ impl Peer {
         result
     }
 
-    async fn recv_hello_inner(&mut self, timeout_secs: u64) -> Result<()> {
+    async fn recv_hello_inner(&mut self, timeout_secs: u64) -> Result<Hello> {
         let frame = self
             .connection
             .recv_timeout(timeout_secs)
@@ -532,22 +563,19 @@ impl Peer {
 
         match message {
             StellarMessage::Hello(peer_hello) => {
-                if let Err(e) = self.process_hello(peer_hello) {
+                if let Err(e) = self.process_hello_phase1(&peer_hello) {
                     // Best-effort ERR_CONF before dropping, matching
                     // stellar-core Peer::recvHello() → sendErrorAndDrop().
                     self.try_send_err_conf(&e).await;
                     return Err(e);
                 }
+                Ok(peer_hello)
             }
-            other => {
-                return Err(OverlayError::InvalidMessage(format!(
-                    "expected Hello, got {}",
-                    helpers::message_type_name(&other)
-                )));
-            }
+            other => Err(OverlayError::InvalidMessage(format!(
+                "expected Hello, got {}",
+                helpers::message_type_name(&other)
+            ))),
         }
-
-        Ok(())
     }
 
     /// Best-effort send of ERR_CONF for HELLO failures.
@@ -641,7 +669,17 @@ impl Peer {
 
         Ok(())
     }
-    fn process_hello(&mut self, hello: Hello) -> Result<()> {
+    /// Phase-1 of peer-level HELLO processing.
+    ///
+    /// Verifies the AuthCert, derives MAC keys, transitions the auth state to
+    /// `HelloReceived` (via [`AuthContext::process_hello_phase1`]), and records
+    /// the peer identity / advertised versions on `self.info` so the post-HELLO
+    /// ban check has the peer id available.
+    ///
+    /// Deliberately does NOT run the overlay-version / self-connection /
+    /// network-ID / port checks — those are deferred to [`validate_hello_phase2`]
+    /// so the responder can echo its HELLO first (OVERLAY §4.4.2-6).
+    fn process_hello_phase1(&mut self, hello: &Hello) -> Result<()> {
         // State guard: reject if not in Handshaking state
         if self.state != PeerState::Handshaking {
             return Err(OverlayError::InvalidMessage(format!(
@@ -650,18 +688,8 @@ impl Peer {
             )));
         }
 
-        // Port validation: XDR uses i32, but valid ports are 1-65535.
-        // Reject port 0 — matches stellar-core Peer::recvHello() which rejects
-        // listeningPort <= 0 to prevent poisoning peer gossip with ephemeral ports.
-        if hello.listening_port <= 0 || hello.listening_port > u16::MAX as i32 {
-            return Err(OverlayError::InvalidMessage(format!(
-                "invalid listening port: {}",
-                hello.listening_port
-            )));
-        }
-
-        // Let auth context process it (network ID, version, cert checks)
-        self.auth.process_hello(&hello)?;
+        // AuthCert verify + X25519 key derivation + HelloReceived state.
+        self.auth.process_hello_phase1(hello)?;
 
         // Extract peer info
         let peer_id = self
@@ -670,30 +698,60 @@ impl Peer {
             .cloned()
             .ok_or_else(|| OverlayError::AuthenticationFailed("no peer ID".to_string()))?;
 
-        // Self-connection check: reject if peer is ourselves
-        let local_peer_id = self.auth.local_peer_id();
-        if peer_id == local_peer_id {
-            return Err(OverlayError::InvalidMessage(
-                "received Hello from self".to_string(),
-            ));
-        }
-
-        let version_string: String = hello.version_str.to_string();
-
         self.info.peer_id = peer_id;
-        self.info.version_string = version_string;
+        self.info.version_string = hello.version_str.to_string();
         self.info.overlay_version = hello.overlay_version;
         self.info.ledger_version = hello.ledger_version;
-        if hello.listening_port > 0 {
-            let port = hello.listening_port as u16;
-            let ip = self.info.address.ip();
-            self.info.address = SocketAddr::new(ip, port);
-        }
 
         debug!(
             "Received Hello from {} (version: {}, overlay: {})",
             self.info.peer_id, self.info.version_string, self.info.overlay_version
         );
+
+        Ok(())
+    }
+
+    /// Phase-2 of peer-level HELLO processing — the validation checks that, on
+    /// the responder path, run AFTER the local HELLO has been echoed.
+    ///
+    /// Check order matches stellar-core `Peer::recvHello`: overlay version →
+    /// self-connection → network ID → listening port. On the first failure the
+    /// caller emits an (unauthenticated) ERR_CONF and drops the connection.
+    fn validate_hello_phase2(&mut self, hello: &Hello) -> Result<()> {
+        // 1. Overlay-version range + network-ID checks (auth-level).
+        //    Note: validate_hello_post_send checks version BEFORE network, so
+        //    the version error takes precedence — matching stellar-core order.
+        //    The network check is the last of the auth-level checks; the
+        //    self-connection check (peer-level) is interposed between them
+        //    below to mirror stellar-core's version → self → network ordering.
+        self.auth.validate_overlay_version(hello)?;
+
+        // 2. Self-connection check: reject if peer is ourselves.
+        let local_peer_id = self.auth.local_peer_id();
+        if self.info.peer_id == local_peer_id {
+            return Err(OverlayError::InvalidMessage(
+                "received Hello from self".to_string(),
+            ));
+        }
+
+        // 3. Network-ID check (auth-level).
+        self.auth.validate_network_id(hello)?;
+
+        // 4. Listening-port validation: XDR uses i32, but valid ports are
+        //    1-65535. Reject port 0 — matches stellar-core Peer::recvHello()
+        //    which rejects listeningPort <= 0 to prevent poisoning peer gossip
+        //    with ephemeral ports.
+        if hello.listening_port <= 0 || hello.listening_port > u16::MAX as i32 {
+            return Err(OverlayError::InvalidMessage(format!(
+                "invalid listening port: {}",
+                hello.listening_port
+            )));
+        }
+
+        // All checks passed — record the peer's advertised listening port.
+        let port = hello.listening_port as u16;
+        let ip = self.info.address.ip();
+        self.info.address = SocketAddr::new(ip, port);
 
         Ok(())
     }

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -1251,4 +1251,274 @@ mod tests {
         assert_eq!(snap.outbound_drop, 23);
         assert_eq!(snap.outbound_reject, 24);
     }
+
+    // ── OVERLAY §4.4.2-6: responder sends HELLO before ERROR_MSG (#3067) ──
+
+    use crate::auth::AuthContext;
+    use crate::connection::Connection;
+    use henyey_crypto::SecretKey;
+    use stellar_xdr::curr::Hello;
+
+    /// Build a responder `Peer` (inbound, `Handshaking`) wired over an in-memory
+    /// duplex to a raw client-side `(Connection, AuthContext)` initiator pair.
+    /// The responder is driven via `handshake()`; the client crafts and sends a
+    /// HELLO, then reads the responder's reply frames.
+    fn make_responder_and_client(client_local: LocalNode) -> (Peer, Connection, AuthContext) {
+        let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+        let client_addr: SocketAddr = "127.0.0.1:11625".parse().unwrap();
+        let server_addr: SocketAddr = "127.0.0.1:11626".parse().unwrap();
+
+        let client_conn =
+            Connection::from_io(client_io, server_addr, ConnectionDirection::Outbound).unwrap();
+        let server_conn =
+            Connection::from_io(server_io, client_addr, ConnectionDirection::Inbound).unwrap();
+
+        let responder_local = LocalNode::new_testnet(SecretKey::generate());
+        let responder_auth = AuthContext::new(responder_local, false); // they called us
+        let client_auth = AuthContext::new(client_local, true); // we called remote
+
+        let responder = Peer {
+            info: PeerInfo {
+                peer_id: PeerId::from_bytes([0u8; 32]),
+                address: client_addr,
+                direction: ConnectionDirection::Inbound,
+                version_string: String::new(),
+                overlay_version: 0,
+                ledger_version: 0,
+                connected_at: Instant::now(),
+                original_address: None,
+            },
+            state: PeerState::Connecting,
+            connection: server_conn,
+            auth: responder_auth,
+            stats: Arc::new(PeerStats::default()),
+            metrics: Arc::new(OverlayMetrics::new()),
+            holds_pending_peer_id: false,
+        };
+
+        (responder, client_conn, client_auth)
+    }
+
+    /// Drive the responder handshake against a client that sends `hello`, then
+    /// collect the StellarMessages the responder sent back (in order) until the
+    /// connection closes or two frames have been read.
+    async fn responder_reply_frames(
+        client_local: LocalNode,
+        mutate_hello: impl FnOnce(&mut Hello),
+    ) -> Vec<StellarMessage> {
+        let (mut responder, mut client_conn, mut client_auth) =
+            make_responder_and_client(client_local);
+
+        // Build the client's HELLO and apply the test mutation.
+        let mut hello = client_auth.create_hello();
+        mutate_hello(&mut hello);
+
+        // Spawn the responder's full handshake. It will receive HELLO, run
+        // phase-1, ban check, send_hello(), then phase-2 — which fails for the
+        // mismatched HELLO, sends ERR_CONF, and drops.
+        let responder_task = tokio::spawn(async move {
+            let res = responder.handshake(5, None, None, 0, 0).await;
+            // Return the result so the test can assert the responder dropped.
+            res
+        });
+
+        // Client sends its (mismatched) HELLO unauthenticated.
+        let hello_frame = client_auth.wrap_unauthenticated(StellarMessage::Hello(hello));
+        client_conn
+            .send(hello_frame)
+            .await
+            .expect("client send hello");
+
+        // Read frames the responder sends back. Expect HELLO then ERR_CONF.
+        let mut frames = Vec::new();
+        for _ in 0..2 {
+            match client_conn.recv_timeout(5).await {
+                Ok(Some(frame)) => {
+                    // Pre-auth framing: unwrap without MAC enforcement.
+                    let msg = client_auth
+                        .unwrap_message(frame.message)
+                        .expect("unwrap responder frame");
+                    frames.push(msg);
+                }
+                _ => break,
+            }
+        }
+
+        // The responder must have dropped with an error (not authenticated).
+        let res = responder_task.await.expect("responder task join");
+        assert!(
+            res.is_err(),
+            "responder must drop after a mismatched HELLO, got {:?}",
+            res
+        );
+
+        frames
+    }
+
+    #[tokio::test]
+    async fn test_responder_sends_hello_before_error_on_version_mismatch() {
+        // Regression for #3067: on an overlay-version mismatch the responder
+        // MUST send its HELLO before the ERROR_MSG(Conf). On main the version
+        // check runs before send_hello(), so the first (and only) frame is the
+        // ERR_CONF — this test FAILS on main and PASSES after the reorder.
+        let client_local = LocalNode::new_testnet(SecretKey::generate());
+        let frames = responder_reply_frames(client_local, |hello| {
+            // Advertise an incompatible (too-old) overlay version range.
+            hello.overlay_version = 5;
+            hello.overlay_min_version = 1;
+        })
+        .await;
+
+        assert!(
+            frames.len() >= 2,
+            "responder must send HELLO then ERROR, got {} frame(s): {:?}",
+            frames.len(),
+            frames
+                .iter()
+                .map(helpers::message_type_name)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            matches!(frames[0], StellarMessage::Hello(_)),
+            "first frame must be HELLO, got {}",
+            helpers::message_type_name(&frames[0])
+        );
+        match &frames[1] {
+            StellarMessage::ErrorMsg(e) => {
+                assert_eq!(
+                    e.code,
+                    stellar_xdr::curr::ErrorCode::Conf,
+                    "second frame must be ERR_CONF"
+                );
+            }
+            other => panic!(
+                "second frame must be ERROR_MSG, got {}",
+                helpers::message_type_name(other)
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_responder_sends_hello_before_error_on_network_mismatch() {
+        // Regression for #3067: same ordering requirement on a network-ID
+        // mismatch.
+        let client_local = LocalNode::new_testnet(SecretKey::generate());
+        let frames = responder_reply_frames(client_local, |hello| {
+            // Wrong network id (compatible overlay version preserved).
+            hello.network_id = stellar_xdr::curr::Hash([0xAB; 32]);
+        })
+        .await;
+
+        assert!(
+            frames.len() >= 2,
+            "responder must send HELLO then ERROR, got {} frame(s): {:?}",
+            frames.len(),
+            frames
+                .iter()
+                .map(helpers::message_type_name)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            matches!(frames[0], StellarMessage::Hello(_)),
+            "first frame must be HELLO, got {}",
+            helpers::message_type_name(&frames[0])
+        );
+        assert!(
+            matches!(frames[1], StellarMessage::ErrorMsg(_)),
+            "second frame must be ERROR_MSG, got {}",
+            helpers::message_type_name(&frames[1])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_responder_sends_hello_before_error_on_port_mismatch() {
+        // Regression for #3067: a bad listening port is a peer-level check that
+        // must also run AFTER the HELLO echo on the responder path.
+        let client_local = LocalNode::new_testnet(SecretKey::generate());
+        let frames = responder_reply_frames(client_local, |hello| {
+            hello.listening_port = 0; // invalid
+        })
+        .await;
+
+        assert!(
+            matches!(frames.first(), Some(StellarMessage::Hello(_))),
+            "first frame must be HELLO, got {:?}",
+            frames
+                .iter()
+                .map(helpers::message_type_name)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            matches!(frames.get(1), Some(StellarMessage::ErrorMsg(_))),
+            "second frame must be ERROR_MSG, got {:?}",
+            frames
+                .iter()
+                .map(helpers::message_type_name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_initiator_still_rejects_version_mismatch() {
+        // Guard for #3067: the initiator path still runs the full phase-2
+        // checks. We construct an initiator Peer and feed it a HELLO with an
+        // incompatible overlay version; it must reject (drop) rather than
+        // silently dropping the check after the responder reorder.
+        let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+        let initiator_addr: SocketAddr = "127.0.0.1:11625".parse().unwrap();
+        let remote_addr: SocketAddr = "127.0.0.1:11626".parse().unwrap();
+
+        let initiator_conn =
+            Connection::from_io(client_io, remote_addr, ConnectionDirection::Outbound).unwrap();
+        let mut remote_conn =
+            Connection::from_io(server_io, initiator_addr, ConnectionDirection::Inbound).unwrap();
+
+        let initiator_local = LocalNode::new_testnet(SecretKey::generate());
+        let initiator_auth = AuthContext::new(initiator_local, true);
+
+        let mut initiator = Peer {
+            info: PeerInfo {
+                peer_id: PeerId::from_bytes([0u8; 32]),
+                address: remote_addr,
+                direction: ConnectionDirection::Outbound,
+                version_string: String::new(),
+                overlay_version: 0,
+                ledger_version: 0,
+                connected_at: Instant::now(),
+                original_address: None,
+            },
+            state: PeerState::Connecting,
+            connection: initiator_conn,
+            auth: initiator_auth,
+            stats: Arc::new(PeerStats::default()),
+            metrics: Arc::new(OverlayMetrics::new()),
+            holds_pending_peer_id: false,
+        };
+
+        // The remote side: a raw responder AuthContext that replies to the
+        // initiator's HELLO with an incompatible-version HELLO of its own.
+        let remote_local = LocalNode::new_testnet(SecretKey::generate());
+        let remote_auth = AuthContext::new(remote_local, false);
+
+        let task = tokio::spawn(async move { initiator.handshake(5, None, None, 0, 0).await });
+
+        // Read the initiator's HELLO (so the duplex doesn't stall), then send
+        // back a mismatched HELLO.
+        let _ = remote_conn
+            .recv_timeout(5)
+            .await
+            .expect("recv initiator hello");
+        let mut bad_hello = remote_auth.create_hello();
+        bad_hello.overlay_version = 5;
+        bad_hello.overlay_min_version = 1;
+        let frame = remote_auth.wrap_unauthenticated(StellarMessage::Hello(bad_hello));
+        remote_conn.send(frame).await.expect("send bad hello");
+
+        let res = task.await.expect("initiator task join");
+        assert!(
+            matches!(res, Err(OverlayError::VersionMismatch(_))),
+            "initiator must reject incompatible overlay version, got {:?}",
+            res
+        );
+    }
 }


### PR DESCRIPTION
Closes #3067

## Summary

OVERLAY §4.4.2-6 requires the responder to echo its HELLO **before** the overlay-version / self-connection / network-ID / listening-port checks, so the remote — still awaiting an unauthenticated HELLO — can decode the subsequent (seq-0, zero-MAC) ERROR_MSG. Previously the responder ran the network-ID and overlay-version checks inside `auth.process_hello()` before `send_hello()`, so on a mismatch it emitted only an ERR_CONF and never the HELLO.

This reorders the responder branch of `Peer::handshake` to: `recv_hello` (phase-1: AuthCert verify + X25519 key derivation + `HelloReceived`) → ban check → `send_hello` → phase-2 (version → self → network → port; on failure `try_send_err_conf` then drop). The initiator runs phase-1 + phase-2 back-to-back (it already sent HELLO first) and is observably unchanged. ERROR framing stays unauthenticated (seq 0, zero MAC), matching stellar-core `Hmac.cpp` `setAuthenticatedMessageBody` which exempts ERROR_MSG and HELLO. Matches stellar-core `Peer::recvHello` (Peer.cpp:1778–1915).

`AuthContext::process_hello` is split into `process_hello_phase1` and `validate_overlay_version` / `validate_network_id` (with a `validate_hello_post_send` wrapper retaining the combined semantics); `peer.rs` gains `process_hello_phase1` / `validate_hello_phase2`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3067#issuecomment-4618920276)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (clean)
- [x] cargo test -p henyey-overlay passes (460 lib tests + integration + doctests)

## Regression test (kind: bug-fix)

- **Tests:** `crates/overlay/src/peer.rs::test_responder_sends_hello_before_error_on_{version,network,port}_mismatch` (plus `auth.rs::test_process_hello_phase1_succeeds_before_version_check`)
- **Pre-fix:** committed as `f874fde5` — verified the three responder tests FAILED with "responder must send HELLO then ERROR, got 1 frame(s): [\"ERROR\"]" (responder emitted ERROR_MSG as the first/only frame)
- **Post-fix:** verified all PASS after `4ac1d3e0`
- **Initiator guard:** `peer.rs::test_initiator_still_rejects_version_mismatch` confirms the initiator path still rejects an incompatible overlay version.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)