### PR TITLE
Document §4.11/INV-L13 commit-sequence mapping; disambiguate §4.2 8-step comment

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -115,6 +115,42 @@ struct LedgerPersistInputs {
 
 impl LedgerPersistInputs {
     /// Serialize XDR/JSON and write to SQLite on a blocking thread.
+    ///
+    /// LEDGER_SPEC §4.11 / §15.13 / INV-L13 mapping (#3066). stellar-core's
+    /// §4.11 commit/persist sequence prescribes 8 ordered steps; henyey
+    /// *flattens* the durable subset of them into the single atomic
+    /// `db.transaction` closure below. This is equivalent-or-stronger than the
+    /// stepwise approach, not a regression — there is no observable window in
+    /// which the persisted state is partially advanced.
+    ///
+    ///   - **§4.11 Step 1 (queue checkpoint):** `enqueue_publish` (below) runs
+    ///     *inside* this same transaction on checkpoint ledgers, so the publish
+    ///     queue entry and the ledger state commit either both land or neither
+    ///     does (co-transactional, per #3057) — stronger than stellar-core's
+    ///     separate-step queueing.
+    ///   - **§4.11 Step 2 (commit LedgerTxn):** the header, tx history/results,
+    ///     bucket-list snapshot, per-tx rows, contract events, and SCP history
+    ///     are all written in this one transaction.
+    ///   - **INV-L13 (MUST): on reload, persisted HAS and persisted LCL header
+    ///     MUST agree on `ledgerSeq`.** Henyey satisfies this *by construction*:
+    ///     the HAS write (`set_state(HISTORY_ARCHIVE_STATE)`) and the LCL write
+    ///     (`set_last_closed_ledger`) below are both inside this single atomic
+    ///     transaction, so a crash either commits both (agreeing on `ledgerSeq`)
+    ///     or neither. No torn intermediate state is observable on reload.
+    ///   - **§4.11 Step 3 (finalize checkpoint files):** performed by the
+    ///     bucket/hot-archive flush in `persist::PersistJob::run_blocking`
+    ///     *before* this DB write — see that function.
+    ///   - **§4.11 Steps 7-8 (advance LCL+publish+GC, notify herder):** realized
+    ///     post-persist in `handle_close_complete_inner` (see the bucket-GC and
+    ///     herder-notify annotations there).
+    ///   - **§4.11 Steps 5-6 (copy Soroban state for the invariant snapshot):**
+    ///     intentionally absent — the state-snapshot invariant hook is not yet
+    ///     wired (`crates/invariant/PARITY_STATUS.md`, "Snapshot hook not yet
+    ///     wired"). That is separate work, NOT part of #3066. Do not infer from
+    ///     this comment that the snapshot copy happens here.
+    ///
+    /// No ordering, control-flow, or transaction-boundary change is implied by
+    /// this comment; it is traceability annotation only.
     fn serialize_and_write_to_db(&self, db: &henyey_db::Database) -> anyhow::Result<()> {
         use henyey_db::queries::*;
 
@@ -2882,6 +2918,24 @@ impl App {
         // Signal heartbeat to sync recovery.
         self.sync_recovery_heartbeat();
 
+        // LEDGER_SPEC §4.11 Steps 7-8 (#3066): this function is henyey's
+        // "main thread" analog for the post-seal commit sequence. stellar-core
+        // runs Steps 7-8 (advance LCL + publish queued history + GC buckets,
+        // then notify herder + take invariant snapshot) on the main thread in
+        // `advanceLedgerStateAndPublish` → `publishQueuedHistory` /
+        // `forgetUnreferencedBuckets` / `ledgerCloseComplete`. Henyey runs the
+        // equivalent work here on the single event loop:
+        //   - LCL advance / history publish are durable via the atomic
+        //     transaction in `LedgerPersistInputs::serialize_and_write_to_db`
+        //     (LCL write + checkpoint `enqueue_publish`); the publish-queue
+        //     processor drains those entries asynchronously.
+        //   - Step 7 bucket GC = `cleanup_stale_bucket_files_background()` below.
+        //   - Step 8 herder notify = the `herder.advance_tracking_to` /
+        //     `herder.bootstrap` calls earlier in this function.
+        //   - Step 8's invariant-snapshot half is intentionally absent — the
+        //     snapshot hook is not yet wired (`crates/invariant/PARITY_STATUS.md`,
+        //     "Snapshot hook not yet wired"); separate work, NOT part of #3066.
+        //
         // Garbage collect stale bucket files after every ledger close, matching
         // stellar-core's unconditional `forgetUnreferencedBuckets` in
         // `advanceLedgerStateAndPublish` (LedgerManagerImpl.cpp:1429). The work

--- a/crates/app/src/app/persist.rs
+++ b/crates/app/src/app/persist.rs
@@ -302,8 +302,19 @@ impl PersistJob {
             } => {
                 let persist_start = std::time::Instant::now();
 
+                // LEDGER_SPEC §4.11 Step 3 (#3066): "finalize checkpoint files".
+                // Henyey finalizes the on-disk bucket and hot-archive files via
+                // this flush, which runs *before* the DB write below so the
+                // bucket files referenced by the about-to-be-committed HAS are
+                // durable on disk first. (The publish-queue enqueue itself, the
+                // §4.11 Step 1 "queue checkpoint", is co-transactional inside
+                // `write_fn` — see `LedgerPersistInputs::serialize_and_write_to_db`.)
                 flush_hot_archive_and_buckets_sync(&ledger_manager, &bucket_dir);
 
+                // LEDGER_SPEC §4.11 Step 2 (#3066): "commit LedgerTxn". This is
+                // the single atomic SQLite transaction that co-writes header,
+                // HAS, and LCL (the INV-L13 agreement guarantee). Ordering is
+                // unchanged by #3066; this comment is traceability only.
                 if let Err(e) = write_fn(&db) {
                     fatal_persist_error("ledger close DB write", &e);
                 }

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -4781,7 +4781,8 @@ impl LedgerCloseContext<'_> {
 
     /// Commit the ledger close: finalize state, update bucket list, build header.
     ///
-    /// LEDGER_SPEC §4.2 / §15.13 / Appendix E — commit sequence:
+    /// LEDGER_SPEC **§4.2** / §15.13 / Appendix E — the *in-seal* 8-step commit
+    /// sequence (ledger-state sealing, all on the close thread):
     ///   1. Compute tx result hash
     ///   2. Apply upgrades
     ///   3. Update bucket list with delta
@@ -4794,6 +4795,33 @@ impl LedgerCloseContext<'_> {
     /// Henyey combines some of these steps (e.g., bucket list update and hash
     /// computation happen together under a single write lock), but the logical
     /// ordering is preserved.
+    ///
+    /// IMPORTANT — disambiguation (#3066): this **§4.2** list is NOT the same as
+    /// the spec **§4.11** 8-step *commit/persist* sequence (queue checkpoint →
+    /// commit LedgerTxn → finalize checkpoint files → start bg eviction → exit
+    /// COMMITTING → copy Soroban state for invariant → advance LCL + publish
+    /// history + GC buckets → notify herder + invariant snapshot). Both lists
+    /// happen to have eight steps and both use the word "commit", which is the
+    /// exact collision that produced the §15.13 / INV-L13 spec-adherence
+    /// finding. The two map to different henyey code:
+    ///   - §4.2 (this function): in-`commit` sealing of ledger state.
+    ///   - §4.11 (post-seal, cross-thread): realized by the persist pipeline —
+    ///     the single atomic SQLite transaction in
+    ///     `app::ledger_close::LedgerPersistInputs::serialize_and_write_to_db`
+    ///     (Steps 1-2), the bucket/hot-archive flush in
+    ///     `app::persist::PersistJob::run_blocking` (Step 3), and the
+    ///     post-persist bookkeeping (LCL advance / history publish / bucket GC /
+    ///     herder notify) in `app::ledger_close::handle_close_complete_inner`
+    ///     (Steps 7-8). See those sites for the full INV-L13 mapping.
+    ///
+    /// Note on the two lists' shared steps: §4.2 Step 4 (eviction scan) is the
+    /// same eviction work the §4.11 list calls "start bg eviction" — henyey runs
+    /// it here, inside `commit`, rather than as a separate post-commit
+    /// background scan. The §4.11 "copy Soroban state for invariant" step (its
+    /// Steps 5-6) has no henyey counterpart in either list: the state-snapshot
+    /// invariant hook is not yet wired (`crates/invariant/PARITY_STATUS.md`,
+    /// "Snapshot hook not yet wired") and is tracked as separate work, NOT part
+    /// of #3066.
     fn commit(mut self, rss_before: u64) -> Result<LedgerCloseResult> {
         tracing::debug!(
             ledger_seq = self.close_data.ledger_seq,


### PR DESCRIPTION
Closes #3066

## Summary

Doc-only change (zero behavioral / ordering / transaction-boundary change) adding §4.11 8-step / INV-L13 traceability comments to henyey's commit-persist path, and disambiguating the existing §4.2-vs-§4.11 "8-step" comment in `manager.rs`.

- `crates/app/src/app/ledger_close.rs`: documents `serialize_and_write_to_db` as the single atomic SQLite transaction realizing §4.11 Steps 1-2 (co-transactional checkpoint enqueue + commit LedgerTxn), and states the **INV-L13** guarantee that the HAS write (`set_state(HISTORY_ARCHIVE_STATE)`) and LCL write (`set_last_closed_ledger`) in one transaction make persisted HAS and LCL agree on `ledgerSeq` at reload *by construction* — equivalent-or-stronger than the stepwise approach. Annotates `handle_close_complete_inner` as the event-loop "main thread" analog for §4.11 Steps 7-8 (advance LCL + publish + GC buckets, notify herder).
- `crates/app/src/app/persist.rs`: ties the bucket/hot-archive flush + DB write in `run_blocking` to §4.11 Step 3 (finalize checkpoint files) and Step 2 (commit).
- `crates/ledger/src/manager.rs`: **highest-value fix** — disambiguates the existing `commit` doc-comment, which labels a *different* §4.2 in-seal 8-step list that collides phrasing-wise with the §4.11 sequence this issue cites. That latent ambiguity is exactly what produced the spec-adherence finding.

Documents (does **not** implement) that the §4.11 Step 5/6 Soroban invariant-snapshot copy is a separate, unwired hook (`crates/invariant/PARITY_STATUS.md`, "Snapshot hook not yet wired"), out of scope for this ordering issue.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3066#issuecomment-4626831848)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build -p henyey-app -p henyey-ledger` (comments only — compiles clean)
- [x] `cargo clippy -p henyey-app -p henyey-ledger -- -D warnings` clean
- [x] Verified the diff is comments-only: every added/removed line is a `//`/`///` comment or blank (the single deletion is the replaced `manager.rs` doc-comment line). No logic, control-flow, ordering, or transaction-boundary change.

## Deviations from plan

None. Per Critic C's REVISE-MINOR: **close-WAD remains an acceptable fallback** — if review finds these comments add no clarity beyond §4.14 / the pre-existing comments, closing the issue work-as-designed (no code change) is legitimate. Doc-only is preferred only because it fixes the stale `manager.rs` §4.2-vs-§4.11 "8-step" ambiguity, which a pure close-WAD would leave in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)