### PR TITLE
Escalate recovery early in the near-tip archive-behind band (#3181)

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -1314,21 +1314,34 @@ impl App {
             // force_post_catchup_hard_reset() blocks it, causing
             // maybe_start_buffered_catchup() to return None on every tick.
             if s.schedule_due {
+                // Near-tip escalation (#3181): when peers are verified ahead
+                // by less than one checkpoint interval, archive catchup is
+                // structurally impossible-yet-imminent (the unblocking
+                // checkpoint publishes within one interval). Escalate to the
+                // state-changing HardReset immediately rather than spinning on
+                // per-tick archive probes for the full wall-clock stall. The
+                // far-behind (#1862) path keeps its unchanged thresholds.
                 let would_hard_reset = recovery_exhausted
                     || s.tx_set_exhausted
-                    || s.stuck_duration >= HARD_RESET_STALL_SECS;
+                    || s.stuck_duration >= HARD_RESET_STALL_SECS
+                    || s.near_tip;
 
                 if would_hard_reset && s.hard_reset_cooldown_active {
                     // Cooldown active — fall back to peer-SCP recovery
                     // while waiting for the archive to publish. The first
                     // HardReset already cleared stale state; repeating it
-                    // before the cooldown expires is futile.
+                    // before the cooldown expires is futile. Preserves #1843
+                    // (and applies equally to the near-tip path).
                     ConsensusStuckAction::AttemptRecovery
                 } else if recovery_exhausted {
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
                 } else if s.tx_set_exhausted {
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindTxSetExhausted)
                 } else if s.stuck_duration >= HARD_RESET_STALL_SECS {
+                    // Either the wall-clock stall threshold was reached, or the
+                    // node is in the near-tip band (#3181) — both escalate via
+                    // the same ArchiveBehindStallWallClock reset, which spawns
+                    // the peer-SCP ProbeAhead fetch + request_scp_state.
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindStallWallClock)
                 } else {
                     ConsensusStuckAction::AttemptRecovery
@@ -1985,6 +1998,20 @@ impl App {
                     let current_gap = latest_ext.saturating_sub(current_ledger as u64);
                     let hard_reset_cooldown_active = self.is_hard_reset_on_cooldown(current_gap);
 
+                    // Near-tip predicate (#3181): peers verified ahead by at
+                    // least PEER_AHEAD_ESCALATION_THRESHOLD but less than one
+                    // checkpoint interval. Uses the verified peer-gap (not the
+                    // raw latest_externalized), matching the consensus.rs
+                    // escalation gate so both paths agree (single source of
+                    // truth, #1831). False when there is no peer-ahead evidence
+                    // (gap < threshold) or the node is genuinely far behind
+                    // (gap >= checkpoint_frequency() — the #1862 path). Read
+                    // checkpoint_frequency() live for parity (64 default / 8
+                    // accelerated).
+                    let peer_gap = self.effective_peer_gap(current_ledger);
+                    let near_tip = peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD
+                        && peer_gap < checkpoint_frequency() as u64;
+
                     let signals = StuckSignals {
                         catchup_in_progress: self.catchup_in_progress.load(Ordering::SeqCst),
                         archive_behind,
@@ -1993,6 +2020,7 @@ impl App {
                         stuck_duration,
                         recovery_attempts: effective_attempts,
                         hard_reset_cooldown_active,
+                        near_tip,
                     };
 
                     let decision = Self::decide_consensus_stuck_action(signals);
@@ -2906,6 +2934,7 @@ mod tests {
             stuck_duration: 0,
             recovery_attempts,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         })
     }
 
@@ -3001,6 +3030,7 @@ mod tests {
             stuck_duration: 30,
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert!(matches!(
             action,
@@ -3019,6 +3049,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS,
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert!(matches!(
             action,
@@ -3037,6 +3068,7 @@ mod tests {
             stuck_duration: 60,
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
     }
@@ -3052,6 +3084,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 100,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert_eq!(action, ConsensusStuckAction::TriggerCatchup);
     }
@@ -3067,11 +3100,133 @@ mod tests {
             stuck_duration: 0,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert!(matches!(
             action,
             ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
         ));
+    }
+
+    // ================================================================
+    // #3181: near-tip early escalation (archive behind, peers ahead by
+    // < one checkpoint interval). The escalation must fire on the first
+    // due tick — NOT after the full wall-clock stall — without waiting on
+    // recovery exhaustion, tx_set exhaustion, or stuck_duration. The 60s
+    // cooldown floor (#1843) and the far-behind (#1862) path are preserved.
+    // ================================================================
+
+    #[test]
+    fn test_decide_near_tip_archive_behind_escalates_early() {
+        // archive_behind + near_tip + schedule_due, but NONE of the legacy
+        // hard-reset gates met (attempts=0, no tx_set exhaustion,
+        // stuck_duration=0) and no cooldown → HardReset immediately.
+        //
+        // On origin/main (no `near_tip` field) these signals fall through
+        // every `would_hard_reset` gate and return AttemptRecovery; the
+        // near-tip branch makes the state-changing escalation fire early.
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: 0,
+            recovery_attempts: 0,
+            hard_reset_cooldown_active: false,
+            near_tip: true,
+        });
+        assert!(
+            matches!(
+                action,
+                ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindStallWallClock)
+            ),
+            "near-tip + archive-behind must escalate to HardReset on the first \
+             due tick, not after the full wall-clock stall (#3181); got {action:?}"
+        );
+    }
+
+    #[test]
+    fn test_decide_near_tip_respects_cooldown() {
+        // Same near-tip signals, but the HardReset cooldown is active.
+        // Must fall back to AttemptRecovery — the early-escalation path is
+        // still cooldown-gated, preserving #1843 (no reset storms).
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: 0,
+            recovery_attempts: 0,
+            hard_reset_cooldown_active: true,
+            near_tip: true,
+        });
+        assert_eq!(
+            action,
+            ConsensusStuckAction::AttemptRecovery,
+            "near-tip escalation must respect the 60s HardReset cooldown (#1843)"
+        );
+    }
+
+    #[test]
+    fn test_decide_not_near_tip_archive_behind_unchanged() {
+        // Far-behind case (#1862): near_tip is false (peer_gap >=
+        // checkpoint_frequency()), and none of the legacy gates are met
+        // (attempts < MAX, no tx_set exhaustion, stuck_duration short).
+        // The decision must remain AttemptRecovery — NOT an early HardReset —
+        // proving the far-behind archive-catchup path is untouched.
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: 0,
+            recovery_attempts: 0,
+            hard_reset_cooldown_active: false,
+            near_tip: false,
+        });
+        assert_eq!(
+            action,
+            ConsensusStuckAction::AttemptRecovery,
+            "not-near-tip (far-behind #1862) must keep the unchanged behavior: \
+             AttemptRecovery until the legacy hard-reset gates fire"
+        );
+    }
+
+    #[test]
+    fn test_near_tip_predicate_boundary() {
+        // The near-tip predicate is true for
+        // PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap < checkpoint_frequency(),
+        // and false at/below the lower threshold and at/above the checkpoint
+        // interval. This mirrors both the StuckSignals build site and the
+        // consensus.rs escalation gate (single source of truth, #1831).
+        let freq = checkpoint_frequency() as u64;
+        let near_tip =
+            |peer_gap: u64| peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD && peer_gap < freq;
+
+        // Below the lower threshold: no peer-ahead evidence → not near-tip.
+        assert!(!near_tip(0), "peer_gap=0 must not be near-tip");
+        assert!(
+            !near_tip(PEER_AHEAD_ESCALATION_THRESHOLD - 1),
+            "just below PEER_AHEAD_ESCALATION_THRESHOLD must not be near-tip"
+        );
+        // At the lower threshold and within the band: near-tip.
+        assert!(
+            near_tip(PEER_AHEAD_ESCALATION_THRESHOLD),
+            "peer_gap == PEER_AHEAD_ESCALATION_THRESHOLD must be near-tip"
+        );
+        assert!(
+            near_tip(freq - 1),
+            "one below checkpoint interval is near-tip"
+        );
+        // At/above the checkpoint interval: far-behind (#1862) → not near-tip.
+        assert!(
+            !near_tip(freq),
+            "peer_gap == checkpoint_frequency() is far-behind"
+        );
+        assert!(
+            !near_tip(freq + 100),
+            "well past checkpoint interval is far-behind"
+        );
     }
 
     #[test]
@@ -3085,6 +3240,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 100,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert_eq!(action, ConsensusStuckAction::Wait);
     }
@@ -3099,6 +3255,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 100,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
     }
@@ -3120,6 +3277,7 @@ mod tests {
             stuck_duration: 130,
             recovery_attempts: 7, // from atomic counter (> MAX_POST_CATCHUP_RECOVERY_ATTEMPTS)
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert!(matches!(action, ConsensusStuckAction::HardReset(_)));
     }
@@ -3136,6 +3294,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 10,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         // recovery_exhausted wins because it's checked first.
         assert!(matches!(
@@ -3152,6 +3311,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 10,
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         // tx_set_exhausted wins over wall_clock.
         assert!(matches!(
@@ -3173,6 +3333,7 @@ mod tests {
                 stuck_duration: sd,
                 recovery_attempts: re,
                 hard_reset_cooldown_active: false,
+                near_tip: false,
             })
         };
 
@@ -4087,6 +4248,7 @@ mod tests {
             stuck_duration: 0,
             catchup_in_progress: false,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         };
         let action = App::decide_consensus_stuck_action(signals_stuck_higher);
         // With recovery_attempts=8 (> MAX_RECOVERY_ATTEMPTS=6) and
@@ -4114,6 +4276,7 @@ mod tests {
             stuck_duration: 0,
             catchup_in_progress: false,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         };
         let action = App::decide_consensus_stuck_action(signals_atomic_higher);
         assert!(
@@ -4142,6 +4305,7 @@ mod tests {
             stuck_duration: 0,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: true,
+            near_tip: false,
         });
         assert_eq!(
             action,
@@ -4162,6 +4326,7 @@ mod tests {
             stuck_duration: 30,
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
+            near_tip: false,
         });
         assert_eq!(
             action,
@@ -4182,6 +4347,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 10,
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
+            near_tip: false,
         });
         assert_eq!(
             action,
@@ -4202,6 +4368,7 @@ mod tests {
             stuck_duration: 0,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         });
         assert!(
             matches!(
@@ -4224,6 +4391,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 100,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: true,
+            near_tip: false,
         });
         assert_eq!(
             action,
@@ -4244,6 +4412,7 @@ mod tests {
             stuck_duration: 30,
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
+            near_tip: false,
         });
         assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
     }
@@ -5011,6 +5180,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 100,
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
+            near_tip: false,
         };
 
         let action = App::decide_consensus_stuck_action(signals);
@@ -6054,6 +6224,7 @@ mod tests {
             stuck_duration: HARD_RESET_STALL_SECS + 100,
             recovery_attempts: MAX_POST_CATCHUP_RECOVERY_ATTEMPTS + 1,
             hard_reset_cooldown_active: true,
+            near_tip: false,
         };
 
         let action = App::decide_consensus_stuck_action(signals);

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -1337,7 +1337,7 @@ impl App {
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
                 } else if s.tx_set_exhausted {
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindTxSetExhausted)
-                } else if s.stuck_duration >= HARD_RESET_STALL_SECS {
+                } else if s.stuck_duration >= HARD_RESET_STALL_SECS || s.near_tip {
                     // Either the wall-clock stall threshold was reached, or the
                     // node is in the near-tip band (#3181) — both escalate via
                     // the same ArchiveBehindStallWallClock reset, which spawns

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -1791,9 +1791,27 @@ impl App {
                 let archive_is_confirmed_behind =
                     self.archive_recovery_snapshot().await.is_confirmed_behind();
                 let peer_gap = self.effective_peer_gap(current_ledger);
+                // Near-tip band (#3181): peers verified ahead by less than one
+                // checkpoint interval. Combined with the gate's existing
+                // `peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD` precondition this
+                // yields the same predicate as the StuckSignals build site
+                // (PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap <
+                // checkpoint_frequency()). In this band, with the archive
+                // confirmed behind, archive catchup is structurally
+                // impossible-yet-imminent, so lower the escalation attempt
+                // threshold (~1–2 ticks / ~10–20s) instead of the default ~11
+                // ticks / ~120s. The far-behind (#1862) path keeps the
+                // unchanged threshold. Read checkpoint_frequency() live (64
+                // default / 8 accelerated) for parity.
+                let near_tip = peer_gap < checkpoint_frequency() as u64;
+                let escalation_attempts = if near_tip && archive_is_confirmed_behind {
+                    RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP
+                } else {
+                    RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS
+                };
                 if archive_is_confirmed_behind
                     && peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD
-                    && attempts >= RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS
+                    && attempts >= escalation_attempts
                     && !self.is_hard_reset_on_cooldown(peer_gap)
                 {
                     use super::types::HardResetReason;

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -257,6 +257,21 @@ const RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS: u64 =
 const RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NO_SCP: u64 =
     (HARD_RESET_STALL_SECS * 3 / 2 / OUT_OF_SYNC_RECOVERY_TIMER_SECS) - 1;
 
+/// Near-tip escalation threshold (issue #3181). When the archive is confirmed
+/// behind, peers are verified ahead, and the peer gap is below one checkpoint
+/// interval (`PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap < checkpoint_frequency()`),
+/// archive-based catchup is structurally impossible-yet-imminent: the next
+/// checkpoint that unblocks recovery will publish within one interval. Spinning
+/// on per-tick archive probes for the full ~120s (`RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS`)
+/// before escalating to the state-changing reset (which spawns a peer-SCP
+/// `ProbeAhead` blocking fetch + `request_scp_state`) produced a ~4.5-min
+/// consensus stall and a `forcing_catchup_behind` counter burst. In the near-tip
+/// band we fire that same escalation on the 2nd recovery tick (~10–20s) instead.
+/// The 60s `HARD_RESET_MIN_COOLDOWN_SECS` floor still prevents reset storms, and
+/// the far-behind (`peer_gap >= checkpoint_frequency()`) #1862 path keeps the
+/// unchanged 11-tick threshold + archive-catchup escalation.
+const RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP: u64 = 1;
+
 /// Attempt-counter seed for partial-progress resets. When the node makes
 /// progress via a fast-track jump but is still significantly behind peers,
 /// we re-seed the attempt counter to this value so re-escalation fires
@@ -11338,6 +11353,17 @@ mod tests {
             "(120 * 3/2) / 10 - 1 = 17"
         );
         assert_eq!(PEER_AHEAD_ESCALATION_THRESHOLD, 3);
+        // #3181: near-tip threshold fires on the 2nd recovery tick (~10–20s),
+        // far earlier than the default 11 ticks (~120s).
+        assert_eq!(
+            RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP, 1,
+            "near-tip escalation must fire on the 2nd recovery tick (#3181)"
+        );
+        assert!(
+            RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP
+                < RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS,
+            "near-tip threshold must be strictly earlier than the default"
+        );
     }
 
     #[tokio::test]
@@ -11537,9 +11563,13 @@ mod tests {
         );
     }
 
-    /// Boundary: attempts just below threshold should NOT fire hard reset.
-    /// The fast-track path enters trigger_recovery_catchup but the
-    /// peer-ahead escalation check fails on attempts.
+    /// Boundary: in the FAR-BEHIND band (peer_gap >= checkpoint_frequency(),
+    /// the #1862 path), attempts just below the default escalation threshold
+    /// should NOT fire hard reset. The fast-track path enters
+    /// trigger_recovery_catchup but the peer-ahead escalation check fails on
+    /// attempts. (Uses a far-behind gap so the #3181 near-tip early-escalation
+    /// threshold does not apply — that path is covered by the catchup_impl
+    /// decide-fn near-tip tests and the consensus.rs near-tip gate.)
     #[tokio::test]
     async fn test_trigger_recovery_archive_behind_low_attempts_no_reset() {
         let (_dir, app) = make_app_for_peer_ahead_test().await;
@@ -11550,7 +11580,9 @@ mod tests {
                 backoff_until: None,
             };
         }
-        app.max_verified_scp_slot.store(110, Ordering::Relaxed);
+        // Far-behind: peer_gap = 200 - 100 = 100 >= checkpoint_frequency() (64),
+        // so the default (not near-tip) escalation threshold of 11 applies.
+        app.max_verified_scp_slot.store(200, Ordering::Relaxed);
         // After fetch_add(1), attempts will be ESCALATION - 1 = 10.
         app.recovery_attempts_without_progress.store(
             RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS - 1,

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -761,6 +761,19 @@ pub(super) struct StuckSignals {
     /// archive is behind — prevents the livelock described in #1843 where
     /// the decision keeps choosing HardReset but the cooldown blocks it.
     pub hard_reset_cooldown_active: bool,
+    /// When `true`, the node is in the near-tip stall band (issue #3181):
+    /// `PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap < checkpoint_frequency()`.
+    /// In this band, with the archive confirmed behind, the next checkpoint
+    /// that unblocks recovery publishes within one interval, so archive
+    /// catchup is structurally impossible-yet-imminent. When set (and the
+    /// HardReset cooldown is inactive), `decide_consensus_stuck_action`
+    /// escalates to `HardReset(ArchiveBehindStallWallClock)` immediately
+    /// without waiting for the full wall-clock stall, eliminating the
+    /// ~4.5-min archive-probe spin. False whenever there is no peer-ahead
+    /// evidence (`peer_gap < PEER_AHEAD_ESCALATION_THRESHOLD`) or the node is
+    /// genuinely far behind (`peer_gap >= checkpoint_frequency()`, the #1862
+    /// path, which keeps the unchanged escalation threshold).
+    pub near_tip: bool,
 }
 
 /// Actions to take when consensus is stuck.


### PR DESCRIPTION
Closes #3181

> [!CAUTION]
> **CRITICAL consensus-liveness fix.** This addresses a ~4.5-min mainnet consensus-participation stall (observed at L62893633, recurrence of #1862). Operators should be aware: it shortens the recovery-escalation latency near the tip from ~120s to ~10–20s. No protocol/XDR/consensus-message semantics change.

## Summary

When the archive is confirmed behind, peers are verified ahead, and the peer gap is in `[PEER_AHEAD_ESCALATION_THRESHOLD(3), checkpoint_frequency()(64))` — a near-tip stall where archive catchup is structurally impossible-yet-imminent (the unblocking checkpoint publishes within one interval) — this fires the **existing** state-changing recovery escalation (`force_post_catchup_hard_reset`: `ProbeAhead` blocking fetch + `request_scp_state`) on the ~2nd recovery tick (~10–20s) instead of the default ~11 ticks (~120s).

The bug was escalation **latency**, not over-escalation. The recovery state machine spent ~4 minutes (376 attempts) spinning on archive-based "forcing catchup" that could never succeed because the archive's latest checkpoint lagged the stuck ledger, before the resolving peer-based escalation fired ~4 min late. The fix introduces a near-tip predicate and, only in that band with the archive confirmed behind, lowers the escalation attempt threshold via a new `RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP = 1`.

**Preserved (not regressed):**
- The 60s `HARD_RESET_MIN_COOLDOWN_SECS` floor (#1843) — near-tip escalation is still cooldown-gated.
- The far-behind (`peer_gap >= checkpoint_frequency()`) #1862 archive-catchup path — unchanged 11-tick threshold.
- The #2789 anti-wedge escalation — escalation fires **earlier**, never suppressed; the state-changing reset still proceeds when peers are ahead.

## Files changed

- `crates/app/src/app/mod.rs` — new `RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP` constant.
- `crates/app/src/app/types.rs` — `near_tip` field on `StuckSignals`.
- `crates/app/src/app/consensus.rs` — peer-ahead escalation gate selects the near-tip threshold when `near_tip && archive_is_confirmed_behind`.
- `crates/app/src/app/catchup_impl.rs` — `decide_consensus_stuck_action` near-tip branch + `StuckSignals` build site populates `near_tip` from `effective_peer_gap`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3181#issuecomment-4633790995)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (lib/bin; matches CI + pre-commit hook)
- [x] `cargo test -p henyey-app` — 999 lib + integration tests pass, including all preserved #2789/#1862/#1843/#2713 tests

## Regression test (bug-fix)

- **Test:** `crates/app/src/app/catchup_impl.rs::test_decide_near_tip_archive_behind_escalates_early`
- **Pre-fix:** committed as `725c851d` — verified FAILED with: `near-tip + archive-behind must escalate to HardReset on the first due tick … got AttemptRecovery`
- **Post-fix:** verified PASSES after `9c4a37ff`
- Companions: `test_decide_near_tip_respects_cooldown` (#1843 cooldown preserved), `test_decide_not_near_tip_archive_behind_unchanged` (#1862 far-behind preserved), `test_near_tip_predicate_boundary` (predicate band), and a `RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP` constant assertion.

## Parity considerations

Mirrors stellar-core `HerderImpl::outOfSyncRecovery` (requests SCP state every out-of-sync tick, escalates to online catchup at the checkpoint boundary; never spins on per-tick archive probes). `checkpoint_frequency()` is read live (64 default / 8 accelerated) as the parity-faithful near-tip boundary.

## Deviations from plan

- `crates/app/src/app/mod.rs::test_trigger_recovery_archive_behind_low_attempts_no_reset` used a near-tip gap (peer_gap=10) with attempts just below the **default** threshold and asserted "no reset" — the exact late-escalation behavior this fix changes. Updated it to use a far-behind gap (peer_gap=100 ≥ 64) so it continues to validate the default-threshold boundary on the #1862 path. The near-tip early-escalation boundary is covered by the new decide-fn + constant tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)