### PR TITLE
Rename tx-queue depth constants to spec-aligned names

### DIFF
--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -129,7 +129,7 @@ const EXPECTED_CLOSE_TIME_MULT: u64 = 2;
 ///
 /// Parity: stellar-core `Config::TRANSACTION_QUEUE_SIZE_MULTIPLIER`
 /// (`src/main/Config.cpp:205`, default `2`) and HERDER_SPEC §12.6. This is
-/// distinct from the pending depth (`DEFAULT_PENDING_DEPTH = 4`); the multiplier
+/// distinct from the pending depth (`TRANSACTION_QUEUE_TIMEOUT_LEDGERS = 4`); the multiplier
 /// scales the resource-based pool capacity, not the number of ledgers a tx may
 /// remain pending.
 pub const TRANSACTION_QUEUE_SIZE_MULTIPLIER: u32 = 2;
@@ -638,7 +638,9 @@ const FEE_MULTIPLIER: u64 = 10;
 
 /// Default pending depth (number of ledgers before auto-ban).
 /// Spec: HERDER_SPEC §17 — TRANSACTION_QUEUE_TIMEOUT_LEDGERS = 4.
-const DEFAULT_PENDING_DEPTH: u32 = 4;
+/// Parity: stellar-core `HerderImpl.cpp:65` —
+/// `constexpr uint32 const TRANSACTION_QUEUE_TIMEOUT_LEDGERS = 4;`.
+const TRANSACTION_QUEUE_TIMEOUT_LEDGERS: u32 = 4;
 
 pub(super) fn envelope_fee_per_op(envelope: &TransactionEnvelope) -> Option<(u64, FeeRate)> {
     QueuedTransaction::extract_fees_and_ops(envelope)
@@ -1322,17 +1324,24 @@ pub struct TransactionQueue {
 }
 
 /// Default ban depth (number of ledgers transactions stay banned).
-const DEFAULT_BAN_DEPTH: u32 = 10;
+/// Spec: HERDER_SPEC §11.7 — TRANSACTION_QUEUE_BAN_LEDGERS = 10.
+/// Parity: stellar-core `HerderImpl.cpp:66` —
+/// `constexpr uint32 const TRANSACTION_QUEUE_BAN_LEDGERS = 10;`.
+const TRANSACTION_QUEUE_BAN_LEDGERS: u32 = 10;
 
 impl TransactionQueue {
     /// Create a new transaction queue.
     pub fn new(config: TxQueueConfig) -> Self {
-        Self::with_depths(config, DEFAULT_BAN_DEPTH, DEFAULT_PENDING_DEPTH)
+        Self::with_depths(
+            config,
+            TRANSACTION_QUEUE_BAN_LEDGERS,
+            TRANSACTION_QUEUE_TIMEOUT_LEDGERS,
+        )
     }
 
     /// Create a new transaction queue with custom ban depth.
     pub fn with_ban_depth(config: TxQueueConfig, ban_depth: u32) -> Self {
-        Self::with_depths(config, ban_depth, DEFAULT_PENDING_DEPTH)
+        Self::with_depths(config, ban_depth, TRANSACTION_QUEUE_TIMEOUT_LEDGERS)
     }
 
     /// Create a new transaction queue with custom ban and pending depths.
@@ -8452,12 +8461,21 @@ mod pending_depth_tests {
     }
 
     // =========================================================================
-    // DEFAULT_PENDING_DEPTH auto-ban tests
+    // TRANSACTION_QUEUE_TIMEOUT_LEDGERS auto-ban tests
     // =========================================================================
 
     #[test]
     fn test_default_pending_depth_is_4() {
-        assert_eq!(DEFAULT_PENDING_DEPTH, 4);
+        assert_eq!(TRANSACTION_QUEUE_TIMEOUT_LEDGERS, 4);
+    }
+
+    /// Parity pin: both depth constants must match stellar-core
+    /// `HerderImpl.cpp:65-66` exactly. A change here is a deliberate
+    /// protocol-parity decision, not an incidental edit.
+    #[test]
+    fn test_transaction_queue_depth_constants_parity() {
+        assert_eq!(TRANSACTION_QUEUE_BAN_LEDGERS, 10);
+        assert_eq!(TRANSACTION_QUEUE_TIMEOUT_LEDGERS, 4);
     }
 
     #[test]


### PR DESCRIPTION
Closes #3047

## Summary

Renames the two transaction-queue depth constants in `crates/herder/src/tx_queue/mod.rs` to the spec-aligned names that mirror stellar-core `HerderImpl.cpp:65-66`:

- `DEFAULT_BAN_DEPTH` (10) → `TRANSACTION_QUEUE_BAN_LEDGERS`
- `DEFAULT_PENDING_DEPTH` (4) → `TRANSACTION_QUEUE_TIMEOUT_LEDGERS`

Pure rename — values stay 10/4, **zero behavioral change**. Updates all references (the two definitions, `new`, `with_ban_depth`, the doc comment, and the test references) and adds parity comments citing stellar-core. After the rename, the §12.4 claim in `crates/herder/SPEC_ADHERENCE.md` (lines 489-490) that references `TRANSACTION_QUEUE_BAN_LEDGERS = 10` / `TRANSACTION_QUEUE_TIMEOUT_LEDGERS = 4` as named source constants is now accurate (previously the names did not exist in source).

Confirmed against stellar-core `HerderImpl.cpp`:
- `:65 constexpr uint32 const TRANSACTION_QUEUE_TIMEOUT_LEDGERS = 4;`
- `:66 constexpr uint32 const TRANSACTION_QUEUE_BAN_LEDGERS = 10;`

Coordinates with PR #3143 (already merged) which added `TRANSACTION_QUEUE_SIZE_MULTIPLIER` to the same file — that constant is untouched.

## Plan reference

Trivial short-circuit — implemented from the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3047#issuecomment-4622766480) Implementation Notes.

## Test plan

- [x] cargo fmt --check (herder)
- [x] cargo clippy -p henyey-herder — no NEW lints from this change (the 10 pre-existing lints in `tx_set_tracker.rs`/`flood_queue.rs` are present on a pristine origin/main checkout and are untouched here)
- [x] `cargo test -p henyey-herder` — 1178 lib tests pass, including the ban/timeout depth tests and a new `test_transaction_queue_depth_constants_parity` parity-pin asserting 10/4

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)