### PR TITLE
Enforce PUBLISH_TO_ARCHIVE_DELAY for checkpoint publishing

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -570,6 +570,17 @@ pub struct App {
     /// Prevent concurrent history publish operations.
     /// When set, a background task is publishing a checkpoint.
     publish_in_progress: AtomicBool,
+    /// Tracks when the head-of-queue checkpoint first became eligible to
+    /// publish, for enforcing `PUBLISH_TO_ARCHIVE_DELAY` (#3032).
+    ///
+    /// Holds `Some((checkpoint_seq, instant))` where `instant` is the moment
+    /// the checkpoint at `checkpoint_seq` first reached the head of the publish
+    /// queue and was otherwise ready. `maybe_publish_history` early-returns
+    /// until `instant.elapsed() >= delay`, mirroring stellar-core's
+    /// `ConditionalWork` delay timer. The marker is stamped once per checkpoint
+    /// (see the stamp-once rule in `maybe_publish_history`) so a
+    /// failing-and-retrying checkpoint never re-arms the delay.
+    pub(crate) publish_ready_since: std::sync::Mutex<Option<(u32, std::time::Instant)>>,
     /// One-shot panic injection for publish tests. When `true`, the next call
     /// to `publish_single_checkpoint` will swap it to `false` and panic.
     #[cfg(test)]
@@ -1339,6 +1350,7 @@ impl App {
             fatal_state_failure: AtomicBool::new(false),
             catchup_needs_full_reset: AtomicBool::new(force_full_catchup),
             publish_in_progress: AtomicBool::new(false),
+            publish_ready_since: std::sync::Mutex::new(None),
             #[cfg(test)]
             publish_panic_inject: AtomicBool::new(false),
             #[cfg(test)]

--- a/crates/app/src/app/publish.rs
+++ b/crates/app/src/app/publish.rs
@@ -83,6 +83,48 @@ impl App {
             return;
         }
 
+        // PUBLISH_TO_ARCHIVE_DELAY gate (#3032). Mirrors stellar-core's
+        // `ConditionalWork("delay-publishing-to-archive", ...)`: the clock
+        // starts at "checkpoint is ready to publish" (this point), and the
+        // publish does not proceed until `elapsed >= delay`. henyey has no
+        // WorkScheduler, so the re-poll loop is realized by the existing
+        // post-close + ~1s validator-tick polling of `maybe_publish_history`.
+        //
+        // Stamp-once rule: stamp the marker only when the slot is empty or the
+        // stored seq differs from the current head; never re-stamp a matching
+        // marker. This measures the delay per-checkpoint from first-eligibility
+        // and prevents a repeatedly-failing publish (permit acquired, publish
+        // errors, checkpoint stays at head) from re-arming the delay on every
+        // poll. At the default delay of 0, the gate passes on the first poll
+        // (`elapsed >= ZERO` is always true) ⇒ zero behavioral change.
+        let delay =
+            std::time::Duration::from_secs(self.config.history.publish_to_archive_delay_seconds);
+        {
+            let mut ready = self
+                .publish_ready_since
+                .lock()
+                .expect("publish_ready_since mutex poisoned");
+            let stamp = match *ready {
+                Some((seq, since)) if seq == checkpoint => since,
+                _ => {
+                    // First time this checkpoint reached the head (or the head
+                    // advanced): stamp the eligibility instant exactly once.
+                    let now = std::time::Instant::now();
+                    *ready = Some((checkpoint, now));
+                    now
+                }
+            };
+            if stamp.elapsed() < delay {
+                tracing::debug!(
+                    checkpoint,
+                    delay_secs = self.config.history.publish_to_archive_delay_seconds,
+                    elapsed_secs = stamp.elapsed().as_secs(),
+                    "publish: delaying checkpoint per PUBLISH_TO_ARCHIVE_DELAY"
+                );
+                return;
+            }
+        }
+
         // Upgrade self_arc before acquiring the permit so that failure
         // doesn't require releasing the flag.
         let app = {
@@ -150,6 +192,15 @@ impl App {
                         henyey_history::publish::delete_published_files(checkpoint, &publish_dir);
                     if cleaned > 0 {
                         tracing::debug!(checkpoint, cleaned, "Deleted local published files");
+                    }
+                    // Clear the delay marker for this checkpoint so the next
+                    // head-of-queue checkpoint re-arms its own delay from
+                    // first-eligibility. (The stamp-once rule would re-stamp on
+                    // seq mismatch anyway; clearing keeps the slot tidy.)
+                    if let Ok(mut ready) = app.publish_ready_since.lock() {
+                        if matches!(*ready, Some((seq, _)) if seq == checkpoint) {
+                            *ready = None;
+                        }
                     }
                     tracing::info!(checkpoint, "Checkpoint published successfully");
                 }
@@ -939,6 +990,72 @@ mod tests {
             custom_bucket_dir.as_path()
         );
         assert_eq!(canonical_bucket_file_count(&derived_bucket_dir), 0);
+    }
+
+    #[tokio::test]
+    async fn test_publish_delay_gates_then_publishes() {
+        // With a large PUBLISH_TO_ARCHIVE_DELAY, the first poll must NOT publish
+        // (the checkpoint is gated), but it must stamp the eligibility marker.
+        let fixture = setup_publish_fixture("delay-gate", |dir, config| {
+            let archive_dir = dir.join("archive");
+            config.history.archives = vec![test_archive_entry("delay-gate", &archive_dir)];
+            config.history.publish_to_archive_delay_seconds = 3600;
+        })
+        .await;
+
+        // First poll: gated, archive stays empty.
+        fixture.app.maybe_publish_history().await;
+        // Nothing should be in flight, and the queue should still hold CHECKPOINT.
+        assert!(!fixture.app.publish_in_progress.load(Ordering::SeqCst));
+        assert_eq!(archive_bucket_file_count(&fixture.archive_dir), 0);
+
+        // The marker must have been stamped for the head-of-queue checkpoint.
+        let marked = {
+            let guard = fixture.app.publish_ready_since.lock().unwrap();
+            *guard
+        };
+        assert_eq!(
+            marked.map(|(seq, _)| seq),
+            Some(CHECKPOINT),
+            "delay marker should be stamped for the head-of-queue checkpoint"
+        );
+
+        // Seed a back-dated Instant older than the delay, simulating elapsed
+        // wall-clock time without sleeping. The gate should now pass.
+        {
+            let mut guard = fixture.app.publish_ready_since.lock().unwrap();
+            let back_dated = std::time::Instant::now()
+                .checked_sub(Duration::from_secs(7200))
+                .expect("instant back-date");
+            *guard = Some((CHECKPOINT, back_dated));
+        }
+
+        fixture.app.maybe_publish_history().await;
+        wait_for_publish_queue_to_drain(&fixture.app).await;
+        assert!(
+            archive_bucket_file_count(&fixture.archive_dir) > 0,
+            "checkpoint should publish once the delay has elapsed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_publish_delay_zero_publishes_immediately() {
+        // With the default delay of 0, the first poll publishes immediately —
+        // guards the default path against an accidental delay regression.
+        let fixture = setup_publish_fixture("delay-zero", |dir, config| {
+            let archive_dir = dir.join("archive");
+            config.history.archives = vec![test_archive_entry("delay-zero", &archive_dir)];
+            // publish_to_archive_delay_seconds left at its default of 0.
+        })
+        .await;
+        assert_eq!(fixture.config.history.publish_to_archive_delay_seconds, 0);
+
+        fixture.app.maybe_publish_history().await;
+        wait_for_publish_queue_to_drain(&fixture.app).await;
+        assert!(
+            archive_bucket_file_count(&fixture.archive_dir) > 0,
+            "default delay 0 should publish on the first poll"
+        );
     }
 
     #[test]

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -26,7 +26,7 @@
 
 use crate::config::{
     AppConfig, CompatHttpConfig, CompatQuorumSafety, DatabaseConfig, FailureSafety,
-    HistoryArchiveEntry, HistoryConfig, ValidationThresholdLevel,
+    HistoryArchiveEntry, ValidationThresholdLevel,
 };
 use henyey_herder::{ValidatorEntryInfo, ValidatorQuality, ValidatorWeightConfig};
 use henyey_overlay::PeerAddress;
@@ -73,6 +73,7 @@ const SUPPORTED_KEYS: &[&str] = &[
     "CATCHUP_RECENT",
     "AUTOMATIC_MAINTENANCE_PERIOD",
     "AUTOMATIC_MAINTENANCE_COUNT",
+    "PUBLISH_TO_ARCHIVE_DELAY",
     "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
     "GENESIS_TEST_ACCOUNT_COUNT",
     "RUN_STANDALONE",
@@ -407,6 +408,13 @@ pub fn translate_stellar_core_config(raw: &toml::Value) -> anyhow::Result<AppCon
         }
     }
 
+    // --- Publish-to-archive delay ---
+    // stellar-core: PUBLISH_TO_ARCHIVE_DELAY (seconds, default 0). Gates the
+    // start of checkpoint publishing on a wall-clock delay. See #3032.
+    if let Some(v) = get_u32(table, "PUBLISH_TO_ARCHIVE_DELAY") {
+        config.history.publish_to_archive_delay_seconds = v as u64;
+    }
+
     // --- History archives ---
     // stellar-core format: [HISTORY.name] with get="cmd {0}" sub-tables
     if let Some(history_table) = get_table_strict(table, "HISTORY")
@@ -448,7 +456,9 @@ pub fn translate_stellar_core_config(raw: &toml::Value) -> anyhow::Result<AppCon
             });
         }
         if !archives.is_empty() {
-            config.history = HistoryConfig { archives };
+            // Preserve the already-parsed publish delay; only the archive list
+            // is sourced from the [HISTORY.*] sub-tables.
+            config.history.archives = archives;
         }
     }
 
@@ -1461,6 +1471,48 @@ mod tests {
         );
         assert!(config.history.archives[0].get_enabled);
         assert!(!config.history.archives[0].put_enabled);
+    }
+
+    #[test]
+    fn test_publish_to_archive_delay_parsed() {
+        // Present: top-level PUBLISH_TO_ARCHIVE_DELAY maps to the history field.
+        let core_toml: toml::Value = toml::from_str(
+            r#"
+            NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+            PUBLISH_TO_ARCHIVE_DELAY = 7
+            "#,
+        )
+        .unwrap();
+        let config = translate_stellar_core_config(&core_toml).unwrap();
+        assert_eq!(config.history.publish_to_archive_delay_seconds, 7);
+
+        // The key must be classified as supported, not unknown.
+        let table = core_toml.as_table().unwrap();
+        let classified = classify_keys(table).unwrap();
+        assert!(
+            !classified
+                .unknown
+                .iter()
+                .any(|k| k == "PUBLISH_TO_ARCHIVE_DELAY"),
+            "PUBLISH_TO_ARCHIVE_DELAY should not be reported unknown"
+        );
+        assert!(
+            !classified
+                .unsupported
+                .iter()
+                .any(|k| k == "PUBLISH_TO_ARCHIVE_DELAY"),
+            "PUBLISH_TO_ARCHIVE_DELAY should be supported, not unsupported-known"
+        );
+
+        // Absent: defaults to 0.
+        let no_delay_toml: toml::Value = toml::from_str(
+            r#"
+            NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+            "#,
+        )
+        .unwrap();
+        let config = translate_stellar_core_config(&no_delay_toml).unwrap();
+        assert_eq!(config.history.publish_to_archive_delay_seconds, 0);
     }
 
     #[test]

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -854,6 +854,17 @@ pub struct HistoryConfig {
     /// Archives for reading history.
     #[serde(default)]
     pub archives: Vec<HistoryArchiveEntry>,
+
+    /// Delay, in wall-clock seconds, before a ready checkpoint begins
+    /// publishing to the history archive.
+    ///
+    /// Mirrors stellar-core's `PUBLISH_TO_ARCHIVE_DELAY` (default `seconds{0}`),
+    /// which wraps the publish pipeline in a `ConditionalWork` whose timeout
+    /// fires once `now - start >= PUBLISH_TO_ARCHIVE_DELAY`. At the default of
+    /// `0` there is no delay and publishing proceeds immediately, matching
+    /// stellar-core's immediate-publish default.
+    #[serde(default)]
+    pub publish_to_archive_delay_seconds: u64,
 }
 
 impl HistoryConfig {
@@ -1676,6 +1687,7 @@ impl AppConfig {
                         mkdir: None,
                     },
                 ],
+                publish_to_archive_delay_seconds: 0,
             },
             overlay: OverlayConfig {
                 known_peers: vec![
@@ -1752,6 +1764,7 @@ impl AppConfig {
                         mkdir: None,
                     },
                 ],
+                publish_to_archive_delay_seconds: 0,
             },
             overlay: OverlayConfig {
                 known_peers: vec![
@@ -4067,8 +4080,26 @@ name = "test"
     }
 
     #[test]
+    fn test_history_config_publish_delay_defaults_to_zero() {
+        // Default HistoryConfig has the field == 0.
+        let config = HistoryConfig::default();
+        assert_eq!(config.publish_to_archive_delay_seconds, 0);
+
+        // A [history] table without the field deserializes to 0.
+        let without: HistoryConfig = toml::from_str("").unwrap();
+        assert_eq!(without.publish_to_archive_delay_seconds, 0);
+
+        // An explicit value is honored.
+        let with: HistoryConfig = toml::from_str("publish_to_archive_delay_seconds = 5").unwrap();
+        assert_eq!(with.publish_to_archive_delay_seconds, 5);
+    }
+
+    #[test]
     fn test_publish_enabled_with_no_archives() {
-        let config = HistoryConfig { archives: vec![] };
+        let config = HistoryConfig {
+            archives: vec![],
+            ..Default::default()
+        };
         assert!(!config.publish_enabled());
     }
 
@@ -4083,6 +4114,7 @@ name = "test"
                 put: None,
                 mkdir: None,
             }],
+            ..Default::default()
         };
         assert!(!config.publish_enabled());
     }
@@ -4098,6 +4130,7 @@ name = "test"
                 put: Some("cp {0} {1}".to_string()),
                 mkdir: Some("mkdir -p {0}".to_string()),
             }],
+            ..Default::default()
         };
         assert!(config.publish_enabled());
     }
@@ -4114,6 +4147,7 @@ name = "test"
                 put: None,
                 mkdir: None,
             }],
+            ..Default::default()
         };
         assert!(!config.publish_enabled());
     }

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -1598,6 +1598,7 @@ fn local_config() -> AppConfig {
                     dir = data_dir.join("history").display()
                 )),
             }],
+            publish_to_archive_delay_seconds: 0,
         },
         overlay: OverlayConfig {
             known_peers: vec![],


### PR DESCRIPTION
Closes #3032

## Summary

Adds a configurable, default-0 publish-to-archive delay (CATCHUP §5.5-1) that gates the start of checkpoint publishing on a wall-clock delay, mirroring stellar-core's `ConditionalWork("delay-publishing-to-archive", ...)`. At the default of `0` there is zero behavioral change — henyey already matched stellar-core's immediate-publish default.

- `HistoryConfig` gains `publish_to_archive_delay_seconds: u64` (`#[serde(default)]` → 0).
- `compat_config` parses the top-level stellar-core `PUBLISH_TO_ARCHIVE_DELAY` key (uint seconds) into `config.history.publish_to_archive_delay_seconds` and lists it as supported, so copying a stellar-core TOML neither flags it unknown nor silently drops it.
- `App` gains `publish_ready_since: Mutex<Option<(u32, Instant)>>`; `maybe_publish_history()` records the eligibility `Instant` for the head-of-queue checkpoint and early-returns until `elapsed >= delay`. henyey has no WorkScheduler, so the re-poll loop is realized by the existing post-close + ~1s validator-tick polling.
- **Stamp-once rule:** the marker is stamped only when the slot is empty or the stored seq differs from the current head — never re-stamped on a matching marker — so a failing-and-retrying checkpoint never re-arms the delay. The marker is cleared on successful publish.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3032#issuecomment-4622626347)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (touched crates, non-test targets — pre-commit hook) clean
- [x] `cargo test -p henyey-app -p henyey-history --lib` passes (987 + 535)

New coverage (all passing):
- `config.rs::test_history_config_publish_delay_defaults_to_zero`
- `compat_config.rs::test_publish_to_archive_delay_parsed`
- `app/publish.rs::test_publish_delay_gates_then_publishes`
- `app/publish.rs::test_publish_delay_zero_publishes_immediately`

## Deviations from plan

None. (Note: pre-existing `cargo clippy --all-targets -- -D warnings` errors exist on origin/main, unrelated to this change; the repo's pre-commit clippy gate passes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)