### PR TITLE
Align §4.4.2 handshake error strings with stellar-core wording

### DIFF
--- a/crates/overlay/src/error.rs
+++ b/crates/overlay/src/error.rs
@@ -55,11 +55,20 @@ pub enum OverlayError {
     InvalidMessage(String),
 
     /// Peer's overlay protocol version is incompatible.
-    #[error("protocol version mismatch: {0}")]
+    ///
+    /// The `Display` string mirrors stellar-core's on-the-wire handshake error
+    /// exactly (`Peer.cpp:1851`, OVERLAY_SPEC §4.4.2-7): `"wrong protocol
+    /// version"`. The wrapped `String` carries the divergence detail (below
+    /// minimum / above maximum / malformed) for local diagnostics and tests —
+    /// stellar-core likewise logs that detail separately (`CLOG_DEBUG`) rather
+    /// than sending it to the peer.
+    #[error("wrong protocol version")]
     VersionMismatch(String),
 
-    /// Peer is on a different network (network ID doesn't match).
-    #[error("network ID mismatch")]
+    /// Peer is on a different network (network passphrase doesn't match).
+    ///
+    /// Mirrors stellar-core `Peer.cpp:1869` / OVERLAY_SPEC §4.4.2-9.
+    #[error("wrong network passphrase")]
     NetworkMismatch,
 
     // ===== Peer Management Errors =====
@@ -80,8 +89,12 @@ pub enum OverlayError {
     PeerDuplicate(String),
 
     /// Already have an active connection to this peer.
-    #[error("already connected to peer")]
-    AlreadyConnected,
+    ///
+    /// Mirrors stellar-core `Peer.cpp:1890` / OVERLAY_SPEC §4.4.2-12. The
+    /// wrapped `String` is the peer ID being rejected (stellar-core appends
+    /// `Config::toShortString(mPeerID)`); henyey renders the strkey peer ID.
+    #[error("already-connected peer: {0}")]
+    AlreadyConnected(String),
 
     // ===== State Errors =====
     /// Operation requires the overlay to be running.
@@ -155,5 +168,41 @@ impl OverlayError {
             self,
             OverlayError::NetworkMismatch | OverlayError::VersionMismatch(_)
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Handshake error strings must mirror stellar-core `Peer.cpp` and
+    // OVERLAY_SPEC §4.4.2 exactly (issue #3080). These assert the on-the-wire
+    // `Display` wording, which is what gets sent to the peer in ERROR_MSG.
+
+    #[test]
+    fn test_version_mismatch_display_matches_spec() {
+        // §4.4.2-7 / Peer.cpp:1851. The wrapped detail is for local diagnostics
+        // only and must NOT leak into the wire string.
+        let err = OverlayError::VersionMismatch("below minimum".to_string());
+        assert_eq!(err.to_string(), "wrong protocol version");
+    }
+
+    #[test]
+    fn test_network_mismatch_display_matches_spec() {
+        // §4.4.2-9 / Peer.cpp:1869.
+        let err = OverlayError::NetworkMismatch;
+        assert_eq!(err.to_string(), "wrong network passphrase");
+    }
+
+    #[test]
+    fn test_already_connected_display_matches_spec() {
+        // §4.4.2-12 / Peer.cpp:1890 — includes the rejected peer ID.
+        let err = OverlayError::AlreadyConnected(
+            "GABC123EXAMPLEPEERID00000000000000000000000000000000000".to_string(),
+        );
+        assert_eq!(
+            err.to_string(),
+            "already-connected peer: GABC123EXAMPLEPEERID00000000000000000000000000000000000"
+        );
     }
 }

--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -279,7 +279,7 @@ impl OverlayManager {
                 let existing_direction = e.get().direction;
                 if existing_direction == new_direction {
                     // Same-direction duplicate — always reject.
-                    return Err(OverlayError::AlreadyConnected);
+                    return Err(OverlayError::AlreadyConnected(peer_id.to_string()));
                 }
                 // Cross-direction collision (mutual-dial).
                 // Tiebreaker: higher peer ID keeps outbound.
@@ -318,7 +318,7 @@ impl OverlayManager {
                         "Mutual-dial tiebreaker: keeping existing {:?} for peer {}, rejecting {:?}",
                         existing_direction, peer_id, new_direction
                     );
-                    return Err(OverlayError::AlreadyConnected);
+                    return Err(OverlayError::AlreadyConnected(peer_id.to_string()));
                 }
             }
         };
@@ -1055,7 +1055,7 @@ pub(super) async fn connect_to_explicit_peer(
             peer.close().await;
             shared.pending_connections.release_peer_id(&peer_id);
             pool.release_pending();
-            return Err(OverlayError::AlreadyConnected);
+            return Err(OverlayError::AlreadyConnected(peer_id.to_string()));
         }
         drop(existing);
     }

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -732,8 +732,10 @@ impl Peer {
         // 2. Self-connection check: reject if peer is ourselves.
         let local_peer_id = self.auth.local_peer_id();
         if self.info.peer_id == local_peer_id {
+            // "connecting to self" mirrors stellar-core Peer.cpp:1857 /
+            // OVERLAY_SPEC §4.4.2-8 (the exact on-the-wire handshake error).
             return Err(OverlayError::InvalidMessage(
-                "received Hello from self".to_string(),
+                "connecting to self".to_string(),
             ));
         }
 
@@ -745,10 +747,9 @@ impl Peer {
         //    which rejects listeningPort <= 0 to prevent poisoning peer gossip
         //    with ephemeral ports.
         if hello.listening_port <= 0 || hello.listening_port > u16::MAX as i32 {
-            return Err(OverlayError::InvalidMessage(format!(
-                "invalid listening port: {}",
-                hello.listening_port
-            )));
+            // "bad address" mirrors stellar-core Peer.cpp:1875 / OVERLAY_SPEC
+            // §4.4.2-10 (the exact on-the-wire handshake error string).
+            return Err(OverlayError::InvalidMessage("bad address".to_string()));
         }
 
         // All checks passed — record the peer's advertised listening port.
@@ -1132,6 +1133,87 @@ mod tests {
             holds_pending_peer_id: false,
         };
         (peer_a, peer_b)
+    }
+
+    /// Build a single inbound `Peer` in `Handshaking` state plus a valid
+    /// `Hello` (correct network + in-range overlay version) crafted by a
+    /// remote node, so `validate_hello_phase2` reaches the peer-level
+    /// self-connection / bad-address checks. Returns the peer and the hello.
+    fn make_peer_for_phase2() -> (Peer, Hello) {
+        use crate::auth::{AuthCert, AuthCertExt, AuthContext};
+        use crate::connection::Connection;
+        use henyey_crypto::SecretKey;
+        use stellar_xdr::curr as xdr;
+        use x25519_dalek::EphemeralSecret;
+
+        let (_client, server) = tokio::io::duplex(1024 * 1024);
+        let addr_local: SocketAddr = "127.0.0.1:11625".parse().unwrap();
+        let addr_remote: SocketAddr = "127.0.0.1:11626".parse().unwrap();
+        let conn = Connection::from_io(server, addr_remote, ConnectionDirection::Inbound).unwrap();
+
+        let local = LocalNode::new_testnet(SecretKey::generate());
+        let remote = LocalNode::new_testnet(SecretKey::generate());
+        let auth = AuthContext::new(local, false);
+
+        // A hello from the remote node: same network + matching overlay version
+        // range (both testnet nodes share these), so the auth-level checks pass
+        // and `validate_hello_phase2` reaches the peer-level checks.
+        let ephemeral = EphemeralSecret::random_from_rng(rand::rngs::OsRng);
+        let cert = AuthCert::new_cert(&remote, &ephemeral);
+        let hello = Hello {
+            ledger_version: 25,
+            overlay_version: remote.overlay_version,
+            overlay_min_version: remote.overlay_min_version,
+            network_id: xdr::Hash(*remote.network_id.as_bytes()),
+            version_str: remote.version_string.clone().try_into().unwrap(),
+            listening_port: remote.listening_port as i32,
+            peer_id: xdr::NodeId(remote.xdr_public_key()),
+            cert,
+            nonce: xdr::Uint256([42u8; 32]),
+        };
+
+        let peer = Peer {
+            info: PeerInfo {
+                peer_id: PeerId::from_xdr(remote.xdr_public_key()),
+                address: addr_local,
+                direction: ConnectionDirection::Inbound,
+                version_string: String::new(),
+                overlay_version: 0,
+                ledger_version: 0,
+                connected_at: Instant::now(),
+                original_address: None,
+            },
+            state: PeerState::Handshaking,
+            connection: conn,
+            auth,
+            stats: Arc::new(PeerStats::default()),
+            metrics: Arc::new(OverlayMetrics::new()),
+            holds_pending_peer_id: false,
+        };
+        (peer, hello)
+    }
+
+    /// §4.4.2-8 / Peer.cpp:1857: the self-connection rejection error string
+    /// must be exactly "connecting to self" (issue #3080).
+    #[test]
+    fn test_self_connection_error_string_matches_spec() {
+        let (mut peer, hello) = make_peer_for_phase2();
+        // Force the self-connection branch: recorded peer id == our own id.
+        peer.info.peer_id = peer.auth.local_peer_id();
+
+        let err = peer.validate_hello_phase2(&hello).unwrap_err();
+        assert_eq!(err.to_string(), "invalid message: connecting to self");
+    }
+
+    /// §4.4.2-10 / Peer.cpp:1875: the bad-address rejection error string must
+    /// be exactly "bad address" (issue #3080).
+    #[test]
+    fn test_bad_address_error_string_matches_spec() {
+        let (mut peer, mut hello) = make_peer_for_phase2();
+        hello.listening_port = 0; // invalid — triggers the bad-address check
+
+        let err = peer.validate_hello_phase2(&hello).unwrap_err();
+        assert_eq!(err.to_string(), "invalid message: bad address");
     }
 
     /// Verify that the byte and async I/O counters are zero on a fresh peer


### PR DESCRIPTION
Closes #3080

## Summary

Corrects all five OVERLAY_SPEC §4.4.2 handshake error strings so the on-the-wire `ERROR_MSG` text matches stellar-core `Peer.cpp` exactly. Each was verified against both the spec and stellar-core before changing; all five were genuine mismatches (none already matched).

| § | Variant / site | Before | After | stellar-core |
|---|---|---|---|---|
| 4.4.2-7 | `OverlayError::VersionMismatch` Display | `protocol version mismatch: {0}` | `wrong protocol version` | Peer.cpp:1851 |
| 4.4.2-9 | `OverlayError::NetworkMismatch` Display | `network ID mismatch` | `wrong network passphrase` | Peer.cpp:1869 |
| 4.4.2-8 | self-connection (`peer.rs`) | `received Hello from self` | `connecting to self` | Peer.cpp:1857 |
| 4.4.2-10 | bad-address (`peer.rs`) | `invalid listening port: {n}` | `bad address` | Peer.cpp:1875 |
| 4.4.2-12 | `OverlayError::AlreadyConnected` Display | `already connected to peer` | `already-connected peer: {0}` (now carries peer ID) | Peer.cpp:1890 |

For VersionMismatch, the wrapped `String` divergence detail (below-minimum / above-maximum / malformed) is retained for local diagnostics and tests but no longer leaks into the wire string — mirroring stellar-core, which logs that detail via a separate `CLOG_DEBUG`. For AlreadyConnected, the variant now carries the rejected peer ID (stellar-core appends `Config::toShortString(mPeerID)`); henyey renders the strkey peer ID at the three call sites.

## Plan reference

Trivial short-circuit — implemented from the [Triage Report Implementation Notes](https://github.com/stellar-experimental/henyey/issues/3080#issuecomment-4627588315).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (pre-commit hook) — clean for changed code
- [x] `cargo test -p henyey-overlay` passes (478 lib + integration + doctests)

## Regression test (bug-fix)

- **Tests:** `error::tests::test_{version,network,already_connected}_*_matches_spec`, `peer::tests::test_{self_connection,bad_address}_error_string_matches_spec`
- **Pre-fix:** verified the four string-only assertions FAIL against the old wording (e.g. `left: "network ID mismatch", right: "wrong network passphrase"`)
- **Post-fix:** all five PASS

## Deviations from plan

None. (Triage cited `error.rs` lines 58/62/84 and `peer.rs` 733/746 — line numbers had drifted on current main, but the variants/sites are identical; `AlreadyConnected` call sites are in `manager/connection.rs`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)