### PR TITLE
Wire EvictionCounters into live eviction scan and export via metrics catalog

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -3009,6 +3009,14 @@ impl App {
             .snapshot()
     }
 
+    /// Snapshot of live eviction counters.
+    pub fn eviction_counters_snapshot(&self) -> henyey_bucket::EvictionCountersSnapshot {
+        self.ledger_manager
+            .bucket_list()
+            .eviction_counters()
+            .snapshot()
+    }
+
     /// Snapshot of overlay metrics (if overlay is running).
     pub async fn overlay_metrics_snapshot(&self) -> Option<henyey_overlay::OverlayMetricsSnapshot> {
         let overlay = self.overlay.read().await;

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -569,6 +569,19 @@ metric_catalog! {
         BUCKET_MERGE_ANNIHILATED_TOTAL = "stellar_bucket_merge_annihilated_total"
             => "Total INIT+DEAD entry pairs annihilated during merges";
 
+        // State-archival eviction counters. Names mirror stellar-core's medida
+        // keys {"state-archival","eviction",*} (BucketUtils.cpp:171-181).
+        EVICTION_ENTRIES_EVICTED_TOTAL = "state_archival_eviction_entries_evicted"
+            => "Total Soroban state entries evicted from the live bucket list";
+        EVICTION_BYTES_SCANNED_TOTAL = "state_archival_eviction_bytes_scanned"
+            => "Total bytes scanned by the eviction scan";
+        EVICTION_INCOMPLETE_SCAN_TOTAL = "state_archival_eviction_incomplete_scan"
+            => "Count of buckets too large to fully scan within their update period";
+        EVICTION_PERIOD = "state_archival_eviction_period"
+            => "Ledger span of the most recently completed eviction cycle";
+        EVICTION_AGE = "state_archival_eviction_age"
+            => "Average age (ledgers) of entries evicted in the last eviction cycle";
+
         // Overlay counters.
         OVERLAY_MESSAGE_READ_TOTAL = "stellar_overlay_message_read_total"
             => "Total overlay messages read from peers";
@@ -1012,6 +1025,16 @@ pub(crate) async fn refresh_gauges(state: &ServerState) {
     BUCKET_MERGE_NEW_META_TOTAL.absolute(mc.new_meta_entries);
     BUCKET_MERGE_SHADOWED_TOTAL.absolute(mc.old_entries_shadowed);
     BUCKET_MERGE_ANNIHILATED_TOTAL.absolute(mc.entries_annihilated);
+
+    // State-archival eviction counters.
+    let ec = state.app.eviction_counters_snapshot();
+    EVICTION_ENTRIES_EVICTED_TOTAL.absolute(ec.entries_evicted);
+    EVICTION_BYTES_SCANNED_TOTAL.absolute(ec.bytes_scanned);
+    EVICTION_INCOMPLETE_SCAN_TOTAL.absolute(ec.incomplete_bucket_scans);
+    // period + age are last-cycle SET-semantics gauges; `.absolute(...)`
+    // faithfully overwrites (matching core's medida Counter::set_count).
+    EVICTION_PERIOD.absolute(ec.eviction_cycle_period);
+    EVICTION_AGE.absolute(ec.average_evicted_entry_age);
 
     // Overlay counters (if overlay is running).
     if let Some(ov) = state.app.overlay_metrics_snapshot().await {
@@ -1591,6 +1614,61 @@ mod tests {
             assert!(
                 output.contains(&format!("{} 0", name)),
                 "counter {} should be pre-registered at 0",
+                name
+            );
+        }
+    }
+
+    /// The five state-archival eviction counters (#3168) are present in the
+    /// catalog under the expected Prometheus names. The names mirror
+    /// stellar-core's medida keys {"state-archival","eviction",*}.
+    #[test]
+    fn test_eviction_counters_in_catalog() {
+        for name in [
+            "state_archival_eviction_entries_evicted",
+            "state_archival_eviction_bytes_scanned",
+            "state_archival_eviction_incomplete_scan",
+            "state_archival_eviction_period",
+            "state_archival_eviction_age",
+        ] {
+            assert!(
+                ALL_COUNTER_NAMES.contains(&name),
+                "eviction counter {} missing from catalog",
+                name
+            );
+            assert!(
+                ALL_PREREGISTERED_COUNTER_NAMES.contains(&name),
+                "eviction counter {} should be pre-registered",
+                name
+            );
+        }
+    }
+
+    /// The five eviction counters are pre-registered at 0 and carry HELP/TYPE.
+    #[test]
+    fn test_eviction_counters_preregistered_at_zero() {
+        let (recorder, handle) = fresh_local_recorder();
+        metrics::with_local_recorder(&recorder, || {
+            describe_metrics();
+            register_label_series();
+        });
+        let output = handle.render();
+
+        for name in [
+            "state_archival_eviction_entries_evicted",
+            "state_archival_eviction_bytes_scanned",
+            "state_archival_eviction_incomplete_scan",
+            "state_archival_eviction_period",
+            "state_archival_eviction_age",
+        ] {
+            assert!(
+                output.contains(&format!("{} 0", name)),
+                "eviction counter {} should be pre-registered at 0",
+                name
+            );
+            assert!(
+                output.contains(&format!("# TYPE {} counter", name)),
+                "eviction counter {} should have TYPE counter",
                 name
             );
         }

--- a/crates/bucket/src/bucket.rs
+++ b/crates/bucket/src/bucket.rs
@@ -686,6 +686,26 @@ impl Bucket {
         }
     }
 
+    /// Total XDR byte size of this bucket's entries.
+    ///
+    /// Mirrors stellar-core `LiveBucket::getSize()` — the on-disk byte size used
+    /// by the eviction "stuck" check (`checkIfEvictionScanIsStuck`). For
+    /// disk-backed buckets this is O(1) via the index's per-type byte totals;
+    /// for in-memory buckets it sums each entry's XDR length. Returns 0 if a
+    /// disk-backed bucket has no index counters or an in-memory entry fails to
+    /// serialize (both unexpected; the value only feeds an observability gauge).
+    pub fn byte_size(&self) -> u64 {
+        match &self.storage {
+            BucketStorage::InMemory { entries, .. } => entries
+                .iter()
+                .map(|e| e.to_xdr_bytes().map(|b| b.len() as u64).unwrap_or(0))
+                .sum(),
+            BucketStorage::DiskBacked { disk_bucket } => {
+                disk_bucket.live_index().counters().total_size()
+            }
+        }
+    }
+
     /// Check if this bucket uses disk-backed storage.
     pub fn is_disk_backed(&self) -> bool {
         matches!(&self.storage, BucketStorage::DiskBacked { .. })

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -58,8 +58,8 @@ use crate::bucket::Bucket;
 use crate::cache::CacheStats;
 use crate::entry::{get_ttl_key, is_ttl_expired, BucketEntry, BucketEntryExt};
 use crate::eviction::{
-    update_starting_eviction_iterator, EvictionCandidate, EvictionIterator, EvictionIteratorExt,
-    EvictionResult,
+    eviction_scan_is_stuck, update_starting_eviction_iterator, EvictionCandidate, EvictionIterator,
+    EvictionIteratorExt, EvictionResult,
 };
 use crate::future_bucket::MergeKey;
 use crate::index::BucketEntryCounters;
@@ -70,7 +70,7 @@ use crate::merge::{
     MergeOptions, MetadataPolicy,
 };
 use crate::merge_map::BucketMergeMap;
-use crate::metrics::MergeCounters;
+use crate::metrics::{EvictionCounters, MergeCounters};
 use crate::{
     protocol_version_is_before, protocol_version_starts_from, BucketError, ProtocolVersion, Result,
 };
@@ -1374,6 +1374,10 @@ pub struct BucketList {
     merge_map: Option<std::sync::Arc<std::sync::RwLock<BucketMergeMap>>>,
     /// Counters for merge operations (shared across all merge calls).
     merge_counters: Arc<MergeCounters>,
+    /// Counters for the live eviction scan (shared across all scan calls and
+    /// with derived `BucketListSnapshot`s, so the background scan records into
+    /// the same instance the app reads). All-atomic; cheaply `Arc`-clonable.
+    eviction_counters: Arc<EvictionCounters>,
     /// Background thread handle for async bucket persistence.
     /// Bounded to one concurrent write; the next add_batch waits for completion.
     pending_persist: Option<std::thread::JoinHandle<std::result::Result<(), String>>>,
@@ -1546,6 +1550,7 @@ impl BucketList {
             completed_merges: Vec::new(),
             merge_map: None,
             merge_counters: Arc::new(MergeCounters::new()),
+            eviction_counters: Arc::new(EvictionCounters::new()),
             pending_persist: None,
         }
     }
@@ -1609,6 +1614,23 @@ impl BucketList {
     /// Returns a reference to the merge counters.
     pub fn merge_counters(&self) -> &MergeCounters {
         &self.merge_counters
+    }
+
+    /// Returns a reference to the eviction counters.
+    ///
+    /// These are shared (via `Arc`) with any `BucketListSnapshot` derived from
+    /// this list, so a background eviction scan running on a snapshot records
+    /// into the same instance an app reads here.
+    pub fn eviction_counters(&self) -> &EvictionCounters {
+        &self.eviction_counters
+    }
+
+    /// Returns the shared `Arc` to the eviction counters.
+    ///
+    /// Used when constructing a `BucketListSnapshot` so its background scan
+    /// records into the same instance as this list.
+    pub(crate) fn eviction_counters_arc(&self) -> Arc<EvictionCounters> {
+        Arc::clone(&self.eviction_counters)
     }
 
     /// Resolve all pending async merges without committing them.
@@ -2762,6 +2784,7 @@ impl BucketList {
             completed_merges: Vec::new(),
             merge_map: None,
             merge_counters: Arc::new(MergeCounters::new()),
+            eviction_counters: Arc::new(EvictionCounters::new()),
             pending_persist: None,
         })
     }
@@ -2851,6 +2874,7 @@ impl BucketList {
             completed_merges: Vec::new(),
             merge_map: None,
             merge_counters: Arc::new(MergeCounters::new()),
+            eviction_counters: Arc::new(EvictionCounters::new()),
             pending_persist: None,
         })
     }
@@ -3372,6 +3396,14 @@ impl BucketList {
                 &self.levels[level].snap
             };
 
+            // Per-bucket "stuck" check before scanning: if the bucket is too
+            // large to fully scan within its update period, record an
+            // incomplete scan. Parity: stellar-core checks this at the top of
+            // each loop iteration (LiveBucketList.cpp:158-173, BucketListSnapshot.cpp:617).
+            if eviction_scan_is_stuck(&iter, settings.eviction_scan_size, bucket.byte_size()) {
+                self.eviction_counters.record_incomplete_scan();
+            }
+
             // Scan entries in this bucket (byte-limited only, no entry count limit)
             let (_entries_scanned, bytes_used, finished_bucket) = self.scan_bucket_region(
                 bucket,
@@ -3398,7 +3430,18 @@ impl BucketList {
 
             // If we finished this bucket, move to the next one
             if finished_bucket {
-                iter.advance_to_next_bucket(settings.starting_eviction_scan_level);
+                let wrapped = iter.advance_to_next_bucket(settings.starting_eviction_scan_level);
+
+                // On a full-list wrap (return to the configured starting level
+                // after the top level), close the eviction cycle and publish
+                // the period + average-age gauges. Parity: stellar-core's
+                // updateEvictionIterAndRecordStats calls
+                // submitMetricsAndRestartCycle exactly on the kNumLevels wrap
+                // (LiveBucketList.cpp:138-143).
+                if wrapped {
+                    self.eviction_counters
+                        .submit_metrics_and_restart_cycle(current_ledger);
+                }
 
                 // Check if we've completed a full cycle - only break when we return
                 // to the exact starting bucket (same level AND same is_curr).
@@ -3410,6 +3453,12 @@ impl BucketList {
                 }
             }
         }
+
+        // Record total bytes scanned this ledger into the shared counters.
+        // Parity note: stellar-core declares `bytesScannedForEviction` but never
+        // increments it (dead there); henyey populating it is additive/benign.
+        self.eviction_counters
+            .record_bytes_scanned(result.bytes_scanned);
 
         result.end_iterator = iter;
 
@@ -3473,6 +3522,7 @@ impl Clone for BucketList {
             completed_merges: self.completed_merges.clone(),
             merge_map: self.merge_map.clone(),
             merge_counters: self.merge_counters.clone(),
+            eviction_counters: self.eviction_counters.clone(),
             pending_persist: None, // Background persist is not cloned
         }
     }
@@ -5260,6 +5310,165 @@ mod tests {
 
         // Should panic: persistent entry lookup returns None (DEAD tombstone)
         let _ = bl.scan_for_eviction_incremental(iter, current_ledger, 23, &settings);
+    }
+
+    // ============ eviction counters wiring tests (#3168) ============
+
+    /// Build a (data entry, TTL entry) pair for a temporary contract-data key,
+    /// with the TTL `live_until_ledger_seq` set to `live_until`.
+    fn make_temp_contract_data_with_ttl(seed: u8, live_until: u32) -> (LedgerEntry, LedgerEntry) {
+        use crate::entry::get_ttl_key;
+        let data = LedgerEntry {
+            last_modified_ledger_seq: 1,
+            data: LedgerEntryData::ContractData(ContractDataEntry {
+                ext: ExtensionPoint::V0,
+                contract: ScAddress::Contract(Hash([seed; 32]).into()),
+                key: ScVal::U32(seed as u32),
+                durability: ContractDataDurability::Temporary,
+                val: ScVal::Void,
+            }),
+            ext: LedgerEntryExt::V0,
+        };
+        let data_key = henyey_common::entry_to_key(&data);
+        let ttl_key = get_ttl_key(&data_key).expect("contract data has TTL key");
+        let key_hash = match &ttl_key {
+            LedgerKey::Ttl(t) => t.key_hash.clone(),
+            _ => unreachable!(),
+        };
+        let ttl = LedgerEntry {
+            last_modified_ledger_seq: 1,
+            data: LedgerEntryData::Ttl(TtlEntry {
+                key_hash,
+                live_until_ledger_seq: live_until,
+            }),
+            ext: LedgerEntryExt::V0,
+        };
+        (data, ttl)
+    }
+
+    fn eviction_test_settings(scan_size: u32, starting_level: u32) -> StateArchivalSettings {
+        StateArchivalSettings {
+            max_entry_ttl: 1_000_000,
+            min_temporary_ttl: 1,
+            min_persistent_ttl: 1,
+            persistent_rent_rate_denominator: 1,
+            temp_rent_rate_denominator: 1,
+            max_entries_to_archive: 100,
+            live_soroban_state_size_window_sample_size: 0,
+            live_soroban_state_size_window_sample_period: 0,
+            eviction_scan_size: scan_size,
+            starting_eviction_scan_level: starting_level,
+        }
+    }
+
+    /// A scan over a non-empty bucket records bytes_scanned into the bucket
+    /// list's shared eviction counters.
+    #[test]
+    fn test_scan_records_bytes_scanned_into_shared_counters() {
+        let starting_level = 2u32;
+        let current_ledger = 100u32;
+        let (data, ttl) = make_temp_contract_data_with_ttl(7, 9999); // not expired
+
+        let mut bl = BucketList::new();
+        // Put the data + TTL into the starting-scan-level curr bucket so the
+        // scan actually reads bytes for them.
+        let bucket = Bucket::from_entries(vec![
+            BucketListEntry::Metaentry(BucketMetadata {
+                ledger_version: TEST_PROTOCOL,
+                ext: BucketMetadataExt::V0,
+            }),
+            BucketListEntry::Liveentry(data),
+            BucketListEntry::Liveentry(ttl),
+        ])
+        .unwrap();
+        bl.level_mut(starting_level as usize).unwrap().curr = Arc::new(bucket);
+
+        let settings = eviction_test_settings(1_000_000, starting_level);
+        let iter = crate::EvictionIterator {
+            bucket_list_level: starting_level,
+            is_curr_bucket: true,
+            bucket_file_offset: 0,
+        };
+
+        let result = bl
+            .scan_for_eviction_incremental(iter, current_ledger, 23, &settings)
+            .expect("scan should succeed");
+
+        assert!(result.bytes_scanned > 0, "scan should read some bytes");
+        assert_eq!(
+            bl.eviction_counters().snapshot().bytes_scanned,
+            result.bytes_scanned,
+            "scan must record bytes_scanned into the shared counters"
+        );
+    }
+
+    /// A scan that wraps the full bucket list publishes the cycle period into
+    /// the shared counters. The first wrap is the baseline (publishes nothing),
+    /// so we drive two scans across two ledgers.
+    #[test]
+    fn test_scan_wrap_submits_cycle_period() {
+        // Empty bucket list with a tiny scan size forces a full wrap each scan
+        // (every bucket finishes immediately, advancing through all levels back
+        // to the starting level).
+        let starting_level = 9u32; // near the top → few buckets to traverse
+        let settings = eviction_test_settings(1_000_000, starting_level);
+        let bl = BucketList::new();
+
+        let iter0 = crate::EvictionIterator {
+            bucket_list_level: starting_level,
+            is_curr_bucket: true,
+            bucket_file_offset: 0,
+        };
+        // First scan at ledger 100 → first wrap (baseline, publishes nothing).
+        let r1 = bl
+            .scan_for_eviction_incremental(iter0, 100, 23, &settings)
+            .expect("scan 1 should succeed");
+        assert_eq!(
+            bl.eviction_counters().snapshot().eviction_cycle_period,
+            0,
+            "first wrap is the baseline; nothing published yet"
+        );
+
+        // Second scan at ledger 142 → second wrap → period = 142 - 100 = 42.
+        let _r2 = bl
+            .scan_for_eviction_incremental(r1.end_iterator, 142, 23, &settings)
+            .expect("scan 2 should succeed");
+        assert_eq!(
+            bl.eviction_counters().snapshot().eviction_cycle_period,
+            42,
+            "second wrap publishes the cycle period (142 - 100)"
+        );
+    }
+
+    /// A `BucketListSnapshot` shares the source list's eviction counters Arc:
+    /// recording into the source is observable via the snapshot, and vice versa.
+    #[test]
+    fn test_snapshot_shares_eviction_counters_arc() {
+        let bl = BucketList::new();
+        let header = LedgerHeader {
+            ledger_seq: 5,
+            ..LedgerHeader::default()
+        };
+        let snapshot = crate::snapshot::BucketListSnapshot::new(&bl, header);
+
+        // Record into the source list; the snapshot sees the same instance.
+        bl.eviction_counters().record_incomplete_scan();
+        assert_eq!(
+            snapshot
+                .eviction_counters()
+                .snapshot()
+                .incomplete_bucket_scans,
+            1,
+            "snapshot must share the source list's eviction counters Arc"
+        );
+
+        // And the reverse direction.
+        snapshot.eviction_counters().record_bytes_scanned(512);
+        assert_eq!(
+            bl.eviction_counters().snapshot().bytes_scanned,
+            512,
+            "recording via the snapshot is visible on the source list"
+        );
     }
 
     // ============ hash assertion tests ============

--- a/crates/bucket/src/eviction.rs
+++ b/crates/bucket/src/eviction.rs
@@ -190,23 +190,40 @@ pub struct EvictionCandidate {
     entry: LedgerEntry,
     /// The EvictionIterator position AFTER this entry (resume point).
     position: EvictionIterator,
+    /// The TTL `liveUntilLedger` of the entry, captured from the TTL entry at
+    /// scan time. Used at resolve time to compute the evicted entry's age
+    /// (`ledger_seq - live_until_ledger`) for the eviction-cycle age metric.
+    /// Mirrors stellar-core's `EvictionResultEntry::liveUntilLedger`.
+    live_until_ledger: u32,
 }
 
 impl EvictionCandidate {
     /// Create an EvictionCandidate.
+    ///
+    /// `live_until_ledger` is the entry's TTL `liveUntilLedger`, captured from
+    /// the TTL entry during the scan, so the resolve phase can record the
+    /// evicted entry's age without re-looking up the TTL.
     ///
     /// # Panics
     /// Panics if the entry is not a Soroban entry with a derivable TTL key.
     /// This constructor is `pub(crate)` — only the eviction scan path calls
     /// it, and that path filters to Soroban entries before reaching here.
     /// The panic is defense-in-depth against internal misuse.
-    pub(crate) fn new(entry: LedgerEntry, position: EvictionIterator) -> Self {
+    pub(crate) fn new(
+        entry: LedgerEntry,
+        position: EvictionIterator,
+        live_until_ledger: u32,
+    ) -> Self {
         let data_key = henyey_common::entry_to_key(&entry);
         assert!(
             get_ttl_key(&data_key).is_some(),
             "EvictionCandidate entry must be a Soroban entry with a derivable TTL key"
         );
-        Self { entry, position }
+        Self {
+            entry,
+            position,
+            live_until_ledger,
+        }
     }
 
     /// The data entry being evicted.
@@ -232,6 +249,11 @@ impl EvictionCandidate {
     /// The EvictionIterator position AFTER this entry (resume point).
     pub fn position(&self) -> &EvictionIterator {
         &self.position
+    }
+
+    /// The entry's TTL `liveUntilLedger` captured at scan time.
+    pub fn live_until_ledger(&self) -> u32 {
+        self.live_until_ledger
     }
 
     /// Consume self, returning the owned entry and position.
@@ -375,10 +397,20 @@ impl EvictionResult {
     /// 4. Set the iterator position:
     ///    - If the entry limit was hit: resume from the last evicted entry's position
     ///    - Otherwise (including max_entries=0): advance to end of scan region
+    /// `ledger_seq` is the resolve-time current ledger; together with each
+    /// evicted candidate's `live_until_ledger` it yields the entry age
+    /// (`ledger_seq - live_until_ledger`) recorded into `counters` for the
+    /// eviction-cycle age gauge. `counters`, when `Some`, also receives the
+    /// per-type evicted count. Both mirror stellar-core
+    /// `BucketManager::resolveBackgroundEvictionScan` (`BucketManager.cpp:1287-1289`):
+    /// the `entriesEvicted` counter and `recordEvictedEntry(age)` happen in the
+    /// resolve phase, per actually-evicted entry (after TTL filter + max cap).
     pub fn resolve(
         self,
         max_entries_to_archive: u32,
         modified_keys: &std::collections::HashSet<LedgerKey>,
+        ledger_seq: u32,
+        counters: Option<&crate::metrics::EvictionCounters>,
     ) -> ResolvedEviction {
         let scan_end_iterator = self.end_iterator;
 
@@ -425,6 +457,7 @@ impl EvictionResult {
             }
 
             let is_temporary = candidate.is_temporary();
+            let live_until_ledger = candidate.live_until_ledger();
             let (entry, position) = candidate.into_parts();
 
             if is_temporary {
@@ -435,6 +468,19 @@ impl EvictionResult {
             }
             // TTL key is always added to deleted_keys for both types
             deleted_keys.push(ttl_key);
+
+            // Record eviction telemetry per actually-evicted entry.
+            // Parity: stellar-core records these in the resolve phase, after the
+            // TTL filter and max-cap, per evicted entry (BucketManager.cpp:1287-1289).
+            // age = ledger_seq - live_until_ledger; saturating_sub is defensive
+            // (expired entries already guarantee live_until_ledger < ledger_seq).
+            if let Some(counters) = counters {
+                let (temp_count, persistent_count) = if is_temporary { (1, 0) } else { (0, 1) };
+                counters.record_evicted(1, temp_count, persistent_count);
+                counters.record_evicted_entry_age(u64::from(
+                    ledger_seq.saturating_sub(live_until_ledger),
+                ));
+            }
 
             last_evicted_position = Some(position);
             remaining -= 1;
@@ -548,6 +594,23 @@ pub fn bucket_update_period(level: u32, is_curr: bool) -> u32 {
 
     // Formula: 2^(2*level - 1)
     1u32 << (2 * level - 1)
+}
+
+/// Check whether the eviction scan can finish scanning the bucket at the
+/// iterator's current position before that bucket next receives an update.
+///
+/// Mirrors stellar-core `LiveBucketList::checkIfEvictionScanIsStuck`
+/// (`LiveBucketList.cpp:158-173`): if `bucketUpdatePeriod(level, isCurr) *
+/// scanSize < bucket.getSize()`, the bucket is too large to fully scan within
+/// its update period, so the scan can never complete a pass over it. Returns
+/// `true` in that "stuck" case so the caller can record an incomplete-scan.
+pub fn eviction_scan_is_stuck(
+    iter: &EvictionIterator,
+    scan_size: u32,
+    bucket_byte_size: u64,
+) -> bool {
+    let period = bucket_update_period(iter.bucket_list_level, iter.is_curr_bucket) as u64;
+    period.saturating_mul(scan_size as u64) < bucket_byte_size
 }
 
 /// Update the eviction iterator based on bucket spills.
@@ -687,6 +750,14 @@ pub(crate) fn scan_bucket_region(
                 break 'process;
             }
 
+            // Capture the TTL liveUntilLedger so resolve can compute the
+            // evicted entry's age (ledger_seq - live_until_ledger) for the
+            // eviction-cycle age metric, without re-looking up the TTL.
+            // is_ttl_expired already confirmed this is a TTL entry, so the
+            // `unwrap_or` fallback (== current_ledger → age 0) is unreachable.
+            let live_until_ledger =
+                crate::entry::get_ttl_live_until(&ttl_entry).unwrap_or(current_ledger);
+
             // Entry is expired — collect as eviction candidate.
             // Spec: BUCKETLISTDB_SPEC §12.4 — Newest-version replacement for persistent
             // entries during eviction. Spec says P24+ only (pre-P24 preserved the
@@ -716,6 +787,7 @@ pub(crate) fn scan_bucket_region(
                     is_curr_bucket: iter.is_curr_bucket,
                     bucket_file_offset: start_offset + bytes_used,
                 },
+                live_until_ledger,
             ));
         }
 
@@ -1074,6 +1146,14 @@ mod tests {
     };
 
     fn make_contract_data_candidate(key_bytes: [u8; 32], is_temporary: bool) -> EvictionCandidate {
+        make_contract_data_candidate_with_ttl(key_bytes, is_temporary, 0)
+    }
+
+    fn make_contract_data_candidate_with_ttl(
+        key_bytes: [u8; 32],
+        is_temporary: bool,
+        live_until_ledger: u32,
+    ) -> EvictionCandidate {
         let entry = LedgerEntry {
             last_modified_ledger_seq: 100,
             data: LedgerEntryData::ContractData(ContractDataEntry {
@@ -1089,7 +1169,11 @@ mod tests {
             }),
             ext: LedgerEntryExt::V0,
         };
-        EvictionCandidate::new(entry, EvictionIterator::with_default_level())
+        EvictionCandidate::new(
+            entry,
+            EvictionIterator::with_default_level(),
+            live_until_ledger,
+        )
     }
 
     #[test]
@@ -1108,7 +1192,7 @@ mod tests {
         let mut modified = std::collections::HashSet::new();
         modified.insert(ttl_key);
 
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
         assert!(
             resolved.deleted_keys.is_empty(),
             "candidate with modified TTL should be filtered out"
@@ -1129,7 +1213,7 @@ mod tests {
 
         let modified = std::collections::HashSet::new(); // empty
 
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
         assert_eq!(
             resolved.deleted_keys.len(),
             2,
@@ -1156,7 +1240,7 @@ mod tests {
         let mut modified = std::collections::HashSet::new();
         modified.insert(data_key); // data key modified, but TTL key is NOT
 
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
         // Parity: stellar-core logs REPORT_INTERNAL_BUG but still proceeds
         // with eviction (++iter, not erase). The candidate should still be
         // evicted.
@@ -1187,7 +1271,7 @@ mod tests {
         modified.insert(data_key);
         modified.insert(ttl_key);
 
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
         assert!(
             resolved.deleted_keys.is_empty(),
             "candidate should be filtered out because TTL was modified"
@@ -1211,7 +1295,7 @@ mod tests {
         let modified = std::collections::HashSet::new();
 
         // Limit to 2 entries
-        let resolved = result.resolve(2, &modified);
+        let resolved = result.resolve(2, &modified, 0, None);
         assert_eq!(
             resolved.deleted_keys.len(),
             4,
@@ -1232,7 +1316,7 @@ mod tests {
         };
 
         let modified = std::collections::HashSet::new();
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
 
         assert_eq!(
             resolved.archived_entries.len(),
@@ -1284,7 +1368,7 @@ mod tests {
         };
 
         let modified = std::collections::HashSet::new();
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
 
         let evicted = resolved.evicted_keys();
 
@@ -1331,7 +1415,7 @@ mod tests {
 
         let modified = std::collections::HashSet::new();
         // Only process first 2 entries (temp1 + persistent2)
-        let resolved = result.resolve(2, &modified);
+        let resolved = result.resolve(2, &modified, 0, None);
 
         let evicted = resolved.evicted_keys();
         let expected = vec![temp1_data, temp1_ttl, persistent2_ttl, persistent2_data];
@@ -1364,7 +1448,7 @@ mod tests {
         };
 
         let modified = std::collections::HashSet::new();
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
 
         let evicted = resolved.evicted_keys();
         let expected = vec![p1_ttl, p2_ttl, p1_data, p2_data];
@@ -1429,7 +1513,7 @@ mod tests {
             ext: LedgerEntryExt::V0,
         };
         // Should panic — non-Soroban entries cannot be eviction candidates
-        EvictionCandidate::new(non_soroban_entry, EvictionIterator::with_default_level());
+        EvictionCandidate::new(non_soroban_entry, EvictionIterator::with_default_level(), 0);
     }
 
     // --- resolve() iterator edge case tests ---
@@ -1454,7 +1538,7 @@ mod tests {
 
         let modified = std::collections::HashSet::new();
         // max_entries_to_archive = 0 means no eviction, use scan end
-        let resolved = result.resolve(0, &modified);
+        let resolved = result.resolve(0, &modified, 0, None);
         assert!(resolved.deleted_keys.is_empty());
         assert!(resolved.archived_entries.is_empty());
         assert_eq!(resolved.end_iterator, scan_end);
@@ -1486,7 +1570,7 @@ mod tests {
         modified.insert(ttl1);
         modified.insert(ttl2);
 
-        let resolved = result.resolve(10, &modified);
+        let resolved = result.resolve(10, &modified, 0, None);
         assert!(resolved.deleted_keys.is_empty());
         assert!(resolved.archived_entries.is_empty());
         // When all are filtered (remaining > 0), use scan end iterator
@@ -1608,11 +1692,124 @@ mod tests {
         let mut modified = std::collections::HashSet::new();
         modified.insert(ttl1);
 
-        let resolved = result.resolve(2, &modified);
+        let resolved = result.resolve(2, &modified, 0, None);
         // c2 and c3 evicted: 2 data_keys + 2 ttl_keys = 4
         assert_eq!(resolved.deleted_keys.len(), 4);
         // With max_entries=2, exactly 2 evicted, remaining=0 → use last position
         // (not scan_end, because we hit the limit)
         assert_ne!(resolved.end_iterator, scan_end);
+    }
+
+    // --- EvictionCounters wiring tests (#3168) ---
+
+    #[test]
+    fn test_scan_populates_incomplete_scan_on_oversized_bucket() {
+        // `eviction_scan_is_stuck` is true when bucketUpdatePeriod * scanSize is
+        // less than the bucket byte size. At level 6 curr the update period is
+        // 2^(2*6-1) = 2048, so with scan_size=10 the budget is 20480 bytes.
+        let iter = EvictionIterator::new(6);
+        let scan_size = 10u32;
+
+        // Oversized: 30000 > 2048 * 10 → stuck.
+        assert!(
+            eviction_scan_is_stuck(&iter, scan_size, 30_000),
+            "an oversized bucket should be reported as stuck"
+        );
+        // Within budget: 5000 < 20480 → not stuck.
+        assert!(
+            !eviction_scan_is_stuck(&iter, scan_size, 5_000),
+            "a bucket smaller than the scan budget should not be stuck"
+        );
+
+        // The scan records one incomplete_bucket_scan per stuck bucket it visits.
+        let counters = crate::metrics::EvictionCounters::new();
+        if eviction_scan_is_stuck(&iter, scan_size, 30_000) {
+            counters.record_incomplete_scan();
+        }
+        assert_eq!(counters.snapshot().incomplete_bucket_scans, 1);
+    }
+
+    #[test]
+    fn test_submit_cycle_period_on_wrap() {
+        // Exercise the previously-discarded wrap signal: the eviction cycle
+        // period is published as (curr_ledger - cycle_start_ledger) on the
+        // SECOND wrap (the first establishes the baseline).
+        let counters = crate::metrics::EvictionCounters::new();
+
+        // First wrap at ledger 100: baseline, publishes nothing.
+        counters.submit_metrics_and_restart_cycle(100);
+        assert_eq!(counters.snapshot().eviction_cycle_period, 0);
+
+        // Second wrap at ledger 142: period = 142 - 100 = 42.
+        counters.submit_metrics_and_restart_cycle(142);
+        assert_eq!(counters.snapshot().eviction_cycle_period, 42);
+    }
+
+    #[test]
+    fn test_resolve_records_evicted_count_and_age() {
+        // Two evicted temp candidates with known live_until_ledger; resolve at
+        // ledger 100 should record entries_evicted == 2 and, after the cycle
+        // closes, average age = ((100-90) + (100-80)) / 2 = (10 + 20) / 2 = 15.
+        let c1 = make_contract_data_candidate_with_ttl([1u8; 32], true, 90);
+        let c2 = make_contract_data_candidate_with_ttl([2u8; 32], true, 80);
+
+        let result = EvictionResult {
+            candidates: vec![c1, c2],
+            end_iterator: EvictionIterator::with_default_level(),
+            bytes_scanned: 2000,
+            scan_complete: true,
+            ..Default::default()
+        };
+
+        let counters = crate::metrics::EvictionCounters::new();
+        // Establish the cycle baseline so the next submit publishes the gauge.
+        counters.submit_metrics_and_restart_cycle(0);
+
+        let modified = std::collections::HashSet::new();
+        let resolved = result.resolve(10, &modified, 100, Some(&counters));
+        // Both temp entries evicted: 2 data keys + 2 TTL keys.
+        assert_eq!(resolved.deleted_keys.len(), 4);
+
+        let snap = counters.snapshot();
+        assert_eq!(snap.entries_evicted, 2, "two entries evicted");
+        assert_eq!(snap.temp_entries_evicted, 2, "both were temporary");
+
+        // Close the cycle to fold per-entry ages into the average gauge.
+        counters.submit_metrics_and_restart_cycle(200);
+        assert_eq!(
+            counters.snapshot().average_evicted_entry_age,
+            15,
+            "average age = ((100-90)+(100-80))/2 = 15"
+        );
+    }
+
+    #[test]
+    fn test_resolve_does_not_record_for_filtered_or_overcap_candidates() {
+        // Three candidates; one filtered by a modified TTL, cap = 1 → only one
+        // actually evicted, so entries_evicted == 1 (not 3).
+        let c1 = make_contract_data_candidate_with_ttl([1u8; 32], true, 90);
+        let c2 = make_contract_data_candidate_with_ttl([2u8; 32], true, 90);
+        let c3 = make_contract_data_candidate_with_ttl([3u8; 32], true, 90);
+        let ttl1 = c1.ttl_key();
+
+        let result = EvictionResult {
+            candidates: vec![c1, c2, c3],
+            end_iterator: EvictionIterator::with_default_level(),
+            bytes_scanned: 3000,
+            scan_complete: true,
+            ..Default::default()
+        };
+
+        let counters = crate::metrics::EvictionCounters::new();
+        let mut modified = std::collections::HashSet::new();
+        modified.insert(ttl1); // c1 filtered out
+
+        // max=1 → only c2 evicted (c3 over cap).
+        let _ = result.resolve(1, &modified, 100, Some(&counters));
+        assert_eq!(
+            counters.snapshot().entries_evicted,
+            1,
+            "only the one actually-evicted candidate is counted"
+        );
     }
 }

--- a/crates/bucket/src/snapshot.rs
+++ b/crates/bucket/src/snapshot.rs
@@ -44,10 +44,11 @@ use crate::{
     bucket_list::BUCKET_LIST_LEVELS,
     entry::{ledger_entry_data_type, ledger_key_type},
     eviction::{
-        update_starting_eviction_iterator, EvictionCandidate, EvictionIterator,
-        EvictionIteratorExt, EvictionResult,
+        eviction_scan_is_stuck, update_starting_eviction_iterator, EvictionCandidate,
+        EvictionIterator, EvictionIteratorExt, EvictionResult,
     },
     index::LiveBucketIndex,
+    metrics::EvictionCounters,
     Bucket, BucketEntry, BucketEntryExt, BucketLevel, BucketList, HotArchiveBucket,
     HotArchiveBucketLevel, HotArchiveBucketList,
 };
@@ -308,6 +309,10 @@ impl HotArchiveBucketLevelSnapshot {
 pub struct BucketListSnapshot {
     levels: Vec<BucketLevelSnapshot>,
     header: LedgerHeader,
+    /// Shared eviction counters, cloned (`Arc`) from the source `BucketList` so
+    /// a background eviction scan running on this snapshot records into the same
+    /// instance the app reads via `BucketList::eviction_counters`.
+    eviction_counters: Arc<EvictionCounters>,
 }
 
 impl BucketListSnapshot {
@@ -315,13 +320,25 @@ impl BucketListSnapshot {
     ///
     /// Per-bucket caches are stored inside each DiskBucket and shared via Arc,
     /// so snapshot lookups automatically benefit from caching.
+    ///
+    /// The source list's eviction counters are shared (`Arc`-cloned) onto the
+    /// snapshot so a background scan records into the same instance.
     pub fn new(bucket_list: &BucketList, header: LedgerHeader) -> Self {
         let levels = bucket_list
             .levels()
             .iter()
             .map(BucketLevelSnapshot::from_level)
             .collect();
-        Self { levels, header }
+        Self {
+            levels,
+            header,
+            eviction_counters: bucket_list.eviction_counters_arc(),
+        }
+    }
+
+    /// Returns a reference to the shared eviction counters.
+    pub fn eviction_counters(&self) -> &EvictionCounters {
+        &self.eviction_counters
     }
 
     /// Returns the ledger sequence number for this snapshot.
@@ -558,6 +575,12 @@ impl BucketListSnapshot {
                 self.levels[level].snap.raw_bucket()
             };
 
+            // Per-bucket "stuck" check before scanning (parity:
+            // BucketListSnapshot.cpp:617, LiveBucketList.cpp:158-173).
+            if eviction_scan_is_stuck(&iter, settings.eviction_scan_size, bucket.byte_size()) {
+                self.eviction_counters.record_incomplete_scan();
+            }
+
             let (_entries_scanned, bytes_used, finished_bucket) = self.scan_bucket_region(
                 bucket,
                 &mut iter,
@@ -581,7 +604,14 @@ impl BucketListSnapshot {
             }
 
             if finished_bucket {
-                iter.advance_to_next_bucket(settings.starting_eviction_scan_level);
+                let wrapped = iter.advance_to_next_bucket(settings.starting_eviction_scan_level);
+
+                // Close the eviction cycle on the full-list wrap (parity:
+                // LiveBucketList.cpp:138-143).
+                if wrapped {
+                    self.eviction_counters
+                        .submit_metrics_and_restart_cycle(current_ledger);
+                }
 
                 if iter.bucket_list_level == start_iter.bucket_list_level
                     && iter.is_curr_bucket == start_iter.is_curr_bucket
@@ -591,6 +621,11 @@ impl BucketListSnapshot {
                 }
             }
         }
+
+        // Record total bytes scanned this ledger (additive/benign vs core,
+        // which declares but never increments this counter).
+        self.eviction_counters
+            .record_bytes_scanned(result.bytes_scanned);
 
         result.end_iterator = iter;
 

--- a/crates/history/src/replay/execution.rs
+++ b/crates/history/src/replay/execution.rs
@@ -120,6 +120,8 @@ fn run_eviction_scan(
     let resolved = eviction_result.resolve(
         context.eviction_settings.max_entries_to_archive,
         &modified_keys,
+        context.header.ledger_seq,
+        Some(bucket_list.eviction_counters()),
     );
 
     Ok(EvictionScanResult {

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -5187,8 +5187,18 @@ impl LedgerCloseContext<'_> {
                         .collect();
 
                     let bytes_scanned = eviction_result.bytes_scanned;
-                    let resolved = eviction_result
-                        .resolve(eviction_settings.max_entries_to_archive, &modified_keys);
+                    // Record evicted count + per-entry age into the bucket list's
+                    // shared eviction counters during resolve (parity:
+                    // BucketManager.cpp:1287-1289). The scan phase (inline or
+                    // background) already recorded bytes-scanned, incomplete-scan,
+                    // and the cycle period/age on the full-list wrap into the same
+                    // shared instance.
+                    let resolved = eviction_result.resolve(
+                        eviction_settings.max_entries_to_archive,
+                        &modified_keys,
+                        self.close_data.ledger_seq,
+                        Some(bucket_list.eviction_counters()),
+                    );
 
                     // Capture evicted keys for LedgerCloseMeta.
                     // Parity: LedgerCloseMetaFrame.cpp:170-187 populateEvictedEntries()


### PR DESCRIPTION
Closes #3168

## Summary

Threads the shared `Arc<EvictionCounters>` (already implemented in `crates/bucket/src/metrics.rs`, formerly dead scaffolding) through the live + background eviction scan/resolve path so all five counters populate, and exports them through the app metrics catalog under stellar-core's `state-archival.eviction.*` names. Telemetry-only: zero consensus/state/hash impact (the counters feed no ledger or bucket hash).

- `BucketList` owns an `Arc<EvictionCounters>` (mirrors the `merge_counters` ownership pattern) with an `eviction_counters()` accessor; `BucketListSnapshot::new` `Arc`-clones it so the background scan thread records into the same instance the app reads.
- `scan_for_eviction_incremental` (both `BucketList` and `BucketListSnapshot`) now: records `bytes-scanned`; runs a per-bucket "stuck" `incomplete-scan` check (`eviction_scan_is_stuck`, mirroring `checkIfEvictionScanIsStuck`); and calls `submit_metrics_and_restart_cycle` on the full-list wrap — the previously-discarded `advance_to_next_bucket` `wrapped` return.
- `EvictionCandidate` carries `live_until_ledger`; `resolve` gains `(ledger_seq, Option<&EvictionCounters>)` and records `entries-evicted` + per-entry age (`ledger_seq - live_until_ledger`) per actually-evicted candidate (after TTL filter + max cap), matching `BucketManager.cpp:1287-1289`.
- App: `eviction_counters_snapshot()` accessor + 5 catalog rows and emit lines.

Parity refs: names `BucketUtils.cpp:171-181`; resolve `BucketManager.cpp:1287-1289`; incomplete-scan `LiveBucketList.cpp:158-173`; period/age on wrap `LiveBucketList.cpp:138-143`. `bytes-scanned` is declared-but-never-incremented in stellar-core; populating it here is additive and benign.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3168#issuecomment-4632933861)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (project standard `--all`) clean on touched crates; `henyey-bucket --all-targets` (incl. new tests) clean
- [x] `cargo test -p henyey-bucket -p henyey-app -p henyey-ledger -p henyey-history` passes (incl. new tests)

New coverage:
- `eviction.rs`: `test_scan_populates_incomplete_scan_on_oversized_bucket`, `test_submit_cycle_period_on_wrap`, `test_resolve_records_evicted_count_and_age`, `test_resolve_does_not_record_for_filtered_or_overcap_candidates`
- `bucket_list.rs`: `test_scan_records_bytes_scanned_into_shared_counters`, `test_scan_wrap_submits_cycle_period`, `test_snapshot_shares_eviction_counters_arc`
- `app/metrics.rs`: `test_eviction_counters_in_catalog`, `test_eviction_counters_preregistered_at_zero`

## Deviations from plan

- The plan listed scan threading as an `Option<&EvictionCounters>` param; since both `BucketList` and `BucketListSnapshot` already own/share the `Arc`, the scan records into `self.eviction_counters` directly (strictly equivalent, fewer call-site changes, all existing scan callers unchanged). `resolve` still takes the explicit `(ledger_seq, Option<&EvictionCounters>)` as planned.
- One file not in the plan's list: `crates/history/src/replay/execution.rs` has a second `EvictionResult::resolve` caller (offline replay path) that had to compile; it now passes the header ledger_seq + the replay bucket list's counters (same telemetry, benign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)