### PR TITLE
Dedup non-Config upgrade-validity rules via henyey-common helper

### DIFF
--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -1880,20 +1880,10 @@ impl ScpDriver {
         ledger_manager: &LedgerManager,
     ) -> bool {
         match upgrade {
-            LedgerUpgrade::Version(new_version) => {
-                // Must be strictly monotonic and within supported range
-                *new_version > current_version
-                    && *new_version <= henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION
-            }
-            LedgerUpgrade::BaseFee(fee) => *fee != 0,
-            LedgerUpgrade::MaxTxSetSize(_) => true, // Any size allowed
-            LedgerUpgrade::BaseReserve(reserve) => *reserve != 0,
-            LedgerUpgrade::Flags(flags) => {
-                // Must be protocol >= 18 and only valid flag bits
-                const MASK_LEDGER_HEADER_FLAGS: u32 = 0x7;
-                protocol_version_starts_from(current_version, ProtocolVersion::V18)
-                    && (*flags & !MASK_LEDGER_HEADER_FLAGS) == 0
-            }
+            // Config is this site's stateful nomination-time variant: it loads
+            // the config upgrade set from ledger state and validates the frame.
+            // The shared helper deliberately does not own Config (it returns
+            // `true`), so we branch it here and never route it through the helper.
             LedgerUpgrade::Config(key) => {
                 // Config upgrades require Soroban protocol.
                 if current_version < henyey_common::MIN_SOROBAN_PROTOCOL_VERSION {
@@ -1936,9 +1926,17 @@ impl ScpDriver {
                     }
                 }
             }
-            LedgerUpgrade::MaxSorobanTxSetSize(_) => {
-                current_version >= henyey_common::MIN_SOROBAN_PROTOCOL_VERSION
-            }
+            // All non-Config (scalar) arms — Version/BaseFee/MaxTxSetSize/
+            // BaseReserve/Flags/MaxSorobanTxSetSize — delegate to the single
+            // shared source of truth in henyey-common. The Version arm's max
+            // bound was hardcoded to CURRENT_LEDGER_PROTOCOL_VERSION here, so we
+            // pass that same constant as `max_protocol_version` to preserve the
+            // bound (`new > current && new <= CURRENT`) byte-for-byte.
+            other => henyey_common::upgrade_valid_for_apply_non_config(
+                other,
+                current_version,
+                henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION,
+            ),
         }
     }
 

--- a/crates/herder/src/upgrades.rs
+++ b/crates/herder/src/upgrades.rs
@@ -657,28 +657,23 @@ pub fn is_valid_for_apply(
     };
 
     let valid = match &upgrade {
-        LedgerUpgrade::Version(new_version) => {
-            // Only allow upgrades to supported versions, must be strictly increasing
-            *new_version <= max_protocol_version && *new_version > current_version
-        }
-        LedgerUpgrade::BaseFee(fee) => *fee != 0,
-        LedgerUpgrade::MaxTxSetSize(_) => true, // Any size allowed
-        LedgerUpgrade::BaseReserve(reserve) => *reserve != 0,
-        LedgerUpgrade::Flags(flags) => {
-            // Flags upgrade requires protocol 18+
-            // MASK_LEDGER_HEADER_FLAGS = 0x7 (bits 0-2)
-            const MASK_LEDGER_HEADER_FLAGS: u32 = 0x7;
-            protocol_version_starts_from(current_version, ProtocolVersion::V18)
-                && (*flags & !MASK_LEDGER_HEADER_FLAGS) == 0
-        }
+        // Config is this site's stateless nomination-time variant: a >= V20 gate
+        // with no ledger-state lookup. The shared helper deliberately does not
+        // own Config (it returns `true`), so we branch it here and never route
+        // it through the helper.
         LedgerUpgrade::Config(_) => {
             // Config upgrade requires Soroban (protocol 20+)
             protocol_version_starts_from(current_version, ProtocolVersion::V20)
         }
-        LedgerUpgrade::MaxSorobanTxSetSize(_) => {
-            // Soroban tx set size requires protocol 20+
-            protocol_version_starts_from(current_version, ProtocolVersion::V20)
-        }
+        // All non-Config (scalar) arms — Version/BaseFee/MaxTxSetSize/BaseReserve/
+        // Flags/MaxSorobanTxSetSize — delegate to the single shared source of
+        // truth in henyey-common. `current_version`/`max_protocol_version` are
+        // threaded straight through, preserving byte-identical behavior.
+        other => henyey_common::upgrade_valid_for_apply_non_config(
+            other,
+            current_version,
+            max_protocol_version,
+        ),
     };
 
     if valid {


### PR DESCRIPTION
Closes #3140

## Summary

Points herder's two non-`Config` upgrade-validity match blocks at `henyey_common::upgrade_valid_for_apply_non_config` (introduced in PR #3139, already consumed by the ledger close path), removing the duplicated scalar rules (Version/BaseFee/MaxTxSetSize/BaseReserve/Flags/MaxSorobanTxSetSize). Each site's distinct `Config` arm is preserved verbatim and `Config` is never routed through the helper. Behavior-preserving refactor with zero observable change.

- `crates/herder/src/upgrades.rs::is_valid_for_apply`: keeps the XDR-decode `XdrInvalid` early-return and the stateless `>= V20` `Config` gate; threads its existing `max_protocol_version` param into the helper for all other variants.
- `crates/herder/src/scp_driver.rs::is_valid_upgrade_for_apply`: keeps the nomination-time ledger-state `Config` validation (`get_config_upgrade_set` + `ConfigUpgradeSetFrame::is_valid_for_apply`); passes `henyey_common::CURRENT_LEDGER_PROTOCOL_VERSION` as `max_protocol_version` to reproduce its previously hardcoded Version bound (`new > current && new <= 26`) byte-for-byte.

The now-dead local `MASK_LEDGER_HEADER_FLAGS` consts were removed; surviving `protocol_version_starts_from`/`ProtocolVersion` imports are retained (still used by the `Config` arm and elsewhere).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3140#issuecomment-4632164688)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (lib targets) -p henyey-herder -p henyey-common -- -D warnings — warning-free
- [x] cargo test -p henyey-herder -p henyey-common passes (herder: 1179, common: 219)
- [x] Named preservation tests green: `test_is_valid_for_apply_{version,base_fee,flags,soroban}`, `test_audit_023_is_valid_upgrade_for_apply_config_with_default_lm`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)