### PR TITLE
Port P23 SAC mint/burn event reconciliation backfill (observability-only)

### DIFF
--- a/crates/ledger/PARITY_STATUS.md
+++ b/crates/ledger/PARITY_STATUS.md
@@ -329,7 +329,6 @@ Features excluded by design. These are NOT counted against parity %.
 | `InMemoryLedgerTxn` / `InMemoryLedgerTxnRoot` (test utilities) | Test-only in-memory backend |
 | `InflationWinner` / inflation queries | Inflation disabled in protocol 12+ |
 | `P23HotArchiveBug::Protocol23CorruptionDataVerifier` | CSV-file-driven catchup verification; Henyey has no corruption-file config concept and it has zero `bucketListHash` effect (no-op exclusion). The `addHotArchiveBatchWithP23HotArchiveFix` batch fix itself IS implemented (`p23_hot_archive_bug.rs`, #3061) |
-| `P23HotArchiveBug::Protocol23CorruptionEventReconciler` | SAC mint/burn event reconciliation (gated on `BACKFILL_STELLAR_ASSET_EVENTS`); distinct SAC-event spec gap, no `bucketListHash` effect (tracked as a follow-up) |
 | `FlushAndRotateMetaDebugWork.h/.cpp` | Operational debug tooling |
 | `LedgerManager::ledgerAbbrev()` | Logging helper, not protocol behavior |
 | Postgres-specific code (`USE_POSTGRES` blocks) | SQLite only per project guidelines |
@@ -439,7 +438,7 @@ The 139 implemented items cover: LedgerManager core operations (31, including `a
 
 The 8 gap items include: timing utilities (2), metrics methods (2), multi-threaded module cache compilation (1 Partial), CompleteConstLedgerState (1 Partial), prefetch (1), and meta streaming (1).
 
-The 31 intentional omissions are primarily SQL backend features (LedgerTxnRoot, offer SQL, header SQL operations), debug tooling (FlushAndRotateMetaDebugWork), the config-gated P23 corruption verifier/reconciler (the `addHotArchiveBatchWithP23HotArchiveFix` batch fix itself is implemented), deprecated functionality (inflation), C++ implementation artifacts (InternalLedgerEntry, EntryPtrState, ThreadInvariant, LedgerEntryScope), features handled by other crates (catchup, checkpoint ranges, app state machine).
+The 30 intentional omissions are primarily SQL backend features (LedgerTxnRoot, offer SQL, header SQL operations), debug tooling (FlushAndRotateMetaDebugWork), the config-gated P23 corruption data verifier (the `addHotArchiveBatchWithP23HotArchiveFix` batch fix is implemented in `p23_hot_archive_bug.rs`, #3061; the `Protocol23CorruptionEventReconciler` SAC mint/burn backfill is implemented in `henyey-tx` `events.rs`, #3126 — observability-only, gated on `BACKFILL_STELLAR_ASSET_EVENTS`, no `bucketListHash` effect), deprecated functionality (inflation), C++ implementation artifacts (InternalLedgerEntry, EntryPtrState, ThreadInvariant, LedgerEntryScope), features handled by other crates (catchup, checkpoint ranges, app state machine).
 
 ## Spec Adherence Notes
 

--- a/crates/ledger/scripts/extract_p23_hot_archive_bug_data.py
+++ b/crates/ledger/scripts/extract_p23_hot_archive_bug_data.py
@@ -5,11 +5,15 @@
 # Extraction/verification script for the CAP-0076 P23 hot-archive bug
 # remediation data table (issue #3061).
 #
-# Reads the two 478-entry base64-XDR string arrays from stellar-core's
+# Reads the two 478-entry base64-XDR string arrays plus the 12-entry
+# P23_CORRUPTED_AFFECTED_ASSETS array from stellar-core's
 #   stellar-core/src/ledger/P23HotArchiveBugData.cpp
 # and emits the generated Rust module
 #   crates/ledger/src/p23_hot_archive_bug_data.rs
 # transcribing the literals *verbatim* (we transcribe, we do not author them).
+#
+# The 12-entry P23_CORRUPTED_AFFECTED_ASSETS array drives the SAC mint/burn
+# event reconciler (Protocol23CorruptionEventReconciler), ported in issue #3126.
 #
 # Provenance: stellar-core v26.0.1, commit e78c97ed0.
 #
@@ -24,16 +28,33 @@ import os
 import re
 import sys
 
-EXPECTED_COUNT = 478
+ENTRIES_COUNT = 478
+AFFECTED_ASSETS_COUNT = 12
 
-# The two arrays we need. The third array in the source file
-# (P23_CORRUPTED_AFFECTED_ASSETS) drives the SAC-event reconciler, which is out
-# of scope for the bucketListHash remediation (see issue #3061 plan).
+# The three arrays we need. The first two are the 478 corrupted/correct
+# hot-archive LedgerEntry pairs (issue #3061). The third
+# (P23_CORRUPTED_AFFECTED_ASSETS) is the 12 affected SAC assets driving the
+# event reconciler (issue #3126).
+#
+# Each entry is (cpp_decl_name, rust_name, count_const, expected_count).
 ARRAYS = [
-    ("P23_CORRUPTED_HOT_ARCHIVE_ENTRIES", "P23_CORRUPTED_HOT_ARCHIVE_ENTRIES"),
+    (
+        "P23_CORRUPTED_HOT_ARCHIVE_ENTRIES",
+        "P23_CORRUPTED_HOT_ARCHIVE_ENTRIES",
+        "P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT",
+        ENTRIES_COUNT,
+    ),
     (
         "P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE",
         "P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE",
+        "P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT",
+        ENTRIES_COUNT,
+    ),
+    (
+        "P23_CORRUPTED_AFFECTED_ASSETS",
+        "P23_CORRUPTED_AFFECTED_ASSETS",
+        "P23_CORRUPTED_AFFECTED_ASSETS_COUNT",
+        AFFECTED_ASSETS_COUNT,
     ),
 ]
 
@@ -145,11 +166,11 @@ def main():
     src_sha = hashlib.sha256(src.encode("utf-8")).hexdigest()
 
     extracted = {}
-    for decl_name, _ in ARRAYS:
+    for decl_name, _rust_name, _count_const, expected_count in ARRAYS:
         entries = extract_array(src, decl_name)
-        if len(entries) != EXPECTED_COUNT:
+        if len(entries) != expected_count:
             raise SystemExit(
-                f"{decl_name}: expected {EXPECTED_COUNT} entries, got {len(entries)}"
+                f"{decl_name}: expected {expected_count} entries, got {len(entries)}"
             )
         extracted[decl_name] = entries
 
@@ -157,9 +178,12 @@ def main():
     lines.append(
         "// GENERATED FILE — DO NOT EDIT BY HAND.\n"
         "//\n"
-        "// CAP-0076 / Protocol 23 hot-archive bug remediation data table\n"
-        "// (478 corrupted/correct base64-XDR `LedgerEntry` pairs), transcribed\n"
-        "// verbatim from stellar-core's `P23HotArchiveBugData.cpp`.\n"
+        "// CAP-0076 / Protocol 23 hot-archive bug remediation data table,\n"
+        "// transcribed verbatim from stellar-core's `P23HotArchiveBugData.cpp`:\n"
+        f"//   - {ENTRIES_COUNT} corrupted/correct base64-XDR `LedgerEntry` pairs\n"
+        "//     (issue #3061, bucketListHash remediation), and\n"
+        f"//   - {AFFECTED_ASSETS_COUNT} base64-XDR `Asset` literals for the SAC\n"
+        "//     mint/burn event reconciler (issue #3126, observability-only).\n"
         "//\n"
         "// Provenance: stellar-core v26.0.1, commit e78c97ed0.\n"
         f"// Source file SHA-256: {src_sha}\n"
@@ -167,23 +191,29 @@ def main():
         "// Regenerate with:\n"
         "//   python3 crates/ledger/scripts/extract_p23_hot_archive_bug_data.py\n"
         "//\n"
-        "// See issue #3061 and `p23_hot_archive_bug.rs`.\n"
+        "// See issues #3061 / #3126 and `p23_hot_archive_bug.rs`.\n"
     )
     lines.append(
-        f"/// Number of hardcoded corrupted hot-archive entries ({EXPECTED_COUNT})."
+        f"/// Number of hardcoded corrupted hot-archive entries ({ENTRIES_COUNT})."
     )
     lines.append(
-        f"pub const P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT: usize = {EXPECTED_COUNT};\n"
+        f"pub const P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT: usize = {ENTRIES_COUNT};\n"
+    )
+    lines.append(
+        f"/// Number of affected SAC assets for the event reconciler ({AFFECTED_ASSETS_COUNT})."
+    )
+    lines.append(
+        f"pub const P23_CORRUPTED_AFFECTED_ASSETS_COUNT: usize = {AFFECTED_ASSETS_COUNT};\n"
     )
 
-    for decl_name, rust_name in ARRAYS:
+    for decl_name, rust_name, count_const, _expected_count in ARRAYS:
         entries = extracted[decl_name]
-        lines.append(
-            f"/// Base64-XDR `LedgerEntry` literals: {rust_name}."
-        )
-        lines.append(
-            f"pub static {rust_name}: [&str; P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT] = ["
-        )
+        if rust_name == "P23_CORRUPTED_AFFECTED_ASSETS":
+            doc = f"/// Base64-XDR `Asset` literals: {rust_name}."
+        else:
+            doc = f"/// Base64-XDR `LedgerEntry` literals: {rust_name}."
+        lines.append(doc)
+        lines.append(f"pub static {rust_name}: [&str; {count_const}] = [")
         for e in entries:
             # Rust raw-free string; base64 contains only [A-Za-z0-9+/=], no
             # escaping required, but use a debug-safe quoting just in case.
@@ -196,7 +226,7 @@ def main():
 
     print(f"Wrote {out_path}")
     print(f"Source SHA-256: {src_sha}")
-    for decl_name, _ in ARRAYS:
+    for decl_name, _rust_name, _count_const, _expected_count in ARRAYS:
         print(f"  {decl_name}: {len(extracted[decl_name])} entries")
 
 

--- a/crates/ledger/src/execution/mod.rs
+++ b/crates/ledger/src/execution/mod.rs
@@ -684,6 +684,58 @@ pub struct TransactionExecutor {
     hot_archive_restored_keys: std::collections::HashSet<LedgerKey>,
     /// Optional invariant manager for runtime integrity checks.
     invariant_manager: Option<std::sync::Arc<henyey_invariant::InvariantManager>>,
+    /// Protocol-23 SAC corruption event reconciler (issue #3126).
+    ///
+    /// Built lazily and only when `classic_events.backfill_stellar_asset_events`
+    /// is enabled AND the protocol version is exactly 23. Observability-only:
+    /// prepends synthetic SAC mint/burn events to InvokeHostFunction op-meta on
+    /// hot-archive restore, with zero effect on any consensus hash. `None` by
+    /// default (and whenever backfill is disabled or the version is not 23).
+    p23_sac_reconciler: Option<std::sync::Arc<henyey_tx::P23SacReconciler>>,
+}
+
+/// Build the protocol-23 SAC corruption event reconciler (issue #3126) if and
+/// only if the SAC-event backfill is active for this ledger.
+///
+/// Returns `None` unless `classic_events.backfill_stellar_asset_events` is
+/// enabled AND `protocol_version == 23` (the corruption only occurred during
+/// protocol 23 — equality gate, mirroring stellar-core). The reconciler decodes
+/// the hardcoded P23 data table (`crate::p23_hot_archive_bug`), so it is built
+/// at most once per executor and skipped entirely in the common (disabled)
+/// case. Observability-only: never affects any consensus hash.
+fn build_p23_sac_reconciler(
+    network_id: &NetworkId,
+    protocol_version: u32,
+    classic_events: ClassicEventConfig,
+) -> Option<std::sync::Arc<henyey_tx::P23SacReconciler>> {
+    if !classic_events.backfill_to_protocol23(protocol_version) {
+        return None;
+    }
+
+    use crate::p23_hot_archive_bug::{
+        P23_CORRUPTED_AFFECTED_ASSETS, P23_CORRUPTED_HOT_ARCHIVE_ENTRIES,
+        P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT, P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE,
+    };
+
+    let pairs: Vec<(&str, &str)> = (0..P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT)
+        .map(|i| {
+            (
+                P23_CORRUPTED_HOT_ARCHIVE_ENTRIES[i],
+                P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE[i],
+            )
+        })
+        .collect();
+
+    match henyey_tx::P23SacReconciler::new(network_id, &P23_CORRUPTED_AFFECTED_ASSETS, &pairs) {
+        Ok(reconciler) => Some(std::sync::Arc::new(reconciler)),
+        Err(e) => {
+            warn!(
+                error = %e,
+                "Failed to build P23 SAC event reconciler; SAC-event backfill disabled for this ledger"
+            );
+            None
+        }
+    }
 }
 
 impl TransactionExecutor {
@@ -696,6 +748,11 @@ impl TransactionExecutor {
     ) -> Self {
         let mut state = LedgerStateManager::new(context.base_reserve as i64, context.sequence);
         state.set_id_pool(id_pool);
+        let p23_sac_reconciler = build_p23_sac_reconciler(
+            &context.network_id,
+            context.protocol_version,
+            classic_events,
+        );
         Self {
             ledger_seq: context.sequence,
             close_time: context.close_time,
@@ -717,6 +774,7 @@ impl TransactionExecutor {
             frozen_key_config: context.frozen_key_config.clone(),
             hot_archive_restored_keys: std::collections::HashSet::new(),
             invariant_manager: None,
+            p23_sac_reconciler,
         }
     }
 
@@ -2251,6 +2309,8 @@ impl TransactionExecutor {
                 module_cache: self.module_cache.as_ref(),
                 guarded_hot_archive,
                 ttl_key_cache: self.ttl_key_cache.as_ref(),
+                classic_events: self.classic_events,
+                p23_sac_reconciler: self.p23_sac_reconciler.as_deref(),
             })
         } else {
             henyey_tx::soroban::OperationContext::Classic

--- a/crates/ledger/src/p23_hot_archive_bug.rs
+++ b/crates/ledger/src/p23_hot_archive_bug.rs
@@ -32,13 +32,15 @@
 //!
 //! stellar-core's `Protocol23CorruptionDataVerifier` (CSV-file-driven catchup
 //! verification) and `Protocol23CorruptionEventReconciler` (SAC mint/burn
-//! event reconciliation) live in the same upstream file but are config-gated
-//! optional machinery that never mutate the hot-archive batch:
+//! event reconciliation) live in the same upstream file:
 //!  - The data verifier is a pure no-op exclusion here — Henyey has no
 //!    corruption-file config concept, so there is nothing to wire up.
-//!  - The SAC-event reconciler (gated on `BACKFILL_STELLAR_ASSET_EVENTS`) is a
-//!    distinct spec gap tracked separately; it has zero `bucketListHash`
-//!    effect and is out of scope for this remediation.
+//!  - The SAC-event reconciler (gated on `BACKFILL_STELLAR_ASSET_EVENTS`) is
+//!    ported in `henyey_tx::events` (issue #3126). It consumes the
+//!    [`P23_CORRUPTED_AFFECTED_ASSETS`] array re-exported below plus the 478
+//!    corrupted/correct pairs above; it has zero `bucketListHash` effect
+//!    (events are op-meta-only, hashed after the success preimage) and is
+//!    off by default.
 
 use stellar_xdr::curr::{LedgerEntry, LedgerKey, Limits, ReadXdr};
 
@@ -48,6 +50,7 @@ use crate::error::LedgerError;
 use crate::Result;
 
 pub use crate::p23_hot_archive_bug_data::{
+    P23_CORRUPTED_AFFECTED_ASSETS, P23_CORRUPTED_AFFECTED_ASSETS_COUNT,
     P23_CORRUPTED_HOT_ARCHIVE_ENTRIES, P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT,
     P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE,
 };
@@ -213,5 +216,24 @@ mod tests {
             let correct = decode_correct_entry(i).unwrap();
             assert_ne!(corrupted, correct, "entry {i} should have been corrected");
         }
+    }
+
+    /// The affected-asset array (issue #3126) has exactly 12 entries, each of
+    /// which decodes to a valid `Asset` (mirrors `P23HotArchiveBug.h:31`
+    /// `P23_CORRUPTED_AFFECTED_ASSETS_COUNT = 12`).
+    #[test]
+    fn affected_assets_array_is_12_and_decodes() {
+        use stellar_xdr::curr::{Asset, ReadXdr};
+        assert_eq!(P23_CORRUPTED_AFFECTED_ASSETS_COUNT, 12);
+        assert_eq!(P23_CORRUPTED_AFFECTED_ASSETS.len(), 12);
+        for (i, s) in P23_CORRUPTED_AFFECTED_ASSETS.iter().enumerate() {
+            Asset::from_xdr_base64(s, Limits::none())
+                .unwrap_or_else(|e| panic!("affected asset {i} failed to decode: {e}"));
+        }
+        // First entry is the native asset (`AAAAAA==`), matching the C++ source.
+        assert_eq!(
+            Asset::from_xdr_base64(P23_CORRUPTED_AFFECTED_ASSETS[0], Limits::none()).unwrap(),
+            Asset::Native
+        );
     }
 }

--- a/crates/ledger/src/p23_hot_archive_bug_data.rs
+++ b/crates/ledger/src/p23_hot_archive_bug_data.rs
@@ -1,8 +1,11 @@
 // GENERATED FILE — DO NOT EDIT BY HAND.
 //
-// CAP-0076 / Protocol 23 hot-archive bug remediation data table
-// (478 corrupted/correct base64-XDR `LedgerEntry` pairs), transcribed
-// verbatim from stellar-core's `P23HotArchiveBugData.cpp`.
+// CAP-0076 / Protocol 23 hot-archive bug remediation data table,
+// transcribed verbatim from stellar-core's `P23HotArchiveBugData.cpp`:
+//   - 478 corrupted/correct base64-XDR `LedgerEntry` pairs
+//     (issue #3061, bucketListHash remediation), and
+//   - 12 base64-XDR `Asset` literals for the SAC
+//     mint/burn event reconciler (issue #3126, observability-only).
 //
 // Provenance: stellar-core v26.0.1, commit e78c97ed0.
 // Source file SHA-256: 8d7b3a6fda453c3dcd2e3187123093856f8fc4cdd9a70a873c688663b9832e8c
@@ -10,10 +13,13 @@
 // Regenerate with:
 //   python3 crates/ledger/scripts/extract_p23_hot_archive_bug_data.py
 //
-// See issue #3061 and `p23_hot_archive_bug.rs`.
+// See issues #3061 / #3126 and `p23_hot_archive_bug.rs`.
 
 /// Number of hardcoded corrupted hot-archive entries (478).
 pub const P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT: usize = 478;
+
+/// Number of affected SAC assets for the event reconciler (12).
+pub const P23_CORRUPTED_AFFECTED_ASSETS_COUNT: usize = 12;
 
 /// Base64-XDR `LedgerEntry` literals: P23_CORRUPTED_HOT_ARCHIVE_ENTRIES.
 pub static P23_CORRUPTED_HOT_ARCHIVE_ENTRIES: [&str; P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT] = [
@@ -977,4 +983,20 @@ pub static P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE: [&str; P23_CORRUPTED_H
     "A3XjlwAAAAYAAAAAAAAAAfBHOqv1q8THHOivBTgpKUD3M6psBCG1m97X6LNL5F21AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAABFvcX+Ntvqp5kuTuq/g6vKYzMD+llrkgr8L7C3CsJ8pwAAAABAAAAEQAAAAEAAAADAAAADwAAAAZhbW91bnQAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAphdXRob3JpemVkAAAAAAAAAAAAAQAAAA8AAAAIY2xhd2JhY2sAAAAAAAAAAAAAAAA=",
     "A3lodgAAAAYAAAAAAAAAAfBHOqv1q8THHOivBTgpKUD3M6psBCG1m97X6LNL5F21AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAABNSL7pTBxyupi/W8TrdvKi44Bnrmw5RSf7iSRiYjUsTwAAAABAAAAEQAAAAEAAAADAAAADwAAAAZhbW91bnQAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAphdXRob3JpemVkAAAAAAAAAAAAAQAAAA8AAAAIY2xhd2JhY2sAAAAAAAAAAAAAAAA=",
     "A35NbAAAAAYAAAAAAAAAAfBHOqv1q8THHOivBTgpKUD3M6psBCG1m97X6LNL5F21AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAABtJBfPve3i1JcJO+a6NMjAJFks1ZkA9QBP2NDGirAhKAAAAABAAAAEQAAAAEAAAADAAAADwAAAAZhbW91bnQAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAphdXRob3JpemVkAAAAAAAAAAAAAQAAAA8AAAAIY2xhd2JhY2sAAAAAAAAAAAAAAAA=",
+];
+
+/// Base64-XDR `Asset` literals: P23_CORRUPTED_AFFECTED_ASSETS.
+pub static P23_CORRUPTED_AFFECTED_ASSETS: [&str; P23_CORRUPTED_AFFECTED_ASSETS_COUNT] = [
+    "AAAAAA==",
+    "AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcU=",
+    "AAAAAlVTVFJZAAAAAAAAAAAAAACjihh9bUETXn31yZR0SCigSeDgfCEzu07aIZmcZ+LBNg==",
+    "AAAAAUJMTkQAAAAA0kPMJPZPS8rFR7mhiMujiCWd5dqlc77zlNPybSXzIdI=",
+    "AAAAAUFRVUEAAAAAW5QuU6wzyP0KgMx8GxqF19g4qcQZd6rRizrwV/jjPfA=",
+    "AAAAAVNIWAAAAAAA5TjI9zmT/KKxDcmCdh/l6VFSRFEDH9BHJShFf036PqQ=",
+    "AAAAAVNUSwAAAAAAfW7IaowF6psp0uDj0Z0IMxUWYHOCFHiZgj3bIdtXwQw=",
+    "AAAAAU5MVAAAAAAAL67mruJq8g1bj8lCiNVHbidAzKmg3NSrNjUbTCiAbaw=",
+    "AAAAAkxJQlJFAAAAAAAAAAAAAAAwIVlEE0w4nxTdJxIEerrFsVIN8WutTUzlhQJHaLR/Mg==",
+    "AAAAAUtQT1AAAAAA43Oh2jfBBl1sJz15HPylcD8Gbbh9XTWsf6/BAUfUlcc=",
+    "AAAAAUtBTEUAAAAAR1vypFiHKHeKgnE2nuA5VhED/841SUAs4KR5zr8bCfU=",
+    "AAAAAVNCSQAAAAAApjwUrepRcx7ax1frLCxCibZizKJrumi41+2I+RW8EAo=",
 ];

--- a/crates/tx/PARITY_STATUS.md
+++ b/crates/tx/PARITY_STATUS.md
@@ -245,6 +245,7 @@ Corresponds to: `EventManager.h`, `LumenEventReconciler.h`
 | `setEvents()` | `set_events()` | Full |
 | `newFeeEvent()` | `new_fee_event()` | Full |
 | `reconcileEvents()` | `reconcile_events()` | Full |
+| `Protocol23CorruptionEventReconciler` (`P23HotArchiveBug.cpp:456-615`) | `P23SacReconciler` (`events.rs`) | Full — issue #3126; observability-only SAC mint/burn backfill on p23 hot-archive auto-restore, gated on `BACKFILL_STELLAR_ASSET_EVENTS` (off by default), zero consensus-hash effect (events prepended to op-meta after the success preimage is hashed). Omits `hasReconciliationAmount`/`mReconciliationAmounts` (only feeds the unimplemented `EventsAreConsistentWithEntryDiffs` invariant) |
 | `getAssetFromEvent()` | Not needed (reconciliation uses different approach) | Full |
 | Muxed account handling | `make_muxed_account_address()` | Full |
 | Contract ID computation | `contract_id_from_asset()` | Full |

--- a/crates/tx/src/events.rs
+++ b/crates/tx/src/events.rs
@@ -37,11 +37,11 @@
 use henyey_common::NetworkId;
 use henyey_crypto::PublicKey as StrKeyPublicKey;
 use stellar_xdr::curr::{
-    AccountId, Asset, ClaimableBalanceId, ContractEvent, ContractEventBody, ContractEventType,
-    ContractEventV0, ContractId, ContractIdPreimage, Hash, HashIdPreimage,
-    HashIdPreimageContractId, Int128Parts, Memo, MuxedAccount, MuxedEd25519Account,
-    PublicKey as XdrPublicKey, ScAddress, ScMap, ScMapEntry, ScString, ScVal, StringM,
-    TransactionEvent, TransactionEventStage,
+    AccountId, Asset, ClaimableBalanceId, ContractDataDurability, ContractEvent, ContractEventBody,
+    ContractEventType, ContractEventV0, ContractId, ContractIdPreimage, Hash, HashIdPreimage,
+    HashIdPreimageContractId, Int128Parts, LedgerEntry, LedgerEntryData, LedgerKey, Limits, Memo,
+    MuxedAccount, MuxedEd25519Account, PublicKey as XdrPublicKey, ReadXdr, ScAddress, ScMap,
+    ScMapEntry, ScString, ScSymbol, ScVal, StringM, TransactionEvent, TransactionEventStage,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -55,8 +55,17 @@ impl ClassicEventConfig {
         self.emit_classic_events
     }
 
-    pub fn backfill_to_protocol23(self, _protocol_version: u32) -> bool {
-        false
+    /// Whether SAC mint/burn event backfill (the P23 corruption reconciler) is
+    /// active for this ledger.
+    ///
+    /// Mirrors stellar-core's gating: the reconciler only runs when
+    /// `BACKFILL_STELLAR_ASSET_EVENTS` is enabled AND the protocol version is
+    /// **exactly** 23 (`protocolVersionEquals(pv, ProtocolVersion::V_23)` in
+    /// `Protocol23CorruptionEventReconciler::getSACReconciliationEventAndTrackDiff`,
+    /// `P23HotArchiveBug.cpp:530`). The equality (not `>=`) is load-bearing —
+    /// the corruption only occurred during protocol 23.
+    pub fn backfill_to_protocol23(self, protocol_version: u32) -> bool {
+        self.backfill_stellar_asset_events && protocol_version == 23
     }
 }
 
@@ -864,6 +873,306 @@ fn get_asset_contract_id(network_id: &NetworkId, asset: &Asset) -> ContractId {
     ContractId(Hash::from(hash))
 }
 
+// ============================================================================
+// Protocol 23 SAC mint/burn event reconciler (issue #3126).
+//
+// Port of stellar-core's `Protocol23CorruptionEventReconciler`
+// (`stellar-core/src/ledger/P23HotArchiveBug.cpp:456-615`).
+//
+// During protocol-23 catchup, when a corrupted SAC (Stellar Asset Contract)
+// balance entry is auto-restored from the hot archive, stellar-core prepends a
+// synthetic mint/burn reconciliation event to the InvokeHostFunction operation
+// meta so the off-chain event stream balances out the corruption. This is
+// observability-only: the events are added to op-meta AFTER the success
+// preimage is hashed (`InvokeHostFunctionOpFrame.cpp:821` hashes `success`
+// before `:825` `setEvents` prepends the reconciliation events), so they have
+// ZERO effect on `bucketListHash`, the tx-result hash, or the
+// `InvokeHostFunctionSuccessPreImage` hash. The whole mechanism is gated on
+// `BACKFILL_STELLAR_ASSET_EVENTS` and off by default.
+//
+// Intentional divergences from stellar-core, both parity-safe:
+//   * We omit `mReconciliationAmounts` / `hasReconciliationAmount` tracking —
+//     its only upstream consumer is the unimplemented
+//     `EventsAreConsistentWithEntryDiffs` invariant.
+//   * We drop stellar-core's `std::mutex` (henyey replays single-threaded for
+//     the reconciler input).
+// ============================================================================
+
+/// A single reconciliation event produced by [`P23SacReconciler`].
+///
+/// Mirrors `Protocol23CorruptionEventReconciler::SACReconciliationInfo`. A
+/// positive `amount` is a mint to `mint_or_burn_address`; a negative `amount`
+/// is a burn from that address (emitting `-amount` as a positive number).
+#[derive(Debug, Clone)]
+pub struct SacReconciliationInfo {
+    /// The affected SAC asset.
+    pub asset: Asset,
+    /// The balance owner address that mints (diff > 0) or burns (diff < 0).
+    pub mint_or_burn_address: ScAddress,
+    /// `restored_balance - correct_balance` (never zero — equal balances yield
+    /// no event).
+    pub amount: i64,
+}
+
+/// Reconciler for the protocol-23 hot-archive SAC corruption.
+///
+/// Built once (decoding the hardcoded data table is non-trivial), then queried
+/// for each hot-archive restore during a protocol-23 ledger.
+pub struct P23SacReconciler {
+    /// SAC contract id → affected `Asset`. Built from the 12-entry
+    /// `P23_CORRUPTED_AFFECTED_ASSETS` array via [`get_asset_contract_id`].
+    sac_asset_map: std::collections::HashMap<ScAddress, Asset>,
+    /// Corrupted-entry `LedgerKey` → (correct entry, corrupted entry), built
+    /// from the 478 corrupted/correct pairs.
+    key_to_entries: std::collections::HashMap<LedgerKey, (LedgerEntry, LedgerEntry)>,
+}
+
+impl P23SacReconciler {
+    /// Construct the reconciler from the hardcoded base64-XDR data table.
+    ///
+    /// `affected_assets` are the base64-XDR `Asset` literals
+    /// (`P23_CORRUPTED_AFFECTED_ASSETS`); `corrupted_correct_pairs` are
+    /// `(corrupted, correct)` base64-XDR `LedgerEntry` literals (the 478 pairs
+    /// from the #3061 data table, in `(P23_CORRUPTED_HOT_ARCHIVE_ENTRIES[i],
+    /// P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE[i])` order).
+    ///
+    /// Mirrors `Protocol23CorruptionEventReconciler::Protocol23CorruptionEventReconciler`
+    /// (`P23HotArchiveBug.cpp:456-482`).
+    ///
+    /// # Errors
+    /// Returns `Err` if any literal fails to decode, or if two affected assets
+    /// map to the same SAC contract id (mirrors stellar-core's
+    /// `releaseAssert(inserted)`).
+    pub fn new(
+        network_id: &NetworkId,
+        affected_assets: &[&str],
+        corrupted_correct_pairs: &[(&str, &str)],
+    ) -> Result<Self, String> {
+        let mut sac_asset_map = std::collections::HashMap::new();
+        for (i, encoded) in affected_assets.iter().enumerate() {
+            let asset = Asset::from_xdr_base64(encoded, Limits::none())
+                .map_err(|e| format!("P23 reconciler: failed to decode affected asset {i}: {e}"))?;
+            let address = ScAddress::Contract(get_asset_contract_id(network_id, &asset));
+            if sac_asset_map.insert(address, asset).is_some() {
+                return Err(format!(
+                    "P23 reconciler: duplicate SAC contract id for affected asset {i}"
+                ));
+            }
+        }
+
+        let mut key_to_entries = std::collections::HashMap::new();
+        for (i, (corrupted_b64, correct_b64)) in corrupted_correct_pairs.iter().enumerate() {
+            let corrupted =
+                LedgerEntry::from_xdr_base64(corrupted_b64, Limits::none()).map_err(|e| {
+                    format!("P23 reconciler: failed to decode corrupted entry {i}: {e}")
+                })?;
+            let correct = LedgerEntry::from_xdr_base64(correct_b64, Limits::none())
+                .map_err(|e| format!("P23 reconciler: failed to decode correct entry {i}: {e}"))?;
+            let key = henyey_common::entry_to_key(&corrupted);
+            key_to_entries.insert(key, (correct, corrupted));
+        }
+
+        Ok(Self {
+            sac_asset_map,
+            key_to_entries,
+        })
+    }
+
+    /// Compute the reconciliation event for a single hot-archive restore.
+    ///
+    /// Mirrors `getSACReconciliationEventAndTrackDiff`
+    /// (`P23HotArchiveBug.cpp:524-588`). Returns `None` (no event) when:
+    ///   * `protocol_version != 23` (equality gate),
+    ///   * the restored key is not in the corrupted-entry table,
+    ///   * the restored entry is not `CONTRACT_DATA`,
+    ///   * the restored entry's contract is not one of the 12 affected SACs, or
+    ///   * the restored balance equals the correct balance.
+    ///
+    /// The restored entry MUST byte-match the hardcoded corrupted entry
+    /// (stellar-core `releaseAssert(restoredEntry == corruptedEntry)`); a
+    /// mismatch is a data/usage error and returns `Err`.
+    pub fn reconciliation_event(
+        &self,
+        restored_key: &LedgerKey,
+        restored_entry: &LedgerEntry,
+        protocol_version: u32,
+    ) -> Result<Option<SacReconciliationInfo>, String> {
+        if protocol_version != 23 {
+            return Ok(None);
+        }
+
+        let Some((correct_entry, corrupted_entry)) = self.key_to_entries.get(restored_key) else {
+            return Ok(None);
+        };
+
+        let LedgerEntryData::ContractData(cd) = &restored_entry.data else {
+            return Ok(None);
+        };
+
+        let Some(asset) = self.sac_asset_map.get(&cd.contract) else {
+            return Ok(None);
+        };
+
+        let (restored_balance, restored_owner) = get_sac_balance(restored_entry)?;
+
+        // The restored entry must be exactly the hardcoded corrupted entry.
+        if restored_entry != corrupted_entry {
+            return Err(
+                "P23 reconciler: restored entry does not match the hardcoded corrupted entry"
+                    .to_string(),
+            );
+        }
+
+        let (correct_balance, correct_owner) = get_sac_balance(correct_entry)?;
+
+        // The balance addresses must match.
+        if correct_owner != restored_owner {
+            return Err("P23 reconciler: correct/restored balance owner mismatch".to_string());
+        }
+
+        if correct_balance == restored_balance {
+            // No change in amount, no reconciliation event.
+            return Ok(None);
+        }
+
+        let amount = restored_balance - correct_balance;
+        Ok(Some(SacReconciliationInfo {
+            asset: asset.clone(),
+            mint_or_burn_address: correct_owner,
+            amount,
+        }))
+    }
+
+    /// Build the raw `ContractEvent`s for a batch of restored entries, in
+    /// restore order.
+    ///
+    /// Each non-`None` reconciliation produces a mint event (amount > 0) or a
+    /// burn event (amount < 0, emitting `-amount`). Mirrors the prepend loop in
+    /// `InvokeHostFunctionOpFrame::setEvents` (`InvokeHostFunctionOpFrame.cpp:772-815`).
+    ///
+    /// The returned events carry no muxed-id/memo data
+    /// (`allow_muxed_id_or_memo = false`), matching `makeMintEvent(.., false)` /
+    /// `makeBurnEvent(..)` upstream.
+    pub fn reconciliation_events_for_restores(
+        &self,
+        network_id: &NetworkId,
+        restores: impl IntoIterator<Item = (LedgerKey, LedgerEntry)>,
+        protocol_version: u32,
+    ) -> Result<Vec<ContractEvent>, String> {
+        let mut events = Vec::new();
+        for (key, entry) in restores {
+            if let Some(info) = self.reconciliation_event(&key, &entry, protocol_version)? {
+                // getSACReconciliationEventAndTrackDiff never returns a zero diff.
+                debug_assert_ne!(info.amount, 0);
+                let address = get_address_with_dropped_muxed_info(&info.mint_or_burn_address);
+                let event = if info.amount > 0 {
+                    make_sac_reconciliation_event(
+                        network_id,
+                        "mint",
+                        &info.asset,
+                        &address,
+                        info.amount,
+                    )
+                } else {
+                    make_sac_reconciliation_event(
+                        network_id,
+                        "burn",
+                        &info.asset,
+                        &address,
+                        -info.amount,
+                    )
+                };
+                events.push(event);
+            }
+        }
+        Ok(events)
+    }
+}
+
+/// Build a raw mint/burn `ContractEvent` for SAC reconciliation, matching
+/// `OpEventManager::makeMintEvent` / `makeBurnEvent` (no muxed-id/memo data).
+fn make_sac_reconciliation_event(
+    network_id: &NetworkId,
+    topic: &str,
+    asset: &Asset,
+    address: &ScAddress,
+    amount: i64,
+) -> ContractEvent {
+    let contract_id = get_asset_contract_id(network_id, asset);
+    let topics = vec![
+        make_symbol_scval(topic),
+        ScVal::Address(address.clone()),
+        make_sep0011_asset_string_scval(asset),
+    ];
+    make_event(contract_id, topics, make_i128_scval(amount))
+}
+
+/// Extract `(balance, owner)` from a SAC balance `CONTRACT_DATA` entry.
+///
+/// Port of `getSACBalance` (`P23HotArchiveBug.cpp:485-522`). For the affected
+/// SACs the balance always fits in `[0, i64::MAX]`; the function enforces every
+/// structural assumption as a hard error (matching stellar-core's
+/// `releaseAssert`s), since the only entries reaching it are the hardcoded
+/// corrupted/correct SAC balances.
+fn get_sac_balance(le: &LedgerEntry) -> Result<(i64, ScAddress), String> {
+    let LedgerEntryData::ContractData(cd) = &le.data else {
+        return Err("P23 getSACBalance: entry is not CONTRACT_DATA".to_string());
+    };
+
+    if cd.durability != ContractDataDurability::Persistent {
+        return Err("P23 getSACBalance: durability is not PERSISTENT".to_string());
+    }
+
+    let ScVal::Vec(Some(key_vec)) = &cd.key else {
+        return Err("P23 getSACBalance: key is not a non-null SCVec".to_string());
+    };
+    if key_vec.0.len() != 2 {
+        return Err("P23 getSACBalance: key SCVec is not length 2".to_string());
+    }
+
+    // The "Balance" symbol must be the first entry in the SCVec.
+    let balance_symbol = ScVal::Symbol(
+        ScSymbol::try_from("Balance".to_string()).expect("\"Balance\" is a valid SCSymbol"),
+    );
+    if key_vec.0[0] != balance_symbol {
+        return Err("P23 getSACBalance: first key entry is not the \"Balance\" symbol".to_string());
+    }
+
+    let ScVal::Address(balance_owner) = &key_vec.0[1] else {
+        return Err("P23 getSACBalance: second key entry is not an address".to_string());
+    };
+
+    let ScVal::Map(Some(val_map)) = &cd.val else {
+        return Err("P23 getSACBalance: val is not a non-null SCMap".to_string());
+    };
+    if val_map.0.len() != 3 {
+        return Err("P23 getSACBalance: val SCMap is not length 3".to_string());
+    }
+
+    let amount_symbol = ScVal::Symbol(
+        ScSymbol::try_from("amount".to_string()).expect("\"amount\" is a valid SCSymbol"),
+    );
+    let amount_entry = &val_map.0[0];
+    if amount_entry.key != amount_symbol {
+        return Err(
+            "P23 getSACBalance: first val entry key is not the \"amount\" symbol".to_string(),
+        );
+    }
+    let ScVal::I128(parts) = &amount_entry.val else {
+        return Err("P23 getSACBalance: amount value is not SCV_I128".to_string());
+    };
+
+    // For the range in question, hi is always 0 and lo fits in i64.
+    if parts.hi != 0 {
+        return Err("P23 getSACBalance: amount hi is not 0".to_string());
+    }
+    if parts.lo > i64::MAX as u64 {
+        return Err("P23 getSACBalance: amount lo exceeds i64::MAX".to_string());
+    }
+
+    Ok((parts.lo as i64, balance_owner.clone()))
+}
+
 fn scval_symbol_bytes(value: &ScVal) -> Option<Vec<u8>> {
     match value {
         ScVal::Symbol(sym) => {
@@ -1032,9 +1341,18 @@ mod tests {
             emit_classic_events: true,
             backfill_stellar_asset_events: true,
         };
-        // backfill_to_protocol23 always returns false in current implementation
+        // SAC-event backfill (the P23 reconciler) is active ONLY on protocol 23
+        // (equality gate, issue #3126), and only when the flag is set.
+        assert!(config.backfill_to_protocol23(23));
         assert!(!config.backfill_to_protocol23(22));
-        assert!(!config.backfill_to_protocol23(23));
+        assert!(!config.backfill_to_protocol23(24));
+
+        // Flag off → never active, even on protocol 23 (off by default).
+        let off = ClassicEventConfig {
+            emit_classic_events: true,
+            backfill_stellar_asset_events: false,
+        };
+        assert!(!off.backfill_to_protocol23(23));
     }
 
     // === OpEventManager tests ===
@@ -1910,5 +2228,307 @@ mod tests {
     #[should_panic(expected = "memo type cannot be None")]
     fn test_make_classic_memo_scval_none_panics() {
         make_classic_memo_scval(&Memo::None);
+    }
+
+    // ====================================================================
+    // Protocol 23 SAC mint/burn event reconciler tests (issue #3126).
+    // ====================================================================
+
+    use stellar_xdr::curr::{
+        ContractDataEntry, ExtensionPoint, LedgerEntryExt, ScSymbol as XdrScSymbol, ScVec, WriteXdr,
+    };
+
+    /// Build a SAC-balance `CONTRACT_DATA` LedgerEntry for the given SAC
+    /// contract id, owner, and amount, mirroring the structure `getSACBalance`
+    /// expects (key = ["Balance", owner]; val = {amount, authorized, clawback}).
+    fn sac_balance_entry(contract_id: ContractId, owner: &ScAddress, amount: i64) -> LedgerEntry {
+        let key = ScVal::Vec(Some(ScVec(
+            vec![
+                ScVal::Symbol(XdrScSymbol::try_from("Balance").unwrap()),
+                ScVal::Address(owner.clone()),
+            ]
+            .try_into()
+            .unwrap(),
+        )));
+        let val = ScVal::Map(Some(ScMap(
+            vec![
+                ScMapEntry {
+                    key: ScVal::Symbol(XdrScSymbol::try_from("amount").unwrap()),
+                    val: make_i128_scval(amount),
+                },
+                ScMapEntry {
+                    key: ScVal::Symbol(XdrScSymbol::try_from("authorized").unwrap()),
+                    val: ScVal::Bool(true),
+                },
+                ScMapEntry {
+                    key: ScVal::Symbol(XdrScSymbol::try_from("clawback").unwrap()),
+                    val: ScVal::Bool(false),
+                },
+            ]
+            .try_into()
+            .unwrap(),
+        )));
+        LedgerEntry {
+            last_modified_ledger_seq: 0,
+            data: LedgerEntryData::ContractData(ContractDataEntry {
+                ext: ExtensionPoint::V0,
+                contract: ScAddress::Contract(contract_id),
+                key,
+                durability: ContractDataDurability::Persistent,
+                val,
+            }),
+            ext: LedgerEntryExt::V0,
+        }
+    }
+
+    fn b64(entry: &LedgerEntry) -> String {
+        entry.to_xdr_base64(Limits::none()).unwrap()
+    }
+
+    fn b64_asset(asset: &Asset) -> String {
+        asset.to_xdr_base64(Limits::none()).unwrap()
+    }
+
+    /// Build a reconciler whose single affected asset is `asset`, with one
+    /// corrupted/correct pair: a SAC balance owned by `owner` that was restored
+    /// as `corrupted_amount` but should have been `correct_amount`.
+    fn single_pair_reconciler(
+        network_id: &NetworkId,
+        asset: &Asset,
+        owner: &ScAddress,
+        corrupted_amount: i64,
+        correct_amount: i64,
+    ) -> (P23SacReconciler, LedgerKey, LedgerEntry) {
+        let contract_id = get_asset_contract_id(network_id, asset);
+        let corrupted = sac_balance_entry(contract_id.clone(), owner, corrupted_amount);
+        let correct = sac_balance_entry(contract_id, owner, correct_amount);
+        let key = henyey_common::entry_to_key(&corrupted);
+
+        let asset_b64 = b64_asset(asset);
+        let corrupted_b64 = b64(&corrupted);
+        let correct_b64 = b64(&correct);
+        let reconciler = P23SacReconciler::new(
+            network_id,
+            &[asset_b64.as_str()],
+            &[(corrupted_b64.as_str(), correct_b64.as_str())],
+        )
+        .unwrap();
+        (reconciler, key, corrupted)
+    }
+
+    fn contract_owner(seed: u8) -> ScAddress {
+        ScAddress::Contract(ContractId(Hash([seed; 32])))
+    }
+
+    #[test]
+    fn test_p23_reconciler_mint_on_positive_diff() {
+        let net = NetworkId::testnet();
+        let asset = test_asset_alphanum4(7);
+        let owner = contract_owner(9);
+        // restored (corrupted) = 1000, correct = 600 → diff +400 → mint.
+        let (rec, key, corrupted) = single_pair_reconciler(&net, &asset, &owner, 1000, 600);
+        let info = rec
+            .reconciliation_event(&key, &corrupted, 23)
+            .unwrap()
+            .expect("expected a reconciliation event");
+        assert_eq!(info.asset, asset);
+        assert_eq!(info.mint_or_burn_address, owner);
+        assert_eq!(info.amount, 400);
+
+        // Built event is a mint for +400.
+        let events = rec
+            .reconciliation_events_for_restores(&net, [(key, corrupted)], 23)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        let ContractEventBody::V0(body) = &events[0].body;
+        assert_eq!(body.topics.first().unwrap(), &make_symbol_scval("mint"));
+        assert_eq!(body.data, make_i128_scval(400));
+    }
+
+    #[test]
+    fn test_p23_reconciler_burn_on_negative_diff() {
+        let net = NetworkId::testnet();
+        let asset = test_asset_alphanum12(11);
+        let owner = contract_owner(3);
+        // restored = 250, correct = 900 → diff -650 → burn of 650.
+        let (rec, key, corrupted) = single_pair_reconciler(&net, &asset, &owner, 250, 900);
+        let info = rec
+            .reconciliation_event(&key, &corrupted, 23)
+            .unwrap()
+            .expect("expected a reconciliation event");
+        assert_eq!(info.amount, -650);
+
+        let events = rec
+            .reconciliation_events_for_restores(&net, [(key, corrupted)], 23)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        let ContractEventBody::V0(body) = &events[0].body;
+        assert_eq!(body.topics.first().unwrap(), &make_symbol_scval("burn"));
+        // A burn emits the positive magnitude.
+        assert_eq!(body.data, make_i128_scval(650));
+    }
+
+    #[test]
+    fn test_p23_reconciler_none_on_equal_balance() {
+        let net = NetworkId::testnet();
+        let asset = test_asset_alphanum4(7);
+        let owner = contract_owner(9);
+        let (rec, key, corrupted) = single_pair_reconciler(&net, &asset, &owner, 500, 500);
+        assert!(rec
+            .reconciliation_event(&key, &corrupted, 23)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_p23_reconciler_none_for_non_contract_data() {
+        let net = NetworkId::testnet();
+        let asset = test_asset_alphanum4(7);
+        let owner = contract_owner(9);
+        let (rec, key, _corrupted) = single_pair_reconciler(&net, &asset, &owner, 1000, 600);
+        // An account entry is not CONTRACT_DATA → None even if the key matched.
+        let account_entry = LedgerEntry {
+            last_modified_ledger_seq: 0,
+            data: LedgerEntryData::Account(stellar_xdr::curr::AccountEntry {
+                account_id: test_account_id(1),
+                balance: 0,
+                seq_num: stellar_xdr::curr::SequenceNumber(0),
+                num_sub_entries: 0,
+                inflation_dest: None,
+                flags: 0,
+                home_domain: Default::default(),
+                thresholds: stellar_xdr::curr::Thresholds([0; 4]),
+                signers: Default::default(),
+                ext: stellar_xdr::curr::AccountEntryExt::V0,
+            }),
+            ext: LedgerEntryExt::V0,
+        };
+        assert!(rec
+            .reconciliation_event(&key, &account_entry, 23)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_p23_reconciler_none_for_key_not_in_corrupted_table() {
+        let net = NetworkId::testnet();
+        let asset = test_asset_alphanum4(7);
+        let owner = contract_owner(9);
+        let (rec, _key, corrupted) = single_pair_reconciler(&net, &asset, &owner, 1000, 600);
+        // A different owner → a different SAC balance key not in the table.
+        let other_owner = contract_owner(42);
+        let contract_id = get_asset_contract_id(&net, &asset);
+        let other_entry = sac_balance_entry(contract_id, &other_owner, 1000);
+        let other_key = henyey_common::entry_to_key(&other_entry);
+        assert_ne!(other_key, henyey_common::entry_to_key(&corrupted));
+        assert!(rec
+            .reconciliation_event(&other_key, &other_entry, 23)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_p23_reconciler_none_for_unaffected_asset() {
+        let net = NetworkId::testnet();
+        // The reconciler knows about asset A, but the restored entry belongs to
+        // asset B's SAC contract → not in sac_asset_map → None.
+        let asset_a = test_asset_alphanum4(7);
+        let owner = contract_owner(9);
+        let (rec, _key, _corrupted) = single_pair_reconciler(&net, &asset_a, &owner, 1000, 600);
+
+        let asset_b = test_asset_alphanum4(8);
+        let contract_b = get_asset_contract_id(&net, &asset_b);
+        let entry_b = sac_balance_entry(contract_b, &owner, 1000);
+        // Re-key against the corrupted table by reusing asset A's key is not
+        // possible; the entry's own key won't be in the table, so None.
+        let key_b = henyey_common::entry_to_key(&entry_b);
+        assert!(rec
+            .reconciliation_event(&key_b, &entry_b, 23)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_p23_reconciler_none_off_protocol_23() {
+        let net = NetworkId::testnet();
+        let asset = test_asset_alphanum4(7);
+        let owner = contract_owner(9);
+        let (rec, key, corrupted) = single_pair_reconciler(&net, &asset, &owner, 1000, 600);
+        // Same data that mints at p23, but p22/p24 → equality gate → None.
+        assert!(rec
+            .reconciliation_event(&key, &corrupted, 22)
+            .unwrap()
+            .is_none());
+        assert!(rec
+            .reconciliation_event(&key, &corrupted, 24)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_backfill_to_protocol23_gating() {
+        let on = ClassicEventConfig {
+            emit_classic_events: true,
+            backfill_stellar_asset_events: true,
+        };
+        assert!(on.backfill_to_protocol23(23));
+        assert!(!on.backfill_to_protocol23(22));
+        assert!(!on.backfill_to_protocol23(24));
+
+        let off = ClassicEventConfig {
+            emit_classic_events: true,
+            backfill_stellar_asset_events: false,
+        };
+        assert!(!off.backfill_to_protocol23(23));
+        assert!(!ClassicEventConfig::default().backfill_to_protocol23(23));
+    }
+
+    /// The 12 affected-asset base64 literals, transcribed verbatim from
+    /// `crates/ledger/src/p23_hot_archive_bug_data.rs`
+    /// (`P23_CORRUPTED_AFFECTED_ASSETS`, in turn from
+    /// `stellar-core/src/ledger/P23HotArchiveBugData.cpp:10040-10063`). Inlined
+    /// here because `henyey-tx` cannot depend on `henyey-ledger` (cycle); the
+    /// ledger crate owns the canonical array and feeds it to `P23SacReconciler`
+    /// at runtime. `henyey-ledger` independently asserts the count is 12.
+    const P23_AFFECTED_ASSETS_B64: [&str; 12] = [
+        "AAAAAA==",
+        "AAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcU=",
+        "AAAAAlVTVFJZAAAAAAAAAAAAAACjihh9bUETXn31yZR0SCigSeDgfCEzu07aIZmcZ+LBNg==",
+        "AAAAAUJMTkQAAAAA0kPMJPZPS8rFR7mhiMujiCWd5dqlc77zlNPybSXzIdI=",
+        "AAAAAUFRVUEAAAAAW5QuU6wzyP0KgMx8GxqF19g4qcQZd6rRizrwV/jjPfA=",
+        "AAAAAVNIWAAAAAAA5TjI9zmT/KKxDcmCdh/l6VFSRFEDH9BHJShFf036PqQ=",
+        "AAAAAVNUSwAAAAAAfW7IaowF6psp0uDj0Z0IMxUWYHOCFHiZgj3bIdtXwQw=",
+        "AAAAAU5MVAAAAAAAL67mruJq8g1bj8lCiNVHbidAzKmg3NSrNjUbTCiAbaw=",
+        "AAAAAkxJQlJFAAAAAAAAAAAAAAAwIVlEE0w4nxTdJxIEerrFsVIN8WutTUzlhQJHaLR/Mg==",
+        "AAAAAUtQT1AAAAAA43Oh2jfBBl1sJz15HPylcD8Gbbh9XTWsf6/BAUfUlcc=",
+        "AAAAAUtBTEUAAAAAR1vypFiHKHeKgnE2nuA5VhED/841SUAs4KR5zr8bCfU=",
+        "AAAAAVNCSQAAAAAApjwUrepRcx7ax1frLCxCibZizKJrumi41+2I+RW8EAo=",
+    ];
+
+    #[test]
+    fn test_p23_affected_assets_array_decodes() {
+        // All 12 base64 strings decode to a valid Asset, and the 12 SAC contract
+        // ids are pairwise distinct (mirrors stellar-core's
+        // releaseAssert(inserted) in the reconciler constructor).
+        let net = NetworkId::mainnet();
+        assert_eq!(P23_AFFECTED_ASSETS_B64.len(), 12);
+        let mut ids = std::collections::HashSet::new();
+        for (i, s) in P23_AFFECTED_ASSETS_B64.iter().enumerate() {
+            let asset = Asset::from_xdr_base64(s, Limits::none())
+                .unwrap_or_else(|e| panic!("affected asset {i} failed to decode: {e}"));
+            let id = get_asset_contract_id(&net, &asset);
+            assert!(ids.insert(id), "duplicate SAC contract id at index {i}");
+        }
+        assert_eq!(ids.len(), 12);
+    }
+
+    #[test]
+    fn test_p23_reconciler_constructor_rejects_duplicate_asset_ids() {
+        // Two identical assets → same SAC contract id → constructor errors,
+        // mirroring stellar-core's releaseAssert(inserted).
+        let net = NetworkId::testnet();
+        let asset = b64_asset(&test_asset_alphanum4(7));
+        let err = P23SacReconciler::new(&net, &[asset.as_str(), asset.as_str()], &[]);
+        assert!(err.is_err());
     }
 }

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -153,7 +153,8 @@ pub mod validation;
 pub use error::TxError;
 pub use events::{
     make_account_address, make_claimable_balance_address, make_muxed_account_address,
-    ClassicEventConfig, EventManagerHierarchy, OpEventManager, TxEventManager,
+    ClassicEventConfig, EventManagerHierarchy, OpEventManager, P23SacReconciler,
+    SacReconciliationInfo, TxEventManager,
 };
 
 // Re-export lumen reconciler types

--- a/crates/tx/src/operations/execute/invoke_host_function.rs
+++ b/crates/tx/src/operations/execute/invoke_host_function.rs
@@ -468,6 +468,7 @@ pub(crate) fn execute_invoke_host_function(
             module_cache: soroban.module_cache,
             guarded_hot_archive: soroban.guarded_hot_archive,
             ttl_key_cache: soroban.ttl_key_cache,
+            p23_sac_reconciler: soroban.p23_sac_reconciler,
         },
         state,
         context,
@@ -483,6 +484,9 @@ struct ContractInvocationRequest<'a> {
     module_cache: Option<&'a PersistentModuleCache>,
     guarded_hot_archive: Option<crate::soroban::GuardedHotArchive<'a>>,
     ttl_key_cache: Option<&'a crate::soroban::TtlKeyCache>,
+    /// Protocol-23 SAC corruption event reconciler (observability-only; off by
+    /// default). Present only when `BACKFILL_STELLAR_ASSET_EVENTS` is enabled.
+    p23_sac_reconciler: Option<&'a crate::events::P23SacReconciler>,
 }
 
 fn execute_contract_invocation(
@@ -500,6 +504,7 @@ fn execute_contract_invocation(
         module_cache,
         guarded_hot_archive,
         ttl_key_cache,
+        p23_sac_reconciler,
     } = request;
 
     // Convert auth entries to a slice
@@ -660,7 +665,13 @@ fn execute_contract_invocation(
 
             Ok(OperationExecutionResult::with_soroban_meta(
                 make_result(InvokeHostFunctionResultCode::Success, result_hash),
-                build_soroban_operation_meta(&result, hot_archive_original_entries),
+                build_soroban_operation_meta(
+                    &result,
+                    hot_archive_original_entries,
+                    p23_sac_reconciler,
+                    &context.network_id,
+                    context.protocol_version,
+                ),
             ))
         }
         Err(exec_error) => {
@@ -757,11 +768,19 @@ fn compute_success_preimage_hash(return_value: &ScVal, events: &[ContractEvent])
 fn build_soroban_operation_meta(
     result: &crate::soroban::SorobanExecutionResult,
     hot_archive_restores: Vec<HotArchiveRestore>,
+    p23_sac_reconciler: Option<&crate::events::P23SacReconciler>,
+    network_id: &henyey_common::NetworkId,
+    protocol_version: u32,
 ) -> SorobanOperationMeta {
     // Use contract_events which contains the decoded Contract and System events.
-    let events = result.contract_events.clone();
+    let mut events = result.contract_events.clone();
 
-    // Build diagnostic events from the contract events
+    // Build diagnostic events from the contract events BEFORE any P23 SAC
+    // reconciliation events are prepended. stellar-core routes reconciliation
+    // events only through the op-meta event stream
+    // (`InvokeHostFunctionOpFrame.cpp:825` `setEvents`), NOT the diagnostic
+    // channel — so we deliberately compute diagnostics off the untouched host
+    // events here.
     let mut diagnostic_events: Vec<DiagnosticEvent> = events
         .iter()
         .map(|event| DiagnosticEvent {
@@ -771,6 +790,37 @@ fn build_soroban_operation_meta(
         .collect();
 
     diagnostic_events.extend(result.diagnostic_events.iter().cloned());
+
+    // Protocol-23 SAC mint/burn event reconciliation backfill (issue #3126).
+    //
+    // Observability-only and off by default: the reconciler is `Some` only when
+    // `BACKFILL_STELLAR_ASSET_EVENTS` is enabled. Synthetic reconciliation
+    // events are PREPENDED to the op-meta event stream, mirroring
+    // `InvokeHostFunctionOpFrame::setEvents` (`InvokeHostFunctionOpFrame.cpp:772-815`).
+    // Critically, this runs AFTER `compute_success_preimage_hash` has already
+    // hashed the UNTOUCHED `result.contract_events`, so it has zero effect on
+    // the InvokeHostFunction success-preimage hash, the tx-result hash, or the
+    // `bucketListHash` — exactly mirroring stellar-core hashing `success`
+    // (`InvokeHostFunctionOpFrame.cpp:821`) before `setEvents` (`:825`).
+    if let Some(reconciler) = p23_sac_reconciler {
+        let restores = hot_archive_restores
+            .iter()
+            .map(|r| (r.key().clone(), r.entry().clone()));
+        match reconciler.reconciliation_events_for_restores(network_id, restores, protocol_version)
+        {
+            Ok(recon_events) if !recon_events.is_empty() => {
+                // Prepend, preserving restore order ahead of the host events.
+                events.splice(0..0, recon_events);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "P23 SAC reconciliation failed; emitting no reconciliation events"
+                );
+            }
+        }
+    }
 
     SorobanOperationMeta {
         events,
@@ -1493,6 +1543,8 @@ mod tests {
             module_cache: None,
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         };
         let result = execute_invoke_host_function(&op, &source, &mut state, &context, &soroban)
             .expect("invoke host function");
@@ -1572,6 +1624,8 @@ mod tests {
             module_cache: None,
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         };
         let result = execute_invoke_host_function(&op, &source, &mut state, &context, &soroban)
             .expect("invoke host function");
@@ -1656,6 +1710,8 @@ mod tests {
             module_cache: Some(&module_cache),
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         };
         let result = execute_invoke_host_function(&op, &source, &mut state, &context, &soroban)
             .expect("invoke host function");
@@ -1741,6 +1797,8 @@ mod tests {
             module_cache: Some(&module_cache),
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         };
         let result = execute_invoke_host_function(&op, &source, &mut state, &context, &soroban)
             .expect("invoke host function");
@@ -1795,6 +1853,8 @@ mod tests {
             module_cache: None,
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         };
         let result = execute_invoke_host_function(&op, &source, &mut state, &context, &soroban)
             .expect("invoke host function");
@@ -4039,6 +4099,8 @@ mod tests {
             module_cache: None,
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         };
         let result = execute_invoke_host_function(&op, &source, &mut state, &context, &soroban)
             .expect("invoke host function");
@@ -4126,6 +4188,8 @@ mod tests {
             module_cache: None,
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         };
         let result = execute_invoke_host_function(&op, &source, &mut state, &context, &soroban)
             .expect("invoke host function");
@@ -4187,6 +4251,231 @@ mod tests {
         assert!(
             combined_size > limit,
             "Combined size exceeding limit must be rejected"
+        );
+    }
+
+    // ====================================================================
+    // Protocol 23 SAC reconciliation wire-in tests (issue #3126):
+    // reconciliation events land in op-meta (prepended) but NEVER in the
+    // hashed success preimage — i.e. zero consensus-hash impact.
+    // ====================================================================
+
+    /// Build a `SorobanExecutionResult` carrying the given host events and a
+    /// fixed return value (everything else neutral).
+    fn make_exec_result(
+        return_value: ScVal,
+        contract_events: Vec<ContractEvent>,
+    ) -> crate::soroban::SorobanExecutionResult {
+        crate::soroban::SorobanExecutionResult {
+            return_value,
+            storage_changes: vec![],
+            contract_events,
+            diagnostic_events: vec![],
+            cpu_insns: 0,
+            mem_bytes: 0,
+            contract_events_and_return_value_size: 0,
+            rent_fee: 0,
+            live_bucket_list_restores: vec![],
+            actual_restored_indices: vec![],
+        }
+    }
+
+    /// Build a SAC-balance CONTRACT_DATA entry + the reconciler that maps it to
+    /// a +diff mint, returning (reconciler, restore, expected_event).
+    fn p23_mint_fixture(
+        net: &henyey_common::NetworkId,
+    ) -> (
+        crate::events::P23SacReconciler,
+        HotArchiveRestore,
+        ContractEvent,
+    ) {
+        use stellar_xdr::curr::{
+            Asset, ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, Hash,
+            LedgerEntry, LedgerEntryData, LedgerEntryExt, Limits, ScAddress, ScMap, ScMapEntry,
+            ScSymbol, ScVal, ScVec, WriteXdr,
+        };
+
+        let asset = Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
+            asset_code: stellar_xdr::curr::AssetCode4(*b"USDC"),
+            issuer: AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::curr::Uint256([7u8; 32]),
+            )),
+        });
+
+        // Compute the SAC contract id the same way events.rs does.
+        use stellar_xdr::curr::{ContractIdPreimage, HashIdPreimage, HashIdPreimageContractId};
+        let preimage = HashIdPreimage::ContractId(HashIdPreimageContractId {
+            network_id: Hash::from(net.0),
+            contract_id_preimage: ContractIdPreimage::Asset(asset.clone()),
+        });
+        let cid = ContractId(Hash::from(henyey_common::Hash256::hash_xdr(&preimage)));
+
+        let owner = ScAddress::Contract(ContractId(Hash([9u8; 32])));
+        let make_entry = |amount: i64| -> LedgerEntry {
+            let key = ScVal::Vec(Some(ScVec(
+                vec![
+                    ScVal::Symbol(ScSymbol::try_from("Balance").unwrap()),
+                    ScVal::Address(owner.clone()),
+                ]
+                .try_into()
+                .unwrap(),
+            )));
+            let amt = {
+                let v = amount as i128;
+                ScVal::I128(stellar_xdr::curr::Int128Parts {
+                    hi: (v >> 64) as i64,
+                    lo: v as u64,
+                })
+            };
+            let val = ScVal::Map(Some(ScMap(
+                vec![
+                    ScMapEntry {
+                        key: ScVal::Symbol(ScSymbol::try_from("amount").unwrap()),
+                        val: amt,
+                    },
+                    ScMapEntry {
+                        key: ScVal::Symbol(ScSymbol::try_from("authorized").unwrap()),
+                        val: ScVal::Bool(true),
+                    },
+                    ScMapEntry {
+                        key: ScVal::Symbol(ScSymbol::try_from("clawback").unwrap()),
+                        val: ScVal::Bool(false),
+                    },
+                ]
+                .try_into()
+                .unwrap(),
+            )));
+            LedgerEntry {
+                last_modified_ledger_seq: 0,
+                data: LedgerEntryData::ContractData(ContractDataEntry {
+                    ext: ExtensionPoint::V0,
+                    contract: ScAddress::Contract(cid.clone()),
+                    key,
+                    durability: ContractDataDurability::Persistent,
+                    val,
+                }),
+                ext: LedgerEntryExt::V0,
+            }
+        };
+
+        // restored (corrupted) = 1000, correct = 600 → diff +400 → mint.
+        let corrupted = make_entry(1000);
+        let correct = make_entry(600);
+        let key = henyey_common::entry_to_key(&corrupted);
+
+        let reconciler = crate::events::P23SacReconciler::new(
+            net,
+            &[asset.to_xdr_base64(Limits::none()).unwrap().as_str()],
+            &[(
+                corrupted.to_xdr_base64(Limits::none()).unwrap().as_str(),
+                correct.to_xdr_base64(Limits::none()).unwrap().as_str(),
+            )],
+        )
+        .unwrap();
+
+        let restore = HotArchiveRestore::new(key, corrupted, 100);
+        let expected = reconciler
+            .reconciliation_events_for_restores(
+                net,
+                [(restore.key().clone(), restore.entry().clone())],
+                23,
+            )
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        (reconciler, restore, expected)
+    }
+
+    #[test]
+    fn test_invoke_host_function_p23_reconciliation_events_in_meta_not_hash() {
+        let net = henyey_common::NetworkId::testnet();
+        let (reconciler, restore, expected_event) = p23_mint_fixture(&net);
+
+        // A single pre-existing host event (distinct from the reconciliation
+        // event so the diagnostic-channel assertion is meaningful), plus a
+        // return value.
+        let host_event = ContractEvent {
+            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            contract_id: Some(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(
+                [123u8; 32],
+            ))),
+            type_: stellar_xdr::curr::ContractEventType::Contract,
+            body: stellar_xdr::curr::ContractEventBody::V0(stellar_xdr::curr::ContractEventV0 {
+                topics: vec![ScVal::U32(999)].try_into().unwrap(),
+                data: ScVal::U32(999),
+            }),
+        };
+        assert_ne!(host_event, expected_event);
+        let return_value = ScVal::U32(42);
+        let result = make_exec_result(return_value.clone(), vec![host_event.clone()]);
+
+        // The success-preimage hash is computed from the UNTOUCHED host events.
+        // It must be identical whether or not the reconciler runs.
+        let hash_baseline = compute_success_preimage_hash(&return_value, &result.contract_events);
+
+        // Backfill OFF (reconciler = None): events = host events only.
+        let meta_off = build_soroban_operation_meta(&result, vec![restore.clone()], None, &net, 23);
+        assert_eq!(
+            meta_off.events,
+            vec![host_event.clone()],
+            "flag off → no reconciliation events"
+        );
+
+        // Backfill ON: the mint event is PREPENDED ahead of the host event.
+        let meta_on = build_soroban_operation_meta(
+            &result,
+            vec![restore.clone()],
+            Some(&reconciler),
+            &net,
+            23,
+        );
+        assert_eq!(
+            meta_on.events.len(),
+            2,
+            "flag on → one reconciliation event prepended"
+        );
+        assert_eq!(
+            meta_on.events[0], expected_event,
+            "reconciliation event must be FIRST (prepended)"
+        );
+        assert_eq!(
+            meta_on.events[1], host_event,
+            "original host event must follow the reconciliation event"
+        );
+
+        // HASH INVARIANCE: the success-preimage hash over the host events is
+        // unaffected by the reconciler. The reconciliation events live ONLY in
+        // op-meta, never in the hashed preimage — zero consensus impact.
+        let hash_on = compute_success_preimage_hash(&return_value, &result.contract_events);
+        assert_eq!(
+            hash_baseline, hash_on,
+            "success-preimage hash must be identical with backfill on vs off"
+        );
+
+        // The diagnostic-event channel must NOT contain the reconciliation
+        // event (stellar-core routes it only through the op-meta event stream).
+        let recon_in_diag = meta_on
+            .diagnostic_events
+            .iter()
+            .any(|d| d.event == expected_event);
+        assert!(
+            !recon_in_diag,
+            "reconciliation events must not enter the diagnostic-event channel"
+        );
+    }
+
+    #[test]
+    fn test_invoke_host_function_p23_no_events_off_protocol_23() {
+        let net = henyey_common::NetworkId::testnet();
+        let (reconciler, restore, _expected) = p23_mint_fixture(&net);
+        let result = make_exec_result(ScVal::U32(1), vec![]);
+        // Even with the reconciler present, protocol != 23 → no events.
+        let meta =
+            build_soroban_operation_meta(&result, vec![restore], Some(&reconciler), &net, 24);
+        assert!(
+            meta.events.is_empty(),
+            "no reconciliation events outside protocol 23"
         );
     }
 }

--- a/crates/tx/src/operations/execute/mod.rs
+++ b/crates/tx/src/operations/execute/mod.rs
@@ -2474,6 +2474,8 @@ mod tests {
             module_cache: None,
             guarded_hot_archive: None,
             ttl_key_cache: None,
+            classic_events: crate::events::ClassicEventConfig::default(),
+            p23_sac_reconciler: None,
         });
 
         // Build RestoreFootprint operation

--- a/crates/tx/src/soroban/mod.rs
+++ b/crates/tx/src/soroban/mod.rs
@@ -145,6 +145,15 @@ pub struct SorobanContext<'a> {
     pub module_cache: Option<&'a PersistentModuleCache>,
     pub guarded_hot_archive: Option<GuardedHotArchive<'a>>,
     pub ttl_key_cache: Option<&'a TtlKeyCache>,
+    /// Classic-event configuration. Drives the protocol-23 SAC mint/burn event
+    /// reconciliation backfill (off by default). Observability-only — never
+    /// affects any consensus hash.
+    pub classic_events: crate::events::ClassicEventConfig,
+    /// Optional protocol-23 SAC corruption event reconciler. Present only when
+    /// `classic_events.backfill_stellar_asset_events` is enabled (built once by
+    /// the caller from the hardcoded P23 data table). Used to prepend synthetic
+    /// mint/burn events to InvokeHostFunction op-meta on hot-archive restore.
+    pub p23_sac_reconciler: Option<&'a crate::events::P23SacReconciler>,
 }
 
 /// Cache of pre-computed TTL key hashes. Built during footprint loading,


### PR DESCRIPTION
Closes #3126

## Summary

Ports stellar-core's `Protocol23CorruptionEventReconciler` (`P23HotArchiveBug.cpp:456-615`) as a config-gated, **off-by-default**, **observability-only** SAC mint/burn event backfill. On an InvokeHostFunction protocol-23 hot-archive auto-restore of a corrupted SAC balance entry, synthetic mint/burn reconciliation events for the 12 affected assets are **prepended** to the operation-meta event stream. Gated on `BACKFILL_STELLAR_ASSET_EVENTS` (off by default) and protocol == 23 (equality gate, mirroring upstream).

**Zero consensus impact.** The InvokeHostFunction success preimage is hashed from the untouched host events at `compute_success_preimage_hash` BEFORE reconciliation events are prepended in `build_soroban_operation_meta` — exactly mirroring stellar-core hashing `success` (`InvokeHostFunctionOpFrame.cpp:821`) before `setEvents` (`:825`). `bucketListHash`, the tx-result hash, and the success-preimage hash are byte-identical with the flag on vs off.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3126#issuecomment-4633769267)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (lib targets, as CI runs it) clean for henyey-tx + henyey-ledger
- [x] `cargo test -p henyey-tx -p henyey-ledger` — 1982 tests pass, incl. new coverage
- [x] cargo build --all

New coverage:
- Reconciler mint/burn/none cases; the protocol-23 equality gate; 12-asset decode + 12 distinct SAC contract ids; duplicate-asset rejection.
- End-to-end `test_invoke_host_function_p23_reconciliation_events_in_meta_not_hash`: asserts the mint event is **prepended** (order), the success-preimage hash is **identical** with backfill on vs off, and the reconciliation event is excluded from the diagnostic-event channel.
- `affected_assets_array_is_12_and_decodes` (ledger): count == 12, all decode, index 0 == native.

## Deviations from plan

- **Reconciler data sourcing (minor plumbing).** The plan placed the reconciler logic in `crates/tx/src/events.rs` and the 12-asset data in `crates/ledger/src/p23_hot_archive_bug_data.rs`. Because `henyey-ledger` depends on `henyey-tx` (not the reverse), the reconciler cannot import the ledger-owned data directly. Resolved without changing observable behavior: `P23SacReconciler::new` accepts the base64 data arrays as input; the ledger executor (which owns the data and dispatches the op) builds the reconciler once and threads it through `SorobanContext` into the tx wire-in. The data table stays in `henyey-ledger` and the reconciler logic stays in `henyey-tx`, as the plan intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)