### PR TITLE
Fire started_ballot_protocol from bump_to_ballot with the ballot (SCP §9.10-1)

### DIFF
--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -47,8 +47,8 @@ use henyey_crypto::{PublicKey, SecretKey, Signature};
 use henyey_ledger::LedgerManager;
 use henyey_scp::{SCPDriver, SlotIndex, ValidationLevel};
 use stellar_xdr::curr::{
-    EnvelopeType, LedgerUpgrade, NodeId, ReadXdr, ScpEnvelope, ScpQuorumSet, ScpStatement,
-    StellarValue, StellarValueExt, Value, WriteXdr,
+    EnvelopeType, LedgerUpgrade, NodeId, ReadXdr, ScpBallot, ScpEnvelope, ScpQuorumSet,
+    ScpStatement, StellarValue, StellarValueExt, Value, WriteXdr,
 };
 
 use crate::error::HerderError;
@@ -3965,7 +3965,7 @@ impl SCPDriver for HerderScpCallback {
         self.driver.record_nomination_start(slot_index);
     }
 
-    fn started_ballot_protocol(&self, slot_index: u64, _value: &Value) {
+    fn started_ballot_protocol(&self, slot_index: u64, _ballot: &ScpBallot) {
         self.driver.record_ballot_start(slot_index);
     }
 

--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -850,15 +850,24 @@ impl BallotProtocol {
     /// # Panics
     /// Panics if the envelope contains a non-ballot statement type (Nominate).
     /// Callers must route nomination envelopes to the nomination protocol.
-    pub(crate) fn set_state_from_envelope(&mut self, envelope: &ScpEnvelope) -> Result<(), String> {
+    pub(crate) fn set_state_from_envelope<D: SCPDriver>(
+        &mut self,
+        envelope: &ScpEnvelope,
+        ctx: &SlotContext<'_, D>,
+    ) -> Result<(), String> {
         if self.current_ballot.is_some() {
             return Err("Cannot set state after starting ballot protocol".into());
         }
 
+        // Recovery first-sets `current_ballot` through `bump_to_ballot` (BEFORE
+        // assigning `phase`), so the `started_ballot_protocol` callback fires for
+        // recovery-driven slots too. Matches stellar-core `setStateFromEnvelope`
+        // (BallotProtocol.cpp:1754/1778/1789), which calls `bumpToBallot` for all
+        // three pledge types before setting `mPhase`.
         match &envelope.statement.pledges {
             ScpStatementPledges::Prepare(prep) => {
                 let value = prep.ballot.value.clone();
-                self.current_ballot = Some(prep.ballot.clone());
+                self.bump_to_ballot(&prep.ballot, true, ctx);
                 self.prepared = prep.prepared.clone();
                 self.prepared_prime = prep.prepared_prime.clone();
                 if prep.n_c != 0 {
@@ -877,7 +886,7 @@ impl BallotProtocol {
             }
             ScpStatementPledges::Confirm(conf) => {
                 let value = conf.ballot.value.clone();
-                self.current_ballot = Some(conf.ballot.clone());
+                self.bump_to_ballot(&conf.ballot, true, ctx);
                 self.prepared = Some(ScpBallot {
                     counter: conf.n_prepared,
                     value: value.clone(),
@@ -900,10 +909,14 @@ impl BallotProtocol {
                     counter: ext.n_h,
                     value: value.clone(),
                 });
-                self.current_ballot = Some(ScpBallot {
-                    counter: u32::MAX,
-                    value: value.clone(),
-                });
+                self.bump_to_ballot(
+                    &ScpBallot {
+                        counter: u32::MAX,
+                        value: value.clone(),
+                    },
+                    true,
+                    ctx,
+                );
                 self.prepared = Some(ScpBallot {
                     counter: u32::MAX,
                     value: value.clone(),
@@ -963,7 +976,7 @@ impl BallotProtocol {
             value: effective_value,
         };
 
-        let updated = self.update_current_value(&ballot);
+        let updated = self.update_current_value(&ballot, ctx);
 
         if updated {
             self.emit_current_state(ctx);
@@ -1064,6 +1077,29 @@ mod tests {
                 slot_index: $slot,
             }
         };
+    }
+
+    /// Call `BallotProtocol::set_state_from_envelope` with a throwaway driver
+    /// and context, for the many recovery tests that don't assert on the
+    /// `started_ballot_protocol` callback (they only need the call to compile
+    /// after the driver/ctx parameter was added). Returns the `Result`.
+    macro_rules! ssfe {
+        ($bp:expr, $env:expr, $node:expr, $qs:expr) => {{
+            let __drv = Arc::new(MockDriver::with_quorum_set($qs.clone()));
+            let __ctx = ctx!($node, $qs, &__drv, 1);
+            $bp.set_state_from_envelope($env, &__ctx)
+        }};
+    }
+
+    /// Owned node/quorum-set/driver triple for the `bump_to_ballot` /
+    /// `update_current_value` unit tests that pre-seed `current_ballot` directly
+    /// and only need a valid `SlotContext` to satisfy the signature (they do not
+    /// assert on the `started_ballot_protocol` callback).
+    fn bare_ctx_parts() -> (NodeId, ScpQuorumSet, Arc<MockDriver>) {
+        let node = make_node_id(1);
+        let qs = make_quorum_set(vec![node.clone()], 1);
+        let driver = Arc::new(MockDriver::with_quorum_set(qs.clone()));
+        (node, qs, driver)
     }
 
     #[test]
@@ -2480,7 +2516,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        ballot.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
         assert_eq!(ballot.phase(), BallotPhase::Prepare);
         assert_eq!(ballot.current_ballot(), Some(&ballot_val));
         assert_eq!(ballot.prepared(), Some(&prepared));
@@ -2517,7 +2553,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        ballot.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
         assert_eq!(ballot.phase(), BallotPhase::Confirm);
         assert_eq!(ballot.current_ballot(), Some(&ballot_val));
         assert_eq!(ballot.prepared().map(|b| b.counter), Some(8));
@@ -2552,7 +2588,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        ballot.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
         assert_eq!(ballot.phase(), BallotPhase::Externalize);
         assert!(ballot.is_externalized());
         assert_eq!(ballot.commit(), Some(&commit));
@@ -2582,7 +2618,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        let _ = ballot.set_state_from_envelope(&envelope);
+        let _ = ssfe!(ballot, &envelope, &node, &quorum_set);
     }
 
     #[test]
@@ -2639,7 +2675,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        ballot.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
 
         // Cannot bump when externalized
         assert!(!ballot.bump_state(&ctx!(&node, &quorum_set, &driver, 1), value.clone(), 10));
@@ -2923,7 +2959,7 @@ mod tests {
             ScpBallot { counter: 5, value },
         );
 
-        let result = bp.set_state_from_envelope(&envelope);
+        let result = ssfe!(bp, &envelope, &node, &quorum_set);
         assert!(result.is_err(), "Should reject when current_ballot is set");
 
         // All state unchanged
@@ -2963,7 +2999,7 @@ mod tests {
                 n_c: 2,
             },
         );
-        bp.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert!(
             bp.check_invariants().is_ok(),
             "PREPARE state should be valid"
@@ -2990,7 +3026,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        bp.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert!(
             bp.check_invariants().is_ok(),
             "CONFIRM state should be valid"
@@ -3015,7 +3051,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        bp.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert!(
             bp.check_invariants().is_ok(),
             "EXTERNALIZE state should be valid"
@@ -3295,6 +3331,8 @@ mod tests {
     #[test]
     fn test_bump_to_ballot_resets_incompatible_high_commit() {
         let mut bp = BallotProtocol::new();
+        let (node, qs, driver) = bare_ctx_parts();
+        let ctx = ctx!(&node, &qs, &driver, 1);
         let value_a = make_value(&[1]);
         let value_b = make_value(&[2]);
 
@@ -3317,7 +3355,7 @@ mod tests {
             counter: 2,
             value: value_b.clone(),
         };
-        assert!(bp.bump_to_ballot(&new_ballot, false));
+        assert!(bp.bump_to_ballot(&new_ballot, false, &ctx));
 
         // h and c should be cleared because value_b != value_a
         assert!(
@@ -3335,6 +3373,8 @@ mod tests {
     #[test]
     fn test_bump_to_ballot_preserves_compatible_high_commit() {
         let mut bp = BallotProtocol::new();
+        let (node, qs, driver) = bare_ctx_parts();
+        let ctx = ctx!(&node, &qs, &driver, 1);
         let value_a = make_value(&[1]);
 
         // Set up state with high and commit
@@ -3356,7 +3396,7 @@ mod tests {
             counter: 2,
             value: value_a.clone(),
         };
-        assert!(bp.bump_to_ballot(&new_ballot, false));
+        assert!(bp.bump_to_ballot(&new_ballot, false, &ctx));
 
         // h and c should be preserved because same value
         assert!(
@@ -3373,6 +3413,8 @@ mod tests {
     #[test]
     fn test_bump_to_ballot_heard_from_quorum_counter_change() {
         let mut bp = BallotProtocol::new();
+        let (node, qs, driver) = bare_ctx_parts();
+        let ctx = ctx!(&node, &qs, &driver, 1);
         let value_a = make_value(&[1]);
 
         // Set initial ballot and heard_from_quorum
@@ -3387,7 +3429,7 @@ mod tests {
             counter: 1,
             value: make_value(&[2]),
         };
-        bp.bump_to_ballot(&same_counter_ballot, false);
+        bp.bump_to_ballot(&same_counter_ballot, false, &ctx);
         assert!(
             bp.heard_from_quorum,
             "heard_from_quorum should not reset when counter stays the same"
@@ -3398,7 +3440,7 @@ mod tests {
             counter: 2,
             value: make_value(&[2]),
         };
-        bp.bump_to_ballot(&new_counter_ballot, false);
+        bp.bump_to_ballot(&new_counter_ballot, false, &ctx);
         assert!(
             !bp.heard_from_quorum,
             "heard_from_quorum should reset when counter changes"
@@ -3782,6 +3824,8 @@ mod tests {
     #[test]
     fn test_update_current_value_rejects_externalize_phase() {
         let mut bp = BallotProtocol::new();
+        let (node, qs, driver) = bare_ctx_parts();
+        let ctx = ctx!(&node, &qs, &driver, 1);
         let value = make_value(&[1]);
 
         bp.phase = BallotPhase::Externalize;
@@ -3792,7 +3836,7 @@ mod tests {
         };
 
         assert!(
-            !bp.update_current_value(&ballot),
+            !bp.update_current_value(&ballot, &ctx),
             "update_current_value should reject in Externalize phase"
         );
     }
@@ -3801,6 +3845,8 @@ mod tests {
     #[test]
     fn test_update_current_value_rejects_commit_incompatible() {
         let mut bp = BallotProtocol::new();
+        let (node, qs, driver) = bare_ctx_parts();
+        let ctx = ctx!(&node, &qs, &driver, 1);
         let value_a = make_value(&[1]);
         let value_b = make_value(&[2]);
 
@@ -3819,7 +3865,7 @@ mod tests {
         };
 
         assert!(
-            !bp.update_current_value(&incompatible_ballot),
+            !bp.update_current_value(&incompatible_ballot, &ctx),
             "update_current_value should reject ballot incompatible with commit"
         );
     }
@@ -3889,7 +3935,7 @@ mod tests {
             },
         );
 
-        bp.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert_eq!(
             bp.last_envelope_emit.as_ref(),
             Some(&envelope),
@@ -3922,7 +3968,7 @@ mod tests {
             9,
         );
 
-        bp.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert_eq!(
             bp.last_envelope_emit.as_ref(),
             Some(&envelope),
@@ -3948,7 +3994,7 @@ mod tests {
             5,
         );
 
-        bp.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert_eq!(
             bp.last_envelope_emit.as_ref(),
             Some(&envelope),
@@ -3965,7 +4011,7 @@ mod tests {
 
         let envelope = make_nomination_envelope(node.clone(), 4, &quorum_set);
 
-        let _ = bp.set_state_from_envelope(&envelope);
+        let _ = ssfe!(bp, &envelope, &node, &quorum_set);
     }
 
     #[test]
@@ -3986,7 +4032,7 @@ mod tests {
             ScpBallot { counter: 1, value },
         );
 
-        bp.set_state_from_envelope(&envelope).unwrap();
+        ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
 
         let emit_before = driver.emit_count.load(Ordering::SeqCst);
         bp.send_latest_envelope(&driver);
@@ -4710,10 +4756,13 @@ mod tests {
 
         // Bump to set current_ballot (counter=1, value=[42])
         let ctx = ctx!(&node, &qs, &driver, 1);
-        ballot.update_current_value(&ScpBallot {
-            counter: 1,
-            value: value.clone(),
-        });
+        ballot.update_current_value(
+            &ScpBallot {
+                counter: 1,
+                value: value.clone(),
+            },
+            &ctx,
+        );
 
         // Now emit — validation should reject
         ballot.emit_current_state(&ctx);
@@ -4756,10 +4805,13 @@ mod tests {
         let value = make_value(&[42]);
 
         let ctx = ctx!(&node, &qs, &driver, 1);
-        ballot.update_current_value(&ScpBallot {
-            counter: 1,
-            value: value.clone(),
-        });
+        ballot.update_current_value(
+            &ScpBallot {
+                counter: 1,
+                value: value.clone(),
+            },
+            &ctx,
+        );
 
         ballot.emit_current_state(&ctx);
 
@@ -4803,10 +4855,13 @@ mod tests {
         let value = make_value(&[42]);
 
         let ctx = ctx!(&node, &qs, &driver, 1);
-        ballot.update_current_value(&ScpBallot {
-            counter: 1,
-            value: value.clone(),
-        });
+        ballot.update_current_value(
+            &ScpBallot {
+                counter: 1,
+                value: value.clone(),
+            },
+            &ctx,
+        );
 
         ballot.emit_current_state(&ctx);
 
@@ -4846,10 +4901,13 @@ mod tests {
         let value = make_value(&[42]);
 
         let ctx = ctx!(&node, &qs, &driver, 1);
-        ballot.update_current_value(&ScpBallot {
-            counter: 1,
-            value: value.clone(),
-        });
+        ballot.update_current_value(
+            &ScpBallot {
+                counter: 1,
+                value: value.clone(),
+            },
+            &ctx,
+        );
 
         ballot.emit_current_state(&ctx);
 
@@ -5288,6 +5346,8 @@ mod tests {
         let value_a: Value = vec![1u8, 0].try_into().unwrap();
 
         let mut bp = BallotProtocol::new();
+        let (node, qs, driver) = bare_ctx_parts();
+        let ctx = ctx!(&node, &qs, &driver, 1);
         // Force a structurally-invalid CONFIRM state: current_ballot is set but
         // prepared/commit/high_ballot are all None. INV-S8 requires all four
         // fields in CONFIRM, so check_invariants() returns Err. current_ballot
@@ -5308,7 +5368,7 @@ mod tests {
         };
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            bp.update_current_value(&ballot)
+            bp.update_current_value(&ballot, &ctx)
         }));
 
         if cfg!(debug_assertions) {
@@ -5372,5 +5432,141 @@ mod tests {
                 "release builds must NOT panic — matches stellar-core dbgAssert under NDEBUG"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // SCP §9.10-1 regression tests (issue #3089): started_ballot_protocol must
+    // fire from bump_to_ballot on the current_ballot null→set transition, with
+    // the actual ScpBallot, including the recovery path.
+    // -----------------------------------------------------------------------
+
+    /// Regression for #3089: restoring ballot state via `set_state_from_envelope`
+    /// (crash recovery) must fire `started_ballot_protocol` exactly once with a
+    /// ballot equal to the envelope's PREPARE ballot.
+    ///
+    /// FAILS on origin/main: recovery assigned `current_ballot` directly,
+    /// bypassing `bump_to_ballot`, so the callback fired 0 times.
+    #[test]
+    fn test_set_state_from_envelope_fires_started_ballot_protocol_prepare() {
+        let node = make_node_id(1);
+        let quorum_set = make_quorum_set(vec![node.clone()], 1);
+        let driver = Arc::new(MockDriver::with_quorum_set(quorum_set.clone()));
+        let mut bp = BallotProtocol::new();
+
+        let ballot_val = ScpBallot {
+            counter: 5,
+            value: make_value(&[1, 2, 3]),
+        };
+        let envelope = make_prepare_envelope(node.clone(), 7, &quorum_set, ballot_val.clone());
+
+        let ctx = ctx!(&node, &quorum_set, &driver, 7);
+        bp.set_state_from_envelope(&envelope, &ctx).unwrap();
+
+        let starts = driver.ballot_starts.lock().unwrap();
+        assert_eq!(
+            starts.len(),
+            1,
+            "recovery must fire started_ballot_protocol exactly once"
+        );
+        assert_eq!(
+            starts[0], ballot_val,
+            "started_ballot_protocol must receive the envelope's ballot"
+        );
+    }
+
+    /// Regression for #3089 (CONFIRM recovery variant).
+    #[test]
+    fn test_set_state_from_envelope_fires_started_ballot_protocol_confirm() {
+        let node = make_node_id(1);
+        let quorum_set = make_quorum_set(vec![node.clone()], 1);
+        let driver = Arc::new(MockDriver::with_quorum_set(quorum_set.clone()));
+        let mut bp = BallotProtocol::new();
+
+        let ballot_val = ScpBallot {
+            counter: 10,
+            value: make_value(&[4, 5, 6]),
+        };
+        let envelope = make_confirm_envelope_with_counters(
+            node.clone(),
+            7,
+            &quorum_set,
+            ballot_val.clone(),
+            8,
+            5,
+            9,
+        );
+
+        let ctx = ctx!(&node, &quorum_set, &driver, 7);
+        bp.set_state_from_envelope(&envelope, &ctx).unwrap();
+
+        let starts = driver.ballot_starts.lock().unwrap();
+        assert_eq!(starts.len(), 1);
+        assert_eq!(starts[0], ballot_val);
+    }
+
+    /// Regression for #3089 (EXTERNALIZE recovery variant): the fired ballot has
+    /// counter `u32::MAX` and the externalized value, matching the recovered
+    /// `current_ballot`.
+    #[test]
+    fn test_set_state_from_envelope_fires_started_ballot_protocol_externalize() {
+        let node = make_node_id(1);
+        let quorum_set = make_quorum_set(vec![node.clone()], 1);
+        let driver = Arc::new(MockDriver::with_quorum_set(quorum_set.clone()));
+        let mut bp = BallotProtocol::new();
+
+        let value = make_value(&[7, 8, 9]);
+        let commit = ScpBallot {
+            counter: 3,
+            value: value.clone(),
+        };
+        let envelope = make_externalize_envelope(node.clone(), 7, &quorum_set, commit, 5);
+
+        let ctx = ctx!(&node, &quorum_set, &driver, 7);
+        bp.set_state_from_envelope(&envelope, &ctx).unwrap();
+
+        let starts = driver.ballot_starts.lock().unwrap();
+        assert_eq!(starts.len(), 1);
+        assert_eq!(
+            starts[0],
+            ScpBallot {
+                counter: u32::MAX,
+                value,
+            }
+        );
+    }
+
+    /// Regression for #3089: `started_ballot_protocol` fires at most once per
+    /// slot even when the ballot counter is later bumped in-phase. The null→set
+    /// transition happens exactly once, so the recorder length stays 1.
+    #[test]
+    fn test_started_ballot_protocol_fires_once() {
+        let node = make_node_id(1);
+        let quorum_set = make_quorum_set(vec![node.clone()], 1);
+        let driver = Arc::new(MockDriver::with_quorum_set(quorum_set.clone()));
+        let mut bp = BallotProtocol::new();
+
+        let value = make_value(&[1, 2, 3]);
+
+        // First bump: current_ballot null→set, fires with counter 1.
+        assert!(bp.bump(&ctx!(&node, &quorum_set, &driver, 1), value.clone(), false));
+        assert_eq!(bp.current_ballot().map(|b| b.counter), Some(1));
+
+        // Further in-protocol bumps re-enter bump_to_ballot with current_ballot
+        // already set, so the null→set arm — and the fire — never triggers again.
+        // (The bump itself may be a no-op if the solo validator already
+        // externalized; what matters is that no second fire is recorded.)
+        let _ = bp.bump(&ctx!(&node, &quorum_set, &driver, 1), value.clone(), true);
+
+        let starts = driver.ballot_starts.lock().unwrap();
+        assert_eq!(
+            starts.len(),
+            1,
+            "started_ballot_protocol must fire exactly once per slot"
+        );
+        assert_eq!(
+            starts[0],
+            ScpBallot { counter: 1, value },
+            "the single fire carries the first ballot (counter 1, composite value)"
+        );
     }
 }

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -267,7 +267,7 @@ impl BallotProtocol {
             }
         }
 
-        did_work = self.update_current_if_needed(&new_h) || did_work;
+        did_work = self.update_current_if_needed(&new_h, ctx) || did_work;
         if did_work {
             self.emit_current_state(ctx);
         }
@@ -359,7 +359,7 @@ impl BallotProtocol {
             self.phase = BallotPhase::Confirm;
             if let Some(current) = &self.current_ballot {
                 if !are_ballots_less_and_compatible(&h, current) {
-                    self.bump_to_ballot(&h, false);
+                    self.bump_to_ballot(&h, false, ctx);
                 }
             }
             self.prepared_prime = None;
@@ -367,7 +367,7 @@ impl BallotProtocol {
         }
 
         if did_work {
-            self.update_current_if_needed(&h);
+            self.update_current_if_needed(&h, ctx);
             // Fire the accept-commit notification callback (SCP §6.5-2),
             // ordered update_current_if_needed -> accepted_commit ->
             // emit_current_state to match stellar-core
@@ -433,7 +433,7 @@ impl BallotProtocol {
         h: ScpBallot,
         ctx: &SlotContext<'_, D>,
     ) -> bool {
-        self.update_current_if_needed(&h);
+        self.update_current_if_needed(&h, ctx);
         self.commit = Some(c);
         self.high_ballot = Some(h);
         self.phase = BallotPhase::Externalize;
@@ -511,14 +511,18 @@ impl BallotProtocol {
         }
     }
 
-    fn update_current_if_needed(&mut self, ballot: &ScpBallot) -> bool {
+    fn update_current_if_needed<D: SCPDriver>(
+        &mut self,
+        ballot: &ScpBallot,
+        ctx: &SlotContext<'_, D>,
+    ) -> bool {
         if self
             .current_ballot
             .as_ref()
             .map(|b| ballot_compare(b, ballot) == Ordering::Less)
             .unwrap_or(true)
         {
-            return self.bump_to_ballot(ballot, true);
+            return self.bump_to_ballot(ballot, true, ctx);
         }
         false
     }
@@ -527,13 +531,17 @@ impl BallotProtocol {
     ///
     /// This is more thorough than `update_current_if_needed`: it checks phase
     /// and commit compatibility before bumping.
-    pub(super) fn update_current_value(&mut self, ballot: &ScpBallot) -> bool {
+    pub(super) fn update_current_value<D: SCPDriver>(
+        &mut self,
+        ballot: &ScpBallot,
+        ctx: &SlotContext<'_, D>,
+    ) -> bool {
         if self.phase != BallotPhase::Prepare && self.phase != BallotPhase::Confirm {
             return false;
         }
 
         let updated = if self.current_ballot.is_none() {
-            self.bump_to_ballot(ballot, true);
+            self.bump_to_ballot(ballot, true, ctx);
             true
         } else {
             // If we have a commit and the new ballot is incompatible, reject
@@ -545,7 +553,7 @@ impl BallotProtocol {
 
             let comp = ballot_compare(self.current_ballot.as_ref().unwrap(), ballot);
             match comp {
-                Ordering::Less => self.bump_to_ballot(ballot, true),
+                Ordering::Less => self.bump_to_ballot(ballot, true, ctx),
                 _ => false,
             }
         };
@@ -563,7 +571,12 @@ impl BallotProtocol {
         updated
     }
 
-    pub(super) fn bump_to_ballot(&mut self, ballot: &ScpBallot, check: bool) -> bool {
+    pub(super) fn bump_to_ballot<D: SCPDriver>(
+        &mut self,
+        ballot: &ScpBallot,
+        check: bool,
+        ctx: &SlotContext<'_, D>,
+    ) -> bool {
         if check {
             if let Some(current) = &self.current_ballot {
                 if ballot_compare(ballot, current) != Ordering::Greater {
@@ -576,6 +589,18 @@ impl BallotProtocol {
             None => true,
             Some(current) => current.counter != ballot.counter,
         };
+
+        // Fire `started_ballot_protocol` exactly once per slot, on the
+        // `current_ballot` null→set transition — matching stellar-core
+        // `BallotProtocol::bumpToBallot` (BallotProtocol.cpp:469-474), guarded on
+        // `!mCurrentBallot`. The argument is the new ballot (not the composite
+        // nomination value). Every production path that first-sets
+        // `current_ballot` flows through here (nomination, follower-receive,
+        // recovery), so this is the single firing site. The catchup helper
+        // `force_externalize` (no stellar-core analog) does not reach it.
+        if self.current_ballot.is_none() {
+            ctx.driver.started_ballot_protocol(ctx.slot_index, ballot);
+        }
 
         self.current_ballot = Some(ballot.clone());
 

--- a/crates/scp/src/driver.rs
+++ b/crates/scp/src/driver.rs
@@ -298,9 +298,17 @@ pub trait SCPDriver: Send + Sync {
 
     /// Called when the ballot protocol is started for a slot.
     ///
-    /// This is called when we transition from nomination to the ballot protocol,
-    /// indicating that we have candidate values and are beginning voting.
-    fn started_ballot_protocol(&self, _slot_index: u64, _value: &Value) {}
+    /// Fired exactly once per slot, at the moment `current_ballot` transitions
+    /// from null to set inside `BallotProtocol::bump_to_ballot`, with `ballot`
+    /// being the new `ScpBallot` (not the composite nomination value). Mirrors
+    /// stellar-core `SCPDriver::startedBallotProtocol(uint64, SCPBallot const&)`
+    /// (`stellar-core/src/scp/SCPDriver.h:227-230`), invoked from
+    /// `BallotProtocol::bumpToBallot` (`BallotProtocol.cpp:469-474`), guarded on
+    /// `!mCurrentBallot`. Every production path that first-sets `current_ballot`
+    /// flows through `bump_to_ballot` — including recovery
+    /// (`set_state_from_envelope`) — so this fires for all of them. The catchup
+    /// helper `force_externalize` (no stellar-core analog) does not fire it.
+    fn started_ballot_protocol(&self, _slot_index: u64, _ballot: &ScpBallot) {}
 
     /// Called when the composite candidate value is updated during nomination.
     ///

--- a/crates/scp/src/scp.rs
+++ b/crates/scp/src/scp.rs
@@ -725,7 +725,7 @@ impl<D: SCPDriver> SCP<D> {
 
         let slot = self.get_or_create_slot(&mut slots, slot_index);
 
-        slot.set_state_from_envelope(envelope)
+        slot.set_state_from_envelope(envelope, self.driver())
     }
 
     /// Abandon the current ballot for a slot.

--- a/crates/scp/src/slot.rs
+++ b/crates/scp/src/slot.rs
@@ -665,10 +665,12 @@ impl Slot {
             // Stop the nomination timer though (candidates already confirmed).
             driver.stop_timer(self.slot_index, crate::driver::SCPTimerType::Nomination);
 
-            // Notify driver that ballot protocol is starting
-            driver.started_ballot_protocol(self.slot_index, &composite);
-
-            // Start ballot protocol with the composite value
+            // Start ballot protocol with the composite value. The
+            // `started_ballot_protocol` callback is fired from inside
+            // `BallotProtocol::bump_to_ballot` on the `current_ballot` null→set
+            // transition (matching stellar-core BallotProtocol.cpp:469-474), not
+            // here — this reaches it via `bump` → `bump_state` →
+            // `update_current_value` → `bump_to_ballot`.
             let ctx = slot_ctx!(self, driver);
             self.ballot.bump(&ctx, composite.clone(), false);
 
@@ -824,7 +826,11 @@ impl Slot {
     /// (i.e. ballot protocol already started). This matches stellar-core's
     /// `throw runtime_error` semantics — it is a programming error, not a
     /// recoverable condition.
-    pub fn set_state_from_envelope(&mut self, envelope: &ScpEnvelope) -> bool {
+    pub fn set_state_from_envelope<D: SCPDriver>(
+        &mut self,
+        envelope: &ScpEnvelope,
+        driver: &Arc<D>,
+    ) -> bool {
         // stellar-core validates nodeID and slotIndex
         if envelope.statement.node_id != self.local_node_id
             || envelope.statement.slot_index != self.slot_index
@@ -844,8 +850,12 @@ impl Slot {
             ScpStatementPledges::Prepare(_)
             | ScpStatementPledges::Confirm(_)
             | ScpStatementPledges::Externalize(_) => {
+                // Build the slot context so `bump_to_ballot` (reached from
+                // `BallotProtocol::set_state_from_envelope`) can fire the
+                // `started_ballot_protocol` callback for recovery-driven slots.
+                let ctx = slot_ctx!(self, driver);
                 self.ballot
-                    .set_state_from_envelope(envelope)
+                    .set_state_from_envelope(envelope, &ctx)
                     .expect("Cannot set state after starting ballot protocol");
                 self.sync_externalized_value_from_ballot();
                 true
@@ -1129,7 +1139,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        assert!(slot.set_state_from_envelope(&envelope));
+        assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
         // stellar-core setStateFromEnvelope does NOT set mNominationStarted = true
         assert!(!slot.nomination().is_started());
     }
@@ -1165,7 +1175,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        assert!(slot.set_state_from_envelope(&envelope));
+        assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
         assert_eq!(slot.ballot().phase(), crate::ballot::BallotPhase::Prepare);
         assert_eq!(slot.ballot().current_ballot().map(|b| b.counter), Some(3));
     }
@@ -1195,7 +1205,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        assert!(slot.set_state_from_envelope(&envelope));
+        assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
         assert!(slot.is_externalized());
         assert_eq!(slot.get_externalized_value(), Some(&value));
     }
@@ -1232,7 +1242,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&envelope);
+        slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
         // Abandon to counter 5
         assert!(slot.abandon_ballot(&driver, 5));
@@ -1396,7 +1406,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&envelope);
+        slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
         // Even though we have state, should return empty since not fully validated
         let messages = slot.get_latest_messages_send();
@@ -1407,7 +1417,7 @@ mod tests {
 
         // Now test with fully validated slot
         let mut slot2 = Slot::new(1, node.clone(), quorum_set.clone(), true);
-        slot2.set_state_from_envelope(&envelope);
+        slot2.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
         let messages2 = slot2.get_latest_messages_send();
         assert!(
             !messages2.is_empty(),
@@ -1457,7 +1467,7 @@ mod tests {
             },
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&own_envelope);
+        slot.set_state_from_envelope(&own_envelope, &Arc::new(MockDriver::bare()));
 
         // After adding one node (self), check got_v_blocking
         // With threshold=2, one node out of 3 is not v-blocking
@@ -1509,7 +1519,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&envelope);
+        slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
         assert!(slot.is_externalized());
         // Since slot is fully validated and we externalized, should include our envelope
@@ -1548,7 +1558,7 @@ mod tests {
 
         // Note: set_state_from_envelope for EXTERNALIZE sets fully_validated=true
         // So we need to reset it after
-        slot.set_state_from_envelope(&envelope);
+        slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
         // Manually override fully_validated back to false for this test
         slot.fully_validated = false;
 
@@ -1586,7 +1596,7 @@ mod tests {
         };
 
         assert!(
-            !slot.set_state_from_envelope(&envelope),
+            !slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())),
             "set_state_from_envelope should reject envelope from wrong node"
         );
     }
@@ -1615,7 +1625,7 @@ mod tests {
         };
 
         assert!(
-            !slot.set_state_from_envelope(&envelope),
+            !slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())),
             "set_state_from_envelope should reject envelope for wrong slot"
         );
     }
@@ -1646,7 +1656,7 @@ mod tests {
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
-        assert!(slot.set_state_from_envelope(&envelope));
+        assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
 
         // stellar-core sets mPrepared = makeBallot(UINT32_MAX, v) for EXTERNALIZE
         let prepared = slot.ballot().prepared();
@@ -1799,7 +1809,7 @@ mod tests {
             },
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&nom_envelope);
+        slot.set_state_from_envelope(&nom_envelope, &Arc::new(MockDriver::bare()));
 
         // Now should find the nomination envelope
         let env = slot.get_latest_envelope(&node);
@@ -1832,7 +1842,7 @@ mod tests {
             },
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&ballot_envelope);
+        slot.set_state_from_envelope(&ballot_envelope, &Arc::new(MockDriver::bare()));
 
         // Now should find the ballot envelope (ballot protocol checked first)
         let env = slot.get_latest_envelope(&node);
@@ -1884,7 +1894,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&envelope);
+        slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
         // After externalization, sync_externalized_value_from_ballot should
         // NOT have restored fully_validated — it should still be false.
@@ -2190,7 +2200,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&envelope);
+        slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
         assert!(
             slot.is_fully_validated(),
             "validator slot starts fully_validated"
@@ -2363,7 +2373,7 @@ mod tests {
             statement,
             signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
-        slot.set_state_from_envelope(&envelope);
+        slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
         assert!(slot.is_fully_validated());
         assert_eq!(slot.ballot().current_ballot().map(|b| b.counter), Some(1));
         (slot, value)
@@ -2730,6 +2740,40 @@ mod tests {
         assert!(
             slot.got_v_blocking(),
             "v-blocking must remain set after bump_ballot_on_timeout"
+        );
+    }
+
+    /// Regression for #3089 (SCP §9.10-1): the nomination→ballot transition must
+    /// fire `started_ballot_protocol` with the actual `ScpBallot` (counter 1,
+    /// composite value), not the composite `Value`.
+    ///
+    /// FAILS on origin/main: the callback was fired from
+    /// `check_nomination_to_ballot` with a `&Value` (composite) — the old
+    /// signature could not carry a ballot, so this assertion is unrepresentable
+    /// there.
+    #[test]
+    fn test_nomination_ballot_start_fires_with_ballot_not_value() {
+        use crate::test_utils::make_quorum_set as make_qs;
+
+        let node = make_node_id(1);
+        let qs = Arc::new(make_qs(vec![node.clone()], 1));
+        let driver = Arc::new(MockDriver::with_quorum_set((*qs).clone()));
+        let mut slot = Slot::new(1, node.clone(), qs.clone(), true);
+
+        let value: Value = vec![1, 2, 3].try_into().unwrap();
+        let prev_value: Value = vec![].try_into().unwrap();
+        slot.nominate(value.clone(), &prev_value, false, &driver);
+
+        let starts = driver.ballot_starts.lock().unwrap();
+        assert_eq!(
+            starts.len(),
+            1,
+            "nomination→ballot must fire started_ballot_protocol exactly once"
+        );
+        assert_eq!(starts[0].counter, 1, "the first ballot has counter 1");
+        assert_eq!(
+            starts[0].value, value,
+            "started_ballot_protocol must receive the composite value as the ballot value"
         );
     }
 }

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -34,6 +34,9 @@ pub struct MockDriver {
     pub heard_from_quorum: AtomicU32,
     /// Counts how many times `accepted_commit` was called.
     pub accepted_commit_count: AtomicU32,
+    /// Records the `ScpBallot` passed to each `started_ballot_protocol` call,
+    /// in order. Lets tests assert fire-once and the exact ballot fired.
+    pub ballot_starts: std::sync::Mutex<Vec<ScpBallot>>,
     /// If true, `get_quorum_set_by_hash` returns the configured quorum set
     /// regardless of the hash. Useful for testing quorum info methods.
     pub return_qset_by_hash: bool,
@@ -115,6 +118,7 @@ impl MockDriverBuilder {
             emit_count: AtomicU32::new(0),
             heard_from_quorum: AtomicU32::new(0),
             accepted_commit_count: AtomicU32::new(0),
+            ballot_starts: std::sync::Mutex::new(Vec::new()),
             return_qset_by_hash: self.return_qset_by_hash,
             custom_node_weight: None,
         }
@@ -190,6 +194,10 @@ impl SCPDriver for MockDriver {
 
     fn accepted_commit(&self, _slot_index: u64, _ballot: &ScpBallot) {
         self.accepted_commit_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn started_ballot_protocol(&self, _slot_index: u64, ballot: &ScpBallot) {
+        self.ballot_starts.lock().unwrap().push(ballot.clone());
     }
 
     fn compute_hash_node(


### PR DESCRIPTION
Closes #3089

## Summary

Relocates the `started_ballot_protocol` SCP driver callback into `BallotProtocol::bump_to_ballot`, firing it exactly once per slot on the `current_ballot` null→set transition with the actual `ScpBallot` — matching stellar-core `BallotProtocol::bumpToBallot` (BallotProtocol.cpp:469-474, guarded on `!mCurrentBallot`). Previously the callback fired from `Slot::check_nomination_to_ballot` with the composite nomination *value*, and the recovery path (`set_state_from_envelope`) assigned `current_ballot` directly and never fired the callback at all. Now every production first-set of `current_ballot` (nomination, follower-receive, recovery) flows through the single firing site. The driver-trait argument changes `&Value`→`&ScpBallot` to match `SCPDriver.h:227-230`; `ctx`/driver is threaded through `bump_to_ballot`/`update_current_value`/`update_current_if_needed` and both `set_state_from_envelope` levels. `force_externalize` (catchup, no core analog) intentionally stays unfired.

## Plan reference

[Converged Plan comment]()

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (workspace gate; clean — verified via pre-commit hook)
- [x] cargo test -p henyey-scp (375 lib + 181 integration, all pass)
- [x] cargo test -p henyey-herder (1176+ pass)

## Regression test (kind: bug-fix)

- **Tests:**
  - `crates/scp/src/ballot/mod.rs::test_set_state_from_envelope_fires_started_ballot_protocol_{prepare,confirm,externalize}`
  - `crates/scp/src/ballot/mod.rs::test_started_ballot_protocol_fires_once`
  - `crates/scp/src/slot.rs::test_nomination_ballot_start_fires_with_ballot_not_value`
- **Pre-fix:** with the firing logic in its pre-fix form (callback not fired from `bump_to_ballot`; recovery assigning `current_ballot` directly), all five tests FAIL — recorder length 0 (callback never fires). The recovery routing was independently verified load-bearing: reverting just the recovery `bump_to_ballot` call (fire left enabled) fails the recovery test.
- **Post-fix:** all five PASS after 6607e568ef96f25ebe3c933cb4c951e39ff6f83d.

## Deviations from plan

- Per the skill's TDD step, the failing test is normally its own commit. The trait-signature change (`&Value`→`&ScpBallot`) and the `ctx` threading are infra the new tests' assertions depend on to compile, so the regression tests and the fix ship in a single commit. The required fail-pre/pass-post property was still verified explicitly (documented above) before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)