### PR TITLE
Reject fee source with insufficient available balance (TX §4.6-1)

### DIFF
--- a/crates/ledger/src/execution/mod.rs
+++ b/crates/ledger/src/execution/mod.rs
@@ -1824,8 +1824,29 @@ impl TransactionExecutor {
             }
         };
 
+        // Fee the affordability guard in validate_preconditions must account
+        // for, mirroring stellar-core's processFeeSeqNum cap then
+        // commonValid(applying=true). The guard caps this against the
+        // fee-source balance itself, so we pass the UNCAPPED fee here.
+        //   - FeeMode::Skip (production tx-set path): process_fee_only already
+        //     deducted the capped fee into self.state, so the fee-source
+        //     balance the guard reads is already net — pass 0.
+        //   - Otherwise (FeeMode::Deduct, single-phase): validation runs before
+        //     the inline deduction below — pass fee_to_charge(base_fee).
+        let guard_fee_to_charge = if fee_mode == FeeMode::Skip {
+            0
+        } else {
+            TransactionFrame::with_network(Arc::clone(tx_envelope), self.network_id)
+                .fee_to_charge(base_fee as i64)
+        };
+
         // Phase 1-6: Validate structure, accounts, fees, preconditions, sequence, signatures
-        let validated = match self.validate_preconditions(snapshot, tx_envelope, base_fee)? {
+        let validated = match self.validate_preconditions(
+            snapshot,
+            tx_envelope,
+            base_fee,
+            guard_fee_to_charge,
+        )? {
             Ok(v) => v,
             Err(validation_failure) => {
                 let mut failure_result = validation_failure.result;
@@ -4468,8 +4489,11 @@ mod tests {
     /// - The executor sees post-fee-deduction balances
     /// - On body failure, rollback doesn't re-add fee (FeeMode::Skip)
     ///
-    /// We simulate this by setting balance=0 (as if fee was already deducted from
-    /// original 50), using FeeMode::Skip, and verifying rollback integrity.
+    /// We simulate this by setting a post-fee balance (as if the fee was already
+    /// deducted on the main delta), using FeeMode::Skip, and verifying rollback
+    /// integrity. The post-fee balance must stay above minBalance so the
+    /// affordability guard (commonValid, applying=true) accepts it — exactly as
+    /// a real funded account would after its fee was charged.
     #[test]
     fn test_execute_with_pre_apply_result_partial_fee_failing_body() {
         use henyey_crypto::{sign_hash, SecretKey};
@@ -4484,9 +4508,12 @@ mod tests {
         let base_fee: u32 = 100;
         let protocol_version: u32 = 25;
 
-        // Source account with balance=0 — simulating post-fee-deduction state.
-        // In the real parallel path, `pre_deduct_soroban_fees` already took the
-        // partial fee (50) from the account (original balance 50 → 0).
+        // Source account with a post-fee-deduction balance that stays above
+        // minBalance (base_reserve 5_000_000 ⇒ minBalance 10_000_000 with no
+        // sub-entries). In the real parallel path, `pre_deduct_soroban_fees`
+        // already took the fee on the main delta; here we model the resulting
+        // net balance. It must clear the affordability guard, as a real funded
+        // account would.
         let secret = SecretKey::from_seed(&[42u8; 32]);
         let source_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
             *secret.public_key().as_bytes(),
@@ -4499,7 +4526,7 @@ mod tests {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::Account(AccountEntry {
                 account_id: source_id.clone(),
-                balance: 0, // Post-fee-deduction: original 50 - partial fee 50 = 0
+                balance: 20_000_000, // Post-fee-deduction; above minBalance (10_000_000).
                 seq_num: SequenceNumber(1),
                 num_sub_entries: 0,
                 inflation_dest: None,
@@ -4596,8 +4623,8 @@ mod tests {
         {
             let acc = executor.state.get_account(&source_id).unwrap();
             assert_eq!(
-                acc.balance, 0,
-                "balance must remain 0 (FeeMode::Skip, no deduction)"
+                acc.balance, 20_000_000,
+                "balance must remain unchanged (FeeMode::Skip, no deduction)"
             );
             assert_eq!(acc.seq_num.0, 2, "seq_num must be bumped to 2");
         }
@@ -4616,8 +4643,8 @@ mod tests {
         // DeltaEntries, so rollback_failed_tx cannot replay seq/signer mutations.
         let acc = executor.state.get_account(&source_id).unwrap();
         assert_eq!(
-            acc.balance, 0,
-            "balance must remain 0 — no fee re-deduction from rollback"
+            acc.balance, 20_000_000,
+            "balance must remain unchanged — no fee re-deduction from rollback"
         );
         assert_eq!(
             acc.seq_num.0, 2,

--- a/crates/ledger/src/execution/preconditions.rs
+++ b/crates/ledger/src/execution/preconditions.rs
@@ -28,6 +28,18 @@ impl TransactionExecutor {
         snapshot: &SnapshotHandle,
         tx_envelope: &Arc<TransactionEnvelope>,
         base_fee: u32,
+        // The fee that processFeeSeqNum will charge (or has charged) against the
+        // fee source, used by the final affordability guard to evaluate
+        // stellar-core's post-fee, applying=true predicate. The guard caps this
+        // at the fee source's balance (mirroring `fee = min(balance, fee)`)
+        // before subtracting, so the value passed here is the UNCAPPED fee:
+        //   - Production tx-set path (`FeeMode::Skip`): `process_fee_only`
+        //     already deducted the capped fee from `self.state`, so the
+        //     fee-source balance read by the guard is already net — pass 0.
+        //   - Single-phase `FeeMode::Deduct`: validation runs before the inline
+        //     deduction, so the balance is pre-fee — pass `fee_to_charge`
+        //     (the guard caps it against the balance it reads).
+        fee_to_charge: i64,
     ) -> Result<std::result::Result<ValidatedTransaction, ValidationFailure>> {
         let val_start = std::time::Instant::now();
         let frame = TransactionFrame::with_network(Arc::clone(tx_envelope), self.network_id);
@@ -534,6 +546,61 @@ impl TransactionExecutor {
                     TransactionResultCode::TxFrozenKeyAccessed,
                     "Transaction accesses frozen ledger key",
                 )));
+            }
+        }
+
+        // Fee affordability guard — final step of stellar-core's commonValid
+        // (applying=true). The fee source's *available* balance must cover the
+        // (capped) fee, where available = balance − minBalance − sellingLiab,
+        // computed WITHOUT saturation (TransactionUtils.cpp:752-778,
+        // getAvailableBalance). With applying=true, feeToPay is 0 because the
+        // fee was (or will be) charged by processFeeSeqNum, so the predicate
+        // reduces to `(balance − chargedFee) − minBalance − sellingLiab < 0`.
+        //
+        // We deliberately compute the three-term subtraction directly in i64
+        // rather than reuse `reserves::available_to_send`, which saturates the
+        // intermediate result to 0 and would make the `< 0` test unreachable.
+        //
+        // The guard checks the FEE SOURCE account for both fee-bump and
+        // non-fee-bump transactions, mirroring:
+        //   - TransactionFrame::commonValid (TransactionFrame.cpp:1742-1755),
+        //     setInnermostError(txINSUFFICIENT_BALANCE) ⇒ post_seq_fail.
+        //   - FeeBumpTransactionFrame::commonValid's independent fee-source
+        //     guard (FeeBumpTransactionFrame.cpp:466-475),
+        //     setError(txINSUFFICIENT_BALANCE) ⇒ fee_bump_outer_fail.
+        //
+        // Read the fee-source balance from `self.state` and cap the fee against
+        // it at the same point the deduction caps (`fee = min(balance, fee)`),
+        // so the charged amount matches the actual deduction.
+        if let Some(fee_source) = self.state.get_account(&fee_source_id) {
+            let charged_fee = std::cmp::min(fee_source.balance, fee_to_charge);
+            let min_balance = crate::reserves::minimum_balance(fee_source, self.base_reserve);
+            let selling_liabilities = crate::reserves::selling_liabilities(fee_source);
+            let available_balance = fee_source
+                .balance
+                .saturating_sub(charged_fee)
+                .saturating_sub(min_balance)
+                .saturating_sub(selling_liabilities);
+            if available_balance < 0 {
+                tracing::debug!(
+                    balance = fee_source.balance,
+                    charged_fee = charged_fee,
+                    min_balance = min_balance,
+                    selling_liabilities = selling_liabilities,
+                    is_fee_bump = is_fee_bump,
+                    "Fee source available balance below zero after fee"
+                );
+                return Ok(Err(if is_fee_bump {
+                    fee_bump_outer_fail(
+                        TransactionResultCode::TxInsufficientBalance,
+                        "Fee source available balance insufficient for fee",
+                    )
+                } else {
+                    post_seq_fail(
+                        TransactionResultCode::TxInsufficientBalance,
+                        "Fee source available balance insufficient for fee",
+                    )
+                }));
             }
         }
 

--- a/crates/ledger/tests/transaction_execution/preconditions.rs
+++ b/crates/ledger/tests/transaction_execution/preconditions.rs
@@ -2733,3 +2733,191 @@ fn test_execute_transaction_rejects_over_depth_envelope() {
         "over-depth envelope must be rejected as TxMalformed"
     );
 }
+
+/// Regression for #3104 (TX §4.6-1): the fee source's *available* balance —
+/// `balance - minBalance - sellingLiabilities` — must be >= the (capped) fee,
+/// matching stellar-core's `commonValid` affordability guard. Here balance=100,
+/// num_sub_entries=1, base_reserve=25 => minBalance=(2+1)*25=75. A 1-op payment
+/// with fee=50 (base_fee=50 so the fee passes the insufficient-fee check and
+/// fee_to_charge=50) leaves available = 100 - 50 - 75 = -25 < 0, so the tx must
+/// be rejected with TxInsufficientBalance.
+///
+/// FAILS on main: with no affordability guard the fee is silently capped at the
+/// balance and the tx is ACCEPTED (body runs), violating the ledger invariant.
+#[test]
+fn test_execute_transaction_insufficient_available_balance_rejects() {
+    let secret = SecretKey::from_seed(&[71u8; 32]);
+    let account_id: AccountId = (&secret.public_key()).into();
+
+    // balance=100, num_sub_entries=1 (V0 ext). minBalance with base_reserve=25
+    // is (2 + 1) * 25 = 75. Available after fee=50 is 100 - 50 - 75 = -25.
+    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        account_id: account_id.clone(),
+    });
+    let entry = LedgerEntry {
+        last_modified_ledger_seq: 1,
+        data: LedgerEntryData::Account(AccountEntry {
+            account_id: account_id.clone(),
+            balance: 100,
+            seq_num: SequenceNumber(1),
+            num_sub_entries: 1,
+            inflation_dest: None,
+            flags: 0,
+            home_domain: String32::default(),
+            thresholds: Thresholds([1, 0, 0, 0]),
+            signers: VecM::default(),
+            ext: AccountEntryExt::V0,
+        }),
+        ext: LedgerEntryExt::V0,
+    };
+    let snapshot = SnapshotBuilder::new(1)
+        .add_entry(key, entry)
+        .build_with_default_header();
+    let snapshot = SnapshotHandle::new(snapshot);
+
+    let operation = Operation {
+        source_account: None,
+        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+            destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
+            asset: stellar_xdr::curr::Asset::Native,
+            amount: 1,
+        }),
+    };
+
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
+        fee: 50,
+        seq_num: SequenceNumber(2),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![operation].try_into().unwrap(),
+        ext: TransactionExt::V0,
+    };
+
+    let mut envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: VecM::default(),
+    });
+    let network_id = NetworkId::testnet();
+    let decorated = sign_envelope(&envelope, &secret, &network_id);
+    if let TransactionEnvelope::Tx(ref mut env) = envelope {
+        env.signatures = vec![decorated].try_into().unwrap();
+    }
+
+    // base_reserve=25, base_fee=50 (so fee=50 passes the insufficient-fee gate
+    // and fee_to_charge = min(inclusion_fee=50, min_inclusion_fee=50) = 50).
+    let context = henyey_tx::LedgerContext::new(1, 1_000, 50, 25, 25, network_id);
+    let mut executor = TransactionExecutor::new(
+        &context,
+        0,
+        SorobanConfig::default(),
+        ClassicEventConfig::default(),
+    );
+
+    let result = executor
+        .execute_transaction(&snapshot, &envelope, 50, None)
+        .expect("execute");
+
+    assert!(!result.success);
+    assert_eq!(
+        result.failure,
+        Some(ExecutionFailure::TxInsufficientBalance),
+        "available balance (100 - 50 fee - 75 minBalance = -25) < 0 must reject \
+         with TxInsufficientBalance, not silently cap the fee and ACCEPT"
+    );
+}
+
+/// Regression for #3104 (TX §4.6-1): the affordability guard must subtract
+/// selling liabilities (V10+ semantics), not only the minimum balance. Here the
+/// balance comfortably exceeds minBalance, but non-zero selling liabilities push
+/// the available balance negative once the fee is charged.
+///
+/// balance=200, num_sub_entries=0, base_reserve=25 => minBalance=50.
+/// selling liabilities=110. fee=50. Available = 200 - 50 - 50 - 110 = -10 < 0.
+///
+/// FAILS on main: the (absent) guard ignores selling liabilities on this path.
+#[test]
+fn test_execute_transaction_insufficient_balance_via_selling_liabilities() {
+    let secret = SecretKey::from_seed(&[72u8; 32]);
+    let account_id: AccountId = (&secret.public_key()).into();
+
+    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        account_id: account_id.clone(),
+    });
+    let entry = LedgerEntry {
+        last_modified_ledger_seq: 1,
+        data: LedgerEntryData::Account(AccountEntry {
+            account_id: account_id.clone(),
+            balance: 200,
+            seq_num: SequenceNumber(1),
+            num_sub_entries: 0,
+            inflation_dest: None,
+            flags: 0,
+            home_domain: String32::default(),
+            thresholds: Thresholds([1, 0, 0, 0]),
+            signers: VecM::default(),
+            ext: AccountEntryExt::V1(AccountEntryExtensionV1 {
+                liabilities: Liabilities {
+                    buying: 0,
+                    selling: 110,
+                },
+                ext: AccountEntryExtensionV1Ext::V0,
+            }),
+        }),
+        ext: LedgerEntryExt::V0,
+    };
+    let snapshot = SnapshotBuilder::new(1)
+        .add_entry(key, entry)
+        .build_with_default_header();
+    let snapshot = SnapshotHandle::new(snapshot);
+
+    let operation = Operation {
+        source_account: None,
+        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+            destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
+            asset: stellar_xdr::curr::Asset::Native,
+            amount: 1,
+        }),
+    };
+
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
+        fee: 50,
+        seq_num: SequenceNumber(2),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![operation].try_into().unwrap(),
+        ext: TransactionExt::V0,
+    };
+
+    let mut envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: VecM::default(),
+    });
+    let network_id = NetworkId::testnet();
+    let decorated = sign_envelope(&envelope, &secret, &network_id);
+    if let TransactionEnvelope::Tx(ref mut env) = envelope {
+        env.signatures = vec![decorated].try_into().unwrap();
+    }
+
+    let context = henyey_tx::LedgerContext::new(1, 1_000, 50, 25, 25, network_id);
+    let mut executor = TransactionExecutor::new(
+        &context,
+        0,
+        SorobanConfig::default(),
+        ClassicEventConfig::default(),
+    );
+
+    let result = executor
+        .execute_transaction(&snapshot, &envelope, 50, None)
+        .expect("execute");
+
+    assert!(!result.success);
+    assert_eq!(
+        result.failure,
+        Some(ExecutionFailure::TxInsufficientBalance),
+        "available balance (200 - 50 fee - 50 minBalance - 110 selling = -10) < 0 \
+         must reject with TxInsufficientBalance; the guard must subtract selling \
+         liabilities"
+    );
+}

--- a/crates/ledger/tests/transaction_execution/preconditions.rs
+++ b/crates/ledger/tests/transaction_execution/preconditions.rs
@@ -673,7 +673,10 @@ fn test_operation_failure_rolls_back_changes() {
     let secret = SecretKey::from_seed(&[11u8; 32]);
     let account_id: AccountId = (&secret.public_key()).into();
 
-    let (key, entry) = create_account_entry(account_id.clone(), 1, 10_000_000);
+    // Balance must clear minBalance (base_reserve 5_000_000, no sub-entries ⇒
+    // 10_000_000) plus the fee so the affordability guard accepts the tx and the
+    // body actually runs (the body then fails on the non-existent destination).
+    let (key, entry) = create_account_entry(account_id.clone(), 1, 20_000_000);
     let snapshot = SnapshotBuilder::new(1)
         .add_entry(key, entry)
         .build_with_default_header();
@@ -739,7 +742,7 @@ fn test_operation_failure_rolls_back_changes() {
 
     let source = state.get_account(&account_id).expect("source account");
     assert_eq!(source.seq_num.0, 2);
-    assert_eq!(source.balance, 10_000_000 - 200);
+    assert_eq!(source.balance, 20_000_000 - 200);
 }
 
 /// Regression test: fee-bump inner TX source account signature must be checked


### PR DESCRIPTION
Closes #3104

## Summary

Adds stellar-core's missing `availableBalance < feeToPay ⇒ txINSUFFICIENT_BALANCE` affordability guard to the production apply-path validator `validate_preconditions` (`crates/ledger/src/execution/preconditions.rs`). A transaction whose fee source's **available** balance — `balance − minBalance − sellingLiabilities`, computed non-saturated — drops below the (capped) fee is now rejected with `TxInsufficientBalance` instead of being silently fee-capped and ACCEPTed (a ledger-invariant violation).

The guard runs as the final step of `validate_preconditions` (post-seq, post-auth), mirroring stellar-core's `commonValid` ordering:
- Non-fee-bump: `TransactionFrame::commonValid` (TransactionFrame.cpp:1742-1755), `setInnermostError` ⇒ `post_seq_fail`.
- Fee-bump: `FeeBumpTransactionFrame::commonValid`'s independent fee-source guard (FeeBumpTransactionFrame.cpp:466-475), `setError` ⇒ `fee_bump_outer_fail`.

With `applying=true`, `feeToPay` reduces to 0 (the fee is charged by `processFeeSeqNum` first), so the predicate is `(balance − chargedFee) − minBalance − sellingLiab < 0`, where `chargedFee = min(balance, fee)` against the same balance the guard reads. A new `fee_to_charge: i64` param is threaded into `validate_preconditions`: `0` on the `FeeMode::Skip` tx-set path (`process_fee_only` already deducted the capped fee so the balance is net), and `fee_to_charge(base_fee)` on the `FeeMode::Deduct` path (validation precedes the inline deduction). The three-term subtraction is computed directly in `i64` (never via the saturating `available_to_send`, which would clamp the intermediate to 0 and make the `< 0` test unreachable).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3104#issuecomment-4619119289)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (clean)
- [x] `cargo test -p henyey-ledger` passes (453 + 94 + others, incl. 2 new tests)
- [x] `cargo test -p henyey-tx -p henyey-app` passes (no ledger-close regressions)

## Regression test (kind: bug-fix)

- **Tests:** `crates/ledger/tests/transaction_execution/preconditions.rs::test_execute_transaction_insufficient_available_balance_rejects` and `::test_execute_transaction_insufficient_balance_via_selling_liabilities`
- **Pre-fix:** committed as `7cfe55e5` — verified FAILED with `left: Some(TxFailed)` / `right: Some(TxInsufficientBalance)` (body ran instead of being rejected)
- **Post-fix:** verified PASS after `c66d18be`

## Deviations from plan

- The plan named the threaded parameter `already_charged_fee` and described passing the *capped* fee on the Deduct path by reading the fee-source balance at the call site. The fee source account is only loaded into `self.state` *inside* `validate_preconditions` (via `load_account`), so it isn't readable at the call site in Deduct mode. Equivalent and simpler: the parameter (renamed `fee_to_charge`) carries the **uncapped** fee, and the guard caps it (`min(balance, fee_to_charge)`) against the balance it already reads — exactly mirroring stellar-core's `fee = min(balance, fee)` against the same balance the affordability check evaluates. Identical observable predicate; `FeeMode::Skip` still passes 0.
- Two existing tests (`test_execute_with_pre_apply_result_partial_fee_failing_body`, `test_operation_failure_rolls_back_changes`) used fixtures sitting at/below `minBalance` — states the correct guard rejects (and which stellar-core also rejects). Their source balances were raised above `minBalance` to preserve their rollback / Skip-path intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)