### PR TITLE
Remove dead SHA-256 message_hash; document BLAKE2b flood dedup

### DIFF
--- a/crates/overlay/src/codec.rs
+++ b/crates/overlay/src/codec.rs
@@ -284,25 +284,18 @@ impl Encoder<AuthenticatedMessage> for MessageCodec {
 
 /// Helper functions for working with Stellar messages.
 ///
-/// Provides utilities for message classification, hashing, and display.
+/// Provides utilities for message classification and display.
+///
+/// # Flood deduplication hashing
+///
+/// This module does **not** provide the flood-dedup hash. Per
+/// `OVERLAY_SPEC.md` §3.3, flood message deduplication uses **BLAKE2b-256**
+/// over the XDR serialization of the entire `StellarMessage` (matching
+/// stellar-core's `xdrBlake2()` in `Floodgate::broadcast()`) — **not**
+/// SHA-256. The authoritative implementation is
+/// [`crate::flood::compute_message_hash`]; all flood-gate call sites use it.
 pub mod helpers {
-    use super::*;
     use stellar_xdr::curr::StellarMessage;
-
-    /// Computes the SHA-256 hash of a message for flood tracking.
-    ///
-    /// The hash is computed over the XDR-encoded message bytes.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the message cannot be XDR-serialized (should never happen
-    /// for valid `StellarMessage` values).
-    pub fn message_hash(message: &StellarMessage) -> henyey_common::Hash256 {
-        let bytes = message
-            .to_xdr(Limits::none())
-            .expect("StellarMessage XDR serialization must not fail");
-        henyey_common::Hash256::hash(&bytes)
-    }
 
     /// Returns true if this message type is flow-controlled (uses flood/flow
     /// capacity). This includes both globally-deduplicated flood payloads

--- a/crates/overlay/src/flood.rs
+++ b/crates/overlay/src/flood.rs
@@ -526,6 +526,32 @@ mod tests {
         PeerId::from_bytes([v; 32])
     }
 
+    /// OVERLAY_SPEC.md §3.3: flood message deduplication MUST use BLAKE2b-256
+    /// over the XDR serialization of the entire `StellarMessage` (matching
+    /// stellar-core's `xdrBlake2()`), NOT SHA-256. This guards against a
+    /// regression to SHA-256 — the dedup hash is local-only, so a divergence
+    /// would silently waste CPU without a wire-visible failure.
+    #[test]
+    fn test_flood_dedup_hash_is_blake2b_not_sha256() {
+        use stellar_xdr::curr::{Limits, WriteXdr};
+
+        let message = StellarMessage::Peers(Default::default());
+        let bytes = message.to_xdr(Limits::none()).unwrap();
+
+        // The flood-dedup hash must equal BLAKE2b-256 of the XDR bytes.
+        let expected_blake2 = henyey_crypto::blake2(&bytes);
+        assert_eq!(compute_message_hash(&message), expected_blake2);
+
+        // ...and must NOT equal SHA-256 of the same bytes, which is the
+        // wrong primitive the spec audit (#3081) flagged.
+        let sha256 = henyey_common::Hash256::hash(&bytes);
+        assert_ne!(
+            compute_message_hash(&message),
+            sha256,
+            "flood dedup hash must be BLAKE2b-256, not SHA-256"
+        );
+    }
+
     #[test]
     fn test_flood_gate_basic() {
         let gate = FloodGate::new();


### PR DESCRIPTION
Closes #3081

## Summary

The `/spec-adhere` audit flagged a possible flood-dedup hash divergence (OVERLAY §3.3-blake2: BLAKE2b-256 vs SHA-256). Investigation confirms henyey's **live flood-dedup path already uses BLAKE2b-256** correctly — there is no behavior gap. The audit was tripped by a dead, misleading helper.

`flood::compute_message_hash` (BLAKE2b-256 over `XDR(StellarMessage)`, matching stellar-core's `xdrBlake2()` in `Floodgate::broadcast()`) is the authoritative flood-dedup hash. It is wired through both:
- the overlay manager peer loop (`manager/peer_loop.rs`, `manager/mod.rs`), and
- the app event loop (`crates/app/src/app/lifecycle.rs`).

`codec::helpers::message_hash()` used SHA-256 with a comment claiming it was "for flood tracking", but had **zero call sites** anywhere in the workspace (verified via grep across overlay, manager, and app). It was dead code that made the actual algorithm ambiguous. This PR removes it, documents the `helpers` module to point at the authoritative BLAKE2b implementation, and adds a regression test that locks the spec contract.

## Classification

Not a behavior gap — doc/dead-code cleanup (matches the triage verdict: `kind: refactor`, code already correct per spec). No semantics change; the dedup hash is local-only and was never wrong on the live path.

## Plan reference

No separate converged plan — trivial short-circuit via the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3081#issuecomment-4628775247).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-overlay -- -D warnings` (clean; the 11 `--all-targets` errors on `connection.rs`/`manager/mod.rs` test code are pre-existing on main, unrelated to this change)
- [x] `cargo test -p henyey-overlay` — 479 + 8 + 3 + 1 + 4 pass, including new `test_flood_dedup_hash_is_blake2b_not_sha256`

## Parity reference

stellar-core `Floodgate::broadcast()` → `xdrBlake2()` (libsodium `crypto_generichash`, 32-byte BLAKE2b-256 over XDR(`StellarMessage`)). henyey matches via `henyey_crypto::blake2`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)