### PR TITLE
Move ballot_did_confirm into inner compatible block of set_confirm_prepared

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -2325,35 +2325,104 @@ mod tests {
     #[test]
     fn test_confirm_prepared_callback_gated_on_inner_block() {
         // SCP §6.5-1 structural parity (issue #3165): `set_confirm_prepared`
-        // must fire `ballot_did_confirm` ONLY inside the inner ballot-compatible
+        // must fire `ballot_did_confirm` INSIDE the inner ballot-compatible
         // block, gated on the inner `did_work`, and BEFORE
         // `update_current_if_needed` — matching stellar-core
         // `BallotProtocol::setConfirmPrepared` (BallotProtocol.cpp:1074-1079),
         // where `confirmedBallotPrepared` fires inside `if (didWork)` within the
-        // `areBallotsCompatible` guard.
+        // `areBallotsCompatible` guard, before `updateCurrentIfNeeded`.
         //
-        // The divergence the old (outer-block) placement caused: on an
-        // incompatible-ballot path where `update_current_if_needed` returns true
-        // (a lower-counter, value-incompatible `current_ballot`), the inner block
-        // is skipped but the outer `did_work` becomes true via the update — so
-        // the outer-block placement fired the callback there, while stellar-core
-        // never does. This test pins both the negative (incompatible) and
-        // positive (compatible) paths.
-        let (node, qs, driver) = bare_ctx_parts();
+        // The genuine observable difference between the inner-block placement
+        // and the previous outer-block placement (post-`update_current_if_needed`)
+        // is the relative ORDER of driver callbacks within a single invocation:
+        //
+        //   - inner placement:  ballot_did_confirm  → started_ballot_protocol
+        //   - outer placement:  started_ballot_protocol → ballot_did_confirm
+        //
+        // because `update_current_if_needed` bumps `current_ballot` from `None`
+        // (via `bump_to_ballot`, which fires `started_ballot_protocol` on the
+        // null→set transition). The callback `callback_sequence` log on
+        // `MockDriver` records this order.
 
-        // --- Incompatible path: callback must NOT fire ---
+        // --- Compatible path: callback fires, gated on inner did_work, and
+        //     BEFORE update_current_if_needed (i.e. before started_ballot_protocol).
+        //
+        // Fresh protocol with no `current_ballot` (treated as compatible). The
+        // high ballot is raised inside the inner block (inner `did_work` true),
+        // so the callback fires with the high ballot `new_h`, then
+        // `update_current_if_needed` bumps current from `None`, firing
+        // `started_ballot_protocol`.
+        let node = make_node_id(1);
+        let qs = make_quorum_set(vec![node.clone()], 1);
+        let driver = Arc::new(MockDriver::with_quorum_set(qs.clone()));
+        let mut bp = BallotProtocol::new();
+        let new_h = ScpBallot {
+            counter: 3,
+            value: make_value(&[7]),
+        };
+        let did_work = bp.set_confirm_prepared(
+            ScpBallot {
+                counter: 0,
+                value: make_value(&[7]),
+            },
+            new_h.clone(),
+            &ctx!(&node, &qs, &driver, 1),
+        );
+        assert!(did_work);
+        // The callback fired with the high ballot `new_h`.
+        assert!(driver.confirmed_prepared_count.load(Ordering::SeqCst) >= 1);
+        assert_eq!(
+            driver
+                .confirmed_prepared_ballots
+                .lock()
+                .unwrap()
+                .first()
+                .cloned(),
+            Some(new_h.clone()),
+            "ballot_did_confirm must fire with the high ballot `new_h`"
+        );
+        // Ordering: ballot_did_confirm fires BEFORE started_ballot_protocol,
+        // proving the callback is positioned inside the inner block (pre-update),
+        // not in the outer block after `update_current_if_needed`.
+        let confirm_idx;
+        let started_idx;
+        {
+            let seq = driver.callback_sequence.lock().unwrap();
+            confirm_idx = seq
+                .iter()
+                .position(|&c| c == "ballot_did_confirm")
+                .expect("ballot_did_confirm must fire on the compatible path");
+            started_idx = seq
+                .iter()
+                .position(|&c| c == "started_ballot_protocol")
+                .expect("started_ballot_protocol must fire when current_ballot is first set");
+            assert!(
+                confirm_idx < started_idx,
+                "ballot_did_confirm (idx {confirm_idx}) must fire BEFORE \
+                 started_ballot_protocol (idx {started_idx}) — the inner-block \
+                 placement fires the callback before update_current_if_needed; the \
+                 old outer-block placement fired it after. seq={seq:?}"
+            );
+        }
+
+        // --- Incompatible-in-frame gating: the inner block is skipped, so the
+        //     callback does NOT fire from the incompatible call's own frame
+        //     before `update_current_if_needed` runs.
         //
         // `current_ballot` has a LOWER counter than `new_h` (so
-        // `update_current_if_needed` bumps and returns true) but an INCOMPATIBLE
-        // value (so the inner compatibility block is skipped and inner `did_work`
-        // stays false). stellar-core never fires `confirmedBallotPrepared` here.
-        let mut bp = BallotProtocol::new();
+        // `update_current_if_needed` will bump and return true) but an
+        // INCOMPATIBLE value (so the inner compatibility block is skipped and the
+        // inner `did_work` stays false). The first callback observed must be
+        // `started_ballot_protocol`/bump-driven, NOT a `ballot_did_confirm` fired
+        // from the outer `did_work`-via-update path (which the old placement did
+        // and stellar-core never does).
+        let driver2 = Arc::new(MockDriver::with_quorum_set(qs.clone()));
+        let mut bp2 = BallotProtocol::new();
         let current_incompat = ScpBallot {
             counter: 1,
             value: make_value(&[1]),
         };
-        bp.current_ballot = Some(current_incompat.clone());
-
+        bp2.current_ballot = Some(current_incompat.clone());
         let new_h_incompat = ScpBallot {
             counter: 2,
             value: make_value(&[2]),
@@ -2365,59 +2434,32 @@ mod tests {
         );
         assert!(!ballot_compatible(&current_incompat, &new_h_incompat));
 
-        let did_work = bp.set_confirm_prepared(
+        let did_work2 = bp2.set_confirm_prepared(
             ScpBallot {
                 counter: 0,
                 value: make_value(&[2]),
             },
             new_h_incompat.clone(),
-            &ctx!(&node, &qs, &driver, 1),
-        );
-        // `update_current_if_needed` did work (the ballot was bumped), but the
-        // inner confirm-prepared block did not — so the callback must NOT have
-        // fired even though overall `did_work` is true.
-        assert!(did_work, "update_current_if_needed should have bumped");
-        assert_eq!(
-            driver.confirmed_prepared_count.load(Ordering::SeqCst),
-            0,
-            "ballot_did_confirm must NOT fire on the incompatible-ballot path \
-             (inner block skipped) — see BallotProtocol.cpp:1074-1079"
-        );
-        assert!(driver.confirmed_prepared_ballots.lock().unwrap().is_empty());
-
-        // --- Compatible path: callback fires once, with `new_h` ---
-        //
-        // Fresh protocol with no `current_ballot` (treated as compatible). The
-        // high ballot is raised inside the inner block (inner `did_work` true),
-        // so the callback fires exactly once with the high ballot `new_h`.
-        let driver2 = Arc::new(MockDriver::with_quorum_set(qs.clone()));
-        let mut bp2 = BallotProtocol::new();
-        let new_h_compat = ScpBallot {
-            counter: 3,
-            value: make_value(&[7]),
-        };
-        let did_work2 = bp2.set_confirm_prepared(
-            ScpBallot {
-                counter: 0,
-                value: make_value(&[7]),
-            },
-            new_h_compat.clone(),
             &ctx!(&node, &qs, &driver2, 1),
         );
-        assert!(did_work2);
+        assert!(did_work2, "update_current_if_needed should have bumped");
+        // The inner block was skipped (incompatible), so the incompatible call's
+        // OWN frame must NOT fire `ballot_did_confirm`. The callback fires exactly
+        // ONCE here — from the legitimate self-emission re-entry on the now-
+        // compatible bumped ballot (henyey `emit_current_state` → `advance_slot`,
+        // mirrored in stellar-core by `emitCurrentStateStatement` →
+        // `processEnvelope` → `advanceSlot`). The previous OUTER-block placement
+        // fired the callback an EXTRA time from the in-frame update-driven
+        // `did_work` (yielding count == 2), which stellar-core never does — that
+        // surplus fire is the structural divergence this fix removes
+        // (BallotProtocol.cpp:1074-1079).
         assert_eq!(
             driver2.confirmed_prepared_count.load(Ordering::SeqCst),
             1,
-            "ballot_did_confirm must fire exactly once on the compatible path"
-        );
-        assert_eq!(
-            driver2
-                .confirmed_prepared_ballots
-                .lock()
-                .unwrap()
-                .as_slice(),
-            &[new_h_compat.clone()],
-            "ballot_did_confirm must fire with the high ballot `new_h`"
+            "ballot_did_confirm must fire exactly once on the incompatible path \
+             (re-entry only); the old outer-block placement fired it twice. \
+             seq={:?}",
+            driver2.callback_sequence.lock().unwrap()
         );
     }
 

--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -2323,6 +2323,105 @@ mod tests {
     }
 
     #[test]
+    fn test_confirm_prepared_callback_gated_on_inner_block() {
+        // SCP §6.5-1 structural parity (issue #3165): `set_confirm_prepared`
+        // must fire `ballot_did_confirm` ONLY inside the inner ballot-compatible
+        // block, gated on the inner `did_work`, and BEFORE
+        // `update_current_if_needed` — matching stellar-core
+        // `BallotProtocol::setConfirmPrepared` (BallotProtocol.cpp:1074-1079),
+        // where `confirmedBallotPrepared` fires inside `if (didWork)` within the
+        // `areBallotsCompatible` guard.
+        //
+        // The divergence the old (outer-block) placement caused: on an
+        // incompatible-ballot path where `update_current_if_needed` returns true
+        // (a lower-counter, value-incompatible `current_ballot`), the inner block
+        // is skipped but the outer `did_work` becomes true via the update — so
+        // the outer-block placement fired the callback there, while stellar-core
+        // never does. This test pins both the negative (incompatible) and
+        // positive (compatible) paths.
+        let (node, qs, driver) = bare_ctx_parts();
+
+        // --- Incompatible path: callback must NOT fire ---
+        //
+        // `current_ballot` has a LOWER counter than `new_h` (so
+        // `update_current_if_needed` bumps and returns true) but an INCOMPATIBLE
+        // value (so the inner compatibility block is skipped and inner `did_work`
+        // stays false). stellar-core never fires `confirmedBallotPrepared` here.
+        let mut bp = BallotProtocol::new();
+        let current_incompat = ScpBallot {
+            counter: 1,
+            value: make_value(&[1]),
+        };
+        bp.current_ballot = Some(current_incompat.clone());
+
+        let new_h_incompat = ScpBallot {
+            counter: 2,
+            value: make_value(&[2]),
+        };
+        // Sanity: the precondition (lower counter, incompatible value) holds.
+        assert_eq!(
+            ballot_compare(&current_incompat, &new_h_incompat),
+            std::cmp::Ordering::Less
+        );
+        assert!(!ballot_compatible(&current_incompat, &new_h_incompat));
+
+        let did_work = bp.set_confirm_prepared(
+            ScpBallot {
+                counter: 0,
+                value: make_value(&[2]),
+            },
+            new_h_incompat.clone(),
+            &ctx!(&node, &qs, &driver, 1),
+        );
+        // `update_current_if_needed` did work (the ballot was bumped), but the
+        // inner confirm-prepared block did not — so the callback must NOT have
+        // fired even though overall `did_work` is true.
+        assert!(did_work, "update_current_if_needed should have bumped");
+        assert_eq!(
+            driver.confirmed_prepared_count.load(Ordering::SeqCst),
+            0,
+            "ballot_did_confirm must NOT fire on the incompatible-ballot path \
+             (inner block skipped) — see BallotProtocol.cpp:1074-1079"
+        );
+        assert!(driver.confirmed_prepared_ballots.lock().unwrap().is_empty());
+
+        // --- Compatible path: callback fires once, with `new_h` ---
+        //
+        // Fresh protocol with no `current_ballot` (treated as compatible). The
+        // high ballot is raised inside the inner block (inner `did_work` true),
+        // so the callback fires exactly once with the high ballot `new_h`.
+        let driver2 = Arc::new(MockDriver::with_quorum_set(qs.clone()));
+        let mut bp2 = BallotProtocol::new();
+        let new_h_compat = ScpBallot {
+            counter: 3,
+            value: make_value(&[7]),
+        };
+        let did_work2 = bp2.set_confirm_prepared(
+            ScpBallot {
+                counter: 0,
+                value: make_value(&[7]),
+            },
+            new_h_compat.clone(),
+            &ctx!(&node, &qs, &driver2, 1),
+        );
+        assert!(did_work2);
+        assert_eq!(
+            driver2.confirmed_prepared_count.load(Ordering::SeqCst),
+            1,
+            "ballot_did_confirm must fire exactly once on the compatible path"
+        );
+        assert_eq!(
+            driver2
+                .confirmed_prepared_ballots
+                .lock()
+                .unwrap()
+                .as_slice(),
+            &[new_h_compat.clone()],
+            "ballot_did_confirm must fire with the high ballot `new_h`"
+        );
+    }
+
+    #[test]
     fn test_ballot_statement_sanity_prepare_constraints() {
         let node = make_node_id(1);
         let quorum_set = make_quorum_set(vec![node.clone()], 1);

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -275,17 +275,26 @@ impl BallotProtocol {
                 self.commit = Some(new_c);
                 did_work = true;
             }
+
+            if did_work {
+                // Fire the confirm-prepared notification callback (SCP §6.5-1),
+                // with `new_h` being the high ballot. This fires INSIDE the
+                // ballot-compatible block, gated on the inner `did_work` (high
+                // ballot raised or commit set), and BEFORE
+                // `update_current_if_needed` — mirroring stellar-core
+                // BallotProtocol::setConfirmPrepared (BallotProtocol.cpp:1074-1079),
+                // where `confirmedBallotPrepared` fires inside the inner
+                // `if (didWork)` within the `areBallotsCompatible` guard. The
+                // outer-block placement would have fired the callback on an
+                // incompatible-ballot path where `update_current_if_needed`
+                // alone made overall `did_work` true — which stellar-core never
+                // does (see issue #3165).
+                ctx.driver.ballot_did_confirm(ctx.slot_index, &new_h);
+            }
         }
 
         did_work = self.update_current_if_needed(&new_h, ctx) || did_work;
         if did_work {
-            // Fire the confirm-prepared notification callback (SCP §6.5-1),
-            // with `new_h` being the high ballot, mirroring stellar-core
-            // BallotProtocol::setConfirmPrepared (BallotProtocol.cpp:1074-1075).
-            // Ordered update_current_if_needed -> ballot_did_confirm ->
-            // emit_current_state, matching the accepted_commit ordering in
-            // set_accept_commit (SCP §6.5-2).
-            ctx.driver.ballot_did_confirm(ctx.slot_index, &new_h);
             self.emit_current_state(ctx);
         }
 

--- a/crates/scp/src/ballot/state_machine.rs
+++ b/crates/scp/src/ballot/state_machine.rs
@@ -246,7 +246,7 @@ impl BallotProtocol {
         new_c
     }
 
-    fn set_confirm_prepared<D: SCPDriver>(
+    pub(super) fn set_confirm_prepared<D: SCPDriver>(
         &mut self,
         new_c: ScpBallot,
         new_h: ScpBallot,

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -36,6 +36,9 @@ pub struct MockDriver {
     pub accepted_commit_count: AtomicU32,
     /// Counts how many times `ballot_did_confirm` was called.
     pub confirmed_prepared_count: AtomicU32,
+    /// Records the `ScpBallot` passed to each `ballot_did_confirm` call, in
+    /// order. Lets tests assert the exact ballot confirmed prepared.
+    pub confirmed_prepared_ballots: std::sync::Mutex<Vec<ScpBallot>>,
     /// Records the `ScpBallot` passed to each `started_ballot_protocol` call,
     /// in order. Lets tests assert fire-once and the exact ballot fired.
     pub ballot_starts: std::sync::Mutex<Vec<ScpBallot>>,
@@ -121,6 +124,7 @@ impl MockDriverBuilder {
             heard_from_quorum: AtomicU32::new(0),
             accepted_commit_count: AtomicU32::new(0),
             confirmed_prepared_count: AtomicU32::new(0),
+            confirmed_prepared_ballots: std::sync::Mutex::new(Vec::new()),
             ballot_starts: std::sync::Mutex::new(Vec::new()),
             return_qset_by_hash: self.return_qset_by_hash,
             custom_node_weight: None,
@@ -203,8 +207,12 @@ impl SCPDriver for MockDriver {
 
     fn ballot_did_prepare(&self, _slot_index: u64, _ballot: &ScpBallot) {}
 
-    fn ballot_did_confirm(&self, _slot_index: u64, _ballot: &ScpBallot) {
+    fn ballot_did_confirm(&self, _slot_index: u64, ballot: &ScpBallot) {
         self.confirmed_prepared_count.fetch_add(1, Ordering::SeqCst);
+        self.confirmed_prepared_ballots
+            .lock()
+            .unwrap()
+            .push(ballot.clone());
     }
 
     fn ballot_did_hear_from_quorum(&self, _slot_index: u64, _ballot: &ScpBallot) {

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -39,6 +39,10 @@ pub struct MockDriver {
     /// Records the `ScpBallot` passed to each `ballot_did_confirm` call, in
     /// order. Lets tests assert the exact ballot confirmed prepared.
     pub confirmed_prepared_ballots: std::sync::Mutex<Vec<ScpBallot>>,
+    /// Ordered log of selected driver-callback names as they fire. Lets tests
+    /// assert relative ordering between callbacks within a single ballot-protocol
+    /// invocation (e.g. `ballot_did_confirm` before `started_ballot_protocol`).
+    pub callback_sequence: std::sync::Mutex<Vec<&'static str>>,
     /// Records the `ScpBallot` passed to each `started_ballot_protocol` call,
     /// in order. Lets tests assert fire-once and the exact ballot fired.
     pub ballot_starts: std::sync::Mutex<Vec<ScpBallot>>,
@@ -125,6 +129,7 @@ impl MockDriverBuilder {
             accepted_commit_count: AtomicU32::new(0),
             confirmed_prepared_count: AtomicU32::new(0),
             confirmed_prepared_ballots: std::sync::Mutex::new(Vec::new()),
+            callback_sequence: std::sync::Mutex::new(Vec::new()),
             ballot_starts: std::sync::Mutex::new(Vec::new()),
             return_qset_by_hash: self.return_qset_by_hash,
             custom_node_weight: None,
@@ -213,6 +218,10 @@ impl SCPDriver for MockDriver {
             .lock()
             .unwrap()
             .push(ballot.clone());
+        self.callback_sequence
+            .lock()
+            .unwrap()
+            .push("ballot_did_confirm");
     }
 
     fn ballot_did_hear_from_quorum(&self, _slot_index: u64, _ballot: &ScpBallot) {
@@ -225,6 +234,10 @@ impl SCPDriver for MockDriver {
 
     fn started_ballot_protocol(&self, _slot_index: u64, ballot: &ScpBallot) {
         self.ballot_starts.lock().unwrap().push(ballot.clone());
+        self.callback_sequence
+            .lock()
+            .unwrap()
+            .push("started_ballot_protocol");
     }
 
     fn compute_hash_node(


### PR DESCRIPTION
Closes #3165

## Summary

Moves the `ctx.driver.ballot_did_confirm(ctx.slot_index, &new_h)` call in `BallotProtocol::set_confirm_prepared` from the OUTER `if did_work` block (after `update_current_if_needed`) INTO the INNER ballot-compatible block, gated on the inner `did_work` (high ballot raised or commit set), BEFORE `update_current_if_needed` — matching stellar-core `BallotProtocol::setConfirmPrepared` (BallotProtocol.cpp:1074-1079), where `confirmedBallotPrepared` fires inside the inner `if (didWork)` within the `areBallotsCompatible` guard.

The previous outer-block placement fired the callback an extra time on an incompatible-ballot path where `update_current_if_needed` alone made the overall `did_work` true — a fire stellar-core never produces. With the fix the only fire on that path is the legitimate self-emission re-entry on the now-compatible bumped ballot (`emit_current_state` → `advance_slot`, mirrored by stellar-core's `emitCurrentStateStatement` → `processEnvelope` → `advanceSlot`).

No observable behavior change today: `ballot_did_confirm` is a logging-only no-op consumer (and `confirmedBallotPrepared` is an empty no-op in stellar-core). This is exact structural parity for future driver implementations that read ballot-protocol state during the callback.

## Plan reference

Trivial short-circuit — see the `## Triage Report` → `## Implementation Notes` on [#3165](https://github.com/stellar-experimental/henyey/issues/3165#issuecomment-4631898335).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (CI-equivalent invocation) clean
- [x] cargo test -p henyey-scp passes (383 lib + integration tests)

## Regression test

- **Test:** `crates/scp/src/ballot/mod.rs::test_confirm_prepared_callback_gated_on_inner_block`
- **Pre-fix:** committed as `15286d85` — verified FAILED on the outer-block placement (compatible-path ordering assertion: `ballot_did_confirm` fired AFTER `started_ballot_protocol` instead of before; incompatible-path callback count == 2 instead of 1)
- **Post-fix:** verified PASSES after `e008b37f`

The test pins two observable structural properties:
1. **Ordering** (compatible path): `ballot_did_confirm` fires BEFORE `started_ballot_protocol` (i.e. before `update_current_if_needed` bumps `current_ballot` from `None`).
2. **Gating** (incompatible path): the callback fires exactly ONCE (re-entry only), not twice — the surplus in-frame fire of the old outer-block placement is removed.

A new `MockDriver.confirmed_prepared_ballots` field records confirmed ballots and a `callback_sequence` field records relative callback ordering; `set_confirm_prepared` was widened to `pub(super)` for the focused unit test.

## Deviations from plan

The triage's stated negative check ("callback must NOT fire when incompatible") needed refinement: henyey's `emit_current_state` → `advance_slot` self-emission legitimately re-enters `set_confirm_prepared` on the now-compatible bumped ballot and fires the callback once (stellar-core's `emitCurrentStateStatement` → `processEnvelope` → `advanceSlot` does the same). So the divergence is the EXTRA in-frame fire (count 2 vs 1), not an absolute "never fires" — the test asserts count == 1 accordingly, plus the callback-ordering property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)