### PR TITLE
Document shadow-version omission in merge protocol-version calc

### DIFF
--- a/crates/bucket/src/merge.rs
+++ b/crates/bucket/src/merge.rs
@@ -1063,11 +1063,24 @@ fn extract_metadata(entries: &[BucketEntry]) -> Option<BucketMetadata> {
 ///   Matches stellar-core's `LiveBucket::mergeInMemory` (`LiveBucket.cpp:569`).
 ///   Used for level-0 merges.
 ///
-/// NOTE (BUCKETLISTDB_SPEC §6.1 / §7.2 / INV-B4): stellar-core also includes
-/// shadow bucket versions in the max calculation. Since shadow filtering was
-/// removed in protocol 12, and henyey only supports protocol 24+, shadow
-/// versions are never present and can be safely ignored here. Textually
-/// divergent from spec but correct under P24+ scope.
+/// NOTE (BUCKETLISTDB_SPEC §6.1 / §7.2 / INV-B4): stellar-core's
+/// `calculateMergeProtocolVersion()` takes the max over the new, old, AND
+/// shadow bucket versions. The shadow contribution is gated behind the spec
+/// §6.1 guard `if s.metadata.ledgerVersion < FIRST_PROTOCOL_SHADOWS_REMOVED`
+/// (stellar-core `BucketBase.cpp`), where `FIRST_PROTOCOL_SHADOWS_REMOVED`
+/// is protocol 12 — i.e. shadows are only ever populated, and thus only ever
+/// contribute to the max, for buckets produced under protocol < 12.
+///
+/// henyey supports protocol 24+ only (see CLAUDE.md), so the shadow list is
+/// always empty and the guard `ledgerVersion < 12` can never be true. The
+/// shadow term in the max() is therefore unreachable dead code under
+/// henyey's scope and is omitted entirely rather than written as an
+/// always-false loop. Computing the max over only `old_meta`/`new_meta`
+/// below produces output byte-identical to stellar-core for every input
+/// henyey can ever construct — this is a documentation-only divergence from
+/// the spec's literal text, with zero behavioral difference. If pre-protocol-12
+/// support is ever reintroduced, the shadow versions must be folded back into
+/// the max() here per spec §6.1.
 fn build_output_metadata(
     old_meta: Option<&BucketMetadata>,
     new_meta: Option<&BucketMetadata>,


### PR DESCRIPTION
Closes #3026

## Summary

`build_output_metadata` in `crates/bucket/src/merge.rs` computes the merged bucket's protocol version as `max(old_meta, new_meta)`, whereas stellar-core's `calculateMergeProtocolVersion()` also folds in shadow-bucket versions. This PR expands the existing comment block to explicitly state why that shadow term is omitted: the spec §6.1 guard `ledgerVersion < FIRST_PROTOCOL_SHADOWS_REMOVED` (protocol 12) can never hold under henyey's protocol-24+-only scope, so the shadow list is always empty and the shadow contribution is unreachable dead code. The change is documentation-only with zero behavioral difference, and the comment now notes that the shadow versions must be re-folded into the max() if pre-protocol-12 support is ever reintroduced.

## Plan reference

Trivial short-circuit per the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3026#issuecomment-4623093235) (kind: refactor, documentation, XS). No `/plan` stage; the triage report specifies the fix (option A: expanded comment, no dead shadow loop).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-bucket --all-targets -- -D warnings (clean)
- [x] cargo test -p henyey-bucket passes (all merge/protocol-version tests green, including test_shadow_filtering_pre_protocol_12 and test_shadow_filtering_disabled_post_protocol_12)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)