### PR TITLE
Fire ballot_did_confirm callback in set_confirm_prepared (SCP §6.5-1)

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -2232,6 +2232,97 @@ mod tests {
     }
 
     #[test]
+    fn test_ballot_confirmed_prepared_callback() {
+        // SCP §6.5-1: `set_confirm_prepared` must fire the `ballot_did_confirm`
+        // (confirmedBallotPrepared) SCPDriver callback when a ballot is
+        // confirmed prepared (high ballot raised inside the `did_work` block),
+        // mirroring stellar-core `BallotProtocol::setConfirmPrepared`
+        // (BallotProtocol.cpp:1074-1075).
+        //
+        // Drives prepare -> confirm-prepared following the same proven envelope
+        // pattern as `test_ballot_accepted_commit_callback`: a fresh ballot
+        // bumped to a value, then a quorum's worth of PREPARE statements
+        // carrying `prepared`/`n_c`/`n_h` to confirm the ballot prepared (which
+        // also drives the slot into the Confirm phase). The callback must fire
+        // on that transition.
+        let node = make_node_id(1);
+        let node2 = make_node_id(2);
+        let node3 = make_node_id(3);
+        let node4 = make_node_id(4);
+        let node5 = make_node_id(5);
+        let quorum_set = make_quorum_set(
+            vec![
+                node.clone(),
+                node2.clone(),
+                node3.clone(),
+                node4.clone(),
+                node5.clone(),
+            ],
+            4,
+        );
+        let driver = Arc::new(MockDriver::with_quorum_set(quorum_set.clone()));
+        let mut ballot = BallotProtocol::new();
+
+        let value = make_value(&[9]);
+        assert!(ballot.bump(&ctx!(&node, &quorum_set, &driver, 16), value.clone(), false));
+
+        // A plain bump (PREPARE only, no confirm-prepared) must NOT fire the
+        // callback — it lives strictly inside the `did_work` confirm-prepared
+        // path.
+        assert_eq!(driver.confirmed_prepared_count.load(Ordering::SeqCst), 0);
+
+        let current = ballot.current_ballot().expect("current ballot").clone();
+        let prep2 = make_prepare_envelope(node2.clone(), 16, &quorum_set, current.clone());
+        let prep3 = make_prepare_envelope(node3.clone(), 16, &quorum_set, current.clone());
+        let prep4 = make_prepare_envelope(node4.clone(), 16, &quorum_set, current.clone());
+        let prep5 = make_prepare_envelope(node5.clone(), 16, &quorum_set, current.clone());
+
+        for env in [&prep2, &prep3, &prep4, &prep5] {
+            ballot.process_envelope(
+                env,
+                &ctx!(&node, &quorum_set, &driver, 16),
+                crate::ValidationLevel::FullyValidated,
+            );
+        }
+
+        // Still only accept-prepared (no quorum confirming the ballot prepared
+        // yet) — confirm-prepared has not happened.
+        assert_eq!(driver.confirmed_prepared_count.load(Ordering::SeqCst), 0);
+
+        let make_prepared = |n: NodeId| {
+            make_prepare_envelope_with_counters(
+                n,
+                16,
+                &quorum_set,
+                current.clone(),
+                PrepareEnvelopeCounters {
+                    prepared: Some(current.clone()),
+                    prepared_prime: None,
+                    n_c: current.counter,
+                    n_h: current.counter,
+                },
+            )
+        };
+        let prepared2 = make_prepared(node2.clone());
+        let prepared3 = make_prepared(node3.clone());
+        let prepared4 = make_prepared(node4.clone());
+        let prepared5 = make_prepared(node5.clone());
+
+        for env in [&prepared2, &prepared3, &prepared4, &prepared5] {
+            ballot.process_envelope(
+                env,
+                &ctx!(&node, &quorum_set, &driver, 16),
+                crate::ValidationLevel::FullyValidated,
+            );
+        }
+
+        // Confirm-prepared reached: the high ballot was raised inside the
+        // `did_work` block, so the callback fired at least once.
+        assert!(matches!(ballot.phase(), BallotPhase::Confirm));
+        assert!(driver.confirmed_prepared_count.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[test]
     fn test_ballot_statement_sanity_prepare_constraints() {
         let node = make_node_id(1);
         let quorum_set = make_quorum_set(vec![node.clone()], 1);

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -279,6 +279,13 @@ impl BallotProtocol {
 
         did_work = self.update_current_if_needed(&new_h, ctx) || did_work;
         if did_work {
+            // Fire the confirm-prepared notification callback (SCP §6.5-1),
+            // with `new_h` being the high ballot, mirroring stellar-core
+            // BallotProtocol::setConfirmPrepared (BallotProtocol.cpp:1074-1075).
+            // Ordered update_current_if_needed -> ballot_did_confirm ->
+            // emit_current_state, matching the accepted_commit ordering in
+            // set_accept_commit (SCP §6.5-2).
+            ctx.driver.ballot_did_confirm(ctx.slot_index, &new_h);
             self.emit_current_state(ctx);
         }
 

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -34,6 +34,8 @@ pub struct MockDriver {
     pub heard_from_quorum: AtomicU32,
     /// Counts how many times `accepted_commit` was called.
     pub accepted_commit_count: AtomicU32,
+    /// Counts how many times `ballot_did_confirm` was called.
+    pub confirmed_prepared_count: AtomicU32,
     /// Records the `ScpBallot` passed to each `started_ballot_protocol` call,
     /// in order. Lets tests assert fire-once and the exact ballot fired.
     pub ballot_starts: std::sync::Mutex<Vec<ScpBallot>>,
@@ -118,6 +120,7 @@ impl MockDriverBuilder {
             emit_count: AtomicU32::new(0),
             heard_from_quorum: AtomicU32::new(0),
             accepted_commit_count: AtomicU32::new(0),
+            confirmed_prepared_count: AtomicU32::new(0),
             ballot_starts: std::sync::Mutex::new(Vec::new()),
             return_qset_by_hash: self.return_qset_by_hash,
             custom_node_weight: None,
@@ -200,7 +203,9 @@ impl SCPDriver for MockDriver {
 
     fn ballot_did_prepare(&self, _slot_index: u64, _ballot: &ScpBallot) {}
 
-    fn ballot_did_confirm(&self, _slot_index: u64, _ballot: &ScpBallot) {}
+    fn ballot_did_confirm(&self, _slot_index: u64, _ballot: &ScpBallot) {
+        self.confirmed_prepared_count.fetch_add(1, Ordering::SeqCst);
+    }
 
     fn ballot_did_hear_from_quorum(&self, _slot_index: u64, _ballot: &ScpBallot) {
         self.heard_from_quorum.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
Closes #3087

## Summary

Closes spec gap SCP §6.5-1: `BallotProtocol::set_confirm_prepared` now invokes the `SCPDriver::ballot_did_confirm` (confirmedBallotPrepared) callback when a ballot is confirmed prepared (the high ballot `new_h` is raised inside the `did_work` block). The callback was declared on the `SCPDriver` trait but never invoked — it was dead. The invocation is ordered `update_current_if_needed` -> `ballot_did_confirm` -> `emit_current_state`, mirroring stellar-core `BallotProtocol::setConfirmPrepared` (BallotProtocol.cpp:1074-1075) and matching the `accepted_commit` wiring landed in #3088. All real implementors (`HerderSCPDriver`) treat `ballot_did_confirm` as a no-op, so there is no downstream behavior change.

## Plan reference

Trivial short-circuit — see the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3087#issuecomment-4626402951) (ACCEPT, trivial, XS) and its Implementation Notes.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-scp -- -D warnings (clean)
- [x] cargo test -p henyey-scp passes (382 lib tests incl. new test, all integration suites green)

## Regression test (kind: enhancement / spec-adherence)

- **Test:** `crates/scp/src/ballot/mod.rs::test_ballot_confirmed_prepared_callback`
- **Pre-fix:** committed as `77f0ea8c` — verified FAILED with: `assertion failed: driver.confirmed_prepared_count.load(Ordering::SeqCst) >= 1` (callback never fired, count stayed 0).
- **Post-fix:** verified PASSES after `2d275807`.

Adds a `confirmed_prepared_count` counter to `MockDriver` (mirroring `accepted_commit_count` from #3088) and asserts the callback fires on the confirm-prepared transition.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)