### PR TITLE
Align DEFAULT_CHUNK_SIZE with stellar-core LEDGER_ENTRY_BATCH_COMMIT_SIZE

### DIFF
--- a/crates/bucket/src/applicator.rs
+++ b/crates/bucket/src/applicator.rs
@@ -45,7 +45,14 @@ use crate::entry::{ledger_entry_data_type, ledger_key_type, BucketEntry};
 use crate::Result;
 
 /// Default number of entries to process in each chunk.
-pub const DEFAULT_CHUNK_SIZE: usize = 10_000;
+///
+/// Matches stellar-core's `LEDGER_ENTRY_BATCH_COMMIT_SIZE` (`0xfff` = 4095) in
+/// `src/ledger/LedgerTxn.h`. Per BUCKETLISTDB spec §16.2 this is a
+/// performance/memory-chunking parameter only: it controls the interleaving
+/// granularity and per-batch memory footprint during catchup. It does NOT
+/// affect the `bucketListHash` or any other consensus-deterministic output —
+/// the applicator yields identical entries regardless of batch size.
+pub const DEFAULT_CHUNK_SIZE: usize = 4095;
 
 // ============================================================================
 // Applicator Counters


### PR DESCRIPTION
Closes #3020

## Summary

Aligns the catchup applicator's `DEFAULT_CHUNK_SIZE` from `10_000` to `4095` (`0xfff`), matching stellar-core's `LEDGER_ENTRY_BATCH_COMMIT_SIZE` in `src/ledger/LedgerTxn.h` and the BUCKETLISTDB spec §13.1. Adds a doc comment citing stellar-core and spec §16.2.

Per spec §16.2 this is a performance/memory-chunking parameter only — it controls interleaving granularity and per-batch memory footprint during catchup. It does **NOT** affect the `bucketListHash` or any consensus-deterministic output: the applicator returns identical entries regardless of batch size.

## Plan reference

Trivial short-circuit — implemented from the `## Implementation Notes` section of the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3020#issuecomment-4626404495).

## Verification of zero behavioral/hash change

- The constant is referenced only as a default at `applicator.rs:219`; nothing asserts the specific `10_000` value.
- All applicator/catchup unit + integration tests use explicit `with_chunk_size(...)` values and are independent of the default. They pass unchanged.
- The batch size affects only how entries are grouped per yield; the set of applied entries — and thus the bucket-list hash — is identical.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-bucket -- -D warnings` clean
- [x] `cargo test -p henyey-bucket` — 524 tests pass, 0 failures (unchanged outcomes)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)