### PR TITLE
Retry testnet horizon-core-up probe on exit-143 runner shutdown

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -26,9 +26,12 @@ name: Quickstart
 # horizon-core-up probe without forking the entire upstream test matrix.
 # Each probe is run through scripts/ci/run-quickstart-test.sh which adds:
 #   * GNU timeout with diagnostics capture on failure
-#   * Exactly one retry for testnet/core,horizon/horizon-core-up when the
-#     exit is timeout-classified (exit 124)
-#   * No retry for any other shard or non-timeout failure
+#   * Exactly one retry for testnet/core,horizon/horizon-core-up when the exit
+#     is a transient-infra signature: exit 124 (timeout / slow start, #2916) or
+#     exit 143 (SIGTERM — "runner has received a shutdown signal" / spot-runner
+#     reclamation, #3131). The retry is scoped to that one shard only.
+#   * No retry for any other shard, or for any non-transient failure (e.g. a
+#     genuine probe failure exit 1) — those still fail loudly.
 #
 # Upstream contract validation:
 #   The validate-contract job fetches both build.yml and internal-build.yml

--- a/scripts/ci/run-quickstart-test.sh
+++ b/scripts/ci/run-quickstart-test.sh
@@ -21,10 +21,18 @@
 # single retry on top of it (see below).
 #
 # The ONLY retryable case: network=testnet, enable=core,horizon,
-# probe=horizon-core-up, and exit was timeout-classified (exit 124 from
-# GNU timeout). The retry re-runs the probe under the SAME --timeout budget —
-# it is an additional attempt at the same per-attempt budget, not a change to
-# the budget (#2920).
+# probe=horizon-core-up, and exit was a transient-infra-classified code:
+#   * exit 124 — GNU `timeout` killed a slow start (the original #2916 flake).
+#   * exit 143 — the probe (or the runner) received SIGTERM (128+15=143),
+#     i.e. "the runner has received a shutdown signal" spot-runner reclamation
+#     (#3131). When the runner survives the SIGTERM long enough for the wrapper
+#     to observe the probe's 143, re-running once self-heals without a manual
+#     orchestrator re-run; if the runner is fully reclaimed the wrapper dies
+#     too and the workflow's normal re-run path applies.
+# The retry re-runs the probe under the SAME --timeout budget — it is an
+# additional attempt at the same per-attempt budget, not a change to the
+# budget (#2920). It stays scoped to the targeted shard so a genuine probe
+# failure (exit 1, etc.) or any failure on another shard still fails loudly.
 
 set -euo pipefail
 
@@ -59,6 +67,14 @@ mkdir -p "$DIAGNOSTICS_DIR"
 # --- Helper: is this the retryable shard? ---
 is_retryable_shard() {
     [[ "$NETWORK" == "testnet" && "$ENABLE" == "core,horizon" && "$PROBE" == "horizon-core-up" ]]
+}
+
+# --- Helper: is this exit code a retryable transient-infra failure? ---
+# 124: GNU `timeout` killed a slow start (#2916). 143: SIGTERM (128+15) —
+# runner-shutdown / spot-runner reclamation (#3131). Both are infra-transient,
+# not test-logic failures, so they are retried once on the targeted shard only.
+is_retryable_exit() {
+    [[ "$1" -eq 124 || "$1" -eq 143 ]]
 }
 
 # --- Helper: capture diagnostics ---
@@ -114,9 +130,10 @@ if [[ $EXIT_CODE -eq 0 ]]; then
     exit 0
 fi
 
-if [[ $EXIT_CODE -eq 124 ]] && is_retryable_shard; then
-    # Timeout on the known-flaky shard — retry once
-    echo "=== Timeout on retryable shard ($NETWORK/$ENABLE/$PROBE), retrying ===" >&2
+if is_retryable_exit "$EXIT_CODE" && is_retryable_shard; then
+    # Transient-infra failure (timeout 124 / runner-shutdown 143) on the
+    # known-flaky shard — retry once under the same per-attempt budget.
+    echo "=== Transient-infra failure (exit $EXIT_CODE) on retryable shard ($NETWORK/$ENABLE/$PROBE), retrying ===" >&2
     EXIT_CODE=0
     run_probe 2 || EXIT_CODE=$?
 
@@ -129,6 +146,7 @@ if [[ $EXIT_CODE -eq 124 ]] && is_retryable_shard; then
     exit 1
 fi
 
-# Non-timeout failure, or timeout on non-retryable shard — fail immediately
+# Non-transient failure, or transient failure on a non-retryable shard —
+# fail immediately so genuine test failures stay loud.
 echo "=== Failed (exit $EXIT_CODE), not retryable ===" >&2
 exit 1

--- a/scripts/test-quickstart-harness.sh
+++ b/scripts/test-quickstart-harness.sh
@@ -798,11 +798,15 @@ EOF
         tap_not_ok "test_runner_shutdown_exit143_retries_on_targeted_shard" "exit=$exit_code (expected 0 via retry)"
     fi
 
-    # The retry must have happened — attempt-2 diagnostics present.
-    if [[ -d "$diag_dir/attempt-2" ]]; then
-        tap_ok "exit143_retry_made_second_attempt"
+    # The first (exit-143) attempt must have captured diagnostics, proving the
+    # probe failed on attempt 1 and the overall exit 0 came from the retry path.
+    # (A successful retry exits 0 and so leaves no attempt-2 diagnostics dir —
+    # diagnostics are only captured on a non-zero attempt; this mirrors the
+    # exit-124 retry test's attempt-1 assertion.)
+    if [[ -d "$diag_dir/attempt-1" ]]; then
+        tap_ok "exit143_retry_captured_attempt1_diagnostics"
     else
-        tap_not_ok "exit143_retry_made_second_attempt" "no attempt-2 dir (retry did not fire)"
+        tap_not_ok "exit143_retry_captured_attempt1_diagnostics" "no attempt-1 dir (first failure not captured)"
     fi
 }
 

--- a/scripts/test-quickstart-harness.sh
+++ b/scripts/test-quickstart-harness.sh
@@ -754,8 +754,128 @@ EOF
     fi
 }
 
+# ============================================================
+# Test 12: test_runner_shutdown_exit143_retries_on_targeted_shard
+#
+# Regression for #3131. The testnet/core,horizon/horizon-core-up probe flakes
+# with exit 143 ("the runner has received a shutdown signal" — spot-runner
+# reclamation / the probe subprocess receiving SIGTERM, 128+15=143) in addition
+# to the timeout (exit 124) class already handled. The wrapper must treat
+# exit 143 as a retryable transient on the targeted shard, exactly like exit
+# 124: re-run once, and pass if the retry succeeds.
+# ============================================================
+test_runner_shutdown_exit143_retries_on_targeted_shard() {
+    local diag_dir="$TMPDIR_BASE/diag-test12"
+    mkdir -p "$diag_dir"
+
+    # Probe: exits 143 (runner-shutdown signature) on attempt 1, succeeds on 2.
+    local state_file="$TMPDIR_BASE/state-test12"
+    echo "0" > "$state_file"
+    local probe="$TMPDIR_BASE/probe-test12.sh"
+    cat > "$probe" <<'EOF'
+#!/bin/bash
+STATE_FILE="__STATE__"
+COUNT=$(cat "$STATE_FILE")
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$STATE_FILE"
+if [[ $COUNT -eq 1 ]]; then
+    exit 143
+fi
+exit 0
+EOF
+    sed -i "s|__STATE__|$state_file|g" "$probe"
+    chmod +x "$probe"
+
+    local exit_code=0
+    "$WRAPPER" \
+        --network testnet --enable "core,horizon" --probe horizon-core-up \
+        --timeout 10 --diagnostics-dir "$diag_dir" \
+        -- "$probe" >/dev/null 2>&1 || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        tap_ok "test_runner_shutdown_exit143_retries_on_targeted_shard"
+    else
+        tap_not_ok "test_runner_shutdown_exit143_retries_on_targeted_shard" "exit=$exit_code (expected 0 via retry)"
+    fi
+
+    # The retry must have happened — attempt-2 diagnostics present.
+    if [[ -d "$diag_dir/attempt-2" ]]; then
+        tap_ok "exit143_retry_made_second_attempt"
+    else
+        tap_not_ok "exit143_retry_made_second_attempt" "no attempt-2 dir (retry did not fire)"
+    fi
+}
+
+# ============================================================
+# Test 13: test_runner_shutdown_exit143_does_not_retry_on_non_targeted_shard
+#
+# The exit-143 retry must be scoped to the same targeted shard as the exit-124
+# retry — a non-targeted shard exiting 143 must fail immediately with no retry,
+# so a genuine henyey failure elsewhere stays loud.
+# ============================================================
+test_runner_shutdown_exit143_no_retry_on_non_targeted_shard() {
+    local diag_dir="$TMPDIR_BASE/diag-test13"
+    mkdir -p "$diag_dir"
+
+    # Probe exits 143 immediately on a non-targeted shard.
+    local probe
+    probe=$(make_probe "test13" 143 0)
+
+    local exit_code=0
+    "$WRAPPER" \
+        --network local --enable "core" --probe core \
+        --timeout 10 --diagnostics-dir "$diag_dir" \
+        -- "$probe" >/dev/null 2>&1 || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        tap_ok "test_runner_shutdown_exit143_does_not_retry_on_non_targeted_shard"
+    else
+        tap_not_ok "test_runner_shutdown_exit143_does_not_retry_on_non_targeted_shard" "expected failure"
+    fi
+
+    if [[ ! -d "$diag_dir/attempt-2" ]]; then
+        tap_ok "non_targeted_exit143_single_attempt"
+    else
+        tap_not_ok "non_targeted_exit143_single_attempt" "unexpected retry on non-targeted shard"
+    fi
+}
+
+# ============================================================
+# Test 14: test_runner_shutdown_exit143_still_fails_after_second_attempt
+#
+# If exit 143 recurs on the retry, the wrapper must still fail (the retry is a
+# single additional attempt, not an unbounded loop). This proves the exit-143
+# retry mirrors the exit-124 double-failure semantics.
+# ============================================================
+test_runner_shutdown_exit143_double_failure_fails() {
+    local diag_dir="$TMPDIR_BASE/diag-test14"
+    mkdir -p "$diag_dir"
+
+    # Probe always exits 143.
+    local probe
+    probe=$(make_probe "test14" 143 0)
+
+    local exit_code=0
+    "$WRAPPER" \
+        --network testnet --enable "core,horizon" --probe horizon-core-up \
+        --timeout 10 --diagnostics-dir "$diag_dir" \
+        -- "$probe" >/dev/null 2>&1 || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        tap_ok "test_runner_shutdown_exit143_still_fails_after_second_attempt"
+    else
+        tap_not_ok "test_runner_shutdown_exit143_still_fails_after_second_attempt" "expected failure"
+    fi
+
+    if [[ -d "$diag_dir/attempt-1" && -d "$diag_dir/attempt-2" ]]; then
+        tap_ok "exit143_double_failure_preserves_both_diagnostics"
+    else
+        tap_not_ok "exit143_double_failure_preserves_both_diagnostics" "missing attempt dirs"
+    fi
+}
+
 # --- Run all tests ---
-tap_plan 48
+tap_plan 54
 
 test_timeout_retry_on_targeted_shard
 test_non_timeout_failure_no_retry
@@ -768,6 +888,9 @@ test_workflow_uses_upstream_run_attempt_timeout_budget
 test_timeout_budget_matches_upstream_formula
 test_contract_pins_timeout_multiplier
 test_retry_is_layered_on_top_of_budget
+test_runner_shutdown_exit143_retries_on_targeted_shard
+test_runner_shutdown_exit143_no_retry_on_non_targeted_shard
+test_runner_shutdown_exit143_double_failure_fails
 
 echo ""
 echo "# Results: $PASS_COUNT/$TEST_COUNT passed, $FAIL_COUNT failed"


### PR DESCRIPTION
Closes #3131

## Summary

The testnet `core,horizon` / `horizon-core-up` quickstart probe recurrently flakes with **exit 143** ("the runner has received a shutdown signal") from spot-runner reclamation — a transient-infra failure, not a test-logic failure. The existing #2916 fix only retried the startup-**timeout** class (exit 124), so each exit-143 reclamation forced a manual orchestrator re-run (~4× CI on PRs #3125 / #3128 this session).

This extends `scripts/ci/run-quickstart-test.sh` to treat **exit 143 as retryable in addition to 124**, via a new `is_retryable_exit` helper. The retry stays scoped to the same targeted shard (`is_retryable_shard`: `testnet`/`core,horizon`/`horizon-core-up`) and is a single additional attempt at the same per-attempt budget — so a genuine probe failure (exit 1) or **any** failure on **any other shard** still fails loudly and is not masked. The wrapper-script approach (vs. a step-level `nick-fields/retry`) was chosen because it is surgically scoped to exactly the one flaky probe and mirrors the existing exit-124 retry pattern, where a step-level action would coarsely retry the whole probe loop.

## Scope / safety

- Retry fires **only** when *both* `is_retryable_exit` (124 or 143) *and* `is_retryable_shard` (testnet/core,horizon/horizon-core-up) hold.
- Non-targeted shards exiting 143 fail immediately (no retry).
- A second exit-143 on the retry still fails (single retry, not a loop).

## Plan reference

[Triage Report — trivial short-circuit](https://github.com/stellar-experimental/henyey/issues/3131#issuecomment-4631946866)

## Test plan

- [x] cargo fmt --check + cargo clippy (pre-commit hook, clean)
- [x] `bash scripts/test-quickstart-harness.sh` — 54/54 pass
- [x] `bash -n` syntax check on wrapper + harness
- [x] YAML parse of `.github/workflows/quickstart.yml` (4 jobs intact)

## Regression test

- **Tests:** `scripts/test-quickstart-harness.sh` — `test_runner_shutdown_exit143_retries_on_targeted_shard`, `..._does_not_retry_on_non_targeted_shard`, `..._still_fails_after_second_attempt`
- **Pre-fix:** committed as `bd9576b6` — verified FAILED (retry-firing cases 49/54 fail: wrapper only retried exit 124)
- **Post-fix:** verified PASSES — 54/54 green

## Deviations from plan

The triage suggested `nick-fields/retry` as the recommended option but explicitly allowed extending the wrapper script "whichever is cleaner and matches the existing retry pattern". The wrapper-script extension is cleaner and keeps the retry surgically scoped to the one flaky probe (a step-level action would retry the whole probe loop / all probes in the shard), so it was chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)