### PR TITLE
Re-validate upgrades at apply time (LEDGER §7.3.4-2)

### DIFF
--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -240,6 +240,79 @@ pub fn hot_archive_supported(protocol_version: u32) -> bool {
 }
 
 // =============================================================================
+// Apply-time upgrade validity (non-Config)
+// =============================================================================
+
+/// Bitmask of valid ledger-header flags (`MASK_LEDGER_HEADER_FLAGS`).
+///
+/// Mirrors stellar-core's `MASK_LEDGER_HEADER_FLAGS = 0x7` (bits 0-2). A
+/// `LedgerUpgrade::Flags` upgrade is only valid if no bits outside this mask
+/// are set.
+pub const MASK_LEDGER_HEADER_FLAGS: u32 = 0x7;
+
+/// Re-validate a non-`Config` ledger upgrade for application, mirroring
+/// stellar-core `Upgrades::isValidForApply` (Upgrades.cpp:565-637) for the
+/// scalar (non-Config) arms.
+///
+/// This is the single shared source of truth for the apply-time re-check
+/// performed by the ledger close path (LEDGER_SPEC §7.3.4 step 2). It lives in
+/// `henyey-common` because `henyey-ledger` cannot depend on `henyey-herder`
+/// (herder depends on ledger — a cycle), and herder's nomination-time validity
+/// rules cannot be reused directly from the ledger apply path.
+///
+/// The `Config` variant is deliberately out of this helper's remit: Config
+/// validity requires ledger-state lookups (the config upgrade set must be
+/// loadable and structurally valid), which is performed by the ledger-side
+/// `apply_config_upgrades`. Callers must branch on `Config` themselves; this
+/// function returns `true` for `Config` so a caller that forwards every upgrade
+/// here does not incorrectly skip a Config upgrade that the ledger-side path
+/// will validate.
+///
+/// # Arguments
+///
+/// * `upgrade` - the upgrade to validate
+/// * `current_version` - the protocol version in effect *before* this upgrade
+///   (callers thread an `effective_version` that advances as valid `Version`
+///   upgrades are accepted, mirroring core re-reading the header per upgrade)
+/// * `max_protocol_version` - the maximum protocol version this node supports
+///
+/// # Parity
+///
+/// Matches the non-Config arms of stellar-core `Upgrades::isValidForApply`:
+/// - `Version`: `new > current && new <= max`
+/// - `BaseFee`: `fee != 0`
+/// - `MaxTxSetSize`: always valid
+/// - `BaseReserve`: `reserve != 0`
+/// - `Flags`: protocol >= V18 and no bits outside `MASK_LEDGER_HEADER_FLAGS`
+/// - `MaxSorobanTxSetSize`: protocol >= V20
+pub fn upgrade_valid_for_apply_non_config(
+    upgrade: &stellar_xdr::curr::LedgerUpgrade,
+    current_version: u32,
+    max_protocol_version: u32,
+) -> bool {
+    use stellar_xdr::curr::LedgerUpgrade;
+    match upgrade {
+        LedgerUpgrade::Version(new_version) => {
+            *new_version <= max_protocol_version && *new_version > current_version
+        }
+        LedgerUpgrade::BaseFee(fee) => *fee != 0,
+        LedgerUpgrade::MaxTxSetSize(_) => true,
+        LedgerUpgrade::BaseReserve(reserve) => *reserve != 0,
+        LedgerUpgrade::Flags(flags) => {
+            protocol_version_starts_from(current_version, ProtocolVersion::V18)
+                && (*flags & !MASK_LEDGER_HEADER_FLAGS) == 0
+        }
+        LedgerUpgrade::MaxSorobanTxSetSize(_) => {
+            protocol_version_starts_from(current_version, ProtocolVersion::V20)
+        }
+        // Config validity is delegated to the ledger-side apply path (it
+        // requires ledger-state lookups). Treat as valid here so a caller that
+        // forwards every upgrade does not skip a Config upgrade.
+        LedgerUpgrade::Config(_) => true,
+    }
+}
+
+// =============================================================================
 // LCL Context
 // =============================================================================
 
@@ -345,5 +418,135 @@ mod tests {
         let lcl = LclContext::new(23, hash);
         assert_eq!(lcl.protocol_version(), 23);
         assert_eq!(lcl.lcl_hash(), &stellar_xdr::curr::Hash([42u8; 32]));
+    }
+
+    // ---- upgrade_valid_for_apply_non_config -------------------------------
+
+    #[test]
+    fn test_upgrade_valid_version_monotonic_and_range() {
+        use stellar_xdr::curr::LedgerUpgrade;
+        // Strictly increasing and within max → valid.
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Version(26),
+            25,
+            26
+        ));
+        // Regression (new <= current) → invalid.
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Version(25),
+            26,
+            26
+        ));
+        // Equal to current → invalid (not strictly increasing).
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Version(25),
+            25,
+            26
+        ));
+        // Above max supported → invalid.
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Version(27),
+            25,
+            26
+        ));
+    }
+
+    #[test]
+    fn test_upgrade_valid_base_fee_nonzero() {
+        use stellar_xdr::curr::LedgerUpgrade;
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::BaseFee(100),
+            25,
+            26
+        ));
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::BaseFee(0),
+            25,
+            26
+        ));
+    }
+
+    #[test]
+    fn test_upgrade_valid_base_reserve_nonzero() {
+        use stellar_xdr::curr::LedgerUpgrade;
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::BaseReserve(5_000_000),
+            25,
+            26
+        ));
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::BaseReserve(0),
+            25,
+            26
+        ));
+    }
+
+    #[test]
+    fn test_upgrade_valid_max_tx_set_size_always_valid() {
+        use stellar_xdr::curr::LedgerUpgrade;
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::MaxTxSetSize(0),
+            25,
+            26
+        ));
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::MaxTxSetSize(1000),
+            25,
+            26
+        ));
+    }
+
+    #[test]
+    fn test_upgrade_valid_flags_mask_and_protocol() {
+        use stellar_xdr::curr::LedgerUpgrade;
+        // Valid: within mask, protocol >= V18.
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Flags(MASK_LEDGER_HEADER_FLAGS),
+            25,
+            26
+        ));
+        // Invalid: bit outside the mask.
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Flags(MASK_LEDGER_HEADER_FLAGS | 0x8),
+            25,
+            26
+        ));
+        // Invalid: protocol below V18 (not reachable in henyey's 24+ floor,
+        // but the rule must still hold).
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Flags(0x1),
+            17,
+            26
+        ));
+    }
+
+    #[test]
+    fn test_upgrade_valid_max_soroban_tx_set_size_protocol_gate() {
+        use stellar_xdr::curr::LedgerUpgrade;
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::MaxSorobanTxSetSize(100),
+            20,
+            26
+        ));
+        assert!(!upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::MaxSorobanTxSetSize(100),
+            19,
+            26
+        ));
+    }
+
+    #[test]
+    fn test_upgrade_valid_config_delegated_returns_true() {
+        use stellar_xdr::curr::{ConfigUpgradeSetKey, ContractId, Hash, LedgerUpgrade};
+        let key = ConfigUpgradeSetKey {
+            contract_id: ContractId(Hash([0u8; 32])),
+            content_hash: Hash([0u8; 32]),
+        };
+        // Config is delegated to ledger-side validation → helper returns true.
+        assert!(upgrade_valid_for_apply_non_config(
+            &LedgerUpgrade::Config(key),
+            25,
+            26
+        ));
     }
 }

--- a/crates/ledger/src/close.rs
+++ b/crates/ledger/src/close.rs
@@ -1413,9 +1413,23 @@ impl UpgradeContext {
         })
     }
 
-    /// Apply upgrades to a header, returning the modified values.
+    /// Apply upgrades to a header, mutating the scalar header fields.
+    ///
+    /// LEDGER_SPEC §7.3.4 step 2 (`LEDGER §7.3.4-2`): upgrades that are invalid
+    /// at apply time (per [`apply_time_skip_set`]) are SKIPPED — their header
+    /// field is left unchanged — mirroring stellar-core
+    /// `LedgerManagerImpl.cpp:1660-1711`. The full nominated set still goes into
+    /// `scpValue.upgrades` elsewhere, so header-hash parity is preserved.
+    ///
+    /// The skip-set is computed against [`henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION`]
+    /// as the max supported version, matching the manager-side re-check.
     pub fn apply_to_header(&self, header: &mut LedgerHeader) {
-        for upgrade in &self.upgrades {
+        let skips = self.apply_time_skip_set(henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION);
+        for (upgrade, skip) in self.upgrades.iter().zip(skips.iter()) {
+            if *skip {
+                // Invalid at apply time — leave the header field unchanged.
+                continue;
+            }
             match upgrade {
                 LedgerUpgrade::Version(v) => {
                     header.ledger_version = *v;

--- a/crates/ledger/src/close.rs
+++ b/crates/ledger/src/close.rs
@@ -1268,6 +1268,54 @@ impl UpgradeContext {
             .any(|u| matches!(u, LedgerUpgrade::Config(_)))
     }
 
+    /// Compute the apply-time skip decision for every upgrade in `self.upgrades`,
+    /// in list order, mirroring stellar-core `LedgerManagerImpl.cpp:1660-1711`.
+    ///
+    /// LEDGER_SPEC §7.3.4 step 2 (`LEDGER §7.3.4-2`): each upgrade is
+    /// re-validated via `isValidForApply` at apply time; invalid upgrades are
+    /// skipped with a warning rather than aborting the ledger close.
+    ///
+    /// Returns a parallel `Vec<bool>` (one entry per upgrade, same order) where
+    /// `true` means "skip this upgrade at apply time". A skipped upgrade must
+    /// neither mutate header fields ([`apply_to_header`]) nor produce an
+    /// `UpgradeEntryMeta` — but it REMAINS in the header's `scpValue.upgrades`
+    /// (the full nominated set), preserving header-hash parity.
+    ///
+    /// The running `effective_version` starts at `self.current_version` (the
+    /// pre-upgrade protocol version) and advances when a valid `Version`
+    /// upgrade is accepted, so a later upgrade gated on a higher protocol (e.g.
+    /// a `Flags` or `MaxSorobanTxSetSize` upgrade following a `Version` upgrade)
+    /// is evaluated against the version that prior upgrades would have
+    /// established. This mirrors core re-reading the header version per upgrade
+    /// after each prior upgrade commits. SCP emits at most one upgrade per type,
+    /// so the only real cross-upgrade dependency is a single `Version` upgrade
+    /// raising the version — hence a single `effective_version` step suffices.
+    ///
+    /// `Config` upgrades are validated by [`apply_config_upgrades`] (which
+    /// requires ledger-state lookups); the common helper treats them as valid
+    /// here, so a `Config` entry is never skipped by this pass. Its skip is
+    /// decided by the config apply path instead.
+    pub fn apply_time_skip_set(&self, max_protocol_version: u32) -> Vec<bool> {
+        let mut effective_version = self.current_version;
+        let mut skips = Vec::with_capacity(self.upgrades.len());
+        for upgrade in &self.upgrades {
+            let valid = henyey_common::upgrade_valid_for_apply_non_config(
+                upgrade,
+                effective_version,
+                max_protocol_version,
+            );
+            // Advance the running version when a valid Version upgrade is
+            // accepted, so subsequent version-gated upgrades see the new value.
+            if valid {
+                if let LedgerUpgrade::Version(v) = upgrade {
+                    effective_version = *v;
+                }
+            }
+            skips.push(!valid);
+        }
+        skips
+    }
+
     /// Apply all config upgrades to the ledger.
     ///
     /// Loads and validates each config upgrade, then applies the configuration

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -8495,6 +8495,171 @@ mod tests {
         assert!(matches!(decoded[1], LedgerUpgrade::BaseReserve(5_000_000)));
     }
 
+    /// Regression test for #3060 (LEDGER §7.3.4-2): an upgrade that was valid
+    /// at nomination time but is invalid at apply time (a `Version` regression:
+    /// the header is already at 26, the upgrade proposes 25) must be SKIPPED at
+    /// apply time — the header field is left unchanged and no `UpgradeEntryMeta`
+    /// is emitted — while the full nominated set remains in
+    /// `scp_value.upgrades` (header-hash parity).
+    ///
+    /// Mirrors stellar-core `LedgerManagerImpl.cpp:1660-1711`.
+    #[test]
+    fn test_apply_time_revalidation_skips_version_regression() {
+        use stellar_xdr::curr::{LedgerUpgrade, Limits, ReadXdr};
+
+        let manager = LedgerManager::new(
+            "Test SDF Network ; September 2015".to_string(),
+            LedgerManagerConfig {
+                validate_bucket_hash: false,
+                ..Default::default()
+            },
+        );
+
+        let mut ctx = make_test_close_context(&manager, 2);
+        // Header is already at protocol 26.
+        ctx.prev_header.ledger_version = 26;
+        ctx.upgrade_ctx = UpgradeContext::new(26);
+
+        // A version-regression upgrade: valid-at-nomination, invalid-at-apply.
+        let upgrade = LedgerUpgrade::Version(25);
+        ctx.close_data.upgrades = vec![upgrade.clone()];
+        ctx.upgrade_ctx.add_upgrade(upgrade.clone());
+
+        // (b) The skip decision: the regression upgrade must be marked skipped,
+        // so the meta-building loop emits no UpgradeEntryMeta for it.
+        let skips = ctx
+            .upgrade_ctx
+            .apply_time_skip_set(henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION);
+        assert_eq!(
+            skips,
+            vec![true],
+            "version-regression upgrade must be skipped"
+        );
+
+        // (a) The header field must NOT be mutated to 25.
+        let (header, _hash) = ctx
+            .build_and_hash_header(Hash256::ZERO, Hash256::ZERO, false, false)
+            .expect("build_and_hash_header should succeed");
+        assert_eq!(
+            header.ledger_version, 26,
+            "skipped version-regression upgrade must NOT lower ledger_version"
+        );
+
+        // (c) The full nominated set must remain in scp_value.upgrades.
+        assert_eq!(
+            header.scp_value.upgrades.len(),
+            1,
+            "scp_value.upgrades must remain unfiltered (full nominated set)"
+        );
+        let decoded =
+            LedgerUpgrade::from_xdr(&header.scp_value.upgrades[0].0, Limits::none()).unwrap();
+        assert!(
+            matches!(decoded, LedgerUpgrade::Version(25)),
+            "scp_value.upgrades must still contain the nominated Version(25)"
+        );
+    }
+
+    /// Regression test for #3060: an invalid `BaseFee(0)` upgrade is skipped at
+    /// apply time (header `base_fee` unchanged, no meta), while a valid upgrade
+    /// in the same set still applies and the header retains the full nominated
+    /// set in `scp_value.upgrades`.
+    #[test]
+    fn test_apply_time_revalidation_skips_invalid_base_fee() {
+        use stellar_xdr::curr::{LedgerUpgrade, Limits, ReadXdr};
+
+        let manager = LedgerManager::new(
+            "Test SDF Network ; September 2015".to_string(),
+            LedgerManagerConfig {
+                validate_bucket_hash: false,
+                ..Default::default()
+            },
+        );
+
+        let mut ctx = make_test_close_context(&manager, 2);
+        ctx.prev_header.ledger_version = 26;
+        ctx.prev_header.base_fee = 100;
+        ctx.upgrade_ctx = UpgradeContext::new(26);
+
+        // Invalid BaseFee(0) alongside a valid MaxTxSetSize upgrade.
+        let bad = LedgerUpgrade::BaseFee(0);
+        let good = LedgerUpgrade::MaxTxSetSize(5000);
+        ctx.close_data.upgrades = vec![bad.clone(), good.clone()];
+        ctx.upgrade_ctx.add_upgrade(bad.clone());
+        ctx.upgrade_ctx.add_upgrade(good.clone());
+
+        // Skip-set: BaseFee(0) skipped, MaxTxSetSize accepted.
+        let skips = ctx
+            .upgrade_ctx
+            .apply_time_skip_set(henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION);
+        assert_eq!(
+            skips,
+            vec![true, false],
+            "BaseFee(0) must be skipped, MaxTxSetSize accepted"
+        );
+
+        let (header, _hash) = ctx
+            .build_and_hash_header(Hash256::ZERO, Hash256::ZERO, false, false)
+            .expect("build_and_hash_header should succeed");
+
+        // base_fee must NOT be zeroed by the skipped upgrade.
+        assert_eq!(
+            header.base_fee, 100,
+            "skipped BaseFee(0) must NOT mutate header.base_fee"
+        );
+        // The valid upgrade still applies.
+        assert_eq!(
+            header.max_tx_set_size, 5000,
+            "valid MaxTxSetSize upgrade must still apply"
+        );
+
+        // Full nominated set preserved (unfiltered).
+        assert_eq!(header.scp_value.upgrades.len(), 2);
+        let decoded: Vec<LedgerUpgrade> = header
+            .scp_value
+            .upgrades
+            .iter()
+            .map(|u| LedgerUpgrade::from_xdr(&u.0, Limits::none()).unwrap())
+            .collect();
+        assert!(matches!(decoded[0], LedgerUpgrade::BaseFee(0)));
+        assert!(matches!(decoded[1], LedgerUpgrade::MaxTxSetSize(5000)));
+    }
+
+    /// #3060 ordering: a `Flags` upgrade gated on protocol >= V18 alongside a
+    /// `Version` upgrade is evaluated against the running `effective_version`.
+    /// Both are valid here (header already >= V18), confirming the
+    /// `effective_version` threading accepts a Flags upgrade after a Version
+    /// upgrade in the same set.
+    #[test]
+    fn test_apply_time_revalidation_effective_version_ordering() {
+        use stellar_xdr::curr::LedgerUpgrade;
+
+        let manager = LedgerManager::new(
+            "Test SDF Network ; September 2015".to_string(),
+            LedgerManagerConfig {
+                validate_bucket_hash: false,
+                ..Default::default()
+            },
+        );
+
+        let mut ctx = make_test_close_context(&manager, 2);
+        ctx.prev_header.ledger_version = 25;
+        ctx.upgrade_ctx = UpgradeContext::new(25);
+
+        // Version(26) then Flags(0x1): both valid; Flags evaluated at the
+        // advanced effective_version (26).
+        ctx.upgrade_ctx.add_upgrade(LedgerUpgrade::Version(26));
+        ctx.upgrade_ctx.add_upgrade(LedgerUpgrade::Flags(0x1));
+
+        let skips = ctx
+            .upgrade_ctx
+            .apply_time_skip_set(henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION);
+        assert_eq!(
+            skips,
+            vec![false, false],
+            "Version(26) and Flags(0x1) must both be accepted"
+        );
+    }
+
     /// Regression test: bucket_list() read guard must be dropped before
     /// bucket_list_mut() write guard is acquired on the same RwLock.
     /// Holding both simultaneously deadlocks (parking_lot RwLock is not

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -4377,6 +4377,33 @@ impl LedgerCloseContext<'_> {
     ) -> Result<(bool, bool, Vec<UpgradeEntryMeta>)> {
         use stellar_xdr::curr::{LedgerEntryChanges, LedgerUpgrade, Limits, WriteXdr};
 
+        // LEDGER_SPEC §7.3.4 step 2 (LEDGER §7.3.4-2): re-validate each upgrade
+        // via isValidForApply at apply time and SKIP invalid ones with a
+        // warning, rather than aborting the ledger close. Mirrors stellar-core
+        // LedgerManagerImpl.cpp:1660-1711.
+        //
+        // The skip-set is computed against prev_version (the pre-upgrade
+        // protocol, == upgrade_ctx.current_version) with the node's max
+        // supported version as the ceiling. A skipped upgrade must produce NO
+        // UpgradeEntryMeta and must not mutate header fields (handled in
+        // UpgradeContext::apply_to_header). The full nominated set still goes
+        // into scp_value.upgrades unchanged (header-hash parity).
+        //
+        // Spec wording is "skip with a warning"; stellar-core logs at ERROR. We
+        // use warn! to match the spec text — log level is not consensus-observable.
+        let skip_set = self
+            .upgrade_ctx
+            .apply_time_skip_set(henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION);
+        for (upgrade, skip) in self.upgrade_ctx.upgrades.iter().zip(skip_set.iter()) {
+            if *skip {
+                tracing::warn!(
+                    ledger_seq = self.close_data.ledger_seq,
+                    upgrade = ?upgrade,
+                    "Skipping upgrade that is invalid at apply time (LEDGER §7.3.4-2)"
+                );
+            }
+        }
+
         // Parity: Upgrades.cpp:1229-1242 applyVersionUpgrade
         // Version upgrades may create/modify config setting entries in the
         // ledger (e.g. new cost types for V25, state size window for V23+).
@@ -4564,7 +4591,16 @@ impl LedgerCloseContext<'_> {
         // Parity: LedgerManagerImpl.cpp:1671-1680 — stellar-core only appends
         // meta after a successful child-txn commit; failed upgrades produce no meta.
         let mut upgrades_meta = Vec::new();
-        for upgrade in std::mem::take(&mut self.close_data.upgrades) {
+        for (idx, upgrade) in std::mem::take(&mut self.close_data.upgrades)
+            .into_iter()
+            .enumerate()
+        {
+            // LEDGER §7.3.4-2: an upgrade invalid at apply time is skipped —
+            // it produces NO UpgradeEntryMeta. This covers every non-Config
+            // arm, including the header-only `_ => (true, ...)` arm below.
+            if skip_set.get(idx).copied().unwrap_or(false) {
+                continue;
+            }
             let (succeeded, changes) = match &upgrade {
                 LedgerUpgrade::Version(_) => (version_upgrade_succeeded, version_changes.clone()),
                 LedgerUpgrade::Config(key) => {

--- a/crates/ledger/tests/upgrade_sequence_integration.rs
+++ b/crates/ledger/tests/upgrade_sequence_integration.rs
@@ -364,6 +364,50 @@ fn test_config_upgrade_sees_stale_protocol_version() {
 }
 
 // ===========================================================================
+// Test: #3060 — apply-time upgrade re-validation (LEDGER §7.3.4-2)
+// ===========================================================================
+
+/// Integration regression test for #3060 (`LEDGER §7.3.4-2`).
+///
+/// An upgrade set that was valid at nomination time but contains an upgrade
+/// invalid at apply time (a `Version` regression: header already at 26, the
+/// upgrade proposes 25) must be skipped at apply time — `apply_to_header`
+/// leaves `ledger_version` unchanged — while a co-present valid upgrade still
+/// applies. Mirrors stellar-core `LedgerManagerImpl.cpp:1660-1711`.
+#[test]
+fn test_apply_time_revalidation_skips_invalid_version_at_header() {
+    // Header is already at protocol 26.
+    let mut header = make_genesis_header(26);
+    header.base_reserve = 5_000_000;
+
+    let mut ctx = UpgradeContext::new(26);
+    // Version(25) is a regression (invalid at apply time) — must be skipped.
+    ctx.add_upgrade(LedgerUpgrade::Version(25));
+    // BaseReserve(10_000_000) is valid and must still apply.
+    ctx.add_upgrade(LedgerUpgrade::BaseReserve(10_000_000));
+
+    // The skip-set marks only the regression upgrade.
+    let skips = ctx.apply_time_skip_set(henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION);
+    assert_eq!(
+        skips,
+        vec![true, false],
+        "Version(25) regression skipped; BaseReserve accepted"
+    );
+
+    let mut upgraded = header.clone();
+    ctx.apply_to_header(&mut upgraded);
+
+    assert_eq!(
+        upgraded.ledger_version, 26,
+        "skipped Version(25) must NOT lower ledger_version below 26"
+    );
+    assert_eq!(
+        upgraded.base_reserve, 10_000_000,
+        "valid BaseReserve upgrade must still apply"
+    );
+}
+
+// ===========================================================================
 // Test: #1125 — Config upgrade TTL check uses snapshot.ledger_seq (N-1)
 // ===========================================================================
 


### PR DESCRIPTION
Closes #3060

## Summary

Adds an apply-time `isValidForApply` re-check for non-`Config` upgrades in the ledger close path, mirroring stellar-core `LedgerManagerImpl.cpp:1660-1711`. An upgrade that was valid at nomination time but is invalid at apply time (e.g. a `Version` regression, or a `BaseFee(0)`) is now SKIPPED with a warning — it mutates neither the header scalar fields nor the upgrade meta — rather than being applied unconditionally. The full nominated set remains in `header.scp_value.upgrades`, so header-hash parity with core is preserved.

The non-`Config` validity rules are hoisted into a single shared helper `henyey_common::upgrade_valid_for_apply_non_config` because `henyey-ledger` cannot depend on `henyey-herder` (herder depends on ledger — a cycle). `UpgradeContext::apply_time_skip_set` threads a running `effective_version` through the nominated list (advancing on accepted `Version` upgrades) to produce a per-index skip decision consumed by both `apply_to_header` and the meta-building loop in `apply_upgrades_to_delta`. Config validity stays delegated to the existing ledger-side `apply_config_upgrades`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3060#issuecomment-4619711800)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-common -p henyey-ledger -- -D warnings (clean; pre-existing `fs_utils.rs` test-only lint on origin/main is unrelated)
- [x] `cargo test -p henyey-common -p henyey-ledger` passes (common 219, ledger lib 460, upgrade_sequence_integration 16, all other ledger integration suites green)

## Regression test (kind: bug-fix)

- **Tests:** `crates/ledger/src/manager.rs::test_apply_time_revalidation_skips_version_regression` and `::test_apply_time_revalidation_skips_invalid_base_fee`
- **Pre-fix:** committed as `3de9cd9e21b05aa349616f66051eb3949f7251be` — verified FAILED: `apply_to_header` mutated header fields for invalid upgrades (`ledger_version` lowered 26→25; `base_fee` zeroed 100→0)
- **Post-fix:** verified PASSES after `a22e98dda5ac541916fdeb5f6316d215f99f3696`

Additional coverage: `henyey-common` unit tests per validity arm; `apply_time_skip_set` ordering test (`Version`+`Flags` via `effective_version`); integration `test_apply_time_revalidation_skips_invalid_version_at_header`.

## Deviations from plan

- Per the plan's scope discipline (Critic C): herder's existing `is_valid_for_apply` is left untouched to keep this a focused ledger bug-fix. A dedup follow-up ("unify upgrade-validity logic across herder/ledger via the new common helper") should be filed.
- The skip-warning is logged at `warn!` (matching the spec wording "skip with a warning") rather than core's `ERROR` — log level is not consensus-observable; noted in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)