### PR TITLE
Remove deprecated unused Peer::send_more helper

### DIFF
--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -975,12 +975,6 @@ impl Peer {
 
     /// Request peers from this peer.
     /// Note: GetPeers was removed in Protocol 24. This is a no-op.
-    /// Send flow control message.
-    pub async fn send_more(&mut self, num_messages: u32) -> Result<()> {
-        let message = StellarMessage::SendMore(stellar_xdr::curr::SendMore { num_messages });
-        self.send(message).await
-    }
-
     /// Send extended flow control message with byte limit.
     pub async fn send_more_extended(&mut self, num_messages: u32, num_bytes: u32) -> Result<()> {
         let message = StellarMessage::SendMoreExtended(stellar_xdr::curr::SendMoreExtended {


### PR DESCRIPTION
Closes #3078

## Summary

Removes the unused public `Peer::send_more()` method from `crates/overlay/src/peer.rs`. It constructed a deprecated v0 `SEND_MORE` message, which OVERLAY spec §7.6.1 forbids sending (implementations MUST send `SEND_MORE_EXTENDED` instead). The function had zero callers in production or tests; the modern flow-control path uses `send_more_extended`. The receive side already drops deprecated `SEND_MORE` correctly (`peer_loop.rs`), so removing this send helper completes the spec alignment and removes a footgun that could generate spec-violating traffic. Dead-code removal — zero behavioral change.

## Plan reference

Trivial short-circuit per the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3078#issuecomment-4628770686) on #3078 (ACCEPT, trivial, XS, crate:overlay).

## Verification

- Re-confirmed zero callers: `grep -rn '\.send_more\b' crates/ --include='*.rs'` (excluding the definition and `send_more_extended`) returns no matches.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-overlay -- -D warnings` clean
- [x] `cargo test -p henyey-overlay` passes

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)