### PR TITLE
Centralize lastModifiedLedgerSeq stamping at the bucket-update drain (LEDGER §6.6.1)

### DIFF
--- a/crates/ledger/src/delta.rs
+++ b/crates/ledger/src/delta.rs
@@ -710,7 +710,7 @@ impl LedgerDelta {
 
     /// Result of categorizing delta entries for bucket list update.
     pub fn categorize_for_bucket_update(&self) -> DeltaCategorization {
-        categorize_changes(self.changes().cloned(), false)
+        categorize_changes(self.changes().cloned(), false, self.ledger_seq)
     }
 
     /// Drains entries from the delta, categorizing them for bucket list update.
@@ -721,11 +721,12 @@ impl LedgerDelta {
         // Iterate using change_order for deterministic ordering.
         // drain() on a HashMap iterates in arbitrary order, which would
         // produce non-deterministic bucket list updates across nodes.
+        let ledger_seq = self.ledger_seq;
         let order = std::mem::take(&mut self.change_order);
         let changes = order
             .into_iter()
             .filter_map(|key| self.changes.remove(&key));
-        categorize_changes(changes, true)
+        categorize_changes(changes, true, ledger_seq)
     }
 
     /// Get a specific change by key.
@@ -891,9 +892,23 @@ impl LedgerDelta {
 ///
 /// When `collect_offer_pool` is true, offer and pool-share trustline changes
 /// are cloned into `offer_pool_changes` for commit_close processing.
+///
+/// `ledger_seq` is the current ledger sequence. Mirroring stellar-core
+/// `LedgerTxn::Impl::maybeUpdateLastModified()` (`LedgerTxn.cpp:2318`), every
+/// non-deleted entry (Created/Updated) has its `last_modified_ledger_seq`
+/// stamped to `ledger_seq` at this commit-time drain chokepoint, BEFORE the
+/// `offer_pool_changes` clone so the offer-store index and bucket-bound entries
+/// stay byte-identical. Deleted entries are skipped (parity with stellar-core
+/// `isDeleted()`). Because every write site already stamps `ledger_seq`
+/// correctly, this central pass overwrites correct values with identical
+/// values — a provable no-op on every observable hash (see the golden-vector
+/// tests `ledger_close_meta_vectors.rs` / `tx_meta_hash_vectors.rs`). It is a
+/// last-line defense-in-depth guarantee for the consensus-observable
+/// bucket-list-bound entries.
 fn categorize_changes(
     changes: impl Iterator<Item = EntryChange>,
     collect_offer_pool: bool,
+    ledger_seq: u32,
 ) -> DeltaCategorization {
     let mut init = Vec::new();
     let mut live = Vec::new();
@@ -905,7 +920,9 @@ fn categorize_changes(
     let mut has_pool_share_trustlines = false;
     let mut offer_pool_changes = Vec::new();
 
-    for change in changes {
+    for mut change in changes {
+        // TDD-COMMIT1-PLACEHOLDER: central stamping added in the following commit.
+        let _ = (&mut change, ledger_seq);
         let entry_ref = match &change {
             EntryChange::Created(e) | EntryChange::Deleted { previous: e } => e,
             EntryChange::Updated { current, .. } => current,
@@ -2036,6 +2053,72 @@ mod tests {
             vec![10, 5, 20, 1, 15, 8, 25, 3],
             "drain_categorization_for_bucket_update must preserve insertion order"
         );
+    }
+
+    /// Regression test for #3059 (LEDGER §6.6.1): the bucket-update drain is the
+    /// commit-time chokepoint that MUST stamp `last_modified_ledger_seq` to the
+    /// current ledger sequence on every non-deleted entry, mirroring
+    /// stellar-core `LedgerTxn::maybeUpdateLastModified()`. We artificially set
+    /// stale `last_modified_ledger_seq` values on a created and an updated entry,
+    /// then assert the drain re-stamps them to the delta's ledger_seq.
+    ///
+    /// Fails on origin/main (the drain performed no rewrite); passes after the
+    /// central enforcement pass is added to `categorize_changes`.
+    #[test]
+    fn test_drain_enforces_last_modified_on_stale_entry() {
+        let ledger_seq = 100u32;
+        let mut delta = LedgerDelta::new(ledger_seq);
+
+        // Created entry with an artificially stale last_modified_ledger_seq.
+        let mut created = create_test_account(1);
+        created.last_modified_ledger_seq = ledger_seq - 5;
+        delta.record_create(created).unwrap();
+
+        // Updated entry whose `current` value is artificially stale.
+        let prev = create_test_account(2);
+        let mut updated = create_test_account_with_balance(2, 5_000);
+        updated.last_modified_ledger_seq = ledger_seq - 5;
+        delta.record_update(prev, updated).unwrap();
+
+        let cat = delta.drain_categorization_for_bucket_update();
+
+        for entry in &cat.init_entries {
+            assert_eq!(
+                entry.last_modified_ledger_seq, ledger_seq,
+                "drain must stamp created entry to current ledger_seq"
+            );
+        }
+        for entry in &cat.live_entries {
+            assert_eq!(
+                entry.last_modified_ledger_seq, ledger_seq,
+                "drain must stamp updated entry to current ledger_seq"
+            );
+        }
+        assert_eq!(cat.init_entries.len(), 1, "expected one created entry");
+        assert_eq!(cat.live_entries.len(), 1, "expected one updated entry");
+    }
+
+    /// Parity with stellar-core `isDeleted()` skip: the central
+    /// last_modified_ledger_seq pass must NOT mutate a Deleted entry's
+    /// `previous` value (deleted entries contribute only dead keys; their
+    /// previous value is never re-stamped). #3059.
+    #[test]
+    fn test_drain_does_not_stamp_deleted_previous() {
+        let ledger_seq = 100u32;
+        let mut delta = LedgerDelta::new(ledger_seq);
+
+        // Delete an entry whose previous value has a stale last_modified_ledger_seq.
+        let mut deleted = create_test_account(3);
+        deleted.last_modified_ledger_seq = ledger_seq - 5;
+        delta.record_delete(deleted).unwrap();
+
+        let cat = delta.drain_categorization_for_bucket_update();
+
+        // Deleted entries produce only dead keys, no init/live entries.
+        assert!(cat.init_entries.is_empty());
+        assert!(cat.live_entries.is_empty());
+        assert_eq!(cat.dead_keys.len(), 1, "expected one dead key");
+        assert_eq!(cat.deleted_count, 1);
     }
 
     /// Regression test for AUDIT-067: apply_refund_to_account returns false

--- a/crates/ledger/src/delta.rs
+++ b/crates/ledger/src/delta.rs
@@ -921,8 +921,17 @@ fn categorize_changes(
     let mut offer_pool_changes = Vec::new();
 
     for mut change in changes {
-        // TDD-COMMIT1-PLACEHOLDER: central stamping added in the following commit.
-        let _ = (&mut change, ledger_seq);
+        // Central last_modified_ledger_seq enforcement (stellar-core
+        // LedgerTxn::maybeUpdateLastModified parity): stamp every non-deleted
+        // entry to the current ledger_seq in place, BEFORE the offer_pool clone
+        // below, so both the offer-store index and the bucket-bound init/live
+        // entries observe the stamped value. Deleted entries are left untouched
+        // (parity with stellar-core isDeleted() skip).
+        match &mut change {
+            EntryChange::Created(e) => e.last_modified_ledger_seq = ledger_seq,
+            EntryChange::Updated { current, .. } => current.last_modified_ledger_seq = ledger_seq,
+            EntryChange::Deleted { .. } => {}
+        }
         let entry_ref = match &change {
             EntryChange::Created(e) | EntryChange::Deleted { previous: e } => e,
             EntryChange::Updated { current, .. } => current,

--- a/crates/ledger/tests/ledger_close_integration.rs
+++ b/crates/ledger/tests/ledger_close_integration.rs
@@ -6,16 +6,17 @@ use henyey_ledger::{
     compute_header_hash, LedgerCloseData, LedgerManager, LedgerManagerConfig, TransactionSetVariant,
 };
 use stellar_xdr::curr::{
-    AccountEntry, AccountEntryExt, AccountId, BucketListType, BytesM, ContractCodeEntry,
-    ContractCodeEntryExt, ContractEventBody, DecoratedSignature, ExtendFootprintTtlOp,
-    ExtensionPoint, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionInnerTx,
-    Hash, LedgerCloseMeta, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerFootprint,
-    LedgerHeader, LedgerHeaderExt, LedgerKey, LedgerKeyContractCode, Memo, MuxedAccount, Operation,
-    OperationBody, Preconditions, PublicKey, ScVal, SequenceNumber, Signature as XdrSignature,
-    SignatureHint, SorobanResources, SorobanTransactionData, SorobanTransactionDataExt,
-    StellarValue, StellarValueExt, Thresholds, TimePoint, Transaction, TransactionEnvelope,
-    TransactionEventStage, TransactionExt, TransactionMeta, TransactionResultSet, TransactionSet,
-    TransactionV1Envelope, TtlEntry, Uint256, VecM,
+    AccountEntry, AccountEntryExt, AccountId, Asset, BucketListType, BytesM, ContractCodeEntry,
+    ContractCodeEntryExt, ContractEventBody, CreateAccountOp, DecoratedSignature,
+    ExtendFootprintTtlOp, ExtensionPoint, FeeBumpTransaction, FeeBumpTransactionEnvelope,
+    FeeBumpTransactionInnerTx, Hash, LedgerCloseMeta, LedgerEntry, LedgerEntryData, LedgerEntryExt,
+    LedgerFootprint, LedgerHeader, LedgerHeaderExt, LedgerKey, LedgerKeyAccount,
+    LedgerKeyContractCode, Memo, MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions,
+    PublicKey, ScVal, SequenceNumber, Signature as XdrSignature, SignatureHint, SorobanResources,
+    SorobanTransactionData, SorobanTransactionDataExt, StellarValue, StellarValueExt, Thresholds,
+    TimePoint, Transaction, TransactionEnvelope, TransactionEventStage, TransactionExt,
+    TransactionMeta, TransactionResultSet, TransactionSet, TransactionV1Envelope, TtlEntry,
+    Uint256, VecM,
 };
 
 fn make_genesis_header() -> LedgerHeader {
@@ -1646,4 +1647,148 @@ async fn test_close_ledger_with_held_snapshot_preserves_results() {
         .expect("spawn_blocking")
         .expect("close 3 after snapshot drop");
     assert_eq!(result3.header.ledger_seq, 3);
+}
+
+/// Close-level invariant for #3059 (LEDGER §6.6.1): after a ledger close that
+/// creates and updates entries, every entry bound to the bucket list reads
+/// `last_modified_ledger_seq == close_ledger_seq`. The central enforcement pass
+/// in the bucket-update drain (mirroring stellar-core
+/// `LedgerTxn::maybeUpdateLastModified()`) guarantees this for the
+/// consensus-observable bucket-list entries.
+///
+/// This asserts the post-close invariant only; the no-op proof (that the pass
+/// changed no observable hash) is provided by the golden-vector tests in
+/// `ledger_close_meta_vectors.rs` / `tx_meta_hash_vectors.rs`, not by a
+/// before/after diff here.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_close_stamps_last_modified_on_all_entries() {
+    let network_id = NetworkId::testnet();
+    let secret = SecretKey::from_seed(&[7u8; 32]);
+    let source_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+        *secret.public_key().as_bytes(),
+    )));
+    let dest_secret = SecretKey::from_seed(&[8u8; 32]);
+    let dest_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+        *dest_secret.public_key().as_bytes(),
+    )));
+
+    // Seed the bucket list with a source account stamped at a stale ledger seq
+    // (ledger 1). After the close at ledger 100 it must be re-stamped to 100.
+    let mut bucket_list = henyey_ledger::new_bucket_list_with_soroban_config();
+    let source_entry = make_source_account_entry(source_id.clone(), 1, 1_000_000_000);
+    bucket_list
+        .add_batch(
+            1,
+            25,
+            BucketListType::Live,
+            vec![source_entry],
+            vec![],
+            vec![],
+        )
+        .expect("add_batch");
+
+    let config = LedgerManagerConfig {
+        validate_bucket_hash: false,
+        ..Default::default()
+    };
+    let ledger = Arc::new(LedgerManager::new(
+        "Test SDF Network ; September 2015".to_string(),
+        config,
+    ));
+    let hot_archive = HotArchiveBucketList::new();
+    // Start at ledger 99 so the close produces ledger 100 — distinct from the
+    // stale seed seq (1) of the source account.
+    let mut header = make_genesis_header();
+    header.ledger_seq = 99;
+    let header_hash = compute_header_hash(&header).expect("hash");
+    ledger
+        .initialize(bucket_list, hot_archive, header, header_hash)
+        .expect("init");
+
+    // Transaction 1: source creates a new destination account (init entry) and
+    // pays it (the new account + the source are updated within the same close).
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
+        fee: 200,
+        seq_num: SequenceNumber(2),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![
+            Operation {
+                source_account: None,
+                body: OperationBody::CreateAccount(CreateAccountOp {
+                    destination: dest_id.clone(),
+                    starting_balance: 100_000_000,
+                }),
+            },
+            Operation {
+                source_account: None,
+                body: OperationBody::Payment(PaymentOp {
+                    destination: MuxedAccount::Ed25519(Uint256(
+                        *dest_secret.public_key().as_bytes(),
+                    )),
+                    asset: Asset::Native,
+                    amount: 1_000,
+                }),
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        ext: TransactionExt::V0,
+    };
+
+    let mut envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: VecM::default(),
+    });
+    let decorated = sign_envelope(&envelope, &secret, &network_id);
+    if let TransactionEnvelope::Tx(ref mut env) = envelope {
+        env.signatures = vec![decorated].try_into().unwrap();
+    }
+
+    let prev_hash = ledger.current_header_hash();
+    let close_ledger_seq = 100u32;
+    let close_data = LedgerCloseData::new(
+        close_ledger_seq,
+        TransactionSetVariant::Classic(TransactionSet {
+            previous_ledger_hash: Hash::from(prev_hash),
+            txs: vec![envelope].try_into().unwrap(),
+        }),
+        100,
+        prev_hash,
+    );
+
+    let handle = tokio::runtime::Handle::current();
+    let lm = ledger.clone();
+    let result = tokio::task::spawn_blocking(move || lm.close_ledger(close_data, Some(handle)))
+        .await
+        .expect("spawn_blocking task")
+        .expect("close ledger");
+    assert_eq!(result.header.ledger_seq, close_ledger_seq);
+    assert!(
+        matches!(
+            result.tx_results[0].result.result,
+            stellar_xdr::curr::TransactionResultResult::TxSuccess(_)
+        ),
+        "tx should succeed, got {:?}",
+        result.tx_results[0].result.result
+    );
+
+    // Read the bucket-list-bound entries back and assert they were re-stamped to
+    // the close ledger seq. The source account was seeded at ledger 1 (stale);
+    // the destination was created this ledger.
+    let bl = ledger.bucket_list();
+    for (label, account_id) in [("source", &source_id), ("destination", &dest_id)] {
+        let key = LedgerKey::Account(LedgerKeyAccount {
+            account_id: account_id.clone(),
+        });
+        let entry = bl
+            .get(&key)
+            .expect("bucket list get")
+            .unwrap_or_else(|| panic!("{label} account must exist after close"));
+        assert_eq!(
+            entry.last_modified_ledger_seq, close_ledger_seq,
+            "{label} account last_modified_ledger_seq must equal the close ledger seq"
+        );
+    }
 }


### PR DESCRIPTION
Closes #3059

## Summary

Adds a central `last_modified_ledger_seq` enforcement pass at the bucket-update drain chokepoint (`categorize_changes()` in `crates/ledger/src/delta.rs`), mirroring stellar-core `LedgerTxn::Impl::maybeUpdateLastModified()` (`LedgerTxn.cpp:2318`). `ledger_seq` is threaded in from both `drain_categorization_for_bucket_update()` (the commit terminal op) and the prod-unused `categorize_for_bucket_update()` wrapper; every non-deleted entry (Created/Updated) is stamped in place BEFORE the `offer_pool_changes` clone, and Deleted entries are skipped (parity with stellar-core `isDeleted()`).

This is defense-in-depth, **not** a behavior change: every write site already stamps `ledger_seq` correctly, so the central pass rewrites correct values with identical values — a provable no-op on every observable hash. The scattered write-site stamps are intentionally kept (they serve the pre-drain per-transaction meta path). The no-op is empirically guarded by the unchanged golden-vector tests.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3059#issuecomment-4623117634)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-ledger -- -D warnings (clean)
- [x] cargo test -p henyey-ledger — all pass (462 lib + integration + golden vectors)
- [x] Golden-vector hash tests **byte-identical**: `ledger_close_meta_vectors.rs` (header + tx_result hash vectors) and `tx_meta_hash_vectors.rs` all pass unchanged — the empirical no-op proof
- [x] New unit tests `test_drain_enforces_last_modified_on_stale_entry` and `test_drain_does_not_stamp_deleted_previous` pass
- [x] New close-level invariant test `test_close_stamps_last_modified_on_all_entries` passes

## Regression test

- **Test:** `crates/ledger/src/delta.rs::test_drain_enforces_last_modified_on_stale_entry` (load-bearing)
- **Pre-fix:** committed as `4a641d53` — verified FAILED with: `assertion left == right failed: drain must stamp created entry to current ledger_seq — left: 95, right: 100`
- **Post-fix:** verified PASSES after `784502ef`

## Deviations from plan

- The close-level invariant test `test_close_stamps_last_modified_on_all_entries` passes both with and without the central pass (the classic CreateAccount/Payment write sites already stamp these entries correctly during tx execution). This is expected and consistent with the plan: this test asserts the post-close invariant only; the no-op proof and the enforcement proof come from the golden vectors and the delta-level regression test respectively, not from this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)