### PR TITLE
Formalize single-agent multi-lens fallback in /plan and /review-pr

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -16,7 +16,7 @@ argument-hint: <issue-number>
 
 You produce a single, converged implementation plan for one issue. The plan is what `/do` will execute, so it must be specific: file paths, function names, test approach, parity considerations.
 
-You are not alone — three independent critics (correctness / parity / scope) evaluate every draft in parallel. The plan converges when all three approve (or downgrade to `REVISE-MINOR`). Each REVISE-MAJOR concern is then subjected to an **adversarial refute pass** (an independent skeptic sub-agent argues the concern is wrong or non-blocking) before it is allowed to cost a revision round — the distinct correctness/parity/scope lenses remain the primary defense against missed bugs, while the refute pass kills false-positive concerns.
+You are not alone — three independent critic **lenses** (correctness / parity / scope) evaluate every draft. Under the pipeline's current single-level dispatch model (the orchestrator spawns one specialist per issue; that specialist cannot itself spawn nested sub-agents), **you run these three lenses yourself, as clearly-delimited in-agent passes** rather than as nested sub-agents — see the multi-lens discipline in Step 3. The plan converges when all three approve (or downgrade to `REVISE-MINOR`). Each REVISE-MAJOR concern is then subjected to an **adversarial refute pass** (an in-agent skeptic pass argues the concern is wrong or non-blocking) before it is allowed to cost a revision round — the distinct correctness/parity/scope lenses remain the primary defense against missed bugs, while the refute pass kills false-positive concerns.
 
 **Hard cap: 2 rounds.** If round 2 still has REVISE-MAJOR verdicts, the plan **force-converges**: ship the round-2 plan as-is, file one follow-up issue per residual REVISE-MAJOR concern (so the disagreement is preserved as backlog rather than blocking the pipeline), and advance to `ready-for-doing`. The doer reads the converged plan and the follow-up list as "minor items to consider during implementation."
 
@@ -84,11 +84,22 @@ must be preserved. If not parity-critical: write "n/a — non-parity path".>
 <Known unknowns, edge cases, things that might bite at review time. Be honest.>
 ```
 
-## Step 3 — Round 1: Spawn 3 critics in parallel
+## Step 3 — Round 1: Run 3 critic lenses (in-agent multi-lens)
+
+### Multi-lens discipline (how to run the three lenses yourself)
+
+Under the current dispatch model you cannot spawn nested critic sub-agents, so **you run the three lenses (correctness / parity / scope) as three clearly-delimited passes within this agent**. The downstream contract is the **structured comments + verdict markers**, not the number of OS-level agents — so a disciplined in-agent multi-lens pass satisfies every parser as long as you hold to these four properties:
+
+1. **Distinct framing per lens.** Before each pass, adopt ONLY that lens's brief (Critic A / B / C below is the per-pass framing). Do not carry forward the previous lens's conclusions into the next.
+2. **No cross-lens peeking.** Form and **post each lens's verdict as its own separate comment** (a separate `gh pr comment` / issue-comment call) *before* starting the next lens. Never merge the three lenses into one block — the Step 4 / Step 6 parsers key on the `## 🔍 Critic X` header line and keep the latest comment per critic name, so each lens MUST be its own comment.
+3. **Explicit reset between lenses.** When you move to the next lens, evaluate it as if you had not authored the prior one — re-read the plan fresh through the new lens, do not anchor on what you just concluded.
+4. **Refute as a genuine adversary** (Step 4). The refute pass argues the *opposing* case as if it must prove a different reviewer wrong — see Step 4 for the stance-switch wording.
+
+(If a future nested-spawn capability lands, these same three briefs can be dispatched as parallel sub-agents instead — the per-lens framing and comment shapes are unchanged. The workspace-contract / forbidden-scratch sections below still bind any shell-out a lens performs.)
 
 ### Critic workspace contract
 
-**All critic scratch work must live only under `~/data` (the real home directory's `data/` subdirectory, derived from the passwd entry — immune to `$HOME` poisoning).** Critics should prefer the existing checkout for read-only inspection. If a critic needs a scratch checkout (e.g. to run a test or verify a claim), it must live under `~/data`, never in the repo root, the repo parent, or anywhere outside `~/data`. Each critic derives its workspace by sourcing the shared contract helper:
+**All critic scratch work must live only under `~/data` (the real home directory's `data/` subdirectory, derived from the passwd entry — immune to `$HOME` poisoning).** A lens should prefer the existing checkout for read-only inspection. If a lens needs a scratch checkout (e.g. to run a test or verify a claim), it must live under `~/data`, never in the repo root, the repo parent, or anywhere outside `~/data`. Derive the workspace by sourcing the shared contract helper:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -104,9 +115,9 @@ plan_critic_bootstrap "$ISSUE" "critic-a" || exit 1  # or critic-b, critic-c
 mkdir -p "$CRITIC_WORKTREE"
 ```
 
-Include this bootstrap verbatim in each critic's prompt so the sub-agent knows where to place any checkout or build output. The bootstrap is self-seeding: if the parent runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, the critic respects those only if they resolve under the real `~/data` AND under the expected session/issue prefix (`~/data/$SESSION_ID/plan-$ISSUE/...`); otherwise the bootstrap rejects the value and exits non-zero — the `|| exit 1` guard ensures no subsequent commands run with stale env vars. Hostile overrides (paths outside `~/data`, traversal like `~/data/../escape`, HOME-poisoned paths, or cross-session shared directories) are rejected before any `mkdir`, `git clone`, or cargo command runs.
+Use this bootstrap before any lens shell-out so you know where to place any checkout or build output. The bootstrap is self-seeding: if the runtime pre-sets `WORKTREE_BASE` or `CARGO_TARGET_DIR`, it respects those only if they resolve under the real `~/data` AND under the expected session/issue prefix (`~/data/$SESSION_ID/plan-$ISSUE/...`); otherwise the bootstrap rejects the value and exits non-zero — the `|| exit 1` guard ensures no subsequent commands run with stale env vars. Hostile overrides (paths outside `~/data`, traversal like `~/data/../escape`, HOME-poisoned paths, or cross-session shared directories) are rejected before any `mkdir`, `git clone`, or cargo command runs.
 
-**Forbidden scratch patterns (issue #2843 — hard requirement).** Every critic prompt must bind the sub-agent to `$CRITIC_WORKTREE` and explicitly forbid the observed disk-leak patterns — not in the repo tree, not as a `<repo>-pr<N>` sibling, not under `/tmp`:
+**Forbidden scratch patterns (issue #2843 — hard requirement).** Every lens shell-out is bound to `$CRITIC_WORKTREE` and must explicitly avoid the observed disk-leak patterns — not in the repo tree, not as a `<repo>-pr<N>` sibling, not under `/tmp`:
 
 - `.review-data/`
 - `.review-worktrees/`
@@ -115,9 +126,9 @@ Include this bootstrap verbatim in each critic's prompt so the sub-agent knows w
 - `.opencode/worktrees/`
 - any path under `/tmp`
 
-These are the exact out-of-`~/data` scratch dirs that prior pipeline runs leaked and that repeatedly filled the root FS. A critic that needs a checkout uses `$CRITIC_WORKTREE` and nothing else.
+These are the exact out-of-`~/data` scratch dirs that prior pipeline runs leaked and that repeatedly filled the root FS. A lens that needs a checkout uses `$CRITIC_WORKTREE` and nothing else.
 
-Launch three `general-purpose` sub-agents via the **Agent/Task tool** in a single message (so they run in parallel — do not dispatch them one at a time). Each is spawned with `model: opus` and `run_in_background: false`. Three distinct lenses (correctness / parity / scope) are the primary defense against missed bugs. Each gets the issue number, the plan-draft comment ID, and a focused brief:
+Run three lens passes in sequence (correctness / parity / scope), each as its own delimited pass per the multi-lens discipline above. Three distinct lenses are the primary defense against missed bugs. For each pass, frame yourself with that lens's brief, evaluate against the issue number and the plan-draft comment, and **post that lens's verdict as its own separate comment before moving to the next lens**:
 
 ### Critic A — Correctness
 
@@ -195,14 +206,16 @@ If all three converged in round 1 (no `REVISE-MAJOR`) → skip to Step 6 (post C
 
 If any critic returned `REVISE-MAJOR`, do **not** immediately revise. First subject each REVISE-MAJOR concern to an independent adversarial refute pass — this replaces the cross-model diversity the pipeline used to get from a second model, and directly attacks the false-positive concerns that otherwise cost a wasted round.
 
-Enumerate every distinct `REVISE-MAJOR` concern across the three critic comments (one concern = one bullet from a critic's "Key concerns" / details block). For each such concern, spawn an independent `general-purpose` **skeptic** sub-agent via the Agent/Task tool, all in a **single message** so they run in parallel, each with `model: opus` and `run_in_background: false`. The skeptic does NOT inherit the critic's framing — its job is to *refute* the concern:
+Enumerate every distinct `REVISE-MAJOR` concern across the three critic comments (one concern = one bullet from a critic's "Key concerns" / details block). For each such concern, run an independent **refute pass** in-agent — one delimited pass per concern. The refute pass does NOT inherit the critic's framing: switch stance and **argue the opposing case as if you must prove a different reviewer wrong**. Its job is to *refute* the concern. Apply the same multi-lens discipline (Step 3): distinct framing per refute, explicit reset from the critic pass that raised it, and **post each refute as its own separate comment**. Use this framing for each:
 
 > A critic raised the following REVISE-MAJOR concern about the plan on issue
 > #$ISSUE (plan-draft comment <comment-id>):
 >
 > <verbatim concern bullet + the critic lens it came from>
 >
-> Your job is to REFUTE this concern. Argue, with evidence, that it is one of:
+> Switch stance and REFUTE this concern as a genuine adversary — argue the
+> opposing case as if you must prove a different reviewer wrong. Argue, with
+> evidence, that it is one of:
 > (a) **wrong** — the plan already handles this, or the critic misread the
 > plan / the code; (b) **already-satisfied on current `origin/main`** — the
 > behavior the critic wants already exists (read the relevant source to
@@ -215,14 +228,14 @@ Enumerate every distinct `REVISE-MAJOR` concern across the three critic comments
 > if you genuinely cannot refute it on any of the three grounds, say so
 > explicitly. The concern only **stands** if it cannot be refuted.
 >
-> Post your finding as a comment headed `## 🥊 Refute — <critic lens>: <short
+> Post the refute as its own comment headed `## 🥊 Refute — <critic lens>: <short
 > concern summary>` with a `**Outcome:** REFUTED | STANDS` line, followed by a
 > 2–4 bullet justification (cite files/functions for ground (b)).
 
-Wait for all skeptics to post. Then:
+After every refute pass has posted, read the outcomes. Then:
 
-- A concern is **dropped** if its skeptic returned `REFUTED`. Record it in the eventual plan comment under a "Refuted concerns" note as `refuted: <reason>` so the audit trail shows why a flagged concern did not drive a revision.
-- A concern **stands** if its skeptic returned `STANDS` (or failed to post / errored after one retry — an un-refuted concern stands, fail-safe toward the critic).
+- A concern is **dropped** if its refute pass returned `REFUTED`. Record it in the eventual plan comment under a "Refuted concerns" note as `refuted: <reason>` so the audit trail shows why a flagged concern did not drive a revision.
+- A concern **stands** if its refute pass returned `STANDS` (or you could not produce an outcome after one retry — an un-refuted concern stands, fail-safe toward the critic).
 
 **Decision after the refute pass:**
 
@@ -267,7 +280,7 @@ Expand the plan to address the root cause. If expansion would now make the plan 
 **Followup sub-issues filed:** #N1, #N2 (if scope was narrowed)
 ```
 
-Spawn the same three critics again via the Agent/Task tool in a single message (parallel, `model: opus`, `run_in_background: false`), with the same briefs but with "Round 2" in the comment heading. Wait for verdicts. Then run the **same Step 4 adversarial refute pass** on any round-2 `REVISE-MAJOR` concern (parallel `opus` skeptics, one per concern); refuted concerns are dropped and only surviving concerns count below.
+Run the same three critic lenses again as in-agent passes (per the Step 3 multi-lens discipline), with the same briefs but with "Round 2" in the comment heading, posting each lens as its own separate comment. Then run the **same Step 4 adversarial refute pass** on any round-2 `REVISE-MAJOR` concern (one in-agent refute pass per concern); refuted concerns are dropped and only surviving concerns count below.
 
 **Round 2 outcomes (after the refute pass):**
 
@@ -397,7 +410,7 @@ gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
 ## What you do NOT do
 
 - **Do not** write or commit code. `/do` does that.
-- **Do not** run sequential critic rounds — the three critics (and the per-concern refute skeptics) are each launched in a single Agent/Task-tool message so they run in parallel.
+- **Do not** collapse the three lenses into one block — run them as three separate in-agent passes and post each as its own comment (the parsers key on the per-critic header). The per-concern refute passes are likewise each their own delimited pass with their own comment. (You do not run "rounds" of a single lens; each lens is evaluated once per plan round, with an explicit reset between lenses.)
 - **Do not** revise for a REVISE-MAJOR concern before running the refute pass. Only concerns that survive refutation drive a round-2 revision; refuted concerns are dropped (recorded as `refuted: <reason>` in the plan comment).
 - **Do not** exceed 2 rounds. If a round-2 REVISE-MAJOR concern survives refutation, force-converge (Step 5-bis) — file follow-ups for the surviving concerns and ship the round-2 plan to `ready-for-doing`. Do NOT spin a third round.
 - **Do not** "argue back" with a critic by re-opening the same plan. If you genuinely disagree, post your reasoning in the revised plan and let the round-2 critic re-evaluate. If round 2 still has a surviving REVISE-MAJOR, force-converge with the disagreement preserved as follow-up issues — don't block the pipeline.
@@ -405,8 +418,8 @@ gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
 
 ## Failure handling
 
-- **Critic agent failure:** if one of the three critics fails to post (timed out, errored), retry that critic once. If still failing, treat its verdict as REVISE-MAJOR and proceed to the refute pass / round 2; if round 2 also has a critic failure, `blocked` with that reason.
-- **Skeptic agent failure:** if a refute skeptic fails to post after one retry, the concern it was evaluating **stands** (fail-safe toward the critic) — it drives a revision as if un-refuted.
+- **Critic lens failure:** if one of the three lens passes fails to produce its verdict comment (errored, interrupted), retry that lens pass once. If still failing, treat its verdict as REVISE-MAJOR and proceed to the refute pass / round 2; if round 2 also has a lens failure, `blocked` with that reason.
+- **Refute pass failure:** if a refute pass fails to produce its outcome comment after one retry, the concern it was evaluating **stands** (fail-safe toward the critic) — it drives a revision as if un-refuted.
 - **Triage Report missing:** route the issue back to `backlog` with a comment explaining; this is a `/triage` bug, not ours to fix.
 - **GH API failure:** retry once after 5 seconds; if still failing, leave the issue assigned and exit non-zero.
 

--- a/.claude/skills/project-loop/SKILL.md
+++ b/.claude/skills/project-loop/SKILL.md
@@ -100,7 +100,7 @@ Dispatch the picked issues **in parallel** — emit all the Agent/Task tool call
 | `ready-for-doing` | `opus` | `Run /do <ISSUE> and report the final board state transition.` |
 | `in-review` | `opus` | `Run /review-pr <ISSUE> and report the final board state transition.` |
 
-Same rationale as `/project-tick`: haiku for triage, opus for plan/code/review. Cross-model diversity is now provided by the **adversarial refute pass** inside `/plan` and `/review-pr`, not a second model family.
+Same rationale as `/project-tick`: haiku for triage, opus for plan/code/review. Cross-model diversity is now provided by the **adversarial refute pass (run in-agent)** inside `/plan` and `/review-pr`, not a second model family. Under this single-level dispatch model the specialists run their adversarial lenses (the `/plan` critics + refute, the `/review-pr` reviewers + refute) as **in-agent multi-lens passes** — the supported mode — because a dispatched specialist cannot itself spawn nested sub-agents. Option 1 (the orchestrator spawning the adversarial lenses as sibling sub-agents for true OS-level independence) is recorded as a documented **future upgrade hook**, to be wired here should a nested-spawn capability later become available.
 
 All sub-agents run in the **foreground** (`run_in_background: false`) so you block on the batch and collect their reported state transitions. Sub-agent build artifacts (worktrees, cargo-targets) must stay under `~/data/<session>/` — the worktree-contract helper (`scripts/lib/agent-worktree-contract.sh`) enforces this; if a sub-agent reports a workspace that escaped `~/data`, record an anomaly (below).
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -23,7 +23,7 @@ argument-hint: <issue-number>
 
 You are the PR-level gate. Three independent signals decide the merge: **reviewer A**, **reviewer B**, and **CI**. All three must be green to auto-merge. Any red bounces.
 
-You do **not** review the code yourself — you orchestrate two independent reviewer sub-agents that use the existing `/review` and `/spec-adhere` skills (or `/review-fix` in review mode for risk-focused review), then combine their PR reviews with CI state.
+You do **not** review the code as one undifferentiated pass — you run two independent reviewer **lenses** that use the existing `/review` and `/spec-adhere` skills (or `/review-fix` in review mode for risk-focused review), then combine their PR reviews with CI state. Under the pipeline's current single-level dispatch model (the orchestrator spawns one specialist per issue; that specialist cannot itself spawn nested sub-agents), **you run both reviewer lenses yourself, as clearly-delimited in-agent passes** rather than as nested sub-agents — see the multi-lens discipline in Step 4.
 
 ## Inputs
 
@@ -94,7 +94,7 @@ Handle each state:
 
 ### Step 0.5 — Check if auto-merge is already armed
 
-Before spawning reviewers or filing follow-up issues, check whether this PR already has auto-merge enabled from a previous tick:
+Before running the reviewer passes or filing follow-up issues, check whether this PR already has auto-merge enabled from a previous tick:
 
 ```bash
 if ! AUTO_MERGE_STATE=$(is_auto_merge_armed $PR_NUM); then
@@ -282,15 +282,22 @@ If any path matches one of these prefixes, the PR is **parity-critical** — Rev
 
 Otherwise, the PR is **non-parity** — Reviewer B uses risk lens.
 
-## Step 4 — Spawn 2 reviewers in parallel
+## Step 4 — Run 2 reviewer lenses (in-agent multi-lens)
 
-Launch both `general-purpose` reviewers via the **Agent/Task tool** in a single message (so they run in parallel — do not dispatch them one at a time). Each is spawned with `model: opus` and `run_in_background: false`. The two distinct lenses (correctness + parity-or-risk) are the primary missed-bug defense; the adversarial refute pass in Step 6.1c is what trims the false-positive bounces.
+Run both reviewer lenses (correctness + parity-or-risk) as two clearly-delimited passes within this agent. Under the current dispatch model you cannot spawn nested reviewer sub-agents, so the downstream contract is the **structured comments + verdict markers**, not the number of OS-level agents. A disciplined in-agent multi-lens pass satisfies every Step 6 parser as long as you hold to these four properties:
 
-**Self-modifying detection (do the Step 5.5 path-match now, before spawning).** Compute `IS_SELF_MOD` per Step 5.5 first. If the PR is self-modifying, append the **extra-scrutiny checklist** from Step 5.5 to BOTH reviewer prompts below (skill frontmatter/markdown parses, scripts `bash -n` / source cleanly, no dispatch-table/step-numbering breakage). A self-modifying PR is NOT gated — it still auto-merges on triple-green — but the reviewers must confirm it cannot break the orchestrator's or specialists' next run.
+1. **Distinct framing per lens.** Before each pass, adopt ONLY that lens's brief (Reviewer A / B below is the per-pass framing). Do not carry the previous lens's conclusions into the next.
+2. **No cross-lens peeking.** Form and post each lens's verdict as its own separate comment — **two distinct `gh pr comment` calls with the two distinct headers** (`## 🔍 Reviewer: Correctness` and `## 🔍 Reviewer: <Parity|Risk>`), never one merged block — *before* starting the next lens. The Step 6.1 parser keys on the header line and keeps the latest comment per reviewer name, so each lens MUST be its own comment.
+3. **Explicit reset between lenses.** When you move to the second lens, evaluate it as if you had not authored the first — re-read the diff fresh through the new lens.
+4. **Refute as a genuine adversary** (Step 6.1c). The refute pass argues the *opposing* case as if it must prove a different reviewer wrong — see Step 6.1c for the stance-switch wording.
 
-**Review against current `origin/main` (do not review stale state).** Each reviewer prompt must instruct the sub-agent to `git fetch origin` and check out the PR head **rebased onto / merged with the latest `origin/main`** before reviewing or running anything — e.g. `git fetch origin && git checkout pr-$PR_NUM && git merge --no-edit origin/main` inside `$REVIEWER_WORKTREE`. Reviewing on a stale base is what caused historical merge-helper failures (the PR looked clean against an old main but conflicted or regressed against current main); always evaluate the PR as it will actually land.
+The two distinct lenses are the primary missed-bug defense; the adversarial refute pass in Step 6.1c is what trims the false-positive bounces. (If a future nested-spawn capability lands, these same two briefs can be dispatched as parallel sub-agents instead — the per-lens framing and comment shapes are unchanged.)
 
-**Workspace binding (issue #2843 — pass into every reviewer prompt).** Before spawning, run the Workspace-contract bootstrap to derive `$REVIEWER_WORKTREE` (under `~/data/$SESSION_ID/review-pr-$ISSUE/reviewer`). Pass that exact path into each reviewer prompt and require it as the ONLY scratch location:
+**Self-modifying detection (do the Step 5.5 path-match now, before the lens passes).** Compute `IS_SELF_MOD` per Step 5.5 first. If the PR is self-modifying, apply the **extra-scrutiny checklist** from Step 5.5 in BOTH reviewer passes below (skill frontmatter/markdown parses, scripts `bash -n` / source cleanly, no dispatch-table/step-numbering breakage). A self-modifying PR is NOT gated — it still auto-merges on triple-green — but the reviewer passes must confirm it cannot break the orchestrator's or specialists' next run.
+
+**Review against current `origin/main` (do not review stale state).** Each reviewer pass must `git fetch origin` and check out the PR head **rebased onto / merged with the latest `origin/main`** before reviewing or running anything — e.g. `git fetch origin && git checkout pr-$PR_NUM && git merge --no-edit origin/main` inside `$REVIEWER_WORKTREE`. Reviewing on a stale base is what caused historical merge-helper failures (the PR looked clean against an old main but conflicted or regressed against current main); always evaluate the PR as it will actually land.
+
+**Workspace binding (issue #2843 — applies to each reviewer pass).** Before the lens passes, run the Workspace-contract bootstrap to derive `$REVIEWER_WORKTREE` (under `~/data/$SESSION_ID/review-pr-$ISSUE/reviewer`). Use that exact path in each reviewer pass as the ONLY scratch location:
 
 > Your working directory and any checkout/build scratch MUST be `$REVIEWER_WORKTREE` (`<resolved-path>`). If you need a git worktree, run `git worktree add "$REVIEWER_WORKTREE/<sub>"`; if you build, set `CARGO_TARGET_DIR="$REVIEWER_WORKTREE/cargo-target"`. You are FORBIDDEN from creating `.review-data/`, `.review-worktrees/`, `.worktrees/`, `.copilot-tmp/`, `.opencode/worktrees/`, any `<repo>-pr<N>` sibling, or any path under `/tmp`. These are the disk-leak patterns from #2843 and have repeatedly filled the root FS.
 
@@ -434,11 +441,11 @@ Post via `gh pr comment $PR_NUM --repo stellar-experimental/henyey --body-file <
 > previously-raised classes; only add a new class with an explicit
 > \`**NEW CLASS DISCOVERED:**\` flag and rationale.
 
-Wait for both reviewers to post.
+Run both lens passes and post both verdict comments (each its own separate comment) before proceeding.
 
 ## Step 5 — Recheck CI
 
-Reviewers run in parallel with CI. By the time both have posted their reviews, CI may have finished. Re-query:
+The reviewer passes overlap with CI (CI runs on the PR head while you review). By the time both verdict comments are posted, CI may have finished. Re-query:
 
 ```bash
 ROLLUP=$(gh pr view $PR_NUM --repo stellar-experimental/henyey \
@@ -505,7 +512,7 @@ IS_SELF_MOD=$(echo "$SELF_MOD_FILES" | grep -Eq \
 
 If `IS_SELF_MOD == true`, the PR is **flagged** as self-modifying and the reviewers apply **extra scrutiny** — but it is **not** gated or escalated. It proceeds through the normal merge decision (Step 6) and auto-merges autonomously on triple-green, exactly like any other PR. Adversarial review + CI are the gate; there is no separate operator-approval hold.
 
-When the PR is self-modifying, instruct both reviewer sub-agents (Step 4) to explicitly verify the change cannot break the orchestrator's or specialists' next run, in addition to their normal lens. Add this checklist to their brief:
+When the PR is self-modifying, both reviewer passes (Step 4) must explicitly verify the change cannot break the orchestrator's or specialists' next run, in addition to their normal lens. Apply this checklist in each pass:
 
 - **Skill files still parse**: every changed `.claude/skills/*/SKILL.md` has valid YAML frontmatter (`name` / `description` / `argument-hint`) and is well-formed markdown — no truncated frontmatter, no broken fences.
 - **Scripts still source cleanly**: every changed `*.sh` passes `bash -n` (syntax check) and, for sourced libraries, `bash -c 'source <file>'` without error.
@@ -539,7 +546,7 @@ For each comment, extract the reviewer name from the first line (`## 🔍 Review
 - `Correctness` (always)
 - `Parity` or `Risk` (depending on parity-critical detection from Step 3)
 
-If only one verdict is found, **treat the missing one as `CHANGES_REQUESTED` and bounce.** A missing verdict means a reviewer sub-agent failed to post — that's the same failure mode as the "Reviewer sub-agent fails to post" entry in the failure-handling table below. Do NOT wait indefinitely on a missing verdict; bounce so `/do` Mode B can retry, and the next `/review-pr` cycle will spawn fresh reviewers. If both are present, use them. If a reviewer posted twice (e.g. revised verdict), the latest comment wins.
+If only one verdict is found, **treat the missing one as `CHANGES_REQUESTED` and bounce.** A missing verdict means a reviewer pass failed to produce its verdict comment — that's the same failure mode as the "Reviewer pass fails to produce a verdict comment" entry in the failure-handling table below. Do NOT wait indefinitely on a missing verdict; bounce so `/do` Mode B can retry, and the next `/review-pr` cycle will re-run fresh reviewer passes. If both are present, use them. If a reviewer posted twice (e.g. revised verdict), the latest comment wins.
 
 ### 6.1b Parse external reviewer verdicts (GH Copilot bot, humans, other bots)
 
@@ -569,16 +576,18 @@ Each external reviewer's verdict is the `state` of their latest review:
 
 This replaces the cross-model diversity the pipeline used to get from a second model, and directly cuts the false-positive bounces. Run it **after** the reviewers post and **before** applying the matrix.
 
-Enumerate every distinct blocking finding from the **agent** reviewers' latest `CHANGES_REQUESTED` verdicts (one finding = one concern bullet from a reviewer's `<details>` change-list). For each, spawn an independent `general-purpose` **skeptic** sub-agent via the Agent/Task tool, all in a **single message** so they run in parallel, each with `model: opus` and `run_in_background: false`. Each skeptic checks out the PR against current `origin/main` (same `git fetch origin` + merge instruction as Step 4) so it refutes on fresh state:
+Enumerate every distinct blocking finding from the **agent** reviewers' latest `CHANGES_REQUESTED` verdicts (one finding = one concern bullet from a reviewer's `<details>` change-list). For each, run an independent **refute pass** in-agent — one delimited pass per finding, per the Step 4 multi-lens discipline (distinct framing, explicit reset from the reviewer pass that raised it, **each refute posted as its own separate comment**). Switch stance and argue the opposing case as if you must prove a different reviewer wrong. Each refute pass first checks out the PR against current `origin/main` (same `git fetch origin` + merge instruction as Step 4) so it refutes on fresh state. Use this framing for each:
 
 > Reviewer <Correctness|Parity|Risk> raised this blocking finding (CHANGES_REQUESTED)
 > on PR #$PR_NUM in stellar-experimental/henyey:
 >
 > <verbatim finding bullet>
 >
-> Your job is to REFUTE this finding. First `git fetch origin` and check out the
-> PR head merged with the latest `origin/main` inside `$REVIEWER_WORKTREE` (do
-> NOT review stale state). Then argue, with evidence, that the finding is one of:
+> Switch stance and REFUTE this finding as a genuine adversary — argue the
+> opposing case as if you must prove a different reviewer wrong. First
+> `git fetch origin` and check out the PR head merged with the latest
+> `origin/main` inside `$REVIEWER_WORKTREE` (do NOT review stale state). Then
+> argue, with evidence, that the finding is one of:
 > (a) **wrong** — the diff already handles this, or the reviewer misread the
 > code; (b) **already-fixed on current `origin/main`** — the change the reviewer
 > wants already exists once the PR is rebased (confirm by reading the merged
@@ -591,10 +600,10 @@ Enumerate every distinct blocking finding from the **agent** reviewers' latest `
 > finding summary>` with an `**Outcome:** REFUTED | STANDS` line and a 2–4
 > bullet justification (cite files/lines for ground (b)).
 
-Wait for all skeptics. Then:
+After every refute pass has posted, read the outcomes. Then:
 
-- A finding is **dropped** if its skeptic returned `REFUTED` — it does NOT bounce the PR. Record it as `refuted: <reason>` in the eventual verdict comment.
-- A finding **stands** if its skeptic returned `STANDS` (or failed to post / errored after one retry — un-refuted findings stand, fail-safe toward the reviewer).
+- A finding is **dropped** if its refute pass returned `REFUTED` — it does NOT bounce the PR. Record it as `refuted: <reason>` in the eventual verdict comment.
+- A finding **stands** if its refute pass returned `STANDS` (or you could not produce an outcome after one retry — un-refuted findings stand, fail-safe toward the reviewer).
 
 For the matrix below, an **agent** reviewer's verdict is treated as `CHANGES_REQUESTED` only if **at least one** of its findings survived refutation. If every finding from that reviewer was refuted, treat that reviewer's verdict as `APPROVE` for matrix purposes (the dropped findings are still recorded in the verdict comment).
 
@@ -1092,7 +1101,7 @@ Exit.
 
 ## What you do NOT do
 
-- **Do not** post a review yourself. Spawn sub-agents that post their own structured comments — you only orchestrate and combine.
+- **Do not** post a single combined review. Run two reviewer passes that each post their own structured comment (each its own `gh pr comment` with its own header), then combine and parse those comments — do not merge the two lenses into one block (the Step 6.1 parser keys on the per-reviewer header).
 - **Do not** override or summarize the reviewers' verdicts. Their `**Verdict:**` line is the verdict. You read it; you don't rewrite it — except that an agent reviewer's CHANGES_REQUESTED finding is dropped if the Step 6.1c refute pass returns `REFUTED` (recorded as `refuted: <reason>`).
 - **Do not** run the refute pass on **external** CHANGES_REQUESTED reviews (GH Copilot bot, humans, other bots). Only the agent reviewers' own findings are refutable; external reviews gate as-is.
 - **Do** flag a **self-modifying** PR (touches the pipeline's own skills/scripts — see Step 5.5) and apply extra reviewer scrutiny, but **do not** hold it for operator approval — it auto-merges autonomously on triple-green like any other PR. If a reviewer genuinely doubts the change is safe for the live pipeline, that's a CHANGES_REQUESTED bounce, not an operator escalation.
@@ -1104,8 +1113,8 @@ Exit.
 
 | Failure | Action |
 |---|---|
-| Reviewer sub-agent fails to post | Retry once. If still failing, treat as `CHANGES_REQUESTED` and bounce. |
-| Refute skeptic fails to post (Step 6.1c) | Retry once. If still failing, the finding **stands** (fail-safe toward the reviewer) — it gates the matrix as a surviving CHANGES_REQUESTED. |
+| Reviewer pass fails to produce a verdict comment | Retry that pass once. If still failing, treat as `CHANGES_REQUESTED` and bounce. |
+| Refute pass fails to produce an outcome comment (Step 6.1c) | Retry that pass once. If still failing, the finding **stands** (fail-safe toward the reviewer) — it gates the matrix as a surviving CHANGES_REQUESTED. |
 | Reviewer's comment doesn't match the expected header/verdict shape | Treat as `pending`; if it stays malformed after Step 4 completes, bounce with a `## Review: Malformed Verdict` note. |
 | No PR linked | Bounce to `ready-for-doing` with `## Review: No PR Linked`. |
 | `gh pr merge --admin` fails with auto-merge hint | Retry with `--auto` (deferred merge). If `--auto` also fails, hard failure. See Step 7.3. |
@@ -1135,14 +1144,14 @@ mkdir -p "$REVIEWER_WORKTREE"
 
 This ensures build artifacts are isolated per-session and automatically discoverable
 for cleanup. The skill itself is read-only (no code changes), so it rarely needs a
-build cache — but if a reviewer sub-agent builds to verify, the target dir must
+build cache — but if a reviewer pass builds to verify, the target dir must
 resolve under `~/data` and within the session prefix.
 
 **Never create worktrees at the repo root or outside `~/data`.** All worktrees
 must be under `~/data/$SESSION_ID/` to avoid polluting the shared checkout.
 
 **Forbidden scratch patterns (issue #2843 — hard requirement).** Every reviewer
-sub-agent (and any `/review`, `/spec-adhere`, `/review-fix` it invokes) is bound
+pass (and any `/review`, `/spec-adhere`, `/review-fix` it invokes) is bound
 to `$REVIEWER_WORKTREE` and must NEVER create any of these observed disk-leak
 patterns — not in the repo tree, not as a `<repo>-pr<N>` sibling, not under `/tmp`:
 


### PR DESCRIPTION
Closes #3132

## Summary

The `/plan` and `/review-pr` skills previously instructed the dispatched specialist to spawn its adversarial lenses (3 critics for `/plan`; 2 reviewers + per-finding refute skeptics for `/review-pr`) as nested Agent/Task sub-agents. Under the pipeline's single-level dispatch model a dispatched specialist cannot spawn nested sub-agents, so this PR rewords those instructions (Option 2 from the converged plan) into clearly-delimited **in-agent lens passes**: distinct framing per lens, no cross-lens peeking, explicit reset between lenses, and refute as a genuine stance-switching adversary. Every downstream contract is preserved byte-for-intent — each lens still posts its own separate structured comment, so the verdict/refute parsers, convergence/force-converge rules, the Step 6 decision matrix, the Step 5.5 self-modifying gate, and the workspace/forbidden-scratch sections are unchanged. `project-loop/SKILL.md` gains a one-line note that in-agent multi-lens is the supported mode, with Option-1 orchestrator-spawned siblings recorded as a documented future upgrade hook.

This is a **self-modifying** PR (edits pipeline skills) — per the #3176 policy it merges on triple-green with extra reviewer scrutiny.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3132#issuecomment-4632476928)

## Test plan

- [x] Frontmatter intact in all three SKILL.md files (`name`/`description`/`argument-hint`)
- [x] Code fences balanced (even count) in all three files
- [x] Verdict/refute markers preserved: `## 🔍 Critic`, `## 🔍 Reviewer:`, `## 🥊 Refute`, `**Verdict:**`, `**Outcome:**`
- [x] Cross-references resolve (Step 4 / 5.5 / 6.1c / 7-bis / 5-bis)
- [x] Failure-handling rows reworded, not deleted
- [x] No instruction tells a dispatched specialist to spawn nested agents
- [x] `scripts/test-review-pr-skill-snippets.sh` — all 49 tests pass
- [x] pre-commit hook (cargo fmt --check + clippy --all -D warnings) passed

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)