### PR TITLE
Fix /spec-adhere cross-crate blind spot (searches only the spec-named crate)

### DIFF
--- a/.claude/skills/spec-adhere/SKILL.md
+++ b/.claude/skills/spec-adhere/SKILL.md
@@ -33,13 +33,28 @@ against the specs).
 
 | Spec | Primary Rust crate | Notes |
 |------|--------------------|-------|
-| `SCP_SPEC` | `crates/scp` | |
-| `OVERLAY_SPEC` | `crates/overlay` | |
-| `HERDER_SPEC` | `crates/herder` | |
+| `SCP_SPEC` | `crates/scp` | Driver/wiring also in `crates/app` (event loop owns SCP message dispatch & consensus trigger) |
+| `OVERLAY_SPEC` | `crates/overlay` | Dispatch/wiring also in `crates/app` (event loop: `survey_impl.rs`, `tx_flooding.rs`, `peers.rs`, `lifecycle.rs`) |
+| `HERDER_SPEC` | `crates/herder` | Integration/wiring also in `crates/app` (event-loop dispatch, consensus trigger) |
 | `LEDGER_SPEC` | `crates/ledger` | Some integration in `crates/app` |
 | `TX_SPEC` | `crates/tx` | Apply path also touches `crates/app` |
 | `BUCKETLISTDB_SPEC` | `crates/bucket` | |
 | `CATCHUP_SPEC` | `crates/history` | Also `crates/historywork` |
+
+> **Cross-crate caveat (the #3158 blind spot).** `crates/app` owns the live
+> overlay/herder/scp **wiring** — the event loop in `crates/app/src/app/`
+> (`lifecycle.rs`, `survey_impl.rs`, `tx_flooding.rs`, `peers.rs`) is where
+> message dispatch, survey processing, flood scheduling, and consensus triggers
+> actually run. The spec-named library crate (`crates/overlay`, `crates/herder`,
+> `crates/scp`) may contain **dead / unwired code**: a symbol can be `pub` and
+> re-exported yet never instantiated outside `#[cfg(test)]` (e.g.
+> `crates/overlay/src/survey.rs`'s `SurveyManager`, exported at `lib.rs` but only
+> constructed in tests — the real survey logic lives in `crates/app`). Therefore:
+> **never declare an OVERLAY/HERDER/SCP feature "Absent" after searching only the
+> named crate.** Grep `crates/app` (and the rest of the `crates/` tree) for the
+> wiring first. Conversely, do not treat an exported-but-never-instantiated
+> library symbol as "the implementation" — confirm it is reachable from
+> production code before classifying it Full.
 
 Output file (apply mode):
 `/Users/tomer/dev/henyey/crates/<primary-crate>/SPEC_ADHERENCE.md`
@@ -75,6 +90,23 @@ table), read all `.rs` files under `src/`. Skip `tests/`,
 `benches/`, and `#[cfg(test)]` modules — adherence is about
 production code.
 
+**Search ALL crates, not just the name-matched one (the #3158 fix).**
+Before classifying any claim, run a grep-first pass over the **entire
+`crates/` tree** for the spec-bound symbols (function names, constants,
+result-code enum values, dispatch match-arms) — do **not** scope the
+search to the primary crate alone. Henyey's event loop in `crates/app`
+owns much overlay/herder/scp **wiring** (dispatch, survey processing,
+flood scheduling, consensus trigger), so a symbol absent from the
+name-matched crate is **not** absent from the codebase. Keep the
+primary crate as the deep-read target; grep-target the rest of the
+crates (especially `crates/app`) and read only the matching files.
+Concrete command:
+
+```bash
+# Locate candidate implementations across ALL crates before reading.
+grep -rni --include='*.rs' -e '<symbol>' -e '<CONST>' -e '<RESULT_CODE>' crates/
+```
+
 Build a lightweight index of:
 - Public function names and their containing modules
 - Result-code enum values (Rust-side names; usually
@@ -97,6 +129,28 @@ For every claim from Step 1, attempt to locate the Rust enforcement:
 3. **Result-code match**: if the claim ties a check to an XDR
    result code, search for that enum value in the crate.
 4. **Free-text grep**: fall back to grep for distinctive phrases.
+   Search **all crates** (`grep -rn --include='*.rs' … crates/`), not
+   only the name-matched crate.
+
+**Reachability check (the #3158 fix) — run at every Full/Absent
+decision point.** Before recording a found symbol as **Full**, verify it
+is actually **instantiated / called in the production control path**:
+grep for a non-`#[cfg(test)]` caller or constructor.
+
+```bash
+# Is the candidate reachable from production code (not just tests)?
+grep -rn --include='*.rs' '<symbol>' crates/ | grep -v -e '#\[cfg(test)\]' -e '/tests/'
+```
+
+If the only references are tests or re-exports — the
+`crates/overlay/src/survey.rs` `SurveyManager` **dead-scaffold** case
+(exported at `lib.rs` but constructed only under `#[cfg(test)]`) — treat
+it as dead/unwired code and **keep searching** (the live implementation
+is typically the event-loop wiring in `crates/app`) rather than reporting
+it as "the implementation." Symmetrically, **never record Absent without
+an all-crates grep**: confirm the symbol/result-code is missing from the
+**entire `crates/` tree** (especially `crates/app`), using two search
+strategies across all crates, before classifying Absent.
 
 Classify the finding:
 
@@ -234,8 +288,10 @@ it.)
   fixing them is a separate decision.
 - Be precise with classifications. "I couldn't find it in a quick
   grep" is **not** Absent — confirm with at least two search
-  strategies (anchor + symbol, or symbol + result-code) before
-  marking Absent.
+  strategies (anchor + symbol, or symbol + result-code) **across all
+  crates** (grep the entire `crates/` tree, especially `crates/app`,
+  not just the name-matched crate) before marking Absent. This is the
+  #3158 cross-crate fix: overlay/herder/scp wiring lives in `crates/app`.
 - For SHOULD claims, default to noting them in the report but
   excluding from the adherence percentage calculation. Many
   SHOULDs are operational defaults (e.g., recommended timeouts),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run quickstart test harness
         run: bash scripts/test-quickstart-harness.sh
+
+  spec-adhere-skill-snippets:
+    name: Spec-Adhere Skill Snippets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run spec-adhere skill snippet harness
+        run: bash scripts/test-spec-adhere-skill-snippets.sh

--- a/scripts/test-spec-adhere-skill-snippets.sh
+++ b/scripts/test-spec-adhere-skill-snippets.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Smoke-test harness for the /spec-adhere skill guidance.
+#
+# Regression guard for issue #3158: the /spec-adhere audit had a cross-crate
+# blind spot — it searched only the spec-named crate (e.g. crates/overlay for
+# OVERLAY_SPEC) and missed implementations wired in crates/app (the event loop
+# owns overlay/herder/scp dispatch). This produced false-positive "Absent"
+# findings (e.g. #3069/#3070/#3076 — survey/flood subsystem implemented in
+# crates/app/src/app/{survey_impl,tx_flooding}.rs while crates/overlay's
+# SurveyManager is dead code). This harness asserts that SKILL.md codifies:
+#   (a) crates/app as a secondary search target for OVERLAY_SPEC and HERDER_SPEC,
+#   (b) an all-crates search pass before classifying (not just the named crate),
+#   (c) a reachability/instantiation check that distinguishes a live
+#       implementation from a dead scaffold, and a rule forbidding "Absent"
+#       without grepping all crates first.
+#
+# COUPLING: these assertions key on STABLE tokens (crates/app, "all crates" /
+# "entire crates/" tree, "instantiated" / "reachable") rather than full
+# sentences, so benign rewording of SKILL.md is tolerated. If you reword the
+# guidance, keep these tokens (or update this test in the same commit).
+#
+# Usage:
+#   bash scripts/test-spec-adhere-skill-snippets.sh
+#
+# Output: TAP (Test Anything Protocol) on stdout, diagnostics on stderr.
+# Exit: 0 = all pass, 1 = any fail.
+#
+# Portability: GNU/Linux only (Bash 4+, grep).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_MD="$REPO_ROOT/.claude/skills/spec-adhere/SKILL.md"
+
+# ── TAP state ────────────────────────────────────────────────────────────────
+TAP_PLAN=8
+TAP_CURRENT=0
+TAP_FAILURES=0
+
+tap_plan() { echo "1..$TAP_PLAN"; }
+
+tap_ok() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  echo "ok $TAP_CURRENT - $1"
+}
+
+tap_not_ok() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  TAP_FAILURES=$((TAP_FAILURES + 1))
+  echo "not ok $TAP_CURRENT - $1"
+  if [[ -n "${2:-}" ]]; then
+    echo "# $2" >&2
+  fi
+}
+
+# assert_match DESC PATTERN [FILE]
+# Pass if PCRE-less ERE PATTERN matches at least one line of FILE (default SKILL_MD).
+assert_match() {
+  local desc="$1" pattern="$2" file="${3:-$SKILL_MD}"
+  if grep -Eiq -- "$pattern" "$file"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "pattern not found: /$pattern/ in $file"
+  fi
+}
+
+# assert_section_match DESC SECTION_START SECTION_END PATTERN
+# Extract the lines between SECTION_START and SECTION_END (sed BRE addresses,
+# both inclusive) and assert PATTERN matches within that slice. This scopes the
+# assertion to the relevant procedure step so an incidental match elsewhere in
+# the doc does not mask a missing edit.
+assert_section_match() {
+  local desc="$1" start="$2" end="$3" pattern="$4"
+  local slice
+  slice="$(sed -n "/$start/,/$end/p" "$SKILL_MD")"
+  if printf '%s\n' "$slice" | grep -Eiq -- "$pattern"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "pattern not found: /$pattern/ within section [$start .. $end]"
+  fi
+}
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+if [[ ! -f "$SKILL_MD" ]]; then
+  echo "Bail out! spec-adhere SKILL.md not found at $SKILL_MD" >&2
+  exit 1
+fi
+
+tap_plan
+
+# ── (a) Mapping table: crates/app is a secondary target for OVERLAY & HERDER ──
+# The OVERLAY_SPEC and HERDER_SPEC rows must reference crates/app so the auditor
+# knows the event-loop wiring lives there.
+assert_match "OVERLAY_SPEC mapping row references crates/app" \
+  '^\|[[:space:]]*\`?OVERLAY_SPEC\`?[[:space:]]*\|.*crates/app'
+assert_match "HERDER_SPEC mapping row references crates/app" \
+  '^\|[[:space:]]*\`?HERDER_SPEC\`?[[:space:]]*\|.*crates/app'
+
+# ── (b) Step 2: an all-crates search pass, not just the named crate ───────────
+# Must instruct grepping the entire crates/ tree before classifying.
+assert_section_match "Step 2 instructs an all-crates / entire crates tree search" \
+  '### Step 2' '### Step 3' '(all crates|every crate|entire \`?crates/|whole \`?crates/|across all crates)'
+
+# ── (c) Step 3: reachability check + no-Absent-without-all-crates-grep rule ───
+assert_section_match "Step 3 contains a reachability / instantiation check" \
+  '### Step 3' '### Step 4' '(instantiat|reachab|actually called|production (caller|control path)|dead (code|scaffold))'
+assert_section_match "Step 3 forbids reporting Absent without an all-crates grep" \
+  '### Step 3' '### Step 4' '(Absent.*(all crates|every crate|entire \`?crates/)|(all crates|every crate|entire \`?crates/).*Absent)'
+
+# ── Reinforcing assertions (document the intent in stable tokens) ─────────────
+# The dead-scaffold caveat must name the crates/app-owns-live-wiring rule so the
+# auditor does not treat an exported-but-unwired library symbol as "the impl".
+assert_match "doc explains crates/app owns the live overlay/herder/scp wiring" \
+  'crates/app.*(wiring|dispatch|event loop|event-loop)'
+assert_match "doc warns library crates may contain dead / unwired code" \
+  '(dead|unwired|never instantiat|exported.*never).*(code|scaffold|symbol)'
+assert_match "doc references the cross-crate grep as a concrete auditor step" \
+  '(grep|search).*(all crates|entire \`?crates/|whole \`?crates/|every crate|crates/app)'
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+if [[ "$TAP_FAILURES" -gt 0 ]]; then
+  echo "# $TAP_FAILURES of $TAP_PLAN assertions failed" >&2
+  exit 1
+fi
+echo "# all $TAP_PLAN assertions passed" >&2
+exit 0

--- a/scripts/test-spec-adhere-skill-snippets.sh
+++ b/scripts/test-spec-adhere-skill-snippets.sh
@@ -93,21 +93,24 @@ tap_plan
 # ── (a) Mapping table: crates/app is a secondary target for OVERLAY & HERDER ──
 # The OVERLAY_SPEC and HERDER_SPEC rows must reference crates/app so the auditor
 # knows the event-loop wiring lives there.
+# NOTE: use a BARE backtick (`) here, not \` — in GNU grep ERE, \` is the
+# "start of buffer" anchor, not a literal backtick, which silently breaks the
+# match. The bare ` matches the markdown code-span backtick literally.
 assert_match "OVERLAY_SPEC mapping row references crates/app" \
-  '^\|[[:space:]]*\`?OVERLAY_SPEC\`?[[:space:]]*\|.*crates/app'
+  '^\|[[:space:]]*`?OVERLAY_SPEC`?[[:space:]]*\|.*crates/app'
 assert_match "HERDER_SPEC mapping row references crates/app" \
-  '^\|[[:space:]]*\`?HERDER_SPEC\`?[[:space:]]*\|.*crates/app'
+  '^\|[[:space:]]*`?HERDER_SPEC`?[[:space:]]*\|.*crates/app'
 
 # ── (b) Step 2: an all-crates search pass, not just the named crate ───────────
 # Must instruct grepping the entire crates/ tree before classifying.
 assert_section_match "Step 2 instructs an all-crates / entire crates tree search" \
-  '### Step 2' '### Step 3' '(all crates|every crate|entire \`?crates/|whole \`?crates/|across all crates)'
+  '### Step 2' '### Step 3' '(all crates|every crate|entire `?crates/|whole `?crates/|across all crates)'
 
 # ── (c) Step 3: reachability check + no-Absent-without-all-crates-grep rule ───
 assert_section_match "Step 3 contains a reachability / instantiation check" \
   '### Step 3' '### Step 4' '(instantiat|reachab|actually called|production (caller|control path)|dead (code|scaffold))'
 assert_section_match "Step 3 forbids reporting Absent without an all-crates grep" \
-  '### Step 3' '### Step 4' '(Absent.*(all crates|every crate|entire \`?crates/)|(all crates|every crate|entire \`?crates/).*Absent)'
+  '### Step 3' '### Step 4' '(Absent.*(all crates|every crate|entire `?crates/)|(all crates|every crate|entire `?crates/).*Absent)'
 
 # ── Reinforcing assertions (document the intent in stable tokens) ─────────────
 # The dead-scaffold caveat must name the crates/app-owns-live-wiring rule so the
@@ -117,7 +120,7 @@ assert_match "doc explains crates/app owns the live overlay/herder/scp wiring" \
 assert_match "doc warns library crates may contain dead / unwired code" \
   '(dead|unwired|never instantiat|exported.*never).*(code|scaffold|symbol)'
 assert_match "doc references the cross-crate grep as a concrete auditor step" \
-  '(grep|search).*(all crates|entire \`?crates/|whole \`?crates/|every crate|crates/app)'
+  '(grep|search).*(all crates|entire `?crates/|whole `?crates/|every crate|crates/app)'
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 if [[ "$TAP_FAILURES" -gt 0 ]]; then


### PR DESCRIPTION
Closes #3158

## Summary

The `/spec-adhere` audit searched only the spec-named crate (e.g. `crates/overlay` for OVERLAY_SPEC) and missed implementations wired in `crates/app` — the event loop that owns overlay/herder/scp dispatch. This produced ~6 false-positive "Absent" findings this session (#3069/#3070/#3076/#3077: the survey/flood subsystem is implemented in `crates/app/src/app/{survey_impl,tx_flooding}.rs`, while `crates/overlay/src/survey.rs`'s `SurveyManager` is dead code — exported but only constructed under `#[cfg(test)]`).

This PR codifies a cross-crate search step in the skill so the auditor greps `crates/app` (and the whole `crates/` tree) before declaring an overlay/herder/scp feature missing, and adds a reachability check so an exported-but-unwired library symbol is not mistaken for "the implementation."

## Changes

- **`.claude/skills/spec-adhere/SKILL.md`** — three edits:
  1. **Mapping table:** OVERLAY_SPEC / HERDER_SPEC / SCP_SPEC rows now name `crates/app` as a secondary search target, plus a cross-crate caveat block ("`crates/app` owns the live wiring; the library crate may contain dead/unwired code").
  2. **Step 2:** a grep-first **all-crates** search pass over the entire `crates/` tree before classifying (with a concrete `grep -rn --include='*.rs' … crates/` command), not just the name-matched crate.
  3. **Step 3:** a **reachability/instantiation check** (verify a non-`#[cfg(test)]` caller before classifying Full; treat dead scaffolds as unwired and keep searching) and a rule forbidding **Absent** without an all-crates grep. The Guardrails Absent bullet is strengthened to match.
- **`scripts/test-spec-adhere-skill-snippets.sh`** (new) — TAP harness mirroring the existing snippet tests; 8 grep assertions on SKILL.md keyed on stable tokens.
- **`.github/workflows/ci.yml`** — new `spec-adhere-skill-snippets` job (5-min) mirroring `quickstart-harness`.

## Cross-crate search step added (the fix)

Before declaring an OVERLAY/HERDER/SCP claim Absent, the auditor must:
```bash
grep -rni --include='*.rs' -e '<symbol>' -e '<RESULT_CODE>' crates/   # ALL crates, incl. crates/app
grep -rn  --include='*.rs' '<symbol>' crates/ | grep -v -e '#[cfg(test)]' -e '/tests/'  # reachable from production?
```
and treat an exported-but-test-only symbol as a dead scaffold, continuing the search into `crates/app`.

## Self-modifying

This PR modifies pipeline-own tooling (the `/spec-adhere` skill + CI). Flagged `self-modifying` for the review stage's extra scrutiny; merges autonomously on triple-green per current policy.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3158#issuecomment-4632846789)

## Test plan

- [x] `bash -n` + `zsh -n` on `scripts/test-spec-adhere-skill-snippets.sh`
- [x] cross-shell harness (`test-shell-lib-cross-shell.sh`) — 25/25, no regression
- [x] quickstart harness — 54/54, no regression
- [x] `ci.yml` validates as YAML
- [x] no Rust touched → `cargo fmt`/`clippy` not applicable

## Regression test (kind: bug-fix)

- **Test:** `scripts/test-spec-adhere-skill-snippets.sh`
- **Pre-fix:** committed as `5abb2838` — verified FAILED: 8/8 assertions fail on current main (SKILL.md lacks the cross-crate guidance).
- **Post-fix:** verified PASSES after `44e1fb6a` — 8/8 assertions pass.

## Deviations from plan

- Created a `self-modifying` GitHub label (it did not previously exist) and applied it, in addition to the planned `pdr-managed`, per the do-task self-modifying flagging instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)