### PR TITLE
Set HAS download retry count to 10 to match stellar-core

### DIFF
--- a/crates/history/src/download.rs
+++ b/crates/history/src/download.rs
@@ -33,7 +33,7 @@ use crate::error::HistoryError;
 /// Default timeout for HTTP requests.
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Retry count for operations that should retry a few times (e.g. HAS downloads).
+/// Retry count for operations that should retry a few times (e.g. SCP downloads).
 ///
 /// Matches stellar-core's `RETRY_A_FEW = 5`.
 pub const RETRY_A_FEW: u32 = 5;
@@ -42,6 +42,14 @@ pub const RETRY_A_FEW: u32 = 5;
 ///
 /// Matches stellar-core's `RETRY_A_LOT = 32`.
 pub const RETRY_A_LOT: u32 = 32;
+
+/// Retry count for the History Archive State (HAS) download.
+///
+/// CATCHUP_SPEC §13.1-1: stellar-core's `CatchupWork` overrides the default
+/// `RETRY_A_FEW` and constructs `GetHistoryArchiveStateWork` with `10` retries
+/// "to ensure we retry enough in case current checkpoint isn't published yet"
+/// (see `stellar-core/src/catchup/CatchupWork.cpp`). Matches that value.
+pub const HAS_RETRIES: u32 = 10;
 
 /// Default number of retry attempts (uses `RETRY_A_FEW`).
 pub const DEFAULT_RETRIES: u32 = RETRY_A_FEW;
@@ -473,6 +481,15 @@ mod tests {
     #[test]
     fn test_retry_a_lot_is_32() {
         assert_eq!(RETRY_A_LOT, 32, "CATCHUP_SPEC §9.1: RETRY_A_LOT must be 32");
+    }
+
+    #[test]
+    fn test_has_retries_is_10() {
+        assert_eq!(
+            HAS_RETRIES, 10,
+            "CATCHUP_SPEC §13.1-1: HAS download must use 10 retries \
+             (stellar-core CatchupWork overrides RETRY_A_FEW)"
+        );
     }
 
     #[test]

--- a/crates/historywork/src/builder.rs
+++ b/crates/historywork/src/builder.rs
@@ -8,14 +8,16 @@
 //! The builder creates the following work DAG:
 //!
 //! ```text
-//!   get_has ──┬── download_buckets    (RETRY_A_LOT)
+//!   get_has ──┬── download_buckets    (RETRY_A_LOT)   [get_has uses HAS_RETRIES]
 //!             └── download_headers ──┬── download_tx        (RETRY_A_LOT)
 //!                                    ├── download_tx_results (RETRY_A_LOT, after tx)
 //!                                    └── download_scp       (RETRY_A_FEW)
 //! ```
 //!
-//! Work items are retried per CATCHUP_SPEC §9.1:
-//! - `RETRY_A_FEW` (5): lightweight metadata downloads (HAS, SCP)
+//! Work items are retried per CATCHUP_SPEC §9.1 and §13.1-1:
+//! - `HAS_RETRIES` (10): HAS download (stellar-core `CatchupWork` overrides the
+//!   default to retry enough in case the current checkpoint isn't published yet)
+//! - `RETRY_A_FEW` (5): lightweight metadata downloads (SCP)
 //! - `RETRY_A_LOT` (32): bulk data downloads (buckets, headers, txs, results)
 
 use std::path::PathBuf;
@@ -23,7 +25,7 @@ use std::sync::Arc;
 
 use henyey_history::{
     archive::HistoryArchive,
-    download::{RETRY_A_FEW, RETRY_A_LOT},
+    download::{HAS_RETRIES, RETRY_A_FEW, RETRY_A_LOT},
 };
 use henyey_work::{WorkId, WorkScheduler};
 
@@ -116,8 +118,9 @@ impl HistoryWorkBuilder {
     ///
     /// Creates and registers all download work items (HAS, buckets, headers,
     /// transactions, results, SCP) with proper dependency ordering. Each work
-    /// item is configured with appropriate retry counts per CATCHUP_SPEC §9.1:
-    /// HAS downloads use `RETRY_A_FEW` (5), bulk downloads use `RETRY_A_LOT` (32).
+    /// item is configured with appropriate retry counts per CATCHUP_SPEC §9.1
+    /// and §13.1-1: HAS downloads use `HAS_RETRIES` (10), bulk downloads use
+    /// `RETRY_A_LOT` (32).
     ///
     /// # Returns
     ///
@@ -130,7 +133,9 @@ impl HistoryWorkBuilder {
                 state: Arc::clone(&self.state),
             }),
             vec![],
-            RETRY_A_FEW,
+            // Spec: CATCHUP_SPEC §13.1-1 — HAS download uses HAS_RETRIES (10),
+            // matching stellar-core's CatchupWork override of RETRY_A_FEW.
+            HAS_RETRIES,
         );
 
         // Spec: CATCHUP_SPEC §9.1 — bucket downloads use RETRY_A_LOT (32).

--- a/crates/historywork/src/lib.rs
+++ b/crates/historywork/src/lib.rs
@@ -293,7 +293,7 @@ pub async fn build_checkpoint_data(state: &SharedHistoryState) -> Result<Checkpo
 
 #[cfg(test)]
 mod tests {
-    use henyey_history::download::{RETRY_A_FEW, RETRY_A_LOT};
+    use henyey_history::download::{HAS_RETRIES, RETRY_A_FEW, RETRY_A_LOT};
 
     // ── CATCHUP_SPEC §9.1: Retry constants re-exported from download ─
 
@@ -310,6 +310,16 @@ mod tests {
         assert_eq!(
             RETRY_A_LOT, 32,
             "RETRY_A_LOT must be 32 (matches stellar-core)"
+        );
+    }
+
+    #[test]
+    fn test_has_retries_constant() {
+        // CATCHUP_SPEC §13.1-1: HAS download retries to 10, matching
+        // stellar-core CatchupWork's override of RETRY_A_FEW.
+        assert_eq!(
+            HAS_RETRIES, 10,
+            "HAS_RETRIES must be 10 (matches stellar-core CatchupWork)"
         );
     }
 }


### PR DESCRIPTION
Closes #3035

## Summary

CATCHUP_SPEC §13.1-1 requires the History Archive State (HAS) download to retry up to 10 times. The Rust code used `RETRY_A_FEW` (5) for `GetHistoryArchiveStateWork`. stellar-core's `CatchupWork` explicitly overrides the default and constructs `GetHistoryArchiveStateWork` with 10 retries — `stellar-core/src/catchup/CatchupWork.cpp:306-309`, with the comment "Set retries to 10 to ensure we retry enough in case current checkpoint isn't published yet". This PR adds a named `HAS_RETRIES = 10` constant in `henyey-history`'s download module and uses it for the HAS fetch in `crates/historywork/src/builder.rs`. Other retry counts are unchanged: SCP still uses `RETRY_A_FEW` (5), bulk downloads still use `RETRY_A_LOT` (32). This is purely a reliability parameter with no consensus/protocol impact.

## Plan reference

Trivial short-circuit — fix carried in the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3035#issuecomment-4620078019), not a separate plan.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-history -p henyey-historywork --all-targets -- -D warnings (clean)
- [x] cargo test -p henyey-history -p henyey-historywork passes
- [x] New unit assertions `download::tests::test_has_retries_is_10` and `historywork tests::test_has_retries_constant` pass

## Before / after

- **Before:** HAS fetch retries = `RETRY_A_FEW` = **5**
- **After:** HAS fetch retries = `HAS_RETRIES` = **10**
- **stellar-core reference:** `CatchupWork.cpp` constructs `GetHistoryArchiveStateWork(..., true, 10)` ("Set retries to 10 to ensure we retry enough in case current checkpoint isn't published yet")

## Deviations from plan

None. (Triage suggested the literal `10`; used a named `HAS_RETRIES` constant as the triage notes explicitly permitted, matching the existing `RETRY_A_FEW`/`RETRY_A_LOT` style, and added a cheap constant assertion as the orchestrator allowed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)