### PR TITLE
SCP §9.5-1: convert attempt_accept_prepared commit-compat filter to debug_assert!

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -1052,6 +1052,16 @@ impl BallotProtocol {
     ) -> bool {
         self.set_accept_prepared(ballot, ctx)
     }
+
+    /// Test helper: expose attempt_accept_prepared for direct testing.
+    #[cfg(test)]
+    pub(crate) fn attempt_accept_prepared_for_test<D: SCPDriver>(
+        &mut self,
+        hint: &ScpStatement,
+        ctx: &SlotContext<'_, D>,
+    ) -> bool {
+        self.attempt_accept_prepared(hint, ctx)
+    }
 }
 
 #[cfg(test)]
@@ -5369,6 +5379,104 @@ mod tests {
             assert!(
                 bp.commit().is_none(),
                 "commit must be cleared in release builds even if phase is CONFIRM"
+            );
+        }
+    }
+
+    /// SCP §9.5-1 parity regression: the commit-compat check in
+    /// `attempt_accept_prepared` (CONFIRM branch) must be a `debug_assert!`
+    /// mirroring stellar-core's `dbgAssert(areBallotsCompatible(mCommit, ballot))`
+    /// (`BallotProtocol.cpp:823`), NOT a silent `continue` filter. The `p ~ c`
+    /// invariant guarantees commit-compat in CONFIRM, so a violation is a bug that
+    /// must surface (panic in debug/test) rather than being masked.
+    ///
+    /// FAILS on `origin/main` (the site is a silent `continue` → `catch_unwind`
+    /// returns `Ok` even in a debug build, so the `is_err()` assertion fails);
+    /// PASSES after the `debug_assert!` lands. `debug_assert!` is the exact
+    /// analogue of `dbgAssert`: it panics in debug/test and is compiled out under
+    /// `--release` (NDEBUG), so release/mainnet behavior is unchanged. Pattern
+    /// follows `test_set_accept_prepared_phase_guard_matches_debug_assert_semantics`.
+    #[test]
+    fn test_attempt_accept_prepared_commit_compat_invariant_asserts_in_debug() {
+        let node_self = make_node_id(0);
+        let node_b = make_node_id(1);
+        let value_a: Value = vec![1u8, 0].try_into().unwrap();
+        let value_b: Value = vec![2u8, 0].try_into().unwrap();
+        let quorum_set = make_quorum_set(vec![node_self.clone(), node_b.clone()], 1);
+        let driver = Arc::new(
+            MockDriverBuilder::new()
+                .quorum_set(quorum_set.clone())
+                .build(),
+        );
+        let ctx = ctx!(&node_self, &quorum_set, &driver, 1);
+
+        let mut bp = BallotProtocol::new();
+        // CONFIRM phase with a `p ~ c`-violating state: `prepared` is on value_a but
+        // `commit` is on value_b. The candidate C={2, value_a} passes the
+        // prepared-compat filter (prepared={1, value_a} is less-and-compatible with
+        // C) but is commit-INCOMPATIBLE with commit={1, value_b} — violating p ~ c.
+        bp.set_phase_for_test(BallotPhase::Confirm);
+        bp.set_current_ballot_for_test(Some(ScpBallot {
+            counter: 2,
+            value: value_a.clone(),
+        }));
+        bp.set_prepared_ballot_for_test(Some(ScpBallot {
+            counter: 1,
+            value: value_a.clone(),
+        }));
+        bp.set_commit_for_test(Some(ScpBallot {
+            counter: 1,
+            value: value_b.clone(),
+        }));
+
+        // Inject an envelope whose Prepare ballot is C={2, value_a}, so that
+        // `get_prepare_candidates` (driven by the hint top_vote below) yields C.
+        let envelope = make_prepare_envelope(
+            node_b.clone(),
+            1,
+            &quorum_set,
+            ScpBallot {
+                counter: 2,
+                value: value_a.clone(),
+            },
+        );
+        bp.latest_envelopes.insert(node_b.clone(), envelope);
+
+        // Hint with top_vote = C={2, value_a}, so the injected Prepare ballot
+        // (which is less-and-compatible with the top_vote) becomes a candidate.
+        let qs_hash = hash_quorum_set(&quorum_set);
+        let hint = ScpStatement {
+            node_id: node_b.clone(),
+            slot_index: 1,
+            pledges: ScpStatementPledges::Prepare(ScpStatementPrepare {
+                ballot: ScpBallot {
+                    counter: 2,
+                    value: value_a.clone(),
+                },
+                prepared: None,
+                prepared_prime: None,
+                n_c: 0,
+                n_h: 0,
+                quorum_set_hash: qs_hash.into(),
+            }),
+        };
+
+        // In debug builds, the debug_assert! should fire (panic) when the
+        // commit-incompatible candidate reaches the invariant check.
+        // In release builds, the assert compiles out and no panic occurs.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            bp.attempt_accept_prepared_for_test(&hint, &ctx)
+        }));
+
+        if cfg!(debug_assertions) {
+            assert!(
+                result.is_err(),
+                "debug builds must panic on p ~ c invariant violation in attempt_accept_prepared"
+            );
+        } else {
+            assert!(
+                result.is_ok(),
+                "release builds must NOT panic — matches stellar-core dbgAssert semantics"
             );
         }
     }

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -48,7 +48,7 @@ impl BallotProtocol {
         }
     }
 
-    fn attempt_accept_prepared<D: SCPDriver>(
+    pub(super) fn attempt_accept_prepared<D: SCPDriver>(
         &mut self,
         hint: &ScpStatement,
         ctx: &SlotContext<'_, D>,

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -66,11 +66,21 @@ impl BallotProtocol {
                         continue;
                     }
                 }
-                if let Some(commit) = &self.commit {
-                    if !ballot_compatible(commit, ballot) {
-                        continue;
-                    }
-                }
+                // stellar-core BallotProtocol.cpp:823 —
+                // dbgAssert(areBallotsCompatible(mCommit, ballot)). Commit-compat
+                // is an invariant guaranteed by `p ~ c` in CONFIRM, not a defensive
+                // filter; a violation is a bug that must surface (panic in
+                // debug/test) rather than being silently masked. `debug_assert!` is
+                // the exact analogue of `dbgAssert`: compiled out under `--release`
+                // (NDEBUG), so release behavior is unchanged under the invariant.
+                debug_assert!(
+                    self.commit
+                        .as_ref()
+                        .map_or(true, |c| ballot_compatible(c, ballot)),
+                    "p ~ c invariant violated in attempt_accept_prepared: commit={:?} incompatible with candidate ballot={:?}",
+                    self.commit,
+                    ballot,
+                );
             }
 
             if let Some(prepared_prime) = &self.prepared_prime {


### PR DESCRIPTION
Closes #3093

## Summary

In the CONFIRM branch of `attempt_accept_prepared` (`crates/scp/src/ballot/state_machine.rs`), the commit-compatibility check was a silent `continue` filter that masked violations of the `p ~ c` invariant. stellar-core uses `dbgAssert(areBallotsCompatible(mCommit, ballot))` here (`BallotProtocol.cpp:823`), treating commit-compat as an invariant guaranteed by `p ~ c` in CONFIRM — not a defensive filter. This PR converts that `continue` to a `debug_assert!`, the exact analogue of `dbgAssert`: it panics in debug/test to surface state-machine bugs, and is compiled out under `--release` (NDEBUG), so release/mainnet behavior is unchanged under the invariant (the `continue` was never taken when `p ~ c` holds). The prepared-compat filter immediately above stays a `continue` (mirrors stellar-core's first `continue`). The sibling commit-compat site at `state_machine.rs` `update_current_value` maps to stellar-core's genuine `return false` filter (`BallotProtocol.cpp:413`) and is left unchanged (out of scope).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3093#issuecomment-4624378746)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-scp -- -D warnings` clean
- [x] `cargo test -p henyey-scp` passes (378 lib + integration tests, incl. new test)
- [x] `cargo build -p henyey-scp --release` compiles (assert stripped)
- [x] `cargo test -p henyey-scp --release` passes (release branch asserts no-panic)

## Regression test

- **Test:** `crates/scp/src/ballot/mod.rs::test_attempt_accept_prepared_commit_compat_invariant_asserts_in_debug`
- **Pre-fix:** committed as `4dfc5bf1` — verified FAILED in debug with: `debug builds must panic on p ~ c invariant violation in attempt_accept_prepared` (no panic fired; silent `continue`)
- **Post-fix:** verified PASSES after `7abae510`; release build verified no-panic (assert compiled out)

A `pub(super) fn attempt_accept_prepared_for_test` shim (mirroring `set_accept_prepared_for_test`) exposes the private method to the test. The test builds a CONFIRM-phase state where a candidate `{2, V_a}` passes the prepared-compat filter (`prepared={1, V_a}`) but `commit={1, V_b}` is commit-incompatible — violating `p ~ c` — and asserts a panic in debug / no-panic in release via `catch_unwind` + `cfg!(debug_assertions)`.

## Deviations from plan

The plan referenced a `do_bootstrap` helper that does not exist in the contract lib (only `plan_critic_bootstrap` / `review_pr_bootstrap`); per instructions, the `~/data/<session>/do-3093/` workspace contract was replicated inline using `require_home_data_path`. The plan's draft assumed `attempt_accept_prepared` could be called from the test shim as-is; it was module-private, so its visibility was widened to `pub(super)` (matching the sibling `set_accept_prepared`) — committed alongside the failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)