### PR TITLE
Make SCPDriver upgrade-stripping methods required (SCP §6.2-1)

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -2360,6 +2360,20 @@ mod tests {
     }
 
     impl SCPDriver for ValidationDriver {
+        // Upgrade-stripping primitives are required (no trait default); this test
+        // driver reproduces the historical no-op behavior (false / None / u32::MAX).
+        fn has_upgrades(&self, _value: &Value) -> bool {
+            false
+        }
+
+        fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
+            None
+        }
+
+        fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+            u32::MAX
+        }
+
         fn validate_value(
             &self,
             _slot_index: u64,
@@ -3235,6 +3249,20 @@ mod tests {
     }
 
     impl SCPDriver for BallotParityDriver {
+        // Upgrade-stripping primitives are required (no trait default); this test
+        // driver reproduces the historical no-op behavior (false / None / u32::MAX).
+        fn has_upgrades(&self, _value: &Value) -> bool {
+            false
+        }
+
+        fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
+            None
+        }
+
+        fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+            u32::MAX
+        }
+
         fn validate_value(
             &self,
             _slot_index: u64,
@@ -4088,6 +4116,20 @@ mod tests {
     }
 
     impl SCPDriver for ConfigurableValidationDriver {
+        // Upgrade-stripping primitives are required (no trait default); this test
+        // driver reproduces the historical no-op behavior (false / None / u32::MAX).
+        fn has_upgrades(&self, _value: &Value) -> bool {
+            false
+        }
+
+        fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
+            None
+        }
+
+        fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+            u32::MAX
+        }
+
         fn validate_value(
             &self,
             _slot_index: u64,

--- a/crates/scp/src/driver.rs
+++ b/crates/scp/src/driver.rs
@@ -467,33 +467,28 @@ pub trait SCPDriver: Send + Sync {
     /// are causing consensus timeouts. When too many timeouts occur,
     /// upgrades may be stripped to allow consensus to proceed.
     ///
-    /// # Default Implementation
-    /// Returns false (no upgrades).
-    fn has_upgrades(&self, _value: &Value) -> bool {
-        false
-    }
+    /// Required method (no default) — mirrors stellar-core's pure-virtual
+    /// `SCPDriver::haveUpgrades` (`SCPDriver.h:171`). Every driver must make a
+    /// conscious choice; there is intentionally no silent no-op fallback.
+    fn has_upgrades(&self, value: &Value) -> bool;
 
     /// Strip all upgrades from a value.
     ///
     /// Returns a new value with all upgrades removed, or None if the
     /// value cannot have upgrades stripped (e.g., it has no upgrades).
     ///
-    /// # Default Implementation
-    /// Returns None.
-    fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
-        None
-    }
+    /// Required method (no default) — mirrors stellar-core's pure-virtual
+    /// `SCPDriver::stripUpgrades` (`SCPDriver.h:174`).
+    fn strip_all_upgrades(&self, value: &Value) -> Option<Value>;
 
     /// Get the number of nomination timeouts before upgrades are stripped.
     ///
     /// When the nomination timer expires this many times, values with
     /// upgrades will have their upgrades stripped to help consensus proceed.
     ///
-    /// # Default Implementation
-    /// Returns `u32::MAX` (effectively never strip).
-    fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
-        u32::MAX
-    }
+    /// Required method (no default) — mirrors stellar-core's pure-virtual
+    /// `SCPDriver::getUpgradeNominationTimeoutLimit` (`SCPDriver.h:179`).
+    fn get_upgrade_nomination_timeout_limit(&self) -> u32;
 }
 
 /// Compute weight as `ceil(m * threshold / total)`.

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -147,6 +147,20 @@ impl MockDriver {
 }
 
 impl SCPDriver for MockDriver {
+    // Upgrade-stripping primitives are required (no trait default); this test
+    // driver reproduces the historical no-op behavior (false / None / u32::MAX).
+    fn has_upgrades(&self, _value: &Value) -> bool {
+        false
+    }
+
+    fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
+        None
+    }
+
+    fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+        u32::MAX
+    }
+
     fn validate_value(
         &self,
         _slot_index: u64,

--- a/crates/scp/tests/multi_node_simulation.rs
+++ b/crates/scp/tests/multi_node_simulation.rs
@@ -58,6 +58,20 @@ impl SimulationDriver {
 }
 
 impl SCPDriver for SimulationDriver {
+    // Upgrade-stripping primitives are required (no trait default); this test
+    // driver reproduces the historical no-op behavior (false / None / u32::MAX).
+    fn has_upgrades(&self, _value: &Value) -> bool {
+        false
+    }
+
+    fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
+        None
+    }
+
+    fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+        u32::MAX
+    }
+
     fn validate_value(
         &self,
         _slot_index: u64,

--- a/crates/scp/tests/scp_parity_tests/main.rs
+++ b/crates/scp/tests/scp_parity_tests/main.rs
@@ -175,6 +175,20 @@ impl TestSCPDriver {
 }
 
 impl SCPDriver for TestSCPDriver {
+    // Upgrade-stripping primitives are required (no trait default); this test
+    // driver reproduces the historical no-op behavior (false / None / u32::MAX).
+    fn has_upgrades(&self, _value: &Value) -> bool {
+        false
+    }
+
+    fn strip_all_upgrades(&self, _value: &Value) -> Option<Value> {
+        None
+    }
+
+    fn get_upgrade_nomination_timeout_limit(&self) -> u32 {
+        u32::MAX
+    }
+
     fn validate_value(
         &self,
         _slot_index: u64,


### PR DESCRIPTION
Closes #3092

## Summary

stellar-core declares the three upgrade-stripping driver primitives pure-virtual (`= 0`) in `SCPDriver.h:171/174/179`. The Rust `SCPDriver` trait instead supplied default no-op bodies, so any driver that forgot to implement them silently inherited `false` / `None` / `u32::MAX` — a footgun for any future production-adjacent driver. This change removes the three default bodies (`has_upgrades`, `strip_all_upgrades`, `get_upgrade_nomination_timeout_limit`), making them required methods that the compiler forces every implementer to provide. The six default-reliant test/simulation drivers each get an explicit impl reproducing the exact prior values, so observable behavior is unchanged. Zero production behavioral impact — `HerderScpCallback` already overrides all three.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3092#issuecomment-4623710239)

## Changes

- `crates/scp/src/driver.rs` — remove the three default method bodies; leave them as required trait methods. Doc comments updated to note they mirror stellar-core's pure-virtual contract.
- Explicit no-op impls (`false` / `None` / `u32::MAX`) added to the six default-reliant drivers:
  - `MockDriver` (`crates/scp/src/test_utils.rs`)
  - `TestSCPDriver` (`crates/scp/tests/scp_parity_tests/main.rs`)
  - `ValidationDriver`, `BallotParityDriver`, `ConfigurableValidationDriver` (`crates/scp/src/ballot/mod.rs`)
  - `SimulationDriver` (`crates/scp/tests/multi_node_simulation.rs`)
- Untouched (already override): `HerderScpCallback` (production), `ParityMockDriver`, `ZeroWeightDriver`, `StuckDriver`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (CI invocation) — clean
- [x] `cargo test -p henyey-scp` — 124+ pass; compiles all test drivers incl. the `scp_parity_tests` and `multi_node_simulation` integration binaries
- [x] `cargo test -p henyey-herder --no-run` — production `HerderScpCallback` still satisfies the trait

Since the ballot trio and several drivers live in `#[cfg(test)]` modules, test compilation (not just `cargo build`) is the real guard that no impl was missed — all six compile.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)