### PR TITLE
Guard set_error monotonicity in MutableTransactionResult (TX §12.4)

### DIFF
--- a/crates/tx/src/result.rs
+++ b/crates/tx/src/result.rs
@@ -988,6 +988,41 @@ mod tests {
         assert_eq!(result.result_code(), TxResultCode::TxBadSeq);
     }
 
+    // Mirrors stellar-core MutableTransactionResultBase::setError monotonicity
+    // (MutableTransactionResult.cpp:148-160): once an error code is set it may
+    // only be re-set to the same code (idempotent) or be set from a success
+    // state — never changed to a different error. Gated to debug builds because
+    // the guard is a `debug_assert!` (compiled out in release).
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "set_error must be monotonic")]
+    fn test_set_error_rejects_error_to_different_error() {
+        let mut result = MutableTransactionResult::new(100);
+        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        // Changing to a different error code must panic via the entry guard.
+        result.set_error(stellar_xdr::curr::TransactionResultCode::TxInsufficientFee);
+    }
+
+    #[test]
+    fn test_set_error_idempotent_same_code_ok() {
+        let mut result = MutableTransactionResult::new(100);
+        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        // Re-setting the same error code is idempotent and must not panic.
+        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        assert!(!result.is_success());
+        assert_eq!(result.result_code(), TxResultCode::TxBadSeq);
+    }
+
+    #[test]
+    fn test_set_error_from_success_ok() {
+        let mut result = MutableTransactionResult::new(100);
+        assert!(result.is_success());
+        // Transitioning from a success state to an error is always allowed.
+        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        assert!(!result.is_success());
+        assert_eq!(result.result_code(), TxResultCode::TxBadSeq);
+    }
+
     #[test]
     fn test_mutable_result_error_resets_refundable_fees() {
         let mut result = MutableTransactionResult::new(1000);

--- a/crates/tx/src/result.rs
+++ b/crates/tx/src/result.rs
@@ -700,12 +700,36 @@ impl MutableTransactionResult {
     /// This also resets any consumed refundable fees (for Soroban) so that
     /// the maximum refund is returned to the fee source.
     pub fn set_error(&mut self, code: stellar_xdr::curr::TransactionResultCode) {
+        // Mirror stellar-core MutableTransactionResultBase::setError monotonicity
+        // (MutableTransactionResult.cpp:148-160): an error result may only be
+        // re-set to the same code (idempotent) or set from a success state —
+        // never changed to a different error. Use the cheap discriminant
+        // accessor (not result_code(), which clones + round-trips through XDR).
+        // `debug_assert!` is the project-idiomatic mirror of stellar-core's
+        // `releaseAssert` for programming-error invariants on currently-
+        // unreachable paths (cf. meta_builder.rs:149,293): fires in debug/test
+        // builds, compiled out (zero cost) in release.
+        debug_assert!(
+            code == self.inner.result.discriminant() || self.is_success(),
+            "set_error must be monotonic: cannot change error code from {:?} to {:?}",
+            self.inner.result.discriminant(),
+            code
+        );
+
         self.inner.result = code_to_result(code);
 
         // Reset refundable fees on error
         if let Some(ref mut tracker) = self.refundable_fee_tracker {
             tracker.reset_consumed_fee();
         }
+
+        // The new code must itself be a failure (mirrors the trailing
+        // releaseAssert(!isSuccess()) in stellar-core).
+        debug_assert!(
+            !self.is_success(),
+            "set_error called with a success code: {:?}",
+            code
+        );
     }
 
     /// Initialize refundable fee tracker for Soroban transactions.


### PR DESCRIPTION
Closes #3119

## Summary

`MutableTransactionResult::set_error` previously overwrote the result code unconditionally. This adds a monotonicity guard mirroring stellar-core's `MutableTransactionResultBase::setError` (`MutableTransactionResult.cpp:148-160`): an entry guard rejecting a change from one error code to a *different* error (idempotent same-code re-set and success→error transitions stay allowed via `code == self.inner.result.discriminant() || self.is_success()`), plus a trailing check that the new code is itself a failure. Both are `debug_assert!` — the project's parity-idiomatic mirror of `releaseAssert` for currently-unreachable programming-error paths (cf. `meta_builder.rs:149,293`): fires in debug/test builds, zero release cost. No observable/consensus behavior changes since the guarded path is unreachable for any real transaction today.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3119#issuecomment-4619456603)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-tx passes (1356 passed, 0 failed)
- [x] cargo build -p henyey-tx --release compiles; release test run skips the cfg-gated panic test as expected

## Regression test

- **Test:** `crates/tx/src/result.rs::test_set_error_rejects_error_to_different_error` (gated `#[cfg(debug_assertions)]` + `#[should_panic]`)
- **Pre-fix:** committed as `1b65827c` — verified FAILED with: `test did not panic as expected`
- **Post-fix:** verified PASSES after `ea9675ae`
- Plus `test_set_error_idempotent_same_code_ok` and `test_set_error_from_success_ok` lock in the allowed transitions.

## Deviations from plan

None. Out-of-scope advisory items (fee-bump `set_inner_error` symmetry, `to_xdr_result` collapse) intentionally not bundled — noted as follow-ups only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)