### PR TITLE
Run stale-bucket GC every ledger close with re-entrancy guard

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2867,10 +2867,13 @@ impl App {
         // Signal heartbeat to sync recovery.
         self.sync_recovery_heartbeat();
 
-        // Periodically garbage collect stale bucket files.
-        if pending.ledger_seq % 100 == 0 {
-            self.cleanup_stale_bucket_files_background();
-        }
+        // Garbage collect stale bucket files after every ledger close, matching
+        // stellar-core's unconditional `forgetUnreferencedBuckets` in
+        // `advanceLedgerStateAndPublish` (LedgerManagerImpl.cpp:1429). The work
+        // runs on the blocking pool and is self-coalescing via the
+        // `bucket_gc_in_flight` re-entrancy guard, so per-ledger invocation
+        // cannot stack overlapping GC tasks (#3028).
+        self.cleanup_stale_bucket_files_background();
 
         self.clear_tx_set_exhausted();
 

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -829,6 +829,21 @@ pub struct App {
     /// in `HerderImpl::triggerNextLedger` (HerderImpl.cpp:1583).
     is_applying_ledger: Arc<AtomicBool>,
 
+    /// Re-entrancy guard for per-ledger background stale-bucket GC (#3028).
+    ///
+    /// Stale-bucket GC now runs on every ledger close (matching stellar-core's
+    /// unconditional `forgetUnreferencedBuckets`), rather than every 100 ledgers.
+    /// At ~5s cadence a GC run that blocks in `resolve_pending_bucket_merges()`
+    /// during a merge backlog could still be running when the next close fires.
+    /// This flag makes per-ledger GC self-coalescing: at most one background GC
+    /// at a time. If a run falls behind, subsequent ledgers skip GC (deferring
+    /// cleanup by ≤1 ledger — within stellar-core's "retain a few too many
+    /// buckets a little longer" tolerance) until the in-flight run finishes.
+    ///
+    /// The flag is reset panic-safely (see `cleanup_stale_bucket_files_background`)
+    /// so a single panicked GC run cannot permanently disable GC.
+    bucket_gc_in_flight: Arc<AtomicBool>,
+
     /// Wall-clock of the last deferred-pipeline close-complete entry.
     /// Used to compute `henyey_ledger_close_cycle_seconds` — the time between
     /// consecutive production close-complete events.
@@ -1031,6 +1046,21 @@ fn collect_gc_roots(
     }
 
     Some(hashes)
+}
+
+/// RAII guard that clears the bucket-GC re-entrancy flag on drop (#3028).
+///
+/// Held by the detached awaiter task in `cleanup_stale_bucket_files_background`
+/// so the flag is reset on EVERY exit path — normal completion, the inner GC
+/// task erroring or panicking (surfaced as a `JoinError`), or the awaiter task
+/// itself being cancelled. This is the panic-safety mechanism: a single failed
+/// GC run re-arms GC rather than wedging it off permanently.
+struct ResetGuard(Arc<AtomicBool>);
+
+impl Drop for ResetGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
 }
 
 /// Collect bucket hashes referenced only by publish-queue HAS entries.
@@ -1428,6 +1458,7 @@ impl App {
             sync_recovery_handle: parking_lot::RwLock::new(None), // Initialized in run() when needed
             sync_recovery_task: parking_lot::RwLock::new(None),
             is_applying_ledger,
+            bucket_gc_in_flight: Arc::new(AtomicBool::new(false)),
             close_cycle_last_start: parking_lot::Mutex::new(None),
             #[cfg(test)]
             close_complete_inject_blocking_ms: AtomicU64::new(0),
@@ -1906,6 +1937,16 @@ impl App {
     /// populated during startup.
     pub fn query_is_ready(&self) -> &Arc<AtomicBool> {
         &self.query_is_ready
+    }
+
+    /// Test-only accessor for the per-ledger bucket-GC re-entrancy guard (#3028).
+    ///
+    /// Exposed so integration tests in `crates/app/tests/bucket_gc.rs` can assert
+    /// the coalescing + panic-safe reset behavior of
+    /// `cleanup_stale_bucket_files_background`. Not part of the stable API.
+    #[doc(hidden)]
+    pub fn bucket_gc_in_flight(&self) -> &Arc<AtomicBool> {
+        &self.bucket_gc_in_flight
     }
 
     /// Update the bucket snapshot manager with fresh snapshots from the
@@ -2636,7 +2677,36 @@ impl App {
     ///
     /// Spawns on tokio's blocking thread pool so that merge resolution (which may
     /// block) does not stall the async event loop.
-    pub(crate) fn cleanup_stale_bucket_files_background(&self) {
+    ///
+    /// # Re-entrancy guard (#3028)
+    ///
+    /// Because this now runs on every ledger close (~5s) rather than every 100th,
+    /// a slow run (blocked in `resolve_pending_bucket_merges()` during a merge
+    /// backlog) could still be in flight when the next close fires. The
+    /// `bucket_gc_in_flight` flag coalesces overlapping invocations: at most one
+    /// background GC runs at a time, and a ledger whose GC would overlap an
+    /// in-flight run simply skips (deferring cleanup by ≤1 ledger). The flag is
+    /// reset in the detached awaiter regardless of Ok/Err/panic, so a panicked GC
+    /// re-arms rather than permanently disabling GC.
+    ///
+    /// Returns `true` if a GC task was launched, `false` if it coalesced (a GC was
+    /// already in flight).
+    ///
+    /// `#[doc(hidden)] pub` rather than `pub(crate)` so integration tests in
+    /// `crates/app/tests/bucket_gc.rs` can drive it directly; not part of the
+    /// stable API.
+    #[doc(hidden)]
+    pub fn cleanup_stale_bucket_files_background(&self) -> bool {
+        // Acquire the re-entrancy guard. If a GC is already in flight, skip this
+        // ledger — the in-flight run will pick up everything stale.
+        if self
+            .bucket_gc_in_flight
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return false;
+        }
+
         let lm = self.ledger_manager.clone();
         let bm = self.bucket_manager.clone();
         let db = self.db.clone();
@@ -2658,10 +2728,18 @@ impl App {
             }
         });
         // Log any panic/cancellation in a detached task — cleanup is
-        // best-effort and the caller doesn't wait for it.
+        // best-effort and the caller doesn't wait for it. The flag reset lives
+        // here (after the await) so it runs regardless of Ok/Err/panic: a
+        // `ResetGuard` whose Drop clears the flag re-arms GC even if this task
+        // itself is cancelled or panics.
+        let gc_in_flight = self.bucket_gc_in_flight.clone();
         tokio::spawn(async move {
+            // Reset on every exit path (normal, error, panic, cancellation).
+            let _reset = ResetGuard(gc_in_flight);
             let _ = henyey_common::await_blocking_logged("stale-bucket-cleanup", handle).await;
         });
+
+        true
     }
 
     pub fn scp_slot_snapshots(&self, limit: usize) -> Vec<ScpSlotSnapshot> {
@@ -3651,6 +3729,45 @@ mod tests {
     use super::*;
     use stellar_xdr::curr::StellarValueExt;
     use tempfile;
+
+    /// Panic-safety of the bucket-GC re-entrancy guard (#3028): `ResetGuard`
+    /// MUST clear the in-flight flag on drop even when the surrounding scope
+    /// unwinds via panic. This is the mechanism that prevents a single panicked
+    /// GC run from permanently disabling GC.
+    #[test]
+    fn test_bucket_gc_reset_guard_clears_flag_on_panic() {
+        let flag = Arc::new(AtomicBool::new(true));
+        let flag_clone = flag.clone();
+
+        // Run the guard inside a scope that panics. The guard's Drop must still
+        // fire during unwinding and reset the flag to false.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _reset = ResetGuard(flag_clone);
+            assert!(flag.load(Ordering::Acquire), "flag is set while guard held");
+            panic!("simulated GC task panic");
+        }));
+
+        assert!(result.is_err(), "the closure must have panicked");
+        assert!(
+            !flag.load(Ordering::Acquire),
+            "ResetGuard must clear the in-flight flag even when the scope panics, \
+             so a panicked GC run re-arms rather than wedging GC off permanently"
+        );
+    }
+
+    /// Happy-path companion: `ResetGuard` clears the flag on normal drop.
+    #[test]
+    fn test_bucket_gc_reset_guard_clears_flag_on_normal_drop() {
+        let flag = Arc::new(AtomicBool::new(true));
+        {
+            let _reset = ResetGuard(flag.clone());
+            assert!(flag.load(Ordering::Acquire));
+        }
+        assert!(
+            !flag.load(Ordering::Acquire),
+            "ResetGuard must clear the in-flight flag on normal drop"
+        );
+    }
 
     /// Construct a `PendingLedgerClose` with default tx_set/upgrades.
     ///

--- a/crates/app/tests/bucket_gc.rs
+++ b/crates/app/tests/bucket_gc.rs
@@ -1,0 +1,101 @@
+//! Integration tests for per-ledger stale-bucket garbage collection (#3028).
+//!
+//! Issue #3028 removed the every-100-ledger GC throttle so stale-bucket GC runs
+//! on every ledger close, matching stellar-core's unconditional
+//! `forgetUnreferencedBuckets`. Because GC now fires every ~5s rather than every
+//! ~500s, a slow run (blocked resolving an in-flight async merge) could still be
+//! running when the next close fires. The `bucket_gc_in_flight` re-entrancy guard
+//! coalesces overlapping invocations: at most one background GC at a time.
+//!
+//! These tests assert the observable behavior of that guard:
+//!   - a second invocation while a GC is "in flight" coalesces (no new task), and
+//!   - the guard flag resets after a real run so a later close re-arms GC.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use henyey_app::config::ConfigBuilder;
+use henyey_app::App;
+
+/// Build a minimal, hermetic `App` backed by a temp SQLite DB. No overlay peers,
+/// no network — sufficient to exercise the bucket-GC re-entrancy guard, which
+/// only touches the bucket manager / ledger manager / DB.
+async fn build_test_app(db_dir: &std::path::Path) -> Arc<App> {
+    let db_path = db_dir.join("bucket_gc_test.db");
+    let mut config = ConfigBuilder::new().database_path(&db_path).build();
+    config.is_compat_config = true;
+    config.overlay.known_peers = vec![];
+    config.overlay.target_outbound_peers = 0;
+    config.overlay.max_outbound_peers = 0;
+    Arc::new(App::new(config).await.expect("failed to build App"))
+}
+
+/// Spin until `flag` reaches `expected` or the deadline elapses. Returns whether
+/// it reached the expected value.
+async fn await_flag(flag: &Arc<std::sync::atomic::AtomicBool>, expected: bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if flag.load(Ordering::Acquire) == expected {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    flag.load(Ordering::Acquire) == expected
+}
+
+/// Primary coverage for #3028: the re-entrancy guard coalesces a second
+/// invocation while a GC is already in flight, and the flag resets after a real
+/// run completes so a subsequent ledger close re-arms GC.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_gc_reentrancy_guard_coalesces() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let app = build_test_app(tmp.path()).await;
+
+    let flag = app.bucket_gc_in_flight().clone();
+
+    // Precondition: no GC in flight at startup.
+    assert!(
+        !flag.load(Ordering::Acquire),
+        "bucket_gc_in_flight must start false"
+    );
+
+    // Simulate a GC already running by setting the flag, then invoke. The guard's
+    // compare_exchange(false -> true) must fail, so no new task is launched and
+    // the call coalesces (returns false). The flag stays set (we own it).
+    flag.store(true, Ordering::Release);
+    assert!(
+        !app.cleanup_stale_bucket_files_background(),
+        "a second GC invocation while one is in flight must coalesce (return false)"
+    );
+    assert!(
+        flag.load(Ordering::Acquire),
+        "coalescing must not clear the in-flight flag held by the running GC"
+    );
+
+    // Release the simulated in-flight GC. Now a real invocation must acquire the
+    // guard and launch a task (return true)...
+    flag.store(false, Ordering::Release);
+    assert!(
+        app.cleanup_stale_bucket_files_background(),
+        "with no GC in flight, the invocation must launch a GC task (return true)"
+    );
+
+    // ...and once that real run completes, the flag must reset to false so the
+    // next ledger close re-arms GC. The reset lives in a Drop guard on the
+    // detached awaiter task, so it fires regardless of the run's outcome.
+    assert!(
+        await_flag(&flag, false).await,
+        "bucket_gc_in_flight must reset to false after the GC run completes"
+    );
+
+    // Re-arm check: a subsequent close can launch GC again.
+    assert!(
+        app.cleanup_stale_bucket_files_background(),
+        "GC must re-arm after a completed run — a later close launches a new task"
+    );
+    assert!(
+        await_flag(&flag, false).await,
+        "flag must reset again after the second run"
+    );
+}

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -4142,6 +4142,127 @@ mod tests {
         );
     }
 
+    /// Resolve-first GC safety contract (issue #3028): when stale-bucket GC runs
+    /// immediately after a ledger close that still has a live (unresolved) async
+    /// merge, the merge OUTPUT file must survive `retain_buckets`. This holds only
+    /// because the caller resolves pending merges BEFORE collecting the keep-set.
+    ///
+    /// This is the end-to-end retain assertion complementing
+    /// `test_all_referenced_hashes_includes_pending_merge_output` (which covers
+    /// the keep-set side only). It proves both directions:
+    ///   - WITHOUT resolving first, the output hash is absent from the keep-set
+    ///     and `retain_buckets` would delete the on-disk output file.
+    ///   - WITH resolve-first, the output hash is in the keep-set and the file
+    ///     is retained.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_resolve_first_retains_pending_merge_output() {
+        use crate::bucket::Bucket;
+        use crate::manager::{canonical_bucket_filename, BucketManager};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().to_path_buf();
+        let manager = BucketManager::new(dir.clone()).unwrap();
+
+        // Two disjoint input buckets, persisted to disk and loaded disk-backed so
+        // the async merge has real input files to read (and so list_buckets() sees
+        // them as `.bucket.xdr` candidates for GC).
+        let entry1 = make_account_entry([1u8; 32], 100);
+        let entry2 = make_account_entry([2u8; 32], 200);
+        let bucket1_mem = Bucket::from_entries(vec![BucketListEntry::Liveentry(entry1)]).unwrap();
+        let bucket2_mem = Bucket::from_entries(vec![BucketListEntry::Liveentry(entry2)]).unwrap();
+
+        let path1 = dir.join(canonical_bucket_filename(&bucket1_mem.hash()));
+        let path2 = dir.join(canonical_bucket_filename(&bucket2_mem.hash()));
+        bucket1_mem.save_to_xdr_file(&path1).unwrap();
+        bucket2_mem.save_to_xdr_file(&path2).unwrap();
+
+        let bucket1 = Arc::new(Bucket::from_xdr_file_disk_backed(&path1).unwrap());
+        let bucket2 = Arc::new(Bucket::from_xdr_file_disk_backed(&path2).unwrap());
+
+        // Start a disk-backed async merge: its output is written to `dir` as
+        // `<output_hash>.bucket.xdr`.
+        let handle = AsyncMergeHandle::start_merge(AsyncMergeRequest {
+            curr: bucket1.clone(),
+            snap: bucket2.clone(),
+            keep_dead_entries: DeadEntryPolicy::Remove,
+            protocol_version: TEST_PROTOCOL,
+            normalize_init: InitEntryPolicy::NormalizeToLive,
+            shadow_buckets: vec![],
+            level: 1,
+            bucket_dir: Some(dir.clone()),
+            counters: None,
+        });
+
+        let mut bl = BucketList::new();
+        bl.levels[1].next = Some(PendingMerge::Async(handle));
+
+        // Resolve once on a throwaway clone to learn the deterministic output hash
+        // and ensure the output file has been promoted to its canonical path.
+        let output_hash = {
+            let mut probe = BucketList::new();
+            let probe_handle = AsyncMergeHandle::start_merge(AsyncMergeRequest {
+                curr: bucket1.clone(),
+                snap: bucket2.clone(),
+                keep_dead_entries: DeadEntryPolicy::Remove,
+                protocol_version: TEST_PROTOCOL,
+                normalize_init: InitEntryPolicy::NormalizeToLive,
+                shadow_buckets: vec![],
+                level: 1,
+                bucket_dir: Some(dir.clone()),
+                counters: None,
+            });
+            probe.levels[1].next = Some(PendingMerge::Async(probe_handle));
+            probe.resolve_all_pending_merges().unwrap();
+            probe.levels[1].next().unwrap().hash()
+        };
+
+        let output_path = dir.join(canonical_bucket_filename(&output_hash));
+        assert!(
+            output_path.exists(),
+            "merge output file must be on disk after the merge completes"
+        );
+
+        // BEFORE resolving `bl`'s pending merge: the keep-set must NOT contain the
+        // output hash (only the inputs are tracked while Pending). A retain with
+        // this keep-set would delete the output file — exactly the hazard the
+        // resolve-first contract prevents.
+        let pre_resolve_keep = bl.all_referenced_hashes();
+        assert!(
+            !pre_resolve_keep.contains(&output_hash),
+            "pre-resolve keep-set must omit the not-yet-resolved merge output hash"
+        );
+
+        // Now honor the resolve-first contract.
+        bl.resolve_all_pending_merges().unwrap();
+        let keep = bl.all_referenced_hashes();
+        assert!(
+            keep.contains(&output_hash),
+            "post-resolve keep-set must include the merge output hash"
+        );
+        assert!(
+            keep.contains(&bucket1.hash()) && keep.contains(&bucket2.hash()),
+            "post-resolve keep-set must include the merge input hashes"
+        );
+
+        // End-to-end retain: with the resolve-first keep-set, the output file
+        // survives GC.
+        manager.retain_buckets(&keep).unwrap();
+        assert!(
+            output_path.exists(),
+            "resolve-first retain_buckets must keep the merge output file"
+        );
+
+        // Counter-check: had we GC'd with the pre-resolve keep-set, the output
+        // file would have been deleted (it is unreferenced from that set).
+        manager.retain_buckets(&pre_resolve_keep).unwrap();
+        assert!(
+            !output_path.exists(),
+            "GC with the pre-resolve keep-set deletes the unreferenced output — \
+             confirming resolve-first is load-bearing"
+        );
+    }
+
     // ============ P1-1: BucketList sizes at ledger 1 ============
     //
     // stellar-core: BucketListTests.cpp "BucketList sizes at ledger 1"


### PR DESCRIPTION
Closes #3028

## Summary

Removes the every-100-ledger stale-bucket GC throttle (`if pending.ledger_seq % 100 == 0`) so garbage collection runs after every successful ledger close, matching stellar-core's unconditional `forgetUnreferencedBuckets` in `advanceLedgerStateAndPublish` (`LedgerManagerImpl.cpp:1429`). The `% 100` cap was an arbitrary defensive throttle from when GC was a blocking call; GC has since moved to the blocking thread pool, so per-ledger invocation does not re-introduce the event-loop freeze that earlier work fixed.

Because GC now fires every ~5s rather than ~500s, a slow run (blocked resolving an in-flight async merge) could still be running when the next close fires. A panic-safe re-entrancy guard (`bucket_gc_in_flight: Arc<AtomicBool>`) makes per-ledger GC self-coalescing: at most one background GC at a time, skipping ledgers until the in-flight run finishes. A skipped run defers cleanup by ≤1 ledger and the keep-set is always a superset (never deletes a referenced file), so this is within stellar-core's "retain a few too many buckets a little longer" tolerance — no observable divergence.

The flag is reset via a `Drop`-guard (`ResetGuard`) on the detached awaiter task, so a panicked or cancelled GC re-arms rather than permanently disabling GC. The resolve-first safety contract is preserved unchanged: `collect_gc_roots` still calls `resolve_pending_bucket_merges()` before computing the keep-set.

The `DISABLE_BUCKET_GC` kill-switch is intentionally NOT included here — deferred to follow-up #3153 per the converged plan.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3028#issuecomment-4624385693)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (CI-equivalent; clean for touched crates)
- [x] cargo test -p henyey-app passes (989 lib + integration incl. new `bucket_gc` test)
- [x] cargo test -p henyey-bucket passes (incl. new resolve-first retain test)

New coverage:
- `crates/app/tests/bucket_gc.rs::test_gc_reentrancy_guard_coalesces` — a second invocation while a GC is in flight coalesces (returns false, no new task); the flag resets after a real run so a later close re-arms GC.
- `crates/app/src/app/mod.rs::tests::test_bucket_gc_reset_guard_clears_flag_on_panic` + `..._on_normal_drop` — proves the `ResetGuard` Drop clears the flag even when the scope unwinds via panic (panic-safety).
- `crates/bucket/src/bucket_list.rs::tests::test_resolve_first_retains_pending_merge_output` — end-to-end: the pending-merge output file survives `retain_buckets` only when merges are resolved first; the pre-resolve keep-set would delete it.

## Deviations from plan

None. `kind: refactor` — the new tests reference new internal API (re-entrancy flag / `ResetGuard`), so test + implementation are committed together rather than as a separate failing-test commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)