### PR TITLE
Assert SCP ballot invariant violations in debug builds

### DIFF
--- a/crates/scp/src/ballot/envelope.rs
+++ b/crates/scp/src/ballot/envelope.rs
@@ -138,10 +138,17 @@ impl BallotProtocol {
     /// 8. Advance slot (non-Externalize) or just record (Externalize)
     /// 9. Emit via `send_latest_envelope`
     pub(super) fn emit_current_state<D: SCPDriver>(&mut self, ctx: &SlotContext<'_, D>) {
-        // Matches stellar-core BallotProtocol.cpp:529
+        // Matches stellar-core BallotProtocol.cpp:529. checkInvariants() upstream
+        // is a sequence of dbgAssert(...) — a debug-only abort compiled out under
+        // NDEBUG. debug_assert! is the Rust analogue: abort in debug/test builds,
+        // stripped under --release. Keep the warn! so release retains observability.
         if let Err(e) = self.check_invariants() {
             tracing::warn!(
                 slot = ctx.slot_index,
+                "Invariant violation at start of emit_current_state: {e}"
+            );
+            debug_assert!(
+                false,
                 "Invariant violation at start of emit_current_state: {e}"
             );
         }

--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -3487,6 +3487,13 @@ mod tests {
             counter: 1,
             value: value.clone(),
         });
+        // The real protocol path reaches set_confirm_commit only from CONFIRM,
+        // where prepared is already set; mirror that so check_invariants() holds
+        // once the phase becomes Externalize (INV-S8: all four fields required).
+        bp.prepared = Some(ScpBallot {
+            counter: 1,
+            value: value.clone(),
+        });
 
         let c = ScpBallot {
             counter: 1,
@@ -3524,6 +3531,12 @@ mod tests {
         let value = make_value(&[42]);
 
         bp.current_ballot = Some(ScpBallot {
+            counter: 1,
+            value: value.clone(),
+        });
+        // CONFIRM→EXTERNALIZE always carries a prepared ballot in the real path;
+        // set it so check_invariants() holds once the phase becomes Externalize.
+        bp.prepared = Some(ScpBallot {
             counter: 1,
             value: value.clone(),
         });
@@ -4908,6 +4921,12 @@ mod tests {
             value: value.clone(),
         });
         bp.current_ballot = Some(ScpBallot {
+            counter: 2,
+            value: value.clone(),
+        });
+        // CONFIRM phase requires prepared (INV-S8); set it so the EXTERNALIZE
+        // transition driven below keeps check_invariants() satisfied.
+        bp.prepared = Some(ScpBallot {
             counter: 2,
             value: value.clone(),
         });

--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -5166,4 +5166,105 @@ mod tests {
             );
         }
     }
+
+    /// SCP §13.1-6 / INV-S8 parity regression: `update_current_value` must abort
+    /// (not merely `tracing::warn!`) when `check_invariants()` fails, mirroring
+    /// stellar-core's `dbgAssert` at `BallotProtocol.cpp:442`. `debug_assert!` is
+    /// the exact analogue: it panics in debug/test builds and is compiled out
+    /// under `--release` (NDEBUG), so release/mainnet behavior is unchanged.
+    ///
+    /// FAILS on `origin/main` (the site only warns → `catch_unwind` returns `Ok`
+    /// even in a debug build, so the `is_err()` assertion fails); PASSES after the
+    /// `debug_assert!` lands. Pattern follows
+    /// `test_set_accept_prepared_phase_guard_matches_debug_assert_semantics`.
+    #[test]
+    fn test_check_invariants_violation_aborts_in_debug_via_update_current_value() {
+        let value_a: Value = vec![1u8, 0].try_into().unwrap();
+
+        let mut bp = BallotProtocol::new();
+        // Force a structurally-invalid CONFIRM state: current_ballot is set but
+        // prepared/commit/high_ballot are all None. INV-S8 requires all four
+        // fields in CONFIRM, so check_invariants() returns Err. current_ballot
+        // being Some routes update_current_value down the path that reaches the
+        // unconditional check_invariants() call (state_machine.rs:548).
+        bp.set_phase_for_test(BallotPhase::Confirm);
+        bp.set_current_ballot_for_test(Some(ScpBallot {
+            counter: 2,
+            value: value_a.clone(),
+        }));
+
+        // A ballot that is not greater than current_ballot, so the body takes the
+        // `_ => false` arm and falls through to check_invariants() without
+        // mutating state.
+        let ballot = ScpBallot {
+            counter: 1,
+            value: value_a.clone(),
+        };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            bp.update_current_value(&ballot)
+        }));
+
+        if cfg!(debug_assertions) {
+            assert!(
+                result.is_err(),
+                "debug builds must panic on invariant violation in update_current_value \
+                 (matches stellar-core dbgAssert at BallotProtocol.cpp:442)"
+            );
+        } else {
+            assert!(
+                result.is_ok(),
+                "release builds must NOT panic — matches stellar-core dbgAssert under NDEBUG"
+            );
+        }
+    }
+
+    /// SCP §13.1-6 / INV-S8 parity regression: `emit_current_state` must abort
+    /// (not merely `tracing::warn!`) when `check_invariants()` fails, mirroring
+    /// stellar-core's `dbgAssert` at `BallotProtocol.cpp:529`. Same debug/release
+    /// split as the `update_current_value` test above.
+    ///
+    /// FAILS on `origin/main` (only warns → `Ok` in debug); PASSES after the
+    /// `debug_assert!` lands.
+    #[test]
+    fn test_check_invariants_violation_aborts_in_debug_via_emit_current_state() {
+        let node_self = make_node_id(0);
+        let node_b = make_node_id(1);
+        let node_c = make_node_id(2);
+        let value_a: Value = vec![1u8, 0].try_into().unwrap();
+        let quorum_set =
+            make_quorum_set(vec![node_self.clone(), node_b.clone(), node_c.clone()], 3);
+        let driver = Arc::new(
+            MockDriverBuilder::new()
+                .quorum_set(quorum_set.clone())
+                .build(),
+        );
+        let ctx = ctx!(&node_self, &quorum_set, &driver, 1);
+
+        let mut bp = BallotProtocol::new();
+        // Same invariant-violating CONFIRM state: current_ballot set, the other
+        // three required fields None. emit_current_state calls check_invariants()
+        // at the top (envelope.rs:142) before doing any phase-specific work.
+        bp.set_phase_for_test(BallotPhase::Confirm);
+        bp.set_current_ballot_for_test(Some(ScpBallot {
+            counter: 2,
+            value: value_a.clone(),
+        }));
+
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| bp.emit_current_state(&ctx)));
+
+        if cfg!(debug_assertions) {
+            assert!(
+                result.is_err(),
+                "debug builds must panic on invariant violation in emit_current_state \
+                 (matches stellar-core dbgAssert at BallotProtocol.cpp:529)"
+            );
+        } else {
+            assert!(
+                result.is_ok(),
+                "release builds must NOT panic — matches stellar-core dbgAssert under NDEBUG"
+            );
+        }
+    }
 }

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -544,9 +544,14 @@ impl BallotProtocol {
             }
         };
 
-        // Matches stellar-core BallotProtocol.cpp:442
+        // Matches stellar-core BallotProtocol.cpp:442. stellar-core's
+        // checkInvariants() is a sequence of dbgAssert(...) — a debug-only abort
+        // that is compiled out under NDEBUG. The Rust analogue is debug_assert!:
+        // abort in debug/test builds, no-op (and stripped) under --release. Keep
+        // the warn! so release builds retain the observability they have today.
         if let Err(e) = self.check_invariants() {
             tracing::warn!("Invariant violation after update_current_value: {e}");
+            debug_assert!(false, "Invariant violation after update_current_value: {e}");
         }
 
         updated


### PR DESCRIPTION
Closes #3091

## Summary

Promotes the two warn-only `check_invariants()` failure sites in the ballot state machine to **assert-and-warn**, mirroring stellar-core's `dbgAssert` (`BallotProtocol.cpp:442` and `:529`). `update_current_value()` (`state_machine.rs`) and `emit_current_state()` (`envelope.rs`) keep the existing `tracing::warn!` and add `debug_assert!(false, ...)` on an `Err`. A violated SCP ballot invariant now panics in debug/test builds while **release/mainnet behavior is unchanged** (warn + continue) — `debug_assert!` is stripped under `--release` exactly as `dbgAssert` is under `NDEBUG`, so there is no new mainnet-validator panic risk.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3091#issuecomment-4619703574)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-scp -- -D warnings` clean
- [x] `cargo test -p henyey-scp` passes (369 lib + 50 + 7 + 124 integration)
- [x] `cargo build -p henyey-scp --release` compiles (asserts compiled out)
- [x] regression tests pass under `--release` taking the `is_ok()` branch (confirms asserts stripped)

## Regression test (kind: bug-fix)

- **Tests:** `crates/scp/src/ballot/mod.rs::test_check_invariants_violation_aborts_in_debug_via_update_current_value` and `..._via_emit_current_state`
- **Pre-fix:** committed as `5001f572` — verified FAILED in a debug build: both sites only `tracing::warn!`, so `catch_unwind` returned `Ok` and the `cfg!(debug_assertions)` `is_err()` assertion failed.
- **Post-fix:** verified PASS after `d2530454` — debug build aborts (`is_err()`), release build does not (`is_ok()`).

## Deviations from plan

- The plan's "Existing tests preserved" list did not anticipate three tests that drove a *partial* state directly into the EXTERNALIZE phase without setting `prepared` (`test_set_confirm_commit_signals_stop_nomination`, `test_set_confirm_commit_externalizes_commit_value`, `test_attempt_confirm_commit_accepts_confirm_hint`). The new assert correctly flags these (INV-S8 / stellar-core requires all four fields in CONFIRM/EXTERNALIZE). Fixed the **test setups** (not production code) to set `prepared`, matching the real protocol path that always carries a prepared ballot into EXTERNALIZE. No production behavior change beyond the two intended call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)