### PR TITLE
Add accepted_commit SCPDriver callback (SCP §6.5-2)

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -2099,6 +2099,93 @@ mod tests {
     }
 
     #[test]
+    fn test_ballot_accepted_commit_callback() {
+        // SCP §6.5-2: `set_accept_commit` must fire the `accepted_commit`
+        // SCPDriver callback exactly once per accept-commit transition (inside
+        // the `did_work` block), mirroring stellar-core
+        // `BallotProtocol::setAcceptCommit` (BallotProtocol.cpp:1343-1349).
+        //
+        // Drives prepare -> accept-commit following the proven envelope pattern
+        // from `test_ballot_commit_range_externalizes`: a fresh ballot bumped to
+        // a value, then a quorum's worth of PREPARE statements carrying
+        // `prepared`/`n_c`/`n_h` to push the slot into the Confirm phase
+        // (accept-commit). The callback must fire on that transition.
+        let node = make_node_id(1);
+        let node2 = make_node_id(2);
+        let node3 = make_node_id(3);
+        let node4 = make_node_id(4);
+        let node5 = make_node_id(5);
+        let quorum_set = make_quorum_set(
+            vec![
+                node.clone(),
+                node2.clone(),
+                node3.clone(),
+                node4.clone(),
+                node5.clone(),
+            ],
+            4,
+        );
+        let driver = Arc::new(MockDriver::with_quorum_set(quorum_set.clone()));
+        let mut ballot = BallotProtocol::new();
+
+        let value = make_value(&[9]);
+        assert!(ballot.bump(&ctx!(&node, &quorum_set, &driver, 16), value.clone(), false));
+
+        // A plain bump (PREPARE only, no accept-commit) must NOT fire the
+        // callback — it lives strictly inside the `did_work` accept-commit path.
+        assert_eq!(driver.accepted_commit_count.load(Ordering::SeqCst), 0);
+
+        let current = ballot.current_ballot().expect("current ballot").clone();
+        let prep2 = make_prepare_envelope(node2.clone(), 16, &quorum_set, current.clone());
+        let prep3 = make_prepare_envelope(node3.clone(), 16, &quorum_set, current.clone());
+        let prep4 = make_prepare_envelope(node4.clone(), 16, &quorum_set, current.clone());
+        let prep5 = make_prepare_envelope(node5.clone(), 16, &quorum_set, current.clone());
+
+        for env in [&prep2, &prep3, &prep4, &prep5] {
+            ballot.process_envelope(
+                env,
+                &ctx!(&node, &quorum_set, &driver, 16),
+                crate::ValidationLevel::FullyValidated,
+            );
+        }
+
+        // Still in Prepare — no accept-commit yet.
+        assert_eq!(driver.accepted_commit_count.load(Ordering::SeqCst), 0);
+
+        let make_prepared = |n: NodeId| {
+            make_prepare_envelope_with_counters(
+                n,
+                16,
+                &quorum_set,
+                current.clone(),
+                PrepareEnvelopeCounters {
+                    prepared: Some(current.clone()),
+                    prepared_prime: None,
+                    n_c: current.counter,
+                    n_h: current.counter,
+                },
+            )
+        };
+        let prepared2 = make_prepared(node2.clone());
+        let prepared3 = make_prepared(node3.clone());
+        let prepared4 = make_prepared(node4.clone());
+        let prepared5 = make_prepared(node5.clone());
+
+        for env in [&prepared2, &prepared3, &prepared4, &prepared5] {
+            ballot.process_envelope(
+                env,
+                &ctx!(&node, &quorum_set, &driver, 16),
+                crate::ValidationLevel::FullyValidated,
+            );
+        }
+
+        // Accept-commit reached: phase is Confirm and the callback fired exactly
+        // once (fire-once-on-did_work).
+        assert!(matches!(ballot.phase(), BallotPhase::Confirm));
+        assert_eq!(driver.accepted_commit_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
     fn test_ballot_statement_sanity_prepare_constraints() {
         let node = make_node_id(1);
         let quorum_set = make_quorum_set(vec![node.clone()], 1);

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -368,6 +368,12 @@ impl BallotProtocol {
 
         if did_work {
             self.update_current_if_needed(&h);
+            // Fire the accept-commit notification callback (SCP §6.5-2),
+            // ordered update_current_if_needed -> accepted_commit ->
+            // emit_current_state to match stellar-core
+            // BallotProtocol::setAcceptCommit (BallotProtocol.cpp:1343-1349).
+            // The argument is the high ballot `h`.
+            ctx.driver.accepted_commit(ctx.slot_index, &h);
             self.emit_current_state(ctx);
         }
 

--- a/crates/scp/src/driver.rs
+++ b/crates/scp/src/driver.rs
@@ -282,6 +282,20 @@ pub trait SCPDriver: Send + Sync {
     /// Called when we heard from a quorum for the current ballot.
     fn ballot_did_hear_from_quorum(&self, _slot_index: u64, _ballot: &ScpBallot) {}
 
+    /// Called when this node accepts `commit` for a ballot (the accept-commit
+    /// transition in the ballot protocol).
+    ///
+    /// Fired exactly once per accept-commit transition from
+    /// `BallotProtocol::set_accept_commit`, with `ballot` being the high
+    /// ballot `h`. Mirrors stellar-core `SCPDriver::acceptedCommit`
+    /// (`stellar-core/src/scp/SCPDriver.h:246-250`), invoked from
+    /// `BallotProtocol::setAcceptCommit` (`BallotProtocol.cpp:1343-1349`).
+    /// Closes spec gap SCP §6.5-2.
+    ///
+    /// The default implementation does nothing — like stellar-core's empty
+    /// base method, which `HerderSCPDriver` does not override.
+    fn accepted_commit(&self, _slot_index: u64, _ballot: &ScpBallot) {}
+
     /// Called when the ballot protocol is started for a slot.
     ///
     /// This is called when we transition from nomination to the ballot protocol,

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -188,6 +188,10 @@ impl SCPDriver for MockDriver {
         self.heard_from_quorum.fetch_add(1, Ordering::SeqCst);
     }
 
+    fn accepted_commit(&self, _slot_index: u64, _ballot: &ScpBallot) {
+        self.accepted_commit_count.fetch_add(1, Ordering::SeqCst);
+    }
+
     fn compute_hash_node(
         &self,
         _slot_index: u64,

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -32,6 +32,8 @@ pub struct MockDriver {
     pub emit_count: AtomicU32,
     /// Counts how many times `ballot_did_hear_from_quorum` was called.
     pub heard_from_quorum: AtomicU32,
+    /// Counts how many times `accepted_commit` was called.
+    pub accepted_commit_count: AtomicU32,
     /// If true, `get_quorum_set_by_hash` returns the configured quorum set
     /// regardless of the hash. Useful for testing quorum info methods.
     pub return_qset_by_hash: bool,
@@ -112,6 +114,7 @@ impl MockDriverBuilder {
             timeout_mode: self.timeout_mode,
             emit_count: AtomicU32::new(0),
             heard_from_quorum: AtomicU32::new(0),
+            accepted_commit_count: AtomicU32::new(0),
             return_qset_by_hash: self.return_qset_by_hash,
             custom_node_weight: None,
         }


### PR DESCRIPTION
Closes #3088

## Summary

Closes spec gap SCP §6.5-2: stellar-core fires `SCPDriver::acceptedCommit(slotIndex, h)` exactly once per accept-commit transition from inside `BallotProtocol::setAcceptCommit`'s `if (didWork)` block, but henyey's `set_accept_commit` reproduced every step *except* this callback. This adds a default-empty `accepted_commit(&self, _slot_index: u64, _ballot: &ScpBallot) {}` method to the `SCPDriver` trait and invokes it from `set_accept_commit`, ordered `update_current_if_needed(&h)` → `accepted_commit(slot_index, &h)` → `emit_current_state(ctx)`, with the high ballot `h` as the argument, matching stellar-core `BallotProtocol.cpp:1343-1349`. The method is default-empty and no production implementor overrides it (stellar-core's `HerderSCPDriver` also inherits the empty base), so this is pure trait-surface completeness with no observable behavior change.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3088#issuecomment-4620090877)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (clean)
- [x] cargo test -p henyey-scp — 370 lib tests pass (incl. new test) + parity suites green
- [x] cargo test -p henyey-herder — 1176 tests pass (compiles with new default method, no override)

## New coverage

- **Test:** `crates/scp/src/ballot/mod.rs::test_ballot_accepted_commit_callback`
- **Pre-fix:** committed as `544fe370` — verified FAILED with `accepted_commit_count == 0` (expected `1`); callback never fired.
- **Post-fix:** verified PASSES after `a2be9c9e`. Asserts the callback fires exactly once on the accept-commit transition (Confirm phase) and stays `0` after a plain prepare/bump.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)