### PR TITLE
Sanitize received ERROR_MSG bytes before logging (OVERLAY §7.1.3-1)

### DIFF
--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -37,6 +37,7 @@ mod peer_loop;
 mod tick;
 
 pub use connection::AddPeerOutcome;
+pub(crate) use peer_loop::sanitize_error_msg;
 
 use crate::{
     codec::helpers,

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -1379,6 +1379,36 @@ mod tests {
         assert_eq!(truncate_error_msg(""), "");
     }
 
+    // OVERLAY §7.1.3-1: ERROR_MSG sanitization on receipt. Mirrors
+    // stellar-core `Peer::recvError` (Peer.cpp:1698-1733): every byte that is
+    // not ASCII-alphanumeric and not a space is replaced with `*`.
+
+    #[test]
+    fn test_sanitize_error_msg_replaces_control_and_ansi() {
+        // `error` kept, ESC(0x1b)->*, `[`->*, `31` kept, `m` kept, `red` kept,
+        // NUL(0x00)->*.
+        assert_eq!(
+            sanitize_error_msg(b"error\x1b[31mred\x00"),
+            "error**31mred*"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_error_msg_high_bytes() {
+        // Bytes > 0x7f are non-ASCII-alphanumeric -> `*`.
+        assert_eq!(sanitize_error_msg(b"a\xff\x80z"), "a**z");
+    }
+
+    #[test]
+    fn test_sanitize_error_msg_preserves_alnum_space() {
+        assert_eq!(sanitize_error_msg(b"valid error 123"), "valid error 123");
+    }
+
+    #[test]
+    fn test_sanitize_error_msg_empty() {
+        assert_eq!(sanitize_error_msg(b""), "");
+    }
+
     #[test]
     fn test_make_error_msg_creates_valid_xdr() {
         let msg = make_error_msg(ErrorCode::Load, "peer rejected");

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -307,6 +307,30 @@ pub(super) fn make_error_msg(code: ErrorCode, message: &str) -> StellarMessage {
     StellarMessage::ErrorMsg(SError { code, msg })
 }
 
+/// Sanitize a received ERROR_MSG body for logging (OVERLAY §7.1.3-1).
+///
+/// Mirrors stellar-core `Peer::recvError` (Peer.cpp:1698-1733): the message is
+/// built with `std::transform` over the raw `msg.error().msg` bytes using
+/// `(isAsciiAlphaNumeric(c) || c == ' ') ? c : '*'`. Every byte that is not
+/// ASCII-alphanumeric and not a space — including control chars, ANSI escape
+/// sequences, DEL (0x7f), and high bytes (> 0x7f) — is replaced with `*`.
+///
+/// IMPORTANT: this operates on the raw `StringM` bytes (`&err.msg[..]`), NOT on
+/// `StringM::to_string()`, which already escapes non-printable bytes via
+/// `escape_bytes` (e.g. `0x1b` renders as the 4 chars `\x1b`). Sanitizing the
+/// escaped string would not match stellar-core's per-byte transform.
+pub(crate) fn sanitize_error_msg(raw: &[u8]) -> String {
+    raw.iter()
+        .map(|&b| {
+            if b.is_ascii_alphanumeric() || b == b' ' {
+                b as char
+            } else {
+                '*'
+            }
+        })
+        .collect()
+}
+
 /// Send an error to a peer then request its task to shut down.
 ///
 /// Matches stellar-core `Peer::sendErrorAndDrop` (Peer.cpp:722-729).
@@ -1094,21 +1118,23 @@ impl OverlayManager {
         let msg_type = helpers::message_type_name(&message);
         trace!("Processing message_type={} from {}", msg_type, peer_id);
 
-        // Log ERROR messages (Load rejections are expected, log at debug)
+        // Log ERROR messages (Load rejections are expected, log at debug).
+        // OVERLAY §7.1.3-1: sanitize the raw message bytes before logging (do
+        // NOT use `to_string()`, which escapes rather than collapses bytes).
         if let StellarMessage::ErrorMsg(ref err) = message {
             if err.code == ErrorCode::Load {
                 debug!(
                     "Peer sent_error peer={} code={:?} msg={}",
                     peer_id,
                     err.code,
-                    err.msg.to_string()
+                    sanitize_error_msg(&err.msg[..])
                 );
             } else {
                 warn!(
                     "Peer sent_error peer={} code={:?} msg={}",
                     peer_id,
                     err.code,
-                    err.msg.to_string()
+                    sanitize_error_msg(&err.msg[..])
                 );
             }
             // Parity: stellar-core's recvError() unconditionally

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -26,7 +26,7 @@ use crate::{
     codec::helpers,
     connection::{Connection, ConnectionDirection},
     flow_control::msg_body_size,
-    manager::PendingPeerEntry,
+    manager::{sanitize_error_msg, PendingPeerEntry},
     metrics::{OverlayMessageKind, OverlayMetrics},
     LocalNode, OverlayError, PeerAddress, PeerId, Result,
 };
@@ -652,7 +652,10 @@ impl Peer {
                 self.auth.process_auth()?;
             }
             StellarMessage::ErrorMsg(err) => {
-                let err_msg: String = err.msg.to_string();
+                // OVERLAY §7.1.3-1: sanitize raw message bytes before logging /
+                // storing (NOT `to_string()`, which escapes instead of
+                // collapsing non-printable bytes to `*`).
+                let err_msg: String = sanitize_error_msg(&err.msg[..]);
                 warn!("Peer sent error: code={:?}, msg={}", err.code, err_msg);
                 return Err(OverlayError::InvalidMessage(format!(
                     "peer sent ERROR: code={:?}, msg={}",


### PR DESCRIPTION
Closes #3074

## Summary

On receiving an `ERROR_MSG`, henyey logged the message body unsanitized. The spec (OVERLAY §7.1.3-1, SHOULD) and stellar-core `Peer::recvError` (`Peer.cpp:1698-1733`) require that every byte that is not ASCII-alphanumeric and not a space be replaced with `*` before logging or storing. This PR adds `pub(crate) fn sanitize_error_msg(raw: &[u8]) -> String` in `manager::peer_loop` and applies it at both inbound `ERROR_MSG` log sites.

The helper operates on the **raw `StringM` bytes** (`&err.msg[..]`), not `StringM::to_string()`. `StringM`'s `Display` escapes non-printable bytes via `escape_bytes` (e.g. `0x1b` renders as the 4 chars `\x1b`), so sanitizing the escaped string would not match stellar-core's per-byte `std::transform`. `u8::is_ascii_alphanumeric() || == b' '` is exact parity with upstream `isAsciiAlphaNumeric(c) || c == ' '`; all other bytes (control, ANSI, DEL `0x7f`, high bytes `> 0x7f`) map to one `*`. The send-side `make_error_msg`/`truncate_error_msg` path is untouched; `StringM<100>` already bounds received length, so no receive-side truncation is needed (matching upstream).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3074#issuecomment-4626211288)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-overlay passes (470 lib + integration tests green)

## Regression test (kind: bug-fix)

- **Test:** `crates/overlay/src/manager/peer_loop.rs::test_sanitize_error_msg_replaces_control_and_ansi` (+ `_high_bytes`, `_preserves_alnum_space`, `_empty`)
- **Pre-fix:** committed as `e3840010` — verified FAILED on `origin/main` with `error[E0425]: cannot find function sanitize_error_msg in this scope` (no sanitizer exists; `to_string()` would escape-render bytes rather than collapse to `*`).
- **Post-fix:** verified PASSES after `97eaa947` — `test_sanitize_error_msg_replaces_control_and_ansi` asserts `b"error\x1b[31mred\x00"` → `"error**31mred*"`; `_high_bytes` asserts `b"a\xff\x80z"` → `"a**z"`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)