### PR TITLE
Prioritize urgent items in the pick queue and guard flaky-retry against systematic CI reds

### DIFF
--- a/.claude/skills/project-loop/SKILL.md
+++ b/.claude/skills/project-loop/SKILL.md
@@ -79,7 +79,7 @@ Apply `/project-tick` Step 2 (OPEN, status ∈ {backlog, ready-for-planning, rea
 
 ### Step D — Central pick (up to N, conflict-avoiding)
 
-Sort the actionable list by `/project-tick` Step 3 ordering (state priority `in-review` > `ready-for-doing` > `ready-for-planning` > `backlog`; then label priority; then age). Then walk the sorted list and select up to `N − |IN_FLIGHT|` issues, applying **conflict-avoidance**:
+Sort the actionable list by `/project-tick` Step 3 ordering, which **leads with the urgent override**: any OPEN issue labeled `urgent` sorts to the **very top**, ahead of all state-priority tiers (an `urgent` `backlog` item **outranks** a non-urgent `in-review` item); then state priority `in-review` > `ready-for-doing` > `ready-for-planning` > `backlog`; then label priority; then age. An `urgent` issue still in untriaged `backlog` is therefore picked **first** and dispatched to `/triage` immediately on the next pass — never deferred behind lower-priority work. Triage urgents immediately — first, **not a triage bypass**: urgents still flow through `/triage` via the existing `backlog → haiku /triage` dispatch in Step E; they simply go first. Then walk the sorted list and select up to `N − |IN_FLIGHT|` issues, applying **conflict-avoidance**:
 
 - For each candidate, estimate the **area** it will touch:
   - `in-review` / `ready-for-doing`: the crate(s) / script(s) / skill-dir(s) named in the linked PR's changed files (for in-review) or the plan's "Files to change" section (for ready-for-doing). When unknown, treat the issue's primary label/title area as the lock.
@@ -135,13 +135,25 @@ Then handle these special cases before the next pass:
 
   Use the **Bash tool's `run_in_background`** for the poller (a detached re-invoke on completion), not a foreground `sleep`. When CI is **green**, the next pass picks the in-review item and dispatches `/review-pr` to merge. When CI is **red**, the next pass picks it and `/review-pr` bounces it.
 
-- **Known flaky testnet check (#2916 — "horizon core up"):** if the **sole** failing check on a PR is the flaky testnet "horizon core up" job and everything else is green, **re-run that one failed job once**, then re-check:
+- **Known flaky testnet check (#2916 — "horizon core up"):** if the **sole** failing check on a PR is the flaky testnet "horizon core up" job and everything else is green, you may **re-run that one failed job once** — **but only after the main-health pre-check below clears it as a genuine, PR-isolated flake.**
+
+  **Main-health pre-check (before any re-run).** A re-run is only legitimate when the failure is isolated to the PR. First check whether the **same check is systematically red on `main`**. The "horizon core up" leg is a **check within the quickstart workflow**, not a standalone workflow — so query `main`'s recent check-runs and filter **by check name** (`HEAD` + the last ~3 commits), not by a 1:1 workflow:
+
+  ```bash
+  # Per-commit conclusion of the SAME check (by name) on recent main HEAD commits.
+  gh run list --repo stellar-experimental/henyey --branch main --limit 5 \
+    --json headSha,conclusion,name,workflowName,createdAt
+  # (or `gh api` for per-check-run conclusions when the check is a job inside a workflow)
+  ```
+
+  - If the same check is **red across ≥2 recent `main` commits**, classify it as a **regression / infra-outage — NOT flaky**. Do **NOT** re-run. File (or escalate) an **`urgent`-labeled** issue capturing the **green→red commit boundary** (last green `main` sha → first red `main` sha) and record the escalation. The new `urgent` issue is then drained **first** by the urgent-override pick order (Step D), so a systematic CI regression is surfaced and prioritized instead of being masked by a blind re-run.
+  - Only treat it as **flaky and re-run** when **`main` is green** and the failure is isolated to the PR:
 
   ```bash
   gh run rerun <RUN_ID> --repo stellar-experimental/henyey --failed
   ```
 
-  Record an anomaly if you re-run the same check ≥2× (flaky-quarantine candidate). Do not re-run other failing checks automatically — those are real and go to `/review-pr` for a bounce.
+  This regression-escalation path is **distinct from** the existing `flaky-rerun` anomaly (below): `flaky-rerun` records a genuine isolated flake re-run ≥2× (flaky-quarantine candidate); the main-health guard instead escalates a *systematic* red as an `urgent` regression and does not re-run at all. Record an anomaly if you re-run the same check ≥2× on the flaky path. Do not re-run other failing checks automatically — those are real and go to `/review-pr` for a bounce.
 
 - **Sibling nit consolidation:** when several follow-up issues are sibling **nits** touching the **same file/area** (typically self-improvement or post-review follow-ups filed against one PR), consolidate them into **one** `/do` PR rather than one PR each. Dispatch a single `/do` whose prompt lists all the sibling issue numbers and instructs it to close them together (`Closes #a #b #c` in the PR body). This avoids N near-identical PRs churning the same file and N review cycles.
 

--- a/.claude/skills/project-tick/SKILL.md
+++ b/.claude/skills/project-tick/SKILL.md
@@ -159,11 +159,12 @@ Wall-clock latency for the first review is unchanged in expectation because CI (
 
 ### Step 3 — Pick one issue
 
-Order actionable items by:
+Order actionable items by (this numbered list is the **canonical pick order** — `/project-loop` Step D references it):
 
-1. **Close-WIP-first state priority** — descending: `in-review` > `ready-for-doing` > `ready-for-planning` > `backlog`. Reason: prevents PRs from rotting in review while fresh backlog items pile up. (`planning` and `doing` items are never picked — they are always assigned and filtered out.)
-2. **Label priority** within state — descending: `urgent` > `high` > `medium` > `low` > (no priority label).
-3. **Age** within priority tier — oldest `createdAt` first.
+1. **Urgent override** — any OPEN issue labeled `urgent` sorts to the **very top** of the pick order, ahead of all state-priority tiers (e.g. an `urgent` `backlog` item **outranks** a non-urgent `in-review` item). This jumps the pick queue so a systematic urgent CI regression is drained first, not buried behind lower-priority work. Ties among urgents fall through to the rules below (state priority, then age).
+2. **Close-WIP-first state priority** — descending: `in-review` > `ready-for-doing` > `ready-for-planning` > `backlog`. Reason: prevents PRs from rotting in review while fresh backlog items pile up. (`planning` and `doing` items are never picked — they are always assigned and filtered out.)
+3. **Label priority** within state — descending: `urgent` > `high` > `medium` > `low` > (no priority label).
+4. **Age** within priority tier — oldest `createdAt` first.
 
 Pick the head of the sorted list. If the list is empty, print `no actionable issues` and exit 0.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run spec-adhere skill snippet harness
         run: bash scripts/test-spec-adhere-skill-snippets.sh
+
+  project-loop-skill-snippets:
+    name: Project-Loop Skill Snippets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run project-loop skill snippet harness
+        run: bash scripts/test-project-loop-skill-snippets.sh

--- a/scripts/test-project-loop-skill-snippets.sh
+++ b/scripts/test-project-loop-skill-snippets.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Smoke-test harness for the /project-loop + /project-tick pick-priority and
+# flaky-retry guidance.
+#
+# Regression guard for issue #3191: two pipeline-prioritization gaps surfaced
+# when an `urgent` Quickstart-CI regression (#3185) sat unpicked for ~1hr while
+# the orchestrator ground through lower-priority work, and the blind flaky
+# "horizon core up" re-run masked the fact that the same check was already red
+# on `main` (a systematic regression, not a flake). This harness asserts that
+# the skills codify:
+#   (1) an Urgent override at the very top of the pick order, present in BOTH
+#       project-tick/SKILL.md Step 3 (the canonical order) AND project-loop's
+#       Step D inline restatement (so the two skills cannot drift),
+#   (2) the "triage urgents immediately — first, not a triage bypass" rule in
+#       project-loop,
+#   (3) a flaky-retry main-health pre-check that, on a systematic red across
+#       recent `main` commits, escalates a `regression`/`infra-outage` `urgent`
+#       issue (with the green→red commit boundary) and does NOT silently re-run,
+#       re-running only when `main` is green and the failure is PR-isolated.
+#
+# COUPLING: these assertions key on STABLE tokens (`urgent`, `override` /
+# `outranks` / `ahead of`, `regression`, `infra-outage`, `main` + `green`,
+# `green`→`red`) rather than full sentences, so benign rewording of either
+# SKILL.md is tolerated. If you reword the guidance, keep these tokens (or
+# update this test in the same commit).
+#
+# Usage:
+#   bash scripts/test-project-loop-skill-snippets.sh
+#
+# Output: TAP (Test Anything Protocol) on stdout, diagnostics on stderr.
+# Exit: 0 = all pass, 1 = any fail.
+#
+# Portability: GNU/Linux only (Bash 4+, grep).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TICK_MD="$REPO_ROOT/.claude/skills/project-tick/SKILL.md"
+LOOP_MD="$REPO_ROOT/.claude/skills/project-loop/SKILL.md"
+
+# ── TAP state ────────────────────────────────────────────────────────────────
+TAP_PLAN=6
+TAP_CURRENT=0
+TAP_FAILURES=0
+
+tap_plan() { echo "1..$TAP_PLAN"; }
+
+tap_ok() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  echo "ok $TAP_CURRENT - $1"
+}
+
+tap_not_ok() {
+  TAP_CURRENT=$((TAP_CURRENT + 1))
+  TAP_FAILURES=$((TAP_FAILURES + 1))
+  echo "not ok $TAP_CURRENT - $1"
+  if [[ -n "${2:-}" ]]; then
+    echo "# $2" >&2
+  fi
+}
+
+# assert_match DESC PATTERN FILE
+# Pass if (PCRE-less) ERE PATTERN matches at least one line of FILE.
+assert_match() {
+  local desc="$1" pattern="$2" file="$3"
+  if grep -Eiq -- "$pattern" "$file"; then
+    tap_ok "$desc"
+  else
+    tap_not_ok "$desc" "pattern not found: /$pattern/ in $file"
+  fi
+}
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+if [[ ! -f "$TICK_MD" ]]; then
+  echo "Bail out! project-tick SKILL.md not found at $TICK_MD" >&2
+  exit 1
+fi
+if [[ ! -f "$LOOP_MD" ]]; then
+  echo "Bail out! project-loop SKILL.md not found at $LOOP_MD" >&2
+  exit 1
+fi
+
+tap_plan
+
+# ── Gap 1: Urgent override at the top of the canonical pick order ─────────────
+# project-tick Step 3 must lead with an Urgent override that sorts urgents above
+# all state-priority tiers (an urgent backlog item outranks a non-urgent
+# in-review item). On origin/main, Step 3 rule 1 is "Close-WIP-first state
+# priority" and urgent is only a within-state tiebreaker → this FAILS.
+assert_match "project-tick Step 3 leads with an Urgent override above state priority" \
+  'urgent.*(override|outranks|ahead of|jump|very top|top of the pick)' "$TICK_MD"
+
+# project-loop Step D restates the order inline and must lead with the urgent
+# override too (so the two skills do not drift). FAILS on main.
+assert_match "project-loop Step D inline ordering leads with the urgent override" \
+  'urgent.*(override|outranks|ahead of|jump|very top|top of the pick)' "$LOOP_MD"
+
+# Triage-urgents-immediately, and explicitly NOT a triage bypass (urgents still
+# flow through /triage, they just go first). FAILS on main.
+assert_match "project-loop triages urgents immediately — first, not a triage bypass" \
+  '(triage.*urgent|urgent.*triage).*(immediately|first|never.*defer|untriaged)|not a (triage )?bypass' "$LOOP_MD"
+
+# ── Gap 2: flaky-retry main-health guard ──────────────────────────────────────
+# Before re-running the flaky check, the loop must check whether the same check
+# is red on main HEAD + recent commits (by check name). FAILS on main.
+assert_match "flaky bullet has a main-health pre-check before re-run" \
+  '(main).*(HEAD|recent|last .*commit|recent .*commit)' "$LOOP_MD"
+
+# A systematic red (≥2 main commits) is classified as a regression / infra
+# outage and escalated as an urgent issue with the green→red commit boundary,
+# and the re-run is conditioned on main being green. FAILS on main.
+assert_match "systematic red escalates a regression/infra-outage urgent issue (green→red boundary, re-run only when main green)" \
+  '(regression|infra-outage).*urgent|urgent.*(regression|infra-outage)' "$LOOP_MD"
+
+# Do NOT silently re-run on the systematic path: a "NOT flaky" / "do not
+# re-run" classification tied to the systematic-regression case. The existing
+# line-144 "Do not re-run OTHER failing checks" does not match — this must name
+# the systematic / NOT-flaky / regression classification. FAILS on main.
+assert_match "flaky guard does NOT silently re-run on a systematic main failure (NOT flaky)" \
+  '(not flaky|NOT flaky|do *not re-?run.*(systematic|regression|main)|(systematic|regression).*do *not re-?run)' "$LOOP_MD"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+if [[ "$TAP_FAILURES" -gt 0 ]]; then
+  echo "# $TAP_FAILURES of $TAP_PLAN assertions failed" >&2
+  exit 1
+fi
+echo "# all $TAP_PLAN assertions passed" >&2
+exit 0


### PR DESCRIPTION
Closes #3191

## Summary

Codifies two pipeline-prioritization rules into the orchestrator skills:

- **Gap 1 — urgent jumps the pick queue.** `project-tick` Step 3 gains a new canonical rule 1 **Urgent override** (any OPEN `urgent` issue sorts to the very top, ahead of all state-priority tiers; an `urgent` `backlog` item outranks a non-urgent `in-review` item), and the existing state/label/age rules renumber to 2/3/4. `project-loop` Step D's inline restatement now leads with the urgent override and adds "triage urgents immediately — first, **not a triage bypass**" (urgents still flow through `/triage`, they just go first).
- **Gap 2 — flaky-retry main-health guard.** `project-loop` Step F inserts a main-health pre-check before `gh run rerun`: query the same check **by name** on `main` HEAD + the last ~3 commits; if red across **≥2 main commits**, classify as **regression / infra-outage — NOT flaky**, file an **`urgent`** issue with the **green→red commit boundary**, and do **NOT** re-run. Re-run only when `main` is green and the failure is PR-isolated. Kept textually distinct from the existing `flaky-rerun` anomaly.

Self-modifying (edits pipeline-own skills). No parser-depended markers were disturbed — only the Step 3 pick list was renumbered (no skill references its sub-rule numbers) and content was inserted; `## 🔍 Critic`, `## 🔍 Reviewer:`, `## 🥊 Refute`, `**Verdict:**`, `**Outcome:**`, Step 5.5, force-converge, the decision matrix, and the `flaky-rerun` anomaly are all preserved.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3191#issuecomment-4635933595)

## Test plan

- [x] `bash scripts/test-project-loop-skill-snippets.sh` — 6/6 assertions pass
- [x] `bash -n` + `zsh -n` clean on the new harness
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` parses; new `project-loop-skill-snippets` job is additive
- [x] pre-commit fmt + clippy passed

## Regression test (TDD — skill/markdown change)

- **Test:** `scripts/test-project-loop-skill-snippets.sh` (new TAP harness, mirrors `test-spec-adhere-skill-snippets.sh`)
- **Pre-edit:** committed as `0c9ae968` — verified **all 6 assertions FAILED** on origin/main (no urgent-override token in either skill; no main-health pre-check / regression escalation / NOT-flaky classification)
- **Post-edit:** verified **all 6 PASS** after `b7b9dce9`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)