### PR TITLE
Make scripts/lib helper self-location zsh-safe + add cross-shell CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,10 @@ jobs:
         run: bash scripts/test-agent-worktree-contract.sh
       - name: Verify do_bootstrap workspace persist/reap contract
         run: bash scripts/lib/tests/test-do-bootstrap.bats
+      - name: Install zsh (for cross-shell helper self-test)
+        run: sudo apt-get update && sudo apt-get install -y zsh
+      - name: Verify shell-lib helpers source clean under bash and zsh
+        run: bash scripts/test-shell-lib-cross-shell.sh
 
   quickstart-harness:
     name: Quickstart Harness

--- a/scripts/lib/dedup-filing.sh
+++ b/scripts/lib/dedup-filing.sh
@@ -12,7 +12,15 @@
 #   DEDUP_DATA=$(dedup_record "$DEDUP_DATA" "$key" "issue_number=123")
 #   dedup_write "$DEDUP_FILE" "$DEDUP_DATA"
 
-_DEDUP_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dedup-filing.py"
+# Cross-shell self-location. Under bash, ${BASH_SOURCE[0]} is this file's path.
+# Under zsh, BASH_SOURCE is unset/empty, so the :- fallback yields ${(%):-%x}
+# — a zsh prompt-expansion that expands to the path of the file being sourced.
+# Bash never evaluates the literal zsh default (BASH_SOURCE[0] is always set
+# when sourced under bash), so the construct is harmless there. This resolves
+# to the script dir under BOTH shells from any caller cwd (#3137).
+_dedup_src="${BASH_SOURCE[0]:-${(%):-%x}}"
+_DEDUP_SCRIPT="$(cd "$(dirname "$_dedup_src")" && pwd)/dedup-filing.py"
+unset _dedup_src
 
 dedup_load()         { python3 "$_DEDUP_SCRIPT" load "$1"; }
 dedup_prune()        { printf '%s' "$1" | python3 "$_DEDUP_SCRIPT" prune "$2"; }

--- a/scripts/lib/eval-alarms.sh
+++ b/scripts/lib/eval-alarms.sh
@@ -13,7 +13,16 @@
 #   CRASH_RECOVERY, UPTIME_SECONDS, MONITOR_MODE, PID, START_TICKS
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Cross-shell self-location (defensive). This wrapper is normally RUN via its
+# bash shebang, but a `zsh scripts/lib/eval-alarms.sh` invocation must not abort
+# at this line with `BASH_SOURCE[0]: parameter not set` (zsh has no BASH_SOURCE,
+# and `set -u` is active above). Under bash ${BASH_SOURCE[0]} is this file; under
+# zsh the :- fallback yields ${(%):-%x} (the running script's path). Bash never
+# evaluates the literal zsh default. Resolves to the script dir under both
+# shells from any cwd (#3137).
+_eval_alarms_src="${BASH_SOURCE[0]:-${(%):-%x}}"
+SCRIPT_DIR="$(cd "$(dirname "$_eval_alarms_src")" && pwd)"
+unset _eval_alarms_src
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 SESSION_DIR="${HOME}/data/${MONITOR_SESSION_ID:?MONITOR_SESSION_ID required}"

--- a/scripts/lib/pipeline-anomaly-log.sh
+++ b/scripts/lib/pipeline-anomaly-log.sh
@@ -39,8 +39,10 @@ anomaly_log_append() {
   # Strip embedded tabs/newlines so each anomaly stays on one TSV line.
   signal="${signal//$'\t'/ }"; signal="${signal//$'\n'/ }"
   evidence="${evidence//$'\t'/ }"; evidence="${evidence//$'\n'/ }"
+  # Fail loud on append error (e.g. read-only dir, ENOSPC) so a lost anomaly
+  # signal surfaces instead of being silently dropped.
   printf '%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$signal" "$evidence" \
-    >> "$log_file"
+    >> "$log_file" || return 1
 }
 
 # anomaly_log_dump — print the current session's log (nothing if absent).
@@ -59,8 +61,11 @@ anomaly_log_clear() {
   return 0
 }
 
-# Self-test: only runs when executed directly, never when sourced.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Self-test: only runs when executed directly, never when sourced. The guard is
+# quoted with a :- default so it can never abort under a future `setopt nounset`
+# / `set -u` caller (zsh has no BASH_SOURCE → the default yields ""; "" never
+# equals "$0", so the self-test stays bash-execute-only — behavior unchanged).
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
   set -euo pipefail
   tmp_log="$(mktemp)"
   trap 'rm -f "$tmp_log"' EXIT

--- a/scripts/test-shell-lib-cross-shell.sh
+++ b/scripts/test-shell-lib-cross-shell.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# test-shell-lib-cross-shell.sh — dual-shell (bash + zsh) regression guard for
+# the sourced shell-helper layer under scripts/lib/.
+#
+# The project orchestrator and its sub-agents run under zsh, but scripts/lib/*.sh
+# are authored for bash. Several latent cross-shell defects (zsh has no
+# BASH_SOURCE; zsh does not word-split unquoted parameters by default; a fresh
+# shell per Bash tool call breaks "source once" assumptions) can silently break
+# pipeline behavior. This harness sources every SOURCED library under BOTH bash
+# and zsh from a cwd != scripts/lib (with per-helper required-env stubs) and
+# asserts clean rc + expected functions defined, plus three behavioral
+# round-trips. The zsh leg TAP-skips if zsh is absent; CI installs zsh so the
+# zsh leg actually runs there.
+#
+# Usage: bash scripts/test-shell-lib-cross-shell.sh
+# Exit: 0 if all tests pass (or skip), 1 otherwise.
+#
+# Output: Test Anything Protocol (TAP).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB_DIR="$REPO_ROOT/scripts/lib"
+
+# All scratch lives under a mktemp dir (CI ephemeral runner). Locally, honor a
+# ~/data session dir if one is exported, to keep with the #2843 contract; else
+# fall back to a system mktemp.
+if [[ -n "${CLAUDE_SESSION_ID:-}" && -d "${HOME}/data" ]]; then
+  SCRATCH="$(mktemp -d "${HOME}/data/${CLAUDE_SESSION_ID}/shell-lib-xshell.XXXXXX")"
+else
+  SCRATCH="$(mktemp -d)"
+fi
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# A foreign cwd (NOT scripts/lib) used for every source/exec, so that any
+# self-location bug (resolving against the caller cwd instead of the script
+# dir) is exposed.
+FOREIGN_CWD="$SCRATCH"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Manifest: sourced libraries vs executable wrappers.
+#
+# SOURCED_LIBS — documented "source this" libraries with idempotent _LOADED
+# guards. Sourced by skills/tests. The cross-shell test SOURCES these.
+# EXEC_WRAPPERS — documented executable wrappers (# Usage:, set -euo pipefail,
+# exec ...). These are RUN via their bash shebang, never sourced; the test only
+# smoke-checks them (never sources).
+# ─────────────────────────────────────────────────────────────────────────────
+SOURCED_LIBS=(
+  agent-worktree-contract.sh
+  dedup-filing.sh
+  deploy-quarantine.sh
+  monitor-decisions.sh
+  review-pr-merge.sh
+  review-pr-verdicts.sh
+  pipeline-anomaly-log.sh
+)
+
+EXEC_WRAPPERS=(
+  eval-alarms.sh
+)
+
+# Expected functions per sourced library (a representative, load-bearing set;
+# if any is missing after a clean source, the lib failed to define its surface).
+expected_funcs_for() {
+  case "$1" in
+    agent-worktree-contract.sh)
+      echo "_contract_real_home canonicalize_contract_path require_home_data_path require_session_prefix plan_critic_bootstrap review_pr_bootstrap do_bootstrap assert_no_repo_tree_scratch" ;;
+    dedup-filing.sh)
+      echo "dedup_load dedup_prune dedup_check dedup_record dedup_remove dedup_update_field dedup_write" ;;
+    deploy-quarantine.sh)
+      echo "parse_quarantine_file check_quarantine_active check_quarantine_ancestry quarantine_append quarantine_remove" ;;
+    monitor-decisions.sh)
+      echo "check_session_wiped check_long_stale_session detect_crash_state cleanup_guard" ;;
+    review-pr-merge.sh)
+      echo "attempt_merge classify_linked_pr_state is_auto_merge_armed has_armed_waiting_comment check_armed_pr_health" ;;
+    review-pr-verdicts.sh)
+      echo "fetch_reviewer_verdict_comments latest_reviewer_verdict_state validate_reviewer_verdict_shape classify_reviewer" ;;
+    pipeline-anomaly-log.sh)
+      echo "anomaly_log_path anomaly_log_append anomaly_log_dump anomaly_log_clear" ;;
+    *)
+      echo "" ;;
+  esac
+}
+
+# Per-helper required-env stubs (Critic A): set before sourcing so a missing
+# precondition is never mistaken for a BASH_SOURCE / cross-shell regression.
+# Emitted as shell assignments prepended to the source command.
+env_stubs_for() {
+  case "$1" in
+    # eval-alarms reads MONITOR_SESSION_ID; harmless to stub broadly even for
+    # libs that don't read it.
+    *)
+      echo "export MONITOR_SESSION_ID=xshell-stub-session; export CLAUDE_SESSION_ID=\"\${CLAUDE_SESSION_ID:-xshell-stub-session}\";" ;;
+  esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TAP plumbing
+# ─────────────────────────────────────────────────────────────────────────────
+TEST_NUM=0
+FAIL=0
+HAVE_ZSH=0
+if command -v zsh >/dev/null 2>&1; then HAVE_ZSH=1; fi
+
+ok()   { TEST_NUM=$((TEST_NUM + 1)); printf 'ok %d - %s\n' "$TEST_NUM" "$1"; }
+notok(){ TEST_NUM=$((TEST_NUM + 1)); FAIL=$((FAIL + 1)); printf 'not ok %d - %s\n' "$TEST_NUM" "$1"
+         shift; for line in "$@"; do printf '# %s\n' "$line"; done; }
+skip() { TEST_NUM=$((TEST_NUM + 1)); printf 'ok %d - %s # SKIP %s\n' "$TEST_NUM" "$1" "$2"; }
+
+# run_in_shell SHELL_BIN CODE  — run CODE in a fresh `SHELL_BIN -c`, from the
+# foreign cwd. Echoes nothing; sets globals RC and OUT (stdout+stderr merged is
+# NOT what we want — we capture them separately).
+# Sets: _RC, _STDOUT, _STDERR.
+run_in_shell() {
+  local shbin="$1" code="$2"
+  local out_f err_f
+  out_f="$(mktemp "$SCRATCH/out.XXXXXX")"
+  err_f="$(mktemp "$SCRATCH/err.XXXXXX")"
+  ( cd "$FOREIGN_CWD" && "$shbin" -c "$code" ) >"$out_f" 2>"$err_f"
+  _RC=$?
+  _STDOUT="$(cat "$out_f")"
+  _STDERR="$(cat "$err_f")"
+  rm -f "$out_f" "$err_f"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 1: every SOURCED lib sources clean under bash AND zsh.
+#   (all-sourced-libs-clean-source)
+# Asserts: rc==0 AND empty stderr AND every expected function defined.
+# ─────────────────────────────────────────────────────────────────────────────
+assert_sourced_lib_clean() {
+  local shbin="$1" lib="$2" shname="$3"
+  local libpath="$LIB_DIR/$lib"
+  local funcs; funcs="$(expected_funcs_for "$lib")"
+  local stubs; stubs="$(env_stubs_for "$lib")"
+
+  # Build a check that sources then verifies each expected function is defined.
+  local checkcode="$stubs source '$libpath' || { echo 'SOURCE_RC_NONZERO' >&2; exit 3; };"
+  local f
+  for f in $funcs; do
+    checkcode+=" command -v $f >/dev/null 2>&1 || { echo 'MISSING_FUNC:$f' >&2; exit 4; };"
+  done
+  checkcode+=" exit 0"
+
+  run_in_shell "$shbin" "$checkcode"
+
+  local label="source-clean[$shname]: $lib"
+  if [[ "$_RC" -ne 0 ]]; then
+    notok "$label" "rc=$_RC" "stderr: ${_STDERR}"
+    return
+  fi
+  if [[ -n "$_STDERR" ]]; then
+    notok "$label" "non-empty stderr on clean source:" "$_STDERR"
+    return
+  fi
+  ok "$label"
+}
+
+for lib in "${SOURCED_LIBS[@]}"; do
+  assert_sourced_lib_clean bash "$lib" bash
+done
+if [[ "$HAVE_ZSH" -eq 1 ]]; then
+  for lib in "${SOURCED_LIBS[@]}"; do
+    assert_sourced_lib_clean zsh "$lib" zsh
+  done
+else
+  for lib in "${SOURCED_LIBS[@]}"; do
+    skip "source-clean[zsh]: $lib" "zsh not installed"
+  done
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 2: dedup-zsh-script-path  (BUG-FIX regression test)
+#   Source dedup-filing.sh from a foreign cwd; assert _DEDUP_SCRIPT resolves to
+#   <repo>/scripts/lib/dedup-filing.py under BOTH shells. FAILS on main under
+#   zsh (resolves to <cwd>/dedup-filing.py).
+# ─────────────────────────────────────────────────────────────────────────────
+EXPECTED_DEDUP="$LIB_DIR/dedup-filing.py"
+assert_dedup_script_path() {
+  local shbin="$1" shname="$2"
+  run_in_shell "$shbin" "source '$LIB_DIR/dedup-filing.sh'; printf '%s' \"\$_DEDUP_SCRIPT\""
+  local label="dedup-zsh-script-path[$shname]: _DEDUP_SCRIPT resolves to script dir"
+  if [[ "$_RC" -ne 0 ]]; then
+    notok "$label" "rc=$_RC" "stderr: $_STDERR"; return
+  fi
+  if [[ "$_STDOUT" != "$EXPECTED_DEDUP" ]]; then
+    notok "$label" "expected: $EXPECTED_DEDUP" "got:      $_STDOUT"; return
+  fi
+  ok "$label"
+}
+assert_dedup_script_path bash bash
+if [[ "$HAVE_ZSH" -eq 1 ]]; then
+  assert_dedup_script_path zsh zsh
+else
+  skip "dedup-zsh-script-path[zsh]: _DEDUP_SCRIPT resolves to script dir" "zsh not installed"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 3: eval-alarms-zsh-no-paramnotset
+#   Run `zsh scripts/lib/eval-alarms.sh` with a stubbed (non-existent) session;
+#   assert stderr contains NO "BASH_SOURCE[0]: parameter not set". The python
+#   invocation will fail (no metrics) — that's fine; we only assert the
+#   self-location no longer aborts under zsh. FAILS on main.
+# ─────────────────────────────────────────────────────────────────────────────
+assert_eval_alarms_no_paramnotset() {
+  local shbin="$1" shname="$2"
+  local wrapper="$LIB_DIR/eval-alarms.sh"
+  local err_f; err_f="$(mktemp "$SCRATCH/ea-err.XXXXXX")"
+  ( cd "$FOREIGN_CWD" && MONITOR_SESSION_ID="xshell-nonexistent-$$" "$shbin" "$wrapper" ) >/dev/null 2>"$err_f"
+  local stderr; stderr="$(cat "$err_f")"; rm -f "$err_f"
+  local label="eval-alarms-no-paramnotset[$shname]: no BASH_SOURCE parameter-not-set abort"
+  if printf '%s' "$stderr" | grep -qF "BASH_SOURCE[0]: parameter not set"; then
+    notok "$label" "stderr contained BASH_SOURCE parameter-not-set:" "$stderr"
+    return
+  fi
+  ok "$label"
+}
+assert_eval_alarms_no_paramnotset bash bash
+if [[ "$HAVE_ZSH" -eq 1 ]]; then
+  assert_eval_alarms_no_paramnotset zsh zsh
+else
+  skip "eval-alarms-no-paramnotset[zsh]: no BASH_SOURCE parameter-not-set abort" "zsh not installed"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 4: functions-defined-both-shells (anti-regression for the
+#   already-landed agent-worktree-contract.sh zsh fix).
+#   Covered by assert_sourced_lib_clean for the contract helper, but we add an
+#   explicit dedicated assertion so the named guard is unmistakable in TAP.
+# ─────────────────────────────────────────────────────────────────────────────
+assert_contract_funcs_defined() {
+  local shbin="$1" shname="$2"
+  local funcs; funcs="$(expected_funcs_for agent-worktree-contract.sh)"
+  local code="source '$LIB_DIR/agent-worktree-contract.sh' || exit 3;"
+  local f
+  for f in $funcs; do
+    code+=" command -v $f >/dev/null 2>&1 || { echo MISSING:$f; exit 4; };"
+  done
+  code+=" echo ALL_DEFINED"
+  run_in_shell "$shbin" "$code"
+  local label="contract-functions-defined[$shname]"
+  if [[ "$_RC" -eq 0 && "$_STDOUT" == "ALL_DEFINED" ]]; then
+    ok "$label"
+  else
+    notok "$label" "rc=$_RC" "stdout: $_STDOUT" "stderr: $_STDERR"
+  fi
+}
+assert_contract_funcs_defined bash bash
+if [[ "$HAVE_ZSH" -eq 1 ]]; then
+  assert_contract_funcs_defined zsh zsh
+else
+  skip "contract-functions-defined[zsh]" "zsh not installed"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 5: merge-flags-separated-both-shells (anti-regression #2954).
+#   attempt_merge → _review_pr_exec_merge must pass --squash and --admin as TWO
+#   distinct args, not one "--squash --admin" string. A REVIEW_PR_MERGE_CMD mock
+#   records ARGC and the individual flags. Under correct behavior the mock sees
+#   pr_num, repo, --squash, --admin → ARGC=4 with the two flags distinct.
+# ─────────────────────────────────────────────────────────────────────────────
+assert_merge_flags_separated() {
+  local shbin="$1" shname="$2"
+  local probe="$SCRATCH/merge-probe-$shname.txt"
+  rm -f "$probe"
+  # Mock: a function that writes ARGC and each arg on its own line, then exits 0
+  # so attempt_merge treats it as a successful merge.
+  local code="
+    export REVIEW_PR_SCRATCH_DIR='$SCRATCH/merge-scratch-$shname';
+    mkdir -p \"\$REVIEW_PR_SCRATCH_DIR\";
+    source '$LIB_DIR/review-pr-merge.sh';
+    mock_merge() { { echo \"ARGC=\$#\"; for a in \"\$@\"; do echo \"ARG=\$a\"; done; } >'$probe'; return 0; }
+    export REVIEW_PR_MERGE_CMD=mock_merge;
+    out=\"\$(attempt_merge 4242)\";
+    echo \"OUT=\$out\"
+  "
+  run_in_shell "$shbin" "$code"
+  local label="merge-flag-separation[$shname]: --squash and --admin arrive as distinct args"
+  if [[ ! -f "$probe" ]]; then
+    notok "$label" "mock probe file not written" "rc=$_RC stdout=$_STDOUT stderr=$_STDERR"
+    return
+  fi
+  local argc squash admin
+  argc="$(grep -E '^ARGC=' "$probe" | head -1 | cut -d= -f2)"
+  squash="$(grep -cxF 'ARG=--squash' "$probe")"
+  admin="$(grep -cxF 'ARG=--admin' "$probe")"
+  if [[ "$argc" == "4" && "$squash" == "1" && "$admin" == "1" ]]; then
+    ok "$label"
+  else
+    notok "$label" "ARGC=$argc (want 4)" "--squash count=$squash --admin count=$admin (want 1/1)" "probe:" "$(cat "$probe")"
+  fi
+}
+assert_merge_flags_separated bash bash
+if [[ "$HAVE_ZSH" -eq 1 ]]; then
+  assert_merge_flags_separated zsh zsh
+else
+  skip "merge-flag-separation[zsh]: --squash and --admin arrive as distinct args" "zsh not installed"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 6: anomaly-roundtrip-fresh-shells-both (anti-regression #3133).
+#   Append in one fresh shell, dump in a SECOND fresh shell (separate process),
+#   both pointed at the same PIPELINE_ANOMALY_LOG; assert the line persists.
+# ─────────────────────────────────────────────────────────────────────────────
+assert_anomaly_roundtrip() {
+  local shbin="$1" shname="$2"
+  local logf="$SCRATCH/anomaly-$shname.log"
+  rm -f "$logf"
+  local marker="xshell-roundtrip-$shname-$$"
+  # Fresh shell #1: append.
+  run_in_shell "$shbin" "
+    export PIPELINE_ANOMALY_LOG='$logf';
+    source '$LIB_DIR/pipeline-anomaly-log.sh';
+    anomaly_log_append 'merge-helper-fallback' '$marker' || { echo APPEND_FAIL >&2; exit 5; }
+  "
+  if [[ "$_RC" -ne 0 ]]; then
+    notok "anomaly-log-roundtrip[$shname]: append/dump persists across fresh shells" \
+      "append rc=$_RC" "stderr: $_STDERR"
+    return
+  fi
+  # Fresh shell #2 (separate process): dump.
+  run_in_shell "$shbin" "
+    export PIPELINE_ANOMALY_LOG='$logf';
+    source '$LIB_DIR/pipeline-anomaly-log.sh';
+    anomaly_log_dump
+  "
+  local label="anomaly-log-roundtrip[$shname]: append/dump persists across fresh shells"
+  if [[ "$_RC" -eq 0 ]] && printf '%s' "$_STDOUT" | grep -qF "$marker"; then
+    ok "$label"
+  else
+    notok "$label" "dump rc=$_RC" "dump did not contain marker '$marker'" "stdout: $_STDOUT" "stderr: $_STDERR"
+  fi
+}
+assert_anomaly_roundtrip bash bash
+if [[ "$HAVE_ZSH" -eq 1 ]]; then
+  assert_anomaly_roundtrip zsh zsh
+else
+  skip "anomaly-log-roundtrip[zsh]: append/dump persists across fresh shells" "zsh not installed"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 7: executable wrappers smoke-check (never sourced).
+#   For each EXEC_WRAPPER, `bash -n` parses cleanly (syntax check). We do NOT
+#   source these (they exec and replace the shell).
+# ─────────────────────────────────────────────────────────────────────────────
+for w in "${EXEC_WRAPPERS[@]}"; do
+  if bash -n "$LIB_DIR/$w" 2>/dev/null; then
+    ok "exec-wrapper-parses[bash -n]: $w"
+  else
+    notok "exec-wrapper-parses[bash -n]: $w" "bash -n reported a syntax error"
+  fi
+done
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TAP plan line + exit.
+# ─────────────────────────────────────────────────────────────────────────────
+printf '1..%d\n' "$TEST_NUM"
+if [[ "$HAVE_ZSH" -eq 0 ]]; then
+  printf '# NOTE: zsh not installed — zsh legs were SKIPPED. CI installs zsh so the zsh leg runs there.\n'
+fi
+if [[ "$FAIL" -gt 0 ]]; then
+  printf '# FAILED: %d test(s) failed\n' "$FAIL"
+  exit 1
+fi
+printf '# All %d tests passed\n' "$TEST_NUM"
+exit 0


### PR DESCRIPTION
Closes #3137

## Summary

The orchestrator and its sub-agents run under **zsh**, but `scripts/lib/*.sh` are authored for bash. The genuine residual defect (the three originally-cited umbrella bugs are already fixed on main — verified) is in `dedup-filing.sh`, a documented sourced library: its self-location used `${BASH_SOURCE[0]}`, which is empty under zsh → `dirname "" → .` → `_DEDUP_SCRIPT` mis-resolved against the **caller's cwd** instead of the script dir. Fixed with the cross-shell idiom `${BASH_SOURCE[0]:-${(%):-%x}}` (bash uses BASH_SOURCE; zsh falls through to the prompt-expansion of the sourced file path; bash never evaluates the literal zsh default). Verified to resolve to the script dir under **both** shells from any cwd.

Defensive hardening on two sibling sites:
- `eval-alarms.sh` (executable wrapper): same zsh-safe `SCRIPT_DIR` so `zsh scripts/lib/eval-alarms.sh` no longer aborts with `BASH_SOURCE[0]: parameter not set` under `set -u`.
- `pipeline-anomaly-log.sh`: quote the self-test guard `[[ "${BASH_SOURCE[0]:-}" == "${0}" ]]` (no behavior change; immune to a future nounset caller) and fail loud on append-redirect error.

The high-value durable guard: `scripts/test-shell-lib-cross-shell.sh` (TAP, manifest-driven) sources every sourced library under bash AND zsh from a foreign cwd with per-helper env stubs, asserts clean rc + expected functions, and runs three behavioral assertions (contract-functions-defined; merge-flag separation via a `REVIEW_PR_MERGE_CMD` mock → distinct `--squash`/`--admin`; anomaly-log append/dump round-trip across two fresh shells). The zsh leg TAP-skips if zsh is absent. Wired into the "Agent Worktree Contract" CI job, which now installs zsh so the zsh leg runs.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3137#issuecomment-4632875741)

## Test plan

- [x] cargo fmt --check (pre-commit hook)
- [x] cargo clippy --all -- -D warnings (pre-commit hook)
- [x] `scripts/test-shell-lib-cross-shell.sh` passes under bash AND zsh (25/25)
- [x] `bash -n` + `zsh -n` on all touched lib scripts
- [x] ci.yml parses as valid YAML
- [x] preserved: `test-agent-worktree-contract.sh` (32/0), `test-monitor-skill-snippets.sh` (the 4 `pv-label-sync` failures are pre-existing on origin/main, unrelated to this change)

## Regression test (kind: bug-fix)

- **Test:** `scripts/test-shell-lib-cross-shell.sh` — `dedup-zsh-script-path[zsh]` + `eval-alarms-no-paramnotset[zsh]`
- **Pre-fix:** committed as `f0d79d49` — verified FAILED on origin/main: dedup resolves to `<cwd>/dedup-filing.py`; eval-alarms emits `BASH_SOURCE[0]: parameter not set`
- **Post-fix:** verified PASSES after `946d3584` (25/25 under both shells)

The other three behavioral assertions (contract-functions-defined, merge-flag-separation, anomaly-roundtrip) are anti-regression guards for already-fixed behavior (#2954, #3133) and pass on main.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)