### PR TITLE
Route near-tip/archive-behind recovery to peer-SCP, not a doomed archive reset

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -1321,36 +1321,50 @@ impl App {
             // force_post_catchup_hard_reset() blocks it, causing
             // maybe_start_buffered_catchup() to return None on every tick.
             if s.schedule_due {
-                // Near-tip escalation (#3181): when peers are verified ahead
-                // by less than one checkpoint interval, archive catchup is
-                // structurally impossible-yet-imminent (the unblocking
-                // checkpoint publishes within one interval). Escalate to the
-                // state-changing HardReset immediately rather than spinning on
-                // per-tick archive probes for the full wall-clock stall. The
-                // far-behind (#1862) path keeps its unchanged thresholds.
+                // Recovery-ROUTING fix (#3197): the near-tip band
+                // (PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap <
+                // checkpoint_frequency()) must route to peer-SCP recovery
+                // (AttemptRecovery), NOT to an archive HardReset. #3187 made
+                // near-tip escalate EARLY, but the escalation terminated in a
+                // ProbeAhead archive fetch that is structurally doomed near
+                // tip (the next checkpoint is unpublished — same root as
+                // #1862), so it never shortened the outage and the 60s
+                // cooldown then gated the only useful action. stellar-core in
+                // this regime does pure peer-SCP back-fill + buffered-apply
+                // (HerderImpl::outOfSyncRecovery + tryApplySyncingLedgers) and
+                // never touches the archive. So `near_tip` is NO LONGER a
+                // HardReset trigger here. The near-tip PREDICATE and its
+                // constants are preserved (only the consequent action
+                // changes): see the `trigger_recovery_catchup` near-tip arm,
+                // which runs the full `broadcast_recovery_scp_state` analog.
+                //
+                // The genuine escalations still hard-reset: recovery
+                // exhaustion (#1831), tx_set exhaustion, and — critically —
+                // the 120s wall-clock stall backstop (#2789 anti-wedge), so a
+                // peer-SCP back-fill that never resyncs cannot wedge the node
+                // forever. The far-behind (#1862) archive-catchup path is in a
+                // disjoint band (peer_gap >= checkpoint_frequency() →
+                // near_tip == false) and is untouched.
                 let would_hard_reset = recovery_exhausted
                     || s.tx_set_exhausted
-                    || s.stuck_duration >= HARD_RESET_STALL_SECS
-                    || s.near_tip;
+                    || s.stuck_duration >= HARD_RESET_STALL_SECS;
 
                 if would_hard_reset && s.hard_reset_cooldown_active {
                     // Cooldown active — fall back to peer-SCP recovery
                     // while waiting for the archive to publish. The first
                     // HardReset already cleared stale state; repeating it
-                    // before the cooldown expires is futile. Preserves #1843
-                    // (and applies equally to the near-tip path).
+                    // before the cooldown expires is futile. Preserves #1843.
                     ConsensusStuckAction::AttemptRecovery
                 } else if recovery_exhausted {
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
                 } else if s.tx_set_exhausted {
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindTxSetExhausted)
-                } else if s.stuck_duration >= HARD_RESET_STALL_SECS || s.near_tip {
-                    // Either the wall-clock stall threshold was reached, or the
-                    // node is in the near-tip band (#3181) — both escalate via
-                    // the same ArchiveBehindStallWallClock reset, which spawns
-                    // the peer-SCP ProbeAhead fetch + request_scp_state.
+                } else if s.stuck_duration >= HARD_RESET_STALL_SECS {
+                    // The genuine 120s wall-clock stall backstop (#2789).
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindStallWallClock)
                 } else {
+                    // Near-tip (or any non-escalating archive-behind) stall →
+                    // peer-SCP recovery (#3197).
                     ConsensusStuckAction::AttemptRecovery
                 }
             } else {
@@ -3116,22 +3130,28 @@ mod tests {
     }
 
     // ================================================================
-    // #3181: near-tip early escalation (archive behind, peers ahead by
-    // < one checkpoint interval). The escalation must fire on the first
-    // due tick — NOT after the full wall-clock stall — without waiting on
-    // recovery exhaustion, tx_set exhaustion, or stuck_duration. The 60s
-    // cooldown floor (#1843) and the far-behind (#1862) path are preserved.
+    // #3181/#3197: near-tip ROUTING (archive behind, peers ahead by
+    // < one checkpoint interval). #3187 made near-tip escalate EARLY to a
+    // HardReset, but the escalation routed to a doomed archive ProbeAhead.
+    // #3197 corrects the routing: the near-tip band now goes to peer-SCP
+    // recovery (AttemptRecovery), mirroring stellar-core. The #3187
+    // assertions below are intentionally FLIPPED from HardReset to
+    // AttemptRecovery — they encode the now-corrected behavior. The 120s
+    // wall-clock backstop (#2789), the cooldown floor (#1843), and the
+    // far-behind (#1862) path are preserved.
     // ================================================================
 
     #[test]
     fn test_decide_near_tip_archive_behind_escalates_early() {
-        // archive_behind + near_tip + schedule_due, but NONE of the legacy
-        // hard-reset gates met (attempts=0, no tx_set exhaustion,
-        // stuck_duration=0) and no cooldown → HardReset immediately.
+        // archive_behind + near_tip + schedule_due, but NONE of the genuine
+        // escalation gates met (attempts=0, no tx_set exhaustion,
+        // stuck_duration=0) and no cooldown.
         //
-        // On origin/main (no `near_tip` field) these signals fall through
-        // every `would_hard_reset` gate and return AttemptRecovery; the
-        // near-tip branch makes the state-changing escalation fire early.
+        // #3187 returned HardReset here (doomed archive ProbeAhead). #3197
+        // corrects the routing: near-tip must go to peer-SCP recovery
+        // (AttemptRecovery), since the archive cannot supply the next,
+        // unpublished checkpoint near tip — stellar-core uses pure peer-SCP +
+        // buffered-apply in this regime. Assertion FLIPPED to AttemptRecovery.
         let action = App::decide_consensus_stuck_action(StuckSignals {
             catchup_in_progress: false,
             archive_behind: true,
@@ -3142,27 +3162,29 @@ mod tests {
             hard_reset_cooldown_active: false,
             near_tip: true,
         });
-        assert!(
-            matches!(
-                action,
-                ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindStallWallClock)
-            ),
-            "near-tip + archive-behind must escalate to HardReset on the first \
-             due tick, not after the full wall-clock stall (#3181); got {action:?}"
+        assert_eq!(
+            action,
+            ConsensusStuckAction::AttemptRecovery,
+            "near-tip + archive-behind must route to peer-SCP recovery, NOT a \
+             doomed archive HardReset/ProbeAhead (#3197 corrects #3187's \
+             routing); got {action:?}"
         );
     }
 
     #[test]
     fn test_decide_near_tip_respects_cooldown() {
-        // Same near-tip signals, but the HardReset cooldown is active.
-        // Must fall back to AttemptRecovery — the early-escalation path is
-        // still cooldown-gated, preserving #1843 (no reset storms).
+        // A near-tip stall that WOULD hard-reset (120s wall-clock stall) but
+        // with the HardReset cooldown active must fall back to AttemptRecovery,
+        // preserving #1843 (no reset storms). (Pre-#3197 this used a near-tip
+        // early-escalation; post-#3197 the would-hard-reset comes from the
+        // genuine 120s stall, but the cooldown-fallback semantics are
+        // unchanged.)
         let action = App::decide_consensus_stuck_action(StuckSignals {
             catchup_in_progress: false,
             archive_behind: true,
             tx_set_exhausted: false,
             schedule_due: true,
-            stuck_duration: 0,
+            stuck_duration: HARD_RESET_STALL_SECS,
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
             near_tip: true,
@@ -3170,7 +3192,8 @@ mod tests {
         assert_eq!(
             action,
             ConsensusStuckAction::AttemptRecovery,
-            "near-tip escalation must respect the 60s HardReset cooldown (#1843)"
+            "a would-hard-reset near-tip stall must respect the 60s HardReset \
+             cooldown (#1843)"
         );
     }
 

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -3236,6 +3236,145 @@ mod tests {
         );
     }
 
+    // ================================================================
+    // #3197: near-tip / archive-behind ROUTING fix. #3187 fixed the
+    // escalation TIMING (escalate early in the near-tip band) but routed
+    // to a doomed archive ProbeAhead/HardReset. The real fix is to route
+    // the near-tip / archive-behind band to peer-SCP recovery
+    // (AttemptRecovery → out_of_sync_recovery → broadcast_recovery_scp_state),
+    // mirroring stellar-core's HerderImpl::outOfSyncRecovery +
+    // tryApplySyncingLedgers, which never touch the archive near tip.
+    // The genuine 120s wall-clock stall backstop (#2789), recovery
+    // exhaustion (#1831), tx_set exhaustion, the far-behind archive path
+    // (#1862), and the cooldown fallback (#1843) all still escalate.
+    // ================================================================
+
+    /// Lead regression test (#3197). The exact production decision point:
+    /// `archive_behind + near_tip + schedule_due`, none of the genuine
+    /// escalation gates met (attempts=0, no tx_set exhaustion, no 120s
+    /// wall-clock stall, no cooldown). On the #3187 code this returns
+    /// `HardReset(ArchiveBehindStallWallClock)` (the doomed ProbeAhead path)
+    /// → FAILS pre-fix. After the routing fix it must return
+    /// `AttemptRecovery` (peer-SCP back-fill) → PASSES post-fix.
+    #[test]
+    fn test_decide_near_tip_archive_behind_routes_to_recovery_not_hardreset() {
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: 0,
+            recovery_attempts: 0,
+            hard_reset_cooldown_active: false,
+            near_tip: true,
+        });
+        assert_eq!(
+            action,
+            ConsensusStuckAction::AttemptRecovery,
+            "near-tip + archive-behind must route to peer-SCP recovery \
+             (AttemptRecovery), NOT a doomed archive HardReset/ProbeAhead \
+             (#3197); the archive cannot supply the next, unpublished \
+             checkpoint near tip — stellar-core uses pure peer-SCP + \
+             buffered-apply here; got {action:?}"
+        );
+    }
+
+    /// #2789 anti-wedge backstop preserved: the genuine 120s wall-clock
+    /// stall STILL escalates to HardReset even in the near-tip band, so a
+    /// peer-SCP back-fill that never resyncs cannot wedge the node forever.
+    #[test]
+    fn test_decide_near_tip_still_hardresets_on_wallclock_stall() {
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: HARD_RESET_STALL_SECS,
+            recovery_attempts: 0,
+            hard_reset_cooldown_active: false,
+            near_tip: true,
+        });
+        assert!(
+            matches!(
+                action,
+                ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindStallWallClock)
+            ),
+            "the genuine 120s wall-clock stall backstop (#2789) must still \
+             escalate to HardReset even in the near-tip band, so peer-SCP \
+             failure cannot wedge the node; got {action:?}"
+        );
+    }
+
+    /// #1831 recovery-exhaustion escalation preserved in the near-tip band.
+    #[test]
+    fn test_decide_near_tip_recovery_exhausted_still_hardresets() {
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: 0,
+            recovery_attempts: MAX,
+            hard_reset_cooldown_active: false,
+            near_tip: true,
+        });
+        assert!(
+            matches!(
+                action,
+                ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
+            ),
+            "recovery exhaustion (#1831) must still escalate to HardReset in \
+             the near-tip band; got {action:?}"
+        );
+    }
+
+    /// #1862 far-behind path unchanged: not near-tip, recovery exhausted →
+    /// HardReset (the archive-catchup escalation band is disjoint).
+    #[test]
+    fn test_decide_far_behind_archive_behind_unchanged() {
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: 0,
+            recovery_attempts: MAX,
+            hard_reset_cooldown_active: false,
+            near_tip: false,
+        });
+        assert!(
+            matches!(
+                action,
+                ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
+            ),
+            "far-behind (#1862) archive-catchup escalation must be untouched \
+             by the near-tip routing change; got {action:?}"
+        );
+    }
+
+    /// #1843 cooldown fallback preserved: a near-tip stall that WOULD
+    /// hard-reset (e.g. 120s wall-clock stall) falls back to AttemptRecovery
+    /// while the cooldown is active.
+    #[test]
+    fn test_decide_near_tip_cooldown_falls_back_to_recovery() {
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: HARD_RESET_STALL_SECS,
+            recovery_attempts: 0,
+            hard_reset_cooldown_active: true,
+            near_tip: true,
+        });
+        assert_eq!(
+            action,
+            ConsensusStuckAction::AttemptRecovery,
+            "HardReset cooldown (#1843) must still gate the would-hard-reset \
+             near-tip path back to peer-SCP recovery; got {action:?}"
+        );
+    }
+
     #[test]
     fn test_decide_wait_when_not_due() {
         // All hard-reset-qualifying params but schedule not due → Wait.

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -1791,27 +1791,71 @@ impl App {
                 let archive_is_confirmed_behind =
                     self.archive_recovery_snapshot().await.is_confirmed_behind();
                 let peer_gap = self.effective_peer_gap(current_ledger);
-                // Near-tip band (#3181): peers verified ahead by less than one
-                // checkpoint interval. Combined with the gate's existing
-                // `peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD` precondition this
-                // yields the same predicate as the StuckSignals build site
-                // (PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap <
-                // checkpoint_frequency()). In this band, with the archive
-                // confirmed behind, archive catchup is structurally
-                // impossible-yet-imminent, so lower the escalation attempt
-                // threshold (~1–2 ticks / ~10–20s) instead of the default ~11
-                // ticks / ~120s. The far-behind (#1862) path keeps the
-                // unchanged threshold. Read checkpoint_frequency() live (64
+                // Near-tip band (#3181/#3197): peers verified ahead by less
+                // than one checkpoint interval. Combined with the gate's
+                // existing `peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD`
+                // precondition this is the same predicate as the StuckSignals
+                // build site (PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap <
+                // checkpoint_frequency()). Read checkpoint_frequency() live (64
                 // default / 8 accelerated) for parity.
                 let near_tip = peer_gap < checkpoint_frequency() as u64;
-                let escalation_attempts = if near_tip && archive_is_confirmed_behind {
-                    RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP
-                } else {
-                    RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS
-                };
+
+                // Recovery-ROUTING fix (#3197, PRIMARY — this is the dominant
+                // production path because escalate_recovery_to_catchup() pins
+                // recovery attempts at RECOVERY_ESCALATION_CATCHUP on every
+                // far-ahead EXTERNALIZE, short-circuiting out_of_sync_recovery
+                // into this function before it reaches its own
+                // broadcast_recovery_scp_state tail). In the near-tip /
+                // archive-confirmed-behind band, archive catchup is
+                // structurally doomed: the next checkpoint is unpublished, so
+                // the ProbeAhead fetch in force_post_catchup_hard_reset bails
+                // on every fire (#3187 escalated the TIMING but routed here).
+                // stellar-core in this regime does NO archive interaction — it
+                // re-broadcasts its own latest SCP from lcl+1 and pulls SCP
+                // state from 2 peers (HerderImpl::outOfSyncRecovery,
+                // HerderImpl.cpp:521-561), then applies the buffered ledgers
+                // once the gap is back-filled (tryApplySyncingLedgers,
+                // LedgerApplyManagerImpl.cpp:156-160). So instead of the doomed
+                // ProbeAhead HardReset, run the EXISTING full outOfSyncRecovery
+                // analog (broadcast_recovery_scp_state — re-broadcast + bounded
+                // peer pull) every recovery tick and return None, letting the
+                // buffered-apply path advance. The genuine 120s wall-clock
+                // stall backstop (#2789) still escalates via the decide-fn
+                // (ArchiveBehindStallWallClock), so peer-SCP failure cannot
+                // wedge the node forever. The far-behind (#1862) band keeps the
+                // unchanged ProbeAhead/archive escalation below.
+                if near_tip && archive_is_confirmed_behind {
+                    tracing::info!(
+                        current_ledger,
+                        peer_max_verified = self.max_verified_scp_slot.load(Ordering::Relaxed),
+                        peer_gap,
+                        attempts,
+                        next_checkpoint = next_cp,
+                        "Near-tip recovery: archive confirmed behind unpublished checkpoint \
+                         — routing to peer-SCP back-fill (no archive catchup), mirroring \
+                         stellar-core outOfSyncRecovery"
+                    );
+                    crate::metrics::RECOVERY_STALLED_TICK_TOTAL
+                        .increment("near_tip_peer_scp_recovery", 1);
+                    // Full outOfSyncRecovery analog: re-broadcast own latest
+                    // SCP from lcl+1 + bounded peer SCP pull (#3197 parity gap:
+                    // the inline fallback below only does the request half).
+                    self.broadcast_recovery_scp_state(current_ledger).await;
+                    // Also retry exhausted tx_set fetches so the small
+                    // contiguous gap can be back-filled from peers that
+                    // re-acquired the tx_sets.
+                    self.retry_exhausted_tx_sets().await;
+                    // Do NOT re-arm sync_recovery_pending; the recovery timer
+                    // drives the next tick (avoids a 1s spin loop).
+                    return None;
+                }
+
+                // Far-behind (#1862) path: not near-tip (the near-tip band
+                // returned early above into peer-SCP recovery). Keep the
+                // unchanged 11-tick archive HardReset/ProbeAhead escalation.
                 if archive_is_confirmed_behind
                     && peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD
-                    && attempts >= escalation_attempts
+                    && attempts >= RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS
                     && !self.is_hard_reset_on_cooldown(peer_gap)
                 {
                     use super::types::HardResetReason;

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -257,20 +257,19 @@ const RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS: u64 =
 const RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NO_SCP: u64 =
     (HARD_RESET_STALL_SECS * 3 / 2 / OUT_OF_SYNC_RECOVERY_TIMER_SECS) - 1;
 
-/// Near-tip escalation threshold (issue #3181). When the archive is confirmed
-/// behind, peers are verified ahead, and the peer gap is below one checkpoint
-/// interval (`PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap < checkpoint_frequency()`),
-/// archive-based catchup is structurally impossible-yet-imminent: the next
-/// checkpoint that unblocks recovery will publish within one interval. Spinning
-/// on per-tick archive probes for the full ~120s (`RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS`)
-/// before escalating to the state-changing reset (which spawns a peer-SCP
-/// `ProbeAhead` blocking fetch + `request_scp_state`) produced a ~4.5-min
-/// consensus stall and a `forcing_catchup_behind` counter burst. In the near-tip
-/// band we fire that same escalation on the 2nd recovery tick (~10–20s) instead.
-/// The 60s `HARD_RESET_MIN_COOLDOWN_SECS` floor still prevents reset storms, and
-/// the far-behind (`peer_gap >= checkpoint_frequency()`) #1862 path keeps the
-/// unchanged 11-tick threshold + archive-catchup escalation.
-const RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP: u64 = 1;
+// Near-tip escalation threshold (issue #3181) — REMOVED by #3197.
+//
+// #3181/#3187 introduced a lowered escalation threshold so the near-tip /
+// archive-behind band would HardReset early. But that escalation routed to a
+// `ProbeAhead` archive fetch that is structurally doomed near tip (the next
+// checkpoint is unpublished), so it never shortened the outage. #3197 corrects
+// the ROUTING: the near-tip band now goes to peer-SCP back-fill + buffered-apply
+// (mirroring stellar-core's `HerderImpl::outOfSyncRecovery`), so there is no
+// longer a near-tip-specific HardReset escalation threshold. The band-DETECTION
+// constant `PEER_AHEAD_ESCALATION_THRESHOLD` is retained; only this early-
+// escalation threshold (whose sole consumer was the now-removed near-tip
+// HardReset arm in `trigger_recovery_catchup`) is gone. The far-behind (#1862)
+// path keeps the unchanged 11-tick `RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS`.
 
 /// Attempt-counter seed for partial-progress resets. When the node makes
 /// progress via a fast-track jump but is still significantly behind peers,
@@ -11381,17 +11380,10 @@ mod tests {
             "(120 * 3/2) / 10 - 1 = 17"
         );
         assert_eq!(PEER_AHEAD_ESCALATION_THRESHOLD, 3);
-        // #3181: near-tip threshold fires on the 2nd recovery tick (~10–20s),
-        // far earlier than the default 11 ticks (~120s).
-        assert_eq!(
-            RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP, 1,
-            "near-tip escalation must fire on the 2nd recovery tick (#3181)"
-        );
-        assert!(
-            RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP
-                < RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS,
-            "near-tip threshold must be strictly earlier than the default"
-        );
+        // #3197: the near-tip / archive-behind band routes to peer-SCP
+        // recovery (no archive HardReset), so there is no longer a near-tip-
+        // specific escalation threshold. The band-detection threshold
+        // (PEER_AHEAD_ESCALATION_THRESHOLD) is retained above.
     }
 
     #[tokio::test]
@@ -11474,12 +11466,21 @@ mod tests {
     }
 
     /// Regression test for issue #2349: when archive is confirmed behind
-    /// AND peers are verified ahead (peer_gap >= 3) AND attempts >= 11,
-    /// the fast-track → trigger_recovery_catchup path should escalate to
-    /// hard reset instead of falling through to peer SCP request.
+    /// AND peers are verified FAR ahead (peer_gap >= checkpoint_frequency(),
+    /// the #1862 far-behind band) AND attempts >= 11, the fast-track →
+    /// trigger_recovery_catchup path should escalate to hard reset instead of
+    /// falling through to peer SCP request.
     ///
     /// We exercise this through out_of_sync_recovery (the public entry point)
     /// configured to take the fast-track path (AtTip + SCP traffic).
+    ///
+    /// NOTE (#3197): this test uses a FAR-BEHIND peer_gap. The near-tip band
+    /// (3 <= peer_gap < checkpoint_frequency()) no longer fires a hard reset
+    /// here — it routes to peer-SCP recovery (broadcast_recovery_scp_state) —
+    /// so the #2349 hard-reset escalation is now specific to the far-behind
+    /// band, which #3197 leaves unchanged. See
+    /// test_decide_far_behind_archive_behind_unchanged and the near-tip
+    /// routing tests in catchup_impl.rs.
     #[tokio::test]
     async fn test_trigger_recovery_archive_behind_peer_ahead_fires_hard_reset() {
         let (_dir, app) = make_app_for_peer_ahead_test().await;
@@ -11491,7 +11492,11 @@ mod tests {
                 backoff_until: None,
             };
         }
-        app.max_verified_scp_slot.store(110, Ordering::Relaxed); // peer_gap = 10
+        // Far-behind band (#1862): peer_gap >= checkpoint_frequency() so the
+        // near-tip peer-SCP routing (#3197) does not apply and the archive
+        // hard-reset escalation fires.
+        app.max_verified_scp_slot
+            .store(current_ledger as u64 + 200, Ordering::Relaxed); // peer_gap = 200
 
         // Set attempts so that after fetch_add(1) in out_of_sync_recovery,
         // attempts == RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS (11).
@@ -11523,16 +11528,21 @@ mod tests {
         );
     }
 
-    /// Regression test for #2723: when the peer-ahead escalation path fires
-    /// but the archive cache is Fresh at/below current_ledger, the #2713
+    /// Regression test for #2723: when the peer-ahead escalation would fire
+    /// but the archive cache is Fresh at/below current_ledger AND the node is
+    /// at-or-near tip (peer_gap < HARD_RESET_GAP_ESCALATION), the #2713
     /// suppression guard in `force_post_catchup_hard_reset` must suppress the
-    /// hard reset instead of proceeding. This is the mirror image of
-    /// `test_trigger_recovery_archive_behind_peer_ahead_fires_hard_reset`.
+    /// hard reset instead of proceeding.
     ///
-    /// Call chain exercised:
-    ///   out_of_sync_recovery → fast-track → trigger_recovery_catchup
-    ///   → peer-ahead escalation → force_post_catchup_hard_reset
-    ///   → #2713 suppression guard (returns None)
+    /// NOTE (#3197): this guard is exercised directly via
+    /// `force_post_catchup_hard_reset`. Previously it was reached through
+    /// `out_of_sync_recovery → trigger_recovery_catchup` with a near-tip
+    /// peer_gap, but the near-tip band now routes to peer-SCP recovery before
+    /// reaching the hard-reset path (#3197). The suppression guard itself is
+    /// unchanged; we test it at the function it guards (the same entry point
+    /// the #2789 anti-wedge tests use). The suppression regime requires
+    /// peer_gap < HARD_RESET_GAP_ESCALATION (the #2789 narrowing), so a
+    /// near-tip-eligible gap is used here.
     #[tokio::test]
     async fn test_trigger_recovery_archive_behind_peer_ahead_suppressed_by_fresh_cache() {
         let (_dir, app) = make_app_for_peer_ahead_test().await;
@@ -11548,20 +11558,20 @@ mod tests {
         // suppression guard in force_post_catchup_hard_reset.
         app.archive_checkpoint_cache.seed(current_ledger);
 
-        app.max_verified_scp_slot.store(110, Ordering::Relaxed); // peer_gap = 10
+        // peer_gap = 5 < HARD_RESET_GAP_ESCALATION (12): the at-or-near-tip
+        // regime where the #2789 narrowing leaves the #2713 suppression armed.
+        app.max_verified_scp_slot
+            .store(current_ledger as u64 + 5, Ordering::Relaxed);
 
-        // fetch_add(1) returns old value, so `attempts` == threshold when evaluated.
-        app.recovery_attempts_without_progress
-            .store(RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS, Ordering::SeqCst);
-        app.recovery_baseline_ledger
-            .store(current_ledger as u64, Ordering::SeqCst);
-
-        // SCP traffic since reset → fast-track fires.
-        app.scp_messages_received.store(10, Ordering::Relaxed);
-        app.recovery_baseline_scp_received
-            .store(0, Ordering::SeqCst);
-
-        let result = app.out_of_sync_recovery(current_ledger).await;
+        // Invoke the hard-reset entry point directly: the #3197 near-tip
+        // routing diverts the out_of_sync_recovery chain away from here, so we
+        // exercise the suppression guard at its actual location.
+        let result = app
+            .force_post_catchup_hard_reset(
+                current_ledger,
+                HardResetReason::ArchiveBehindStallWallClock,
+            )
+            .await;
 
         // Suppression guard returns None — no PendingCatchup spawned.
         assert!(
@@ -11580,7 +11590,7 @@ mod tests {
         // does NOT call reset_recovery_attempts, unlike the fire path).
         assert_eq!(
             app.max_verified_scp_slot.load(Ordering::Relaxed),
-            110,
+            current_ledger as u64 + 5,
             "suppression must NOT clear max_verified_scp_slot"
         );
 
@@ -11588,6 +11598,72 @@ mod tests {
         assert!(
             app.last_hard_reset_offset.load(Ordering::Relaxed) > 0,
             "suppression must arm cooldown (last_hard_reset_offset > 0)"
+        );
+    }
+
+    /// Regression test for #3197 (PRIMARY production path): in the near-tip
+    /// band (PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap <
+    /// checkpoint_frequency()) with the archive confirmed behind and the
+    /// recovery attempts pinned past the escalation threshold (as
+    /// escalate_recovery_to_catchup does on every far-ahead EXTERNALIZE),
+    /// trigger_recovery_catchup must NOT fire an archive hard reset / ProbeAhead
+    /// (which is structurally doomed near tip). It must route to peer-SCP
+    /// recovery: the confirmed-behind status and max_verified_scp_slot are
+    /// preserved (a hard reset would clear both), and no PendingCatchup is
+    /// spawned. Mirrors stellar-core HerderImpl::outOfSyncRecovery (no archive
+    /// interaction near tip).
+    ///
+    /// Pre-#3197 (the #3187 code) this fired a hard reset and cleared
+    /// max_verified_scp_slot — the doomed routing this PR corrects.
+    #[tokio::test]
+    async fn test_trigger_recovery_near_tip_routes_to_peer_scp_not_hard_reset() {
+        let (_dir, app) = make_app_for_peer_ahead_test().await;
+        let current_ledger = 100u32;
+
+        {
+            *app.archive_recovery_status.write().await = ArchiveRecoveryStatus::ConfirmedBehind {
+                backoff_until: None,
+            };
+        }
+        // Near-tip band: peer_gap = 10 (3 <= 10 < checkpoint_frequency()=64).
+        let peer_slot = current_ledger as u64 + 10;
+        app.max_verified_scp_slot
+            .store(peer_slot, Ordering::Relaxed);
+
+        // Pin attempts past the escalation threshold (mirrors
+        // escalate_recovery_to_catchup pinning on far-ahead EXTERNALIZE).
+        app.recovery_attempts_without_progress.store(
+            RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS + 5,
+            Ordering::SeqCst,
+        );
+        app.recovery_baseline_ledger
+            .store(current_ledger as u64, Ordering::SeqCst);
+        app.scp_messages_received.store(10, Ordering::Relaxed);
+        app.recovery_baseline_scp_received
+            .store(0, Ordering::SeqCst);
+
+        let result = app.out_of_sync_recovery(current_ledger).await;
+
+        // No catchup spawned — the near-tip arm returns None after running the
+        // peer-SCP back-fill.
+        assert!(
+            result.is_none(),
+            "near-tip recovery must not spawn an archive catchup"
+        );
+        // A hard reset would have cleared confirmed-behind; peer-SCP routing
+        // must preserve it.
+        assert!(
+            app.archive_recovery_snapshot().await.is_confirmed_behind(),
+            "near-tip peer-SCP routing must NOT clear confirmed-behind status \
+             (no doomed archive hard reset) — #3197"
+        );
+        // A hard reset (reset_recovery_attempts(Full)) would have cleared
+        // max_verified_scp_slot; peer-SCP routing must preserve it.
+        assert_eq!(
+            app.max_verified_scp_slot.load(Ordering::Relaxed),
+            peer_slot,
+            "near-tip peer-SCP routing must NOT clear max_verified_scp_slot \
+             (no hard reset) — #3197"
         );
     }
 

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -765,14 +765,22 @@ pub(super) struct StuckSignals {
     /// `PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap < checkpoint_frequency()`.
     /// In this band, with the archive confirmed behind, the next checkpoint
     /// that unblocks recovery publishes within one interval, so archive
-    /// catchup is structurally impossible-yet-imminent. When set (and the
-    /// HardReset cooldown is inactive), `decide_consensus_stuck_action`
-    /// escalates to `HardReset(ArchiveBehindStallWallClock)` immediately
-    /// without waiting for the full wall-clock stall, eliminating the
-    /// ~4.5-min archive-probe spin. False whenever there is no peer-ahead
-    /// evidence (`peer_gap < PEER_AHEAD_ESCALATION_THRESHOLD`) or the node is
-    /// genuinely far behind (`peer_gap >= checkpoint_frequency()`, the #1862
-    /// path, which keeps the unchanged escalation threshold).
+    /// catchup is structurally impossible-yet-imminent.
+    ///
+    /// ROUTING (#3197): `decide_consensus_stuck_action` no longer branches on
+    /// this field — the near-tip / archive-behind band is routed to peer-SCP
+    /// recovery (`AttemptRecovery` here, and the full
+    /// `broadcast_recovery_scp_state` analog in
+    /// `trigger_recovery_catchup`), mirroring stellar-core's
+    /// `HerderImpl::outOfSyncRecovery`, instead of the doomed archive
+    /// HardReset/ProbeAhead that #3187 used. The detected near-tip state is
+    /// retained in the snapshot for diagnostics and to keep the band-detection
+    /// predicate (computed at the build site) a single source of truth with
+    /// the `consensus.rs` escalation gate (#1831). `#[allow(dead_code)]`
+    /// because the field is now computed-and-recorded but not action-branched
+    /// in this pure function; the load-bearing near-tip routing is in
+    /// `trigger_recovery_catchup`.
+    #[allow(dead_code)]
     pub near_tip: bool,
 }
 

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -782,7 +782,7 @@ metric_catalog! {
             => "Recovery stalled ticks by reason",
             "reason", ["backoff_active", "forcing_catchup_not_behind", "forcing_catchup_behind",
                        "at_tip_no_scp_hard_reset", "archive_behind_peer_ahead_hard_reset",
-                       "hard_reset_suppressed_archive_behind"];
+                       "hard_reset_suppressed_archive_behind", "near_tip_peer_scp_recovery"];
     }
 
     histograms {


### PR DESCRIPTION
Closes #3197

## Summary

**CRITICAL consensus-liveness production fix.** Corrects the incomplete #3187. The ~6.5-min post-restart consensus stall on every near-tip / archive-behind restart is a recovery-**routing** bug, not the escalation-**timing** bug #3187 addressed.

In the near-tip / archive-behind dead-zone, henyey escalated to archive mechanisms (`ProbeAhead` blocking fetch + the `forcing_catchup_behind` path) that are **structurally guaranteed to fail** until the archive publishes the next (unpublished) checkpoint. #3187 made that escalation fire *early*, but it still terminated in the doomed `ProbeAhead`, so it never shortened the outage — and the 60s hard-reset cooldown then gated the only useful action. stellar-core in this regime does **pure peer-SCP back-fill + buffered-apply** (`HerderImpl::outOfSyncRecovery` + `tryApplySyncingLedgers`) and **never touches the archive**.

The real fix is **recovery routing (peer-SCP), not escalation timing**: route the near-tip band to the existing `broadcast_recovery_scp_state` peer-SCP helper (re-broadcast own latest SCP from `lcl+1` + bounded peer SCP pull), so the small contiguous gap is back-filled from peers and the buffered ledgers apply in seconds-to-tens-of-seconds instead of waiting ~6.5 min for archive checkpoint publication.

## The two edits

- **(primary, load-bearing for the production signature)** `crates/app/src/app/consensus.rs` — `trigger_recovery_catchup`: in the near-tip band (`PEER_AHEAD_ESCALATION_THRESHOLD <= peer_gap < checkpoint_frequency()`) with the archive confirmed behind, skip the doomed `ProbeAhead` hard reset and run the **existing** full `broadcast_recovery_scp_state(current_ledger)` analog + `retry_exhausted_tx_sets()`, returning `None`. This is the dominant path: `escalate_recovery_to_catchup` pins recovery attempts past the escalation threshold on every far-ahead EXTERNALIZE, short-circuiting `out_of_sync_recovery` into this function before it reaches its own `broadcast_recovery_scp_state` tail (the previous fallback only did the `request_scp_state` half, omitting the re-broadcast — the parity gap). Far-behind (#1862) keeps its unchanged `ProbeAhead`/archive escalation.
- **(secondary, decide-fn guard)** `crates/app/src/app/catchup_impl.rs` — `decide_consensus_stuck_action`: remove `near_tip` as a `HardReset` trigger; the near-tip / archive-behind case now returns `AttemptRecovery` instead of `HardReset(ArchiveBehindStallWallClock)`.

Also: removed the now-obsolete `RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NEAR_TIP` constant (its sole consumer was the removed near-tip hard-reset arm); registered the new `near_tip_peer_scp_recovery` recovery-stalled metric label.

## Preserved prior fixes (regression-verified)

- **#2789 anti-wedge:** the genuine **120s wall-clock stall backstop still fires** — `stuck_duration >= HARD_RESET_STALL_SECS` escalates to `HardReset` even in the near-tip band, so a peer-SCP back-fill that never resyncs cannot wedge the node. (`test_decide_near_tip_still_hardresets_on_wallclock_stall`; `test_recovery_loop_unwedges_when_peers_ahead`, `test_hard_reset_not_suppressed_when_peers_ahead` still pass.)
- **#1862 far-behind** (`peer_gap >= checkpoint_frequency()`): disjoint band, unchanged archive-catchup escalation. (`test_decide_far_behind_archive_behind_unchanged`; `test_trigger_recovery_archive_behind_peer_ahead_fires_hard_reset` moved to the far-behind band.)
- **#1843 cooldown:** `is_hard_reset_on_cooldown` → `AttemptRecovery` fallback unchanged. (`test_decide_near_tip_cooldown_falls_back_to_recovery`.)
- **#3187 near-tip DETECTION:** the `near_tip` predicate + `PEER_AHEAD_ESCALATION_THRESHOLD` band detection are kept; only the consequent ACTION changes (route to recovery, not hard-reset/archive-probe). The #3187 `near_tip → HardReset` test assertions are intentionally **flipped** to `AttemptRecovery` (they encode the corrected behavior).

The #3179 classifier is verified behavior-preserving and untouched.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3197#issuecomment-4636146200)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (CI-equivalent) clean
- [x] cargo test -p henyey-app — 1007 lib unittests + integration tests, 0 failures

## Regression test (kind: bug-fix)

- **Lead test:** `catchup_impl.rs::test_decide_near_tip_archive_behind_routes_to_recovery_not_hardreset` — asserts the exact production `StuckSignals` returns `AttemptRecovery`.
- **Pre-fix:** committed as `963feb86` — verified **FAILED** with: `left: HardReset(ArchiveBehindStallWallClock), right: AttemptRecovery`.
- **Post-fix:** verified **PASSES** after `be75ebdd`.
- **Companions:** 120s-stall backstop (#2789), recovery-exhausted (#1831), far-behind (#1862), cooldown (#1843), and a primary-path integration test `mod.rs::test_trigger_recovery_near_tip_routes_to_peer_scp_not_hard_reset` asserting the near-tip arm does NOT hard-reset (confirmed-behind + `max_verified_scp_slot` preserved, no catchup spawned).

## Parity

Mirrors `HerderImpl::outOfSyncRecovery` (HerderImpl.cpp:521-561; `getLatestMessagesSend` re-broadcast :555-558; `getMoreSCPState`→2 peers :2643) and `LedgerApplyManagerImpl::processLedger`/`tryApplySyncingLedgers` (LedgerApplyManagerImpl.cpp:156-160, :205-219). stellar-core never does archive catchup near tip with a sub-checkpoint contiguous gap.

## Deviations from plan

- The plan named only the decide-fn test updates. Implementation also had to update two `consensus.rs` integration tests (`test_trigger_recovery_archive_behind_peer_ahead_fires_hard_reset` → far-behind band; `..._suppressed_by_fresh_cache` → direct `force_post_catchup_hard_reset` entry point), because the near-tip path through `out_of_sync_recovery` no longer reaches the hard-reset escalation. The #2349/#2723/#2713 coverage is preserved at the appropriate band/entry point. Added the primary-path integration test the plan called for "if unit-testable."

🤖 Generated with [Claude Code](https://claude.com/claude-code)