### PR TITLE
Make live post-close hash mismatch fatal

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2213,11 +2213,26 @@ impl App {
                         tracked_lock::tracked_write("syncing_ledgers", &self.syncing_ledgers).await;
                     let cleared_count = buffer.len();
                     buffer.clear();
+                    drop(buffer);
                     tracing::warn!(
                         ledger_seq = pending.ledger_seq,
                         cleared_count,
-                        "Hash mismatch detected - cleared all buffered ledgers, will trigger catchup"
+                        "Hash mismatch detected during live close - local state corrupted"
                     );
+                    // Spec LEDGER §4.2-Step15 / §4.10-Step25 (MUST): an
+                    // expected/computed LCL hash mismatch on the live
+                    // post-close path is an SCP/local-corruption divergence
+                    // and is FATAL — it is NOT a recoverable re-sync. This
+                    // mirrors stellar-core `LedgerManagerImpl::closeLedger`
+                    // (LedgerManagerImpl.cpp:1738-1752), which throws
+                    // "Local node's ledger corrupted during close" rather than
+                    // swallowing the divergence into a catchup. The genuinely
+                    // recoverable bucket-apply re-sync lives in catchup_impl.rs
+                    // (a different path) and is intentionally untouched.
+                    self.trigger_fatal_shutdown(&format!(
+                        "local node's ledger corrupted during close (ledger {})",
+                        pending.ledger_seq
+                    ));
                 }
                 // Clear the closing gate — LCL hasn't advanced, so buffered
                 // envelopes would still hit the apply-lag path (issue #2122).

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -8704,6 +8704,72 @@ mod tests {
         );
     }
 
+    /// Regression for #3056 (spec LEDGER §4.2-Step15 / §4.10-Step25): a live
+    /// post-close expected-hash mismatch is an SCP/local-corruption divergence
+    /// that MUST be fatal, matching stellar-core
+    /// `LedgerManagerImpl::closeLedger`'s "Local node's ledger corrupted during
+    /// close" throw. The background close task returning
+    /// `Err(LedgerError::HashMismatch{..})` must drive
+    /// `handle_close_complete` to set `fatal_state_failure = true` (and still
+    /// return false / drop the deferred sender). On `origin/main` this arm only
+    /// set a recovery phase + cleared the buffer, leaving the flag false — so
+    /// this test FAILS before the fix and PASSES after.
+    #[tokio::test]
+    async fn test_post_close_hash_mismatch_triggers_fatal_shutdown() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+        app.set_applying_ledger(true);
+
+        // Sanity: not already in a fatal state.
+        assert!(
+            !app.fatal_state_failure.load(Ordering::SeqCst),
+            "fatal_state_failure should start false"
+        );
+
+        let mut pending = make_test_pending_close(
+            tokio::task::spawn_blocking(|| {
+                Err(henyey_ledger::LedgerError::HashMismatch {
+                    expected: "expected_hash".to_string(),
+                    actual: "actual_hash".to_string(),
+                })
+            }),
+            1,
+        );
+        let join_result = (&mut pending.handle).await;
+
+        let (persist_tx, mut persist_rx) = tokio::sync::oneshot::channel();
+        let success = app
+            .handle_close_complete(
+                pending,
+                join_result,
+                super::persist::LedgerCloseFinalizer::deferred(persist_tx),
+            )
+            .await;
+
+        assert!(
+            !success,
+            "handle_close_complete should return false on hash mismatch"
+        );
+        // The load-bearing assertion: a live post-close hash mismatch must be
+        // fatal, not a recoverable re-sync.
+        assert!(
+            app.fatal_state_failure.load(Ordering::SeqCst),
+            "post-close hash mismatch must trigger fatal shutdown (#3056)"
+        );
+        // The deferred sender is still dropped (no persist) on the error path.
+        assert!(
+            matches!(
+                persist_rx.try_recv(),
+                Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+            ),
+            "deferred sender must be dropped (not sent) on hash mismatch path"
+        );
+    }
+
     #[tokio::test]
     async fn test_deferred_close_persist_lifecycle() {
         let dir = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
Closes #3056

## Summary

A live event-loop post-close expected/computed LCL hash mismatch in `handle_close_complete_inner` (`crates/app/src/app/ledger_close.rs`) is an SCP/local-corruption divergence that MUST be fatal per spec LEDGER §4.2-Step15 / §4.10-Step25, matching stellar-core `LedgerManagerImpl::closeLedger`'s `throw runtime_error("Local node's ledger corrupted during close")` (`LedgerManagerImpl.cpp:1738-1752`). Previously this arm only set `PHASE_6_1_SYNCING_LEDGERS_HASH_MISMATCH`, cleared buffered ledgers, and returned false — treating the divergence as a recoverable re-sync. It now also calls `trigger_fatal_shutdown` (setting `fatal_state_failure = true` and halting the node), while keeping `clear_closing_gate()` and `return false` for clean teardown.

The genuinely-recoverable bucket-apply re-sync in `crates/app/src/app/catchup_impl.rs:2563-2598` and the already-fatal `ReplayHashMismatch` classification are untouched; the ledger crate keeps its recoverable `Err(HashMismatch)` type. Only the live post-close arm becomes fatal.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3056#issuecomment-4626492522)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-app -- -D warnings
- [x] cargo test -p henyey-app passes (994 lib + integration tests, 0 failures)
- [x] AUDIT-255 catchup recovery tests (`catchup_impl.rs:5318-5375`) stay green — recoverable re-sync preserved

## Regression test (kind: bug-fix)

- **Test:** `crates/app/src/app/mod.rs::test_post_close_hash_mismatch_triggers_fatal_shutdown`
- **Pre-fix:** committed as `228a4bf70d3625e9c6a814fd331fffb8ac68bf23` — verified FAILED with: `post-close hash mismatch must trigger fatal shutdown (#3056)` (`fatal_state_failure` stayed false)
- **Post-fix:** verified PASSES after `c5d868749c481b61c7b592eff0665bf6ccbd761e`

## Deviations from plan

None. (Added a `drop(buffer)` before the fatal call to release the `syncing_ledgers` write guard early; behavior-neutral.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)