### PR TITLE
Fix quickstart auto-retry: move rerun out-of-run and cover exit 137

### DIFF
--- a/.github/workflows/quickstart-retry.yml
+++ b/.github/workflows/quickstart-retry.yml
@@ -1,0 +1,71 @@
+name: Quickstart Retry
+
+# Out-of-run auto-retry for the Quickstart workflow on a whole-runner
+# reclamation (#3193).
+#
+# Why a SEPARATE workflow (not an in-run job): the in-wrapper retry in
+# scripts/ci/run-quickstart-test.sh self-heals a transient-infra exit
+# (124 timeout / 143 SIGTERM / 137 SIGKILL) ONLY when the runner survives long
+# enough for the bash wrapper to observe the probe's non-zero exit and re-run
+# it. When GitHub reclaims the WHOLE runner ("The runner has received a shutdown
+# signal" + "Process completed with exit code 143/137" + "Cleaning up orphan
+# processes"), the wrapper process is itself killed and never reaches its retry
+# block. The only recovery is a fresh job attempt.
+#
+# The previous design put that recovery in an in-run `rerun-on-transient` job,
+# but a job INSIDE a run cannot re-dispatch its own still-running run:
+# `gh run rerun <id> --failed` fails with "run <id> cannot be rerun; This
+# workflow is already running" (exit 1), observed on PR #3187's run
+# 27037187429. The auto-retry never fired and only added a spurious FAILURE
+# check.
+#
+# This workflow instead triggers on `workflow_run` (types: completed) for the
+# Quickstart workflow, so it runs AFTER that run has fully finished — at which
+# point `gh run rerun <id> --failed` is accepted (no "already running"). It
+# re-dispatches the failed jobs of the triggering run exactly once.
+#
+# Bounded one-shot (cannot loop): the guard requires
+#   github.event.workflow_run.conclusion == 'failure'  AND
+#   github.event.workflow_run.run_attempt == 1
+# The re-dispatched run is attempt 2 (run_attempt == 2). If attempt 2 ALSO
+# fails, this workflow fires again on its completion, but the run_attempt == 1
+# guard is now false, so no further rerun is dispatched and attempt 2's failure
+# stays red. A genuine (reproducible) failure therefore fails identically on
+# attempt 2 and surfaces as a hard red — this absorbs exactly one transient
+# reclamation without masking regressions, and the blast radius is bounded to a
+# single extra attempt.
+#
+# IMPORTANT: the `workflows:` value below MUST match the Quickstart workflow's
+# top-level `name:` field in .github/workflows/quickstart.yml ("Quickstart")
+# exactly, or this trigger never fires. The harness asserts this match
+# (scripts/test-quickstart-harness.sh::test_separate_workflow_run_retry_workflow).
+
+on:
+  workflow_run:
+    workflows: ["Quickstart"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun-on-transient:
+    # Only re-dispatch when the triggering Quickstart run FAILED and it was its
+    # FIRST attempt. run_attempt == 2 (the re-dispatched attempt) fails the
+    # guard, so this is a bounded one-shot — it cannot loop.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-dispatch failed jobs once on transient-infra failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          echo "Quickstart run $RUN_ID failed on run_attempt=1;"
+          echo "re-dispatching its failed jobs once (out-of-run, post-completion)"
+          echo "to self-heal a one-off whole-runner reclamation (#3193)."
+          gh run rerun "$RUN_ID" --failed \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -37,12 +37,16 @@ name: Quickstart
 #   * No retry for any other shard, or for any non-transient failure (e.g. a
 #     genuine probe failure exit 1) — those still fail loudly.
 #
-# Whole-runner reclamation (#3185): when GitHub SIGTERMs the entire runner, the
-# bash wrapper is killed too and never reaches its in-script retry. The separate
-# `rerun-on-transient` job recovers that case by re-dispatching the failed jobs
-# once (run_attempt == 1 only) onto a fresh runner. A genuine failure reproduces
-# on attempt 2 and stays red, so this absorbs exactly one transient reclamation
-# without masking regressions.
+# Whole-runner reclamation (#3185 / #3193): when GitHub SIGTERMs/SIGKILLs the
+# entire runner, the bash wrapper is killed too and never reaches its in-script
+# retry. An in-RUN job cannot recover this — a job inside a run cannot
+# re-dispatch (rerun --failed) its own still-running run (it fails with
+# "This workflow is already running", #3193). Recovery therefore lives in a
+# SEPARATE workflow_run-triggered workflow, .github/workflows/quickstart-retry.yml,
+# which fires AFTER this run completes (so the rerun is accepted) and
+# re-dispatches the failed jobs exactly once (conclusion == failure AND
+# run_attempt == 1). A genuine failure reproduces on attempt 2 and stays red,
+# so this absorbs exactly one transient reclamation without masking regressions.
 #
 # Upstream contract validation:
 #   The validate-contract job fetches both build.yml and internal-build.yml
@@ -492,40 +496,10 @@ jobs:
           docker stop quickstart 2>/dev/null || true
           docker rm quickstart 2>/dev/null || true
 
-  # Auto-rerun on whole-runner SIGTERM (exit 143) reclamation (#3185).
-  #
-  # The in-wrapper retry in run-quickstart-test.sh self-heals a transient-infra
-  # exit (124 timeout / 143 SIGTERM) ONLY when the runner survives long enough
-  # for the bash wrapper to observe the probe's non-zero exit and re-run it.
-  # When GitHub reclaims the whole runner ("The runner has received a shutdown
-  # signal" + "Process completed with exit code 143" + "Cleaning up orphan
-  # processes", observed ~2 min into a probe with minutes left on its timeout —
-  # runs 27021800958 / 27028525980), the wrapper process is itself SIGTERM'd and
-  # never reaches its retry block. No in-job mechanism can recover a reclaimed
-  # runner; the only recovery is a fresh job attempt.
-  #
-  # This job runs on a SEPARATE runner after `test` finishes. On the FIRST run
-  # attempt only (run_attempt == 1), if `test` failed, it re-dispatches the
-  # failed jobs once via `gh run rerun --failed`. The re-dispatched attempt 2
-  # gets a fresh runner, so a one-off platform preemption self-heals without a
-  # manual re-run — mirroring the wrapper's single-retry threshold. A genuine
-  # (reproducible) test failure fails identically on attempt 2 and surfaces as a
-  # hard red, so this does not mask real regressions; it only absorbs a single
-  # transient reclamation. Subsequent attempts (run_attempt >= 2) never re-run,
-  # bounding the blast radius to exactly one extra attempt.
-  rerun-on-transient:
-    needs: test
-    if: failure() && github.run_attempt == 1
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Re-dispatch failed jobs once on transient-infra failure
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "test job failed on run_attempt=1; re-dispatching failed jobs once"
-          echo "(self-healing one-off runner reclamation / transient infra — #3185)."
-          gh run rerun "${{ github.run_id }}" --failed \
-            --repo "${{ github.repository }}"
+  # NOTE (#3193): the previous in-run `rerun-on-transient` job was REMOVED. A job
+  # inside a run cannot re-dispatch its own still-running run — the rerun-failed
+  # API call returns "This workflow is already running" (exit 1), so the
+  # auto-retry never fired and only added a spurious FAILURE check. Recovery from
+  # a whole-runner reclamation now lives in .github/workflows/quickstart-retry.yml,
+  # a separate workflow_run-triggered workflow that fires AFTER this run
+  # completes (so the re-dispatch is accepted).

--- a/scripts/ci/run-quickstart-test.sh
+++ b/scripts/ci/run-quickstart-test.sh
@@ -29,6 +29,11 @@
 #     to observe the probe's 143, re-running once self-heals without a manual
 #     orchestrator re-run; if the runner is fully reclaimed the wrapper dies
 #     too and the workflow's normal re-run path applies.
+#   * exit 137 — SIGKILL (128+9=137), the harsher reclamation signature observed
+#     on PR #3187's run 27037187429 ("exit code 137"). Same transient class as
+#     143; retried identically (#3193). Whole-runner reclamation kills this
+#     wrapper too, so the in-script retry only covers the case where the runner
+#     survives; the out-of-run quickstart-retry.yml workflow recovers the rest.
 #
 # Scope widened from probe=horizon-core-up to the whole testnet/core,horizon
 # shard (#3185). Testnet stellar-core is slow to catch up; the GREEN baseline
@@ -89,10 +94,16 @@ is_retryable_shard() {
 
 # --- Helper: is this exit code a retryable transient-infra failure? ---
 # 124: GNU `timeout` killed a slow start (#2916). 143: SIGTERM (128+15) —
-# runner-shutdown / spot-runner reclamation (#3131). Both are infra-transient,
-# not test-logic failures, so they are retried once on the targeted shard only.
+# runner-shutdown / spot-runner reclamation (#3131). 137: SIGKILL (128+9) —
+# the harsher runner-reclamation signature observed on PR #3187's run
+# 27037187429 ("The runner has received a shutdown signal" + "exit code 137",
+# #3193). All three are infra-transient, not test-logic failures, so they are
+# retried once on the targeted shard only. (Note: whole-runner reclamation also
+# kills this wrapper, so the in-script retry only helps when the runner survives
+# long enough to observe the probe's exit; the out-of-run quickstart-retry.yml
+# workflow recovers the fully-reclaimed case.)
 is_retryable_exit() {
-    [[ "$1" -eq 124 || "$1" -eq 143 ]]
+    [[ "$1" -eq 124 || "$1" -eq 143 || "$1" -eq 137 ]]
 }
 
 # --- Helper: capture diagnostics ---

--- a/scripts/test-quickstart-harness.sh
+++ b/scripts/test-quickstart-harness.sh
@@ -9,6 +9,11 @@
 #   4. Workflow shard/probe wiring contract
 #   5. Success path produces no retry artifacts
 #   6. Second timeout still fails
+#   7. Transient-infra exits 124/143/137 are retryable on the targeted shard
+#      only (#3193 adds 137 — SIGKILL runner reclamation)
+#   8. The broken in-run rerun-on-transient job is removed from quickstart.yml
+#      and recovery lives in a separate workflow_run-triggered workflow
+#      (quickstart-retry.yml) that runs AFTER the run completes (#3193)
 #
 # Run: bash scripts/test-quickstart-harness.sh
 # Requires: bash 4+, timeout (coreutils)
@@ -978,48 +983,243 @@ EOF
 }
 
 # ============================================================
-# Test 17: test_workflow_auto_reruns_on_whole_runner_sigterm
+# Test 17: test_exit137_retries_on_targeted_shard
 #
-# Regression for #3185. The in-wrapper retry cannot recover a reclaimed runner
-# (the wrapper is SIGTERM'd too). The workflow must therefore carry a separate
-# job that re-dispatches the failed jobs once on the first attempt. Assert the
-# job exists, is gated on run_attempt == 1 (single extra attempt), holds the
-# actions:write permission needed to re-run, and re-dispatches via
-# `gh run rerun --failed`.
+# Regression for #3193. Whole-runner reclamation on PR #3187's run
+# 27037187429 produced exit 137 (SIGKILL, 128+9) — "The runner has received a
+# shutdown signal" followed by "exit code 137" — NOT the 143 (SIGTERM) the
+# wrapper already covered. When the runner survives the SIGKILL of the probe
+# subprocess long enough for the wrapper to observe the 137, re-running once
+# self-heals. The wrapper must treat exit 137 as a retryable transient on the
+# targeted shard, exactly like exit 124/143.
 # ============================================================
-test_workflow_auto_reruns_on_whole_runner_sigterm() {
+test_exit137_retries_on_targeted_shard() {
+    local diag_dir="$TMPDIR_BASE/diag-test17"
+    mkdir -p "$diag_dir"
+
+    # Probe: exits 137 (SIGKILL signature) on attempt 1, succeeds on 2.
+    local state_file="$TMPDIR_BASE/state-test17"
+    echo "0" > "$state_file"
+    local probe="$TMPDIR_BASE/probe-test17.sh"
+    cat > "$probe" <<'EOF'
+#!/bin/bash
+STATE_FILE="__STATE__"
+COUNT=$(cat "$STATE_FILE")
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$STATE_FILE"
+if [[ $COUNT -eq 1 ]]; then
+    exit 137
+fi
+exit 0
+EOF
+    sed -i "s|__STATE__|$state_file|g" "$probe"
+    chmod +x "$probe"
+
+    local exit_code=0
+    "$WRAPPER" \
+        --network testnet --enable "core,horizon" --probe horizon-core-up \
+        --timeout 10 --diagnostics-dir "$diag_dir" \
+        -- "$probe" >/dev/null 2>&1 || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        tap_ok "test_exit137_retries_on_targeted_shard"
+    else
+        tap_not_ok "test_exit137_retries_on_targeted_shard" "exit=$exit_code (expected 0 via retry)"
+    fi
+
+    if [[ -d "$diag_dir/attempt-1" ]]; then
+        tap_ok "exit137_retry_captured_attempt1_diagnostics"
+    else
+        tap_not_ok "exit137_retry_captured_attempt1_diagnostics" "no attempt-1 dir (first failure not captured)"
+    fi
+}
+
+# ============================================================
+# Test 18: test_exit137_does_not_retry_on_non_targeted_shard
+#
+# The exit-137 retry must be scoped to the same targeted shard as 124/143 — a
+# non-targeted shard exiting 137 must fail immediately with no retry, so a
+# genuine henyey failure elsewhere stays loud.
+# ============================================================
+test_exit137_no_retry_on_non_targeted_shard() {
+    local diag_dir="$TMPDIR_BASE/diag-test18"
+    mkdir -p "$diag_dir"
+
+    local probe
+    probe=$(make_probe "test18" 137 0)
+
+    local exit_code=0
+    "$WRAPPER" \
+        --network local --enable "core" --probe core \
+        --timeout 10 --diagnostics-dir "$diag_dir" \
+        -- "$probe" >/dev/null 2>&1 || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        tap_ok "test_exit137_does_not_retry_on_non_targeted_shard"
+    else
+        tap_not_ok "test_exit137_does_not_retry_on_non_targeted_shard" "expected failure"
+    fi
+
+    if [[ ! -d "$diag_dir/attempt-2" ]]; then
+        tap_ok "non_targeted_exit137_single_attempt"
+    else
+        tap_not_ok "non_targeted_exit137_single_attempt" "unexpected retry on non-targeted shard"
+    fi
+}
+
+# ============================================================
+# Test 19: test_exit137_still_fails_after_second_attempt
+#
+# If exit 137 recurs on the retry, the wrapper must still fail (single extra
+# attempt, not an unbounded loop) — mirrors the 124/143 double-failure case.
+# ============================================================
+test_exit137_double_failure_fails() {
+    local diag_dir="$TMPDIR_BASE/diag-test19"
+    mkdir -p "$diag_dir"
+
+    local probe
+    probe=$(make_probe "test19" 137 0)
+
+    local exit_code=0
+    "$WRAPPER" \
+        --network testnet --enable "core,horizon" --probe horizon-core-up \
+        --timeout 10 --diagnostics-dir "$diag_dir" \
+        -- "$probe" >/dev/null 2>&1 || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        tap_ok "test_exit137_still_fails_after_second_attempt"
+    else
+        tap_not_ok "test_exit137_still_fails_after_second_attempt" "expected failure"
+    fi
+
+    if [[ -d "$diag_dir/attempt-1" && -d "$diag_dir/attempt-2" ]]; then
+        tap_ok "exit137_double_failure_preserves_both_diagnostics"
+    else
+        tap_not_ok "exit137_double_failure_preserves_both_diagnostics" "missing attempt dirs"
+    fi
+}
+
+# ============================================================
+# Test 20: test_in_run_rerun_job_removed_from_quickstart_workflow
+#
+# Regression for #3193. The in-run `rerun-on-transient` job in quickstart.yml
+# tried to `gh run rerun <id> --failed` for ITS OWN still-running run, which
+# fails with "This workflow is already running" (exit 1) — the auto-retry never
+# fired, it only added a spurious FAILURE check. The broken in-run job must be
+# REMOVED from quickstart.yml entirely; recovery moves to a separate
+# workflow_run-triggered workflow (Test 21).
+# ============================================================
+test_in_run_rerun_job_removed() {
     if [[ ! -f "$WORKFLOW" ]]; then
-        tap_not_ok "test_workflow_auto_reruns_on_whole_runner_sigterm" "workflow file not found"
-        tap_not_ok "rerun_job_gated_on_first_attempt" "workflow file not found"
-        tap_not_ok "rerun_job_has_actions_write_permission" "workflow file not found"
+        tap_not_ok "test_in_run_rerun_job_removed_from_quickstart_workflow" "workflow file not found"
         return
     fi
 
-    if grep -q '^  rerun-on-transient:' "$WORKFLOW" \
-        && grep -q 'gh run rerun' "$WORKFLOW" \
-        && grep -q -- '--failed' "$WORKFLOW"; then
-        tap_ok "test_workflow_auto_reruns_on_whole_runner_sigterm"
+    # The broken in-run job key must be gone.
+    if ! grep -q '^  rerun-on-transient:' "$WORKFLOW"; then
+        tap_ok "in_run_rerun_job_key_removed"
     else
-        tap_not_ok "test_workflow_auto_reruns_on_whole_runner_sigterm" "rerun-on-transient job or gh run rerun --failed missing"
+        tap_not_ok "in_run_rerun_job_key_removed" \
+            "rerun-on-transient job still present in quickstart.yml (re-dispatches its own running run -> 'already running')"
     fi
 
-    # Must be bounded to one extra attempt (run_attempt == 1 guard).
-    if grep -q "github.run_attempt == 1" "$WORKFLOW"; then
-        tap_ok "rerun_job_gated_on_first_attempt"
+    # No `gh run rerun` left inside the main workflow at all — the same-run
+    # rerun is the exact bug; recovery belongs in the separate workflow.
+    if ! grep -q 'gh run rerun' "$WORKFLOW"; then
+        tap_ok "no_in_run_gh_run_rerun_in_quickstart"
     else
-        tap_not_ok "rerun_job_gated_on_first_attempt" "missing run_attempt == 1 guard (would loop unboundedly)"
+        tap_not_ok "no_in_run_gh_run_rerun_in_quickstart" \
+            "quickstart.yml still calls gh run rerun in-run (same-run rerun fails 'already running')"
+    fi
+}
+
+# ============================================================
+# Test 21: test_separate_workflow_run_retry_workflow_recovers_transient
+#
+# Regression for #3193. Recovery from a whole-runner reclamation must live in a
+# SEPARATE workflow triggered by `workflow_run` (types: completed) on the
+# Quickstart workflow, so it runs AFTER the Quickstart run finishes and
+# `gh run rerun <id> --failed` works (no "already running"). Assert the new
+# workflow file exists and:
+#   * triggers on workflow_run / completed
+#   * names the EXACT Quickstart workflow (must match quickstart.yml's `name:`)
+#   * is bounded: guards on conclusion == failure AND run_attempt == 1
+#   * grants actions: write
+#   * re-dispatches via `gh run rerun <workflow_run.id> --failed`
+# ============================================================
+test_separate_workflow_run_retry_workflow() {
+    local retry_wf="$REPO_ROOT/.github/workflows/quickstart-retry.yml"
+
+    if [[ ! -f "$retry_wf" ]]; then
+        tap_not_ok "retry_workflow_file_exists" "quickstart-retry.yml not found"
+        tap_not_ok "retry_workflow_triggers_on_workflow_run_completed" "no file"
+        tap_not_ok "retry_workflow_name_matches_quickstart_exactly" "no file"
+        tap_not_ok "retry_workflow_guards_on_failure_conclusion" "no file"
+        tap_not_ok "retry_workflow_bounded_to_first_attempt" "no file"
+        tap_not_ok "retry_workflow_has_actions_write_permission" "no file"
+        tap_not_ok "retry_workflow_reruns_the_triggering_run" "no file"
+        return
+    fi
+    tap_ok "retry_workflow_file_exists"
+
+    # Triggers on workflow_run / completed.
+    if grep -q 'workflow_run:' "$retry_wf" && grep -qE 'types:.*completed|-\s*completed' "$retry_wf"; then
+        tap_ok "retry_workflow_triggers_on_workflow_run_completed"
+    else
+        tap_not_ok "retry_workflow_triggers_on_workflow_run_completed" \
+            "must trigger on: workflow_run: { types: [completed] }"
     fi
 
-    # Must grant actions:write so `gh run rerun` is authorized.
-    if grep -q 'actions: write' "$WORKFLOW"; then
-        tap_ok "rerun_job_has_actions_write_permission"
+    # The workflows: list must name the EXACT Quickstart workflow name string
+    # as declared by quickstart.yml's top-level `name:` field. A mismatch means
+    # the trigger never fires.
+    local quickstart_name
+    quickstart_name=$(grep -E '^name:' "$WORKFLOW" | head -1 | sed -E 's/^name:[[:space:]]*//; s/^"(.*)"$/\1/; s/^'"'"'(.*)'"'"'$/\1/')
+    if [[ -n "$quickstart_name" ]] && grep -qF "$quickstart_name" "$retry_wf"; then
+        tap_ok "retry_workflow_name_matches_quickstart_exactly"
     else
-        tap_not_ok "rerun_job_has_actions_write_permission" "missing actions: write permission for rerun"
+        tap_not_ok "retry_workflow_name_matches_quickstart_exactly" \
+            "workflow_run.workflows must list the exact name '$quickstart_name' from quickstart.yml"
+    fi
+
+    # Guard: only act on a failure conclusion.
+    if grep -q "workflow_run.conclusion == 'failure'" "$retry_wf"; then
+        tap_ok "retry_workflow_guards_on_failure_conclusion"
+    else
+        tap_not_ok "retry_workflow_guards_on_failure_conclusion" \
+            "must guard on github.event.workflow_run.conclusion == 'failure'"
+    fi
+
+    # Bounded one-shot: only re-run when the triggering run was its first attempt
+    # (run_attempt == 1). Attempt 2 carries run_attempt == 2, so the guard fails
+    # and no further rerun is dispatched — cannot loop.
+    if grep -q 'workflow_run.run_attempt == 1' "$retry_wf"; then
+        tap_ok "retry_workflow_bounded_to_first_attempt"
+    else
+        tap_not_ok "retry_workflow_bounded_to_first_attempt" \
+            "must guard on github.event.workflow_run.run_attempt == 1 (bounded one-shot, no loop)"
+    fi
+
+    # Needs actions: write to re-dispatch.
+    if grep -q 'actions: write' "$retry_wf"; then
+        tap_ok "retry_workflow_has_actions_write_permission"
+    else
+        tap_not_ok "retry_workflow_has_actions_write_permission" "missing actions: write permission"
+    fi
+
+    # Re-dispatches the TRIGGERING run (workflow_run.id), not its own run, with --failed.
+    if grep -q 'gh run rerun' "$retry_wf" \
+        && grep -q -- '--failed' "$retry_wf" \
+        && grep -q 'workflow_run.id' "$retry_wf"; then
+        tap_ok "retry_workflow_reruns_the_triggering_run"
+    else
+        tap_not_ok "retry_workflow_reruns_the_triggering_run" \
+            "must run 'gh run rerun \${{ github.event.workflow_run.id }} --failed'"
     fi
 }
 
 # --- Run all tests ---
-tap_plan 60
+tap_plan 72
 
 test_timeout_retry_on_targeted_shard
 test_non_timeout_failure_no_retry
@@ -1037,7 +1237,11 @@ test_runner_shutdown_exit143_no_retry_on_non_targeted_shard
 test_runner_shutdown_exit143_double_failure_fails
 test_transient_retry_covers_whole_testnet_shard
 test_exit143_retries_on_non_horizon_core_up_testnet_probe
-test_workflow_auto_reruns_on_whole_runner_sigterm
+test_exit137_retries_on_targeted_shard
+test_exit137_no_retry_on_non_targeted_shard
+test_exit137_double_failure_fails
+test_in_run_rerun_job_removed
+test_separate_workflow_run_retry_workflow
 
 echo ""
 echo "# Results: $PASS_COUNT/$TEST_COUNT passed, $FAIL_COUNT failed"


### PR DESCRIPTION
Closes #3193

## Summary

The #3185/#3190 rerun-on-transient self-heal was broken in two ways, both observed on PR #3187's run 27037187429:

1. **In-run rerun could never fire.** The `rerun-on-transient` job in `quickstart.yml` ran `gh run rerun <id> --failed` for ITS OWN still-running run, which GitHub rejects with `This workflow is already running` (exit 1). The auto-retry never fired — it only added a spurious FAILURE check to every PR whose testnet leg flaked. **Fix:** remove the in-run job; recovery moves to a new **separate `workflow_run`-triggered workflow** (`.github/workflows/quickstart-retry.yml`) that fires AFTER the Quickstart run completes, at which point the re-dispatch is accepted.

2. **Exit 137 uncovered.** The actual whole-runner reclamation produced exit **137** (SIGKILL, 128+9), not the **143** (SIGTERM) the wrapper already handled. **Fix:** add 137 to `is_retryable_exit` in `run-quickstart-test.sh` alongside 124/143, for the in-probe case where the runner survives long enough for the wrapper to observe the exit.

### The `workflow_run` mechanism

`quickstart-retry.yml` triggers `on: workflow_run: { workflows: ["Quickstart"], types: [completed] }`. The `workflows` value matches `quickstart.yml`'s top-level `name: Quickstart` exactly (verified via parsed YAML; the harness asserts the match). It holds `permissions: { actions: write, contents: read }` and re-dispatches via `gh run rerun ${{ github.event.workflow_run.id }} --failed` (the triggering run, not its own).

### Bounded one-shot — cannot loop

The job guard is `github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1`. The re-dispatched run is attempt 2 (`run_attempt == 2`). If attempt 2 also fails, this workflow fires again on its completion, but the `run_attempt == 1` clause is now false, so no further rerun is dispatched and attempt 2's failure stays red. A genuine regression fails identically on attempt 2 and surfaces as a hard red — exactly one transient reclamation is absorbed, blast radius bounded to one extra attempt.

## Test plan

- [x] `python3 -c 'import yaml,sys; yaml.safe_load(open(sys.argv[1]))'` on both `quickstart.yml` and `quickstart-retry.yml` → both parse OK
- [x] `workflow_run.workflows` name string == `quickstart.yml` `name:` (`Quickstart`), confirmed via parsed YAML
- [x] `bash -n` + `zsh -n` clean on `run-quickstart-test.sh` and the harness
- [x] `bash scripts/test-quickstart-harness.sh` → 72/72 pass
- [x] `cargo fmt --check` + `cargo clippy --all -- -D warnings` (pre-commit hook)

## Regression test (kind: bug-fix)

- **Tests:** `scripts/test-quickstart-harness.sh` — exit-137 retry (targeted shard only / not local-pubnet / not on double-failure), in-run rerun job removed from `quickstart.yml`, and the new `quickstart-retry.yml` (`workflow_run`/completed trigger, exact name-match, `conclusion==failure && run_attempt==1` guard, `actions: write`, rerun-of-triggering-run).
- **Pre-fix:** committed as `9b0c1705` — verified FAILED: exit 137 not retryable + `quickstart-retry.yml` absent + in-run job still present (11 assertions red).
- **Post-fix:** verified PASSES after `1b1233c1` — 72/72.

> Auto-retry cannot be E2E-tested in this PR (it triggers post-run, on `workflow_run`), so verification is static + reasoning per the issue.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)