### PR TITLE
Make archive-behind recovery count cap progress-aware (#3204)

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -1282,21 +1282,27 @@ impl App {
     /// normal TriggerCatchup is preferred; when HardReset cooldown is active,
     /// falls back to AttemptRecovery — see #1843):
     ///
-    /// | catchup_in_progress | archive_behind | rec_exhausted | tx_set_ex | stuck≥120s | cooldown | schedule_due | Action |
-    /// |---|---|---|---|---|---|---|---|
-    /// | true  | *     | *    | *     | *     | *    | true (ab)  | AttemptRecovery |
-    /// | true  | *     | *    | *     | *     | *    | false      | Wait |
-    /// | false | true  | true | -     | -     | false| true       | HardReset(RecoveryExhausted) |
-    /// | false | true  | true | -     | -     | true | true       | AttemptRecovery |
-    /// | false | true  | -    | true  | -     | false| true       | HardReset(TxSetExhausted) |
-    /// | false | true  | -    | true  | -     | true | true       | AttemptRecovery |
-    /// | false | true  | -    | -     | true  | false| true       | HardReset(StallWallClock) |
-    /// | false | true  | -    | -     | true  | true | true       | AttemptRecovery |
-    /// | false | true  | false| false | false | *    | true       | AttemptRecovery |
-    /// | false | true  | *    | *     | *     | *    | false      | Wait |
-    /// | false | false | true | *     | *     | *    | -          | TriggerCatchup |
-    /// | false | false | false| *     | *     | *    | true       | AttemptRecovery |
-    /// | false | false | false| *     | *     | *    | false      | Wait |
+    /// `making_progress` (#3204) is `recovery_making_progress`: true while the
+    /// verified peer gap is strictly shrinking (peer-SCP back-fill is closing
+    /// the gap). It suppresses ONLY the count-based RecoveryExhausted reset; the
+    /// 120s wall-clock backstop (#2789) and tx_set exhaustion stay armed.
+    ///
+    /// | catchup_in_progress | archive_behind | rec_exhausted | making_progress | tx_set_ex | stuck≥120s | cooldown | schedule_due | Action |
+    /// |---|---|---|---|---|---|---|---|---|
+    /// | true  | *     | *    | *    | *     | *     | *    | true (ab)  | AttemptRecovery |
+    /// | true  | *     | *    | *    | *     | *     | *    | false      | Wait |
+    /// | false | true  | true | false| -     | -     | false| true       | HardReset(RecoveryExhausted) |
+    /// | false | true  | true | true | -     | -     | false| true       | AttemptRecovery (#3204) |
+    /// | false | true  | true | *    | -     | -     | true | true       | AttemptRecovery |
+    /// | false | true  | -    | *    | true  | -     | false| true       | HardReset(TxSetExhausted) |
+    /// | false | true  | -    | *    | true  | -     | true | true       | AttemptRecovery |
+    /// | false | true  | -    | *    | -     | true  | false| true       | HardReset(StallWallClock) |
+    /// | false | true  | -    | *    | -     | true  | true | true       | AttemptRecovery |
+    /// | false | true  | false| *    | false | false | *    | true       | AttemptRecovery |
+    /// | false | true  | *    | *    | *     | *     | *    | false      | Wait |
+    /// | false | false | true | *    | *     | *     | *    | -          | TriggerCatchup |
+    /// | false | false | false| *    | *     | *     | *    | true       | AttemptRecovery |
+    /// | false | false | false| *    | *     | *     | *    | false      | Wait |
     fn decide_consensus_stuck_action(s: StuckSignals) -> ConsensusStuckAction {
         let recovery_exhausted = s.recovery_attempts >= MAX_POST_CATCHUP_RECOVERY_ATTEMPTS;
 
@@ -1355,7 +1361,19 @@ impl App {
                     // HardReset already cleared stale state; repeating it
                     // before the cooldown expires is futile. Preserves #1843.
                     ConsensusStuckAction::AttemptRecovery
-                } else if recovery_exhausted {
+                } else if recovery_exhausted && !s.recovery_making_progress {
+                    // #3204: the count-based cap fires ONLY when peer-SCP
+                    // back-fill has stalled (peer_gap stopped strictly
+                    // shrinking for RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS
+                    // ticks). While the verified peer gap is shrinking, #3199's
+                    // back-fill is demonstrably making progress, so we keep
+                    // driving peer-SCP recovery instead of discarding it with a
+                    // hard reset. This restores stellar-core's uncapped
+                    // out-of-sync recovery (HerderImpl::outOfSyncRecovery). The
+                    // suppression is count-cap-only: the 120s wall-clock
+                    // backstop below (#2789) and tx_set exhaustion stay armed,
+                    // and the progress signal (peer_gap-shrink) never touches
+                    // stuck_start, so the 120s ceiling cannot be wedged open.
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
                 } else if s.tx_set_exhausted {
                     ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindTxSetExhausted)
@@ -2033,6 +2051,14 @@ impl App {
                     let near_tip = peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD
                         && peer_gap < checkpoint_frequency() as u64;
 
+                    // #3204: progress-aware suppression of the count-based
+                    // recovery_exhausted HardReset. See
+                    // `update_recovery_gap_progress` for the full rationale —
+                    // the progress signal is peer_gap-shrink ONLY (never
+                    // current_ledger advance), so it cannot re-key stuck_start
+                    // and the 120s wall-clock backstop (#2789) stays armed.
+                    let recovery_making_progress = self.update_recovery_gap_progress(peer_gap);
+
                     let signals = StuckSignals {
                         catchup_in_progress: self.catchup_in_progress.load(Ordering::SeqCst),
                         archive_behind,
@@ -2042,6 +2068,7 @@ impl App {
                         recovery_attempts: effective_attempts,
                         hard_reset_cooldown_active,
                         near_tip,
+                        recovery_making_progress,
                     };
 
                     let decision = Self::decide_consensus_stuck_action(signals);
@@ -2947,15 +2974,40 @@ mod tests {
         since_recovery: u64,
         archive_behind: bool,
     ) -> ConsensusStuckAction {
+        decide_full(
+            catchup_triggered,
+            recovery_attempts,
+            since_recovery,
+            archive_behind,
+            // Existing callers model the steady-state-no-progress case
+            // (peer_gap not shrinking) and a non-stalled wall clock, which
+            // preserves every previously asserted outcome.
+            false,
+            0,
+        )
+    }
+
+    /// Extended helper exposing the two #3204 signals — `recovery_making_progress`
+    /// (peer_gap strictly shrinking → suppress the count cap) and `stuck_duration`
+    /// (the 120s wall-clock backstop arm).
+    fn decide_full(
+        catchup_triggered: bool,
+        recovery_attempts: u32,
+        since_recovery: u64,
+        archive_behind: bool,
+        recovery_making_progress: bool,
+        stuck_duration: u64,
+    ) -> ConsensusStuckAction {
         App::decide_consensus_stuck_action(StuckSignals {
             catchup_in_progress: catchup_triggered,
             archive_behind,
             tx_set_exhausted: false,
             schedule_due: since_recovery >= OUT_OF_SYNC_RECOVERY_TIMER_SECS,
-            stuck_duration: 0,
+            stuck_duration,
             recovery_attempts,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress,
         })
     }
 
@@ -3017,6 +3069,133 @@ mod tests {
         ));
     }
 
+    // ================================================================
+    // #3204: progress-aware count cap. While peer_gap is strictly
+    // shrinking (peer-SCP back-fill making progress), the count-based
+    // RecoveryExhausted HardReset is SUPPRESSED; it re-arms only when
+    // peer_gap stops shrinking, and the 120s wall-clock backstop (#2789)
+    // remains independent.
+    // ================================================================
+
+    /// #3204 core fix: archive_behind + recovery_attempts past the cap, but
+    /// peer_gap is strictly shrinking (recovery_making_progress=true) and the
+    /// wall clock is well under 120s → keep driving peer-SCP recovery
+    /// (AttemptRecovery), NOT a hard reset.
+    ///
+    /// FAILS on origin/main (which returns HardReset(ArchiveBehindRecoveryExhausted)
+    /// at attempt 4 regardless of progress); PASSES post-fix. Reproduces the
+    /// #3204 progress-making episode.
+    #[test]
+    fn test_decide_archive_behind_gap_progress_does_not_hard_reset() {
+        let action = decide_full(
+            false,   // catchup not in flight
+            MAX + 1, // recovery_attempts past the cap (observed: 4 vs max 3)
+            TIMER,   // schedule due
+            true,    // archive_behind
+            true,    // recovery_making_progress (peer_gap strictly shrinking)
+            30,      // stuck_duration well under HARD_RESET_STALL_SECS
+        );
+        assert_eq!(
+            action,
+            ConsensusStuckAction::AttemptRecovery,
+            "peer_gap shrinking must suppress the count-based hard reset (#3204)"
+        );
+
+        // Far past the cap and near-tip: still keep driving recovery.
+        let action = decide_full(false, MAX + 50, TIMER, true, true, 0);
+        assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
+    }
+
+    /// #3204 anti-wedge escape 1: when peer_gap STOPS shrinking
+    /// (recovery_making_progress=false) and recovery is exhausted, the genuine
+    /// stall still escalates to HardReset(ArchiveBehindRecoveryExhausted). This
+    /// is the real #3204 episode (gap grew 15→31→48 → never shrank → fires).
+    #[test]
+    fn test_decide_archive_behind_no_gap_progress_escalates() {
+        let action = decide_full(
+            false, MAX,   // exhausted
+            TIMER, // due
+            true,  // archive_behind
+            false, // NOT making progress (peer_gap flat/growing)
+            30,    // under the wall-clock backstop
+        );
+        assert!(
+            matches!(
+                action,
+                ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindRecoveryExhausted)
+            ),
+            "no peer_gap progress + exhausted must still hard-reset (anti-wedge)"
+        );
+    }
+
+    /// #3204 anti-wedge escape 2 (INDEPENDENCE): the 120s wall-clock backstop
+    /// (#2789) fires HardReset(ArchiveBehindStallWallClock) even when peer_gap
+    /// is still shrinking (recovery_making_progress=true). Proves escape-2 is
+    /// progress-independent — a peer-SCP back-fill that nibbles the gap forever
+    /// without resyncing cannot wedge the node past 120s. The production signal
+    /// is peer_gap-shrink-only and never touches stuck_start, so this ceiling
+    /// stays armed whenever current_ledger is pinned.
+    #[test]
+    fn test_decide_archive_behind_wall_clock_backstop_fires_despite_gap_progress() {
+        let action = decide_full(
+            false,
+            MAX + 100,             // recovery_attempts large
+            TIMER,                 // due
+            true,                  // archive_behind
+            true,                  // STILL making peer_gap progress
+            HARD_RESET_STALL_SECS, // wall clock hit the 120s backstop
+        );
+        assert!(
+            matches!(
+                action,
+                ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindStallWallClock)
+            ),
+            "120s wall-clock backstop must fire independent of peer_gap progress (#2789)"
+        );
+    }
+
+    /// Orthogonality: tx_set exhaustion HardReset is independent of the #3204
+    /// peer_gap progress suppression. With recovery_making_progress=true and
+    /// tx_set_exhausted=true (and recovery NOT exhausted, so the gap-progress
+    /// arm cannot mask it), the decision is HardReset(ArchiveBehindTxSetExhausted).
+    #[test]
+    fn test_decide_tx_set_exhausted_overrides_gap_progress() {
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: true,
+            schedule_due: true,
+            stuck_duration: 30,
+            recovery_attempts: 0,
+            hard_reset_cooldown_active: false,
+            near_tip: false,
+            recovery_making_progress: true,
+        });
+        assert!(matches!(
+            action,
+            ConsensusStuckAction::HardReset(HardResetReason::ArchiveBehindTxSetExhausted)
+        ));
+    }
+
+    /// #1843 preserved under #3204: when the hard-reset cooldown is active,
+    /// every escalation (including the no-progress RecoveryExhausted path)
+    /// falls back to AttemptRecovery rather than a futile repeat hard reset.
+    #[test]
+    fn test_decide_archive_behind_cooldown_falls_back_even_without_progress() {
+        let action = App::decide_consensus_stuck_action(StuckSignals {
+            catchup_in_progress: false,
+            archive_behind: true,
+            tx_set_exhausted: false,
+            schedule_due: true,
+            stuck_duration: 30,
+            recovery_attempts: MAX,
+            hard_reset_cooldown_active: true,
+            near_tip: false,
+            recovery_making_progress: false,
+        });
+        assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
+    }
+
     #[test]
     fn test_decide_archive_behind_waits_when_not_due() {
         let action = decide(false, MAX, TIMER - 1, true);
@@ -3052,6 +3231,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert!(matches!(
             action,
@@ -3071,6 +3251,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert!(matches!(
             action,
@@ -3090,6 +3271,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
     }
@@ -3106,6 +3288,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(action, ConsensusStuckAction::TriggerCatchup);
     }
@@ -3122,6 +3305,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert!(matches!(
             action,
@@ -3161,6 +3345,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: true,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -3188,6 +3373,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
             near_tip: true,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -3213,6 +3399,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -3290,6 +3477,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: true,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -3316,6 +3504,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: true,
+            recovery_making_progress: false,
         });
         assert!(
             matches!(
@@ -3340,6 +3529,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: true,
+            recovery_making_progress: false,
         });
         assert!(
             matches!(
@@ -3364,6 +3554,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert!(
             matches!(
@@ -3389,6 +3580,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
             near_tip: true,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -3410,6 +3602,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(action, ConsensusStuckAction::Wait);
     }
@@ -3425,6 +3618,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
     }
@@ -3447,6 +3641,7 @@ mod tests {
             recovery_attempts: 7, // from atomic counter (> MAX_POST_CATCHUP_RECOVERY_ATTEMPTS)
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert!(matches!(action, ConsensusStuckAction::HardReset(_)));
     }
@@ -3464,6 +3659,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         // recovery_exhausted wins because it's checked first.
         assert!(matches!(
@@ -3481,6 +3677,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         // tx_set_exhausted wins over wall_clock.
         assert!(matches!(
@@ -3503,6 +3700,7 @@ mod tests {
                 recovery_attempts: re,
                 hard_reset_cooldown_active: false,
                 near_tip: false,
+                recovery_making_progress: false,
             })
         };
 
@@ -4418,6 +4616,7 @@ mod tests {
             catchup_in_progress: false,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         };
         let action = App::decide_consensus_stuck_action(signals_stuck_higher);
         // With recovery_attempts=8 (> MAX_RECOVERY_ATTEMPTS=6) and
@@ -4446,6 +4645,7 @@ mod tests {
             catchup_in_progress: false,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         };
         let action = App::decide_consensus_stuck_action(signals_atomic_higher);
         assert!(
@@ -4475,6 +4675,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: true,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -4496,6 +4697,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -4517,6 +4719,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -4538,6 +4741,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert!(
             matches!(
@@ -4561,6 +4765,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: true,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(
             action,
@@ -4582,6 +4787,7 @@ mod tests {
             recovery_attempts: 0,
             hard_reset_cooldown_active: true,
             near_tip: false,
+            recovery_making_progress: false,
         });
         assert_eq!(action, ConsensusStuckAction::AttemptRecovery);
     }
@@ -4893,24 +5099,68 @@ mod tests {
         );
     }
 
-    /// #1844 control: without a previous hard reset (no cooldown),
-    /// the same scenario routes to HardReset(RecoveryExhausted).
+    /// #1844 control (updated for #3204): without a previous hard reset (no
+    /// cooldown), the same scenario routes to HardReset(RecoveryExhausted) —
+    /// but only once the peer-gap-shrink progress suppression has lapsed.
+    ///
+    /// In this scenario there is NO peer-ahead evidence (max_verified_scp_slot
+    /// stays 0 → effective_peer_gap == 0, flat across ticks), so the verified
+    /// peer gap never strictly shrinks. Per #3204 the count-based cap is
+    /// suppressed while back-fill might be making progress and re-arms only
+    /// after RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS consecutive non-shrink
+    /// ticks (escape-1, ~30s). So the HardReset now fires on the Nth tick, not
+    /// the 1st — proving the genuine-no-progress stall still escalates (the
+    /// anti-wedge guarantee), just bounded by the no-progress budget instead of
+    /// an instantaneous count cap.
     #[tokio::test]
     async fn test_no_previous_reset_routes_to_hard_reset() {
         use std::sync::atomic::Ordering;
+        use std::time::Duration;
 
         let (_dir, app) = mk_app_for_cooldown_livelock_scenario().await;
 
         // last_hard_reset_offset stays at 0 (default) → "no previous reset"
-        // → cooldown is inactive → HardReset fires.
+        // → cooldown is inactive → HardReset fires once progress lapses.
 
+        // Drive the no-progress counter to its escalation threshold. The peer
+        // gap is flat at 0 (no peer evidence), so each tick is a non-shrink.
+        // Re-arm the schedule timer between ticks so each one is schedule_due,
+        // and re-seed the stuck state because the prior tick's AttemptRecovery
+        // increments recovery_attempts (kept at/above the cap here).
+        for _ in 0..(RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS - 1) {
+            {
+                let mut guard = app.consensus_stuck_state.write().await;
+                if let Some(state) = guard.as_mut() {
+                    state.last_recovery_attempt = app.clock.now() - Duration::from_secs(15);
+                    state.recovery_attempts = MAX_POST_CATCHUP_RECOVERY_ATTEMPTS;
+                }
+            }
+            let _ = app.maybe_start_buffered_catchup().await;
+            assert_eq!(
+                app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
+                0,
+                "HardReset must be suppressed while the no-progress counter is below threshold"
+            );
+        }
+
+        // Final tick: the no-progress counter now reaches the escalation
+        // threshold → recovery_making_progress=false → HardReset fires.
+        // Re-arm the schedule timer + recovery_attempts so this tick is
+        // schedule_due and still exhausted.
+        {
+            let mut guard = app.consensus_stuck_state.write().await;
+            if let Some(state) = guard.as_mut() {
+                state.last_recovery_attempt = app.clock.now() - Duration::from_secs(15);
+                state.recovery_attempts = MAX_POST_CATCHUP_RECOVERY_ATTEMPTS;
+            }
+        }
         let _result = app.maybe_start_buffered_catchup().await;
 
         // HardReset should have fired:
         assert_eq!(
             app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
             1,
-            "HardReset should fire when cooldown is inactive"
+            "HardReset should fire when cooldown is inactive and progress has lapsed"
         );
         // With the #1862 fix, the cold-cache path enters spawn_catchup
         // which clears consensus_stuck_state (sets it to None when entering
@@ -5350,6 +5600,7 @@ mod tests {
             recovery_attempts: MAX,
             hard_reset_cooldown_active: false,
             near_tip: false,
+            recovery_making_progress: false,
         };
 
         let action = App::decide_consensus_stuck_action(signals);
@@ -6394,6 +6645,7 @@ mod tests {
             recovery_attempts: MAX_POST_CATCHUP_RECOVERY_ATTEMPTS + 1,
             hard_reset_cooldown_active: true,
             near_tip: false,
+            recovery_making_progress: false,
         };
 
         let action = App::decide_consensus_stuck_action(signals);

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -225,6 +225,16 @@ const MAX_POST_CATCHUP_RECOVERY_ATTEMPTS: u32 = 3;
 /// OUT_OF_SYNC_RECOVERY_TIMER_SECS.
 const HARD_RESET_STALL_SECS: u64 = 120;
 
+/// Number of consecutive Path-A ticks with NO peer-gap shrink before the
+/// count-based `recovery_exhausted` HardReset is allowed to fire again (#3204).
+/// While the verified peer gap is strictly shrinking, #3199's peer-SCP
+/// back-fill is demonstrably making progress and must not be aborted by the
+/// 3-attempt count cap; we only escalate after this many ticks without a
+/// strict shrink (~30s at the 10s recovery interval). Tied to
+/// `MAX_POST_CATCHUP_RECOVERY_ATTEMPTS` so the no-progress budget matches the
+/// original count cap.
+const RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS: u32 = MAX_POST_CATCHUP_RECOVERY_ATTEMPTS;
+
 /// Hard floor: never reset more than once per this interval.
 /// Prevents reset storms when the node is legitimately stabilizing.
 const HARD_RESET_MIN_COOLDOWN_SECS: u64 = 60;
@@ -945,6 +955,19 @@ pub struct App {
     /// `process_verified()` for `Verdict::Ok` envelopes only (verify-rejected
     /// envelopes return early). Reset on ledger progress.
     max_verified_scp_slot: AtomicU64,
+    /// Verified peer gap (`effective_peer_gap`) observed at the previous
+    /// Path-A consensus-stuck tick. Used to detect whether peer-SCP back-fill
+    /// is shrinking the gap (#3204). Sentinel `u64::MAX` means "no prior
+    /// observation this episode" (first tick → treated as non-progress).
+    /// Reset to the sentinel on `reset_recovery_attempts(Full)` and on
+    /// `force_post_catchup_hard_reset`.
+    last_recovery_peer_gap: AtomicU64,
+    /// Count of consecutive Path-A ticks in which the verified peer gap did
+    /// NOT strictly decrease (#3204). Reset to 0 on any strict shrink. When it
+    /// reaches `RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS` the count-based
+    /// `recovery_exhausted` HardReset is re-enabled (peer-SCP back-fill has
+    /// stalled). Cleared alongside `last_recovery_peer_gap`.
+    recovery_consecutive_no_gap_progress: AtomicU32,
     /// Number of ledger closes that contained at least one transaction.
     /// Mirrors stellar-core's `ledger.transaction.count` histogram `.count`.
     ledger_tx_count: AtomicU64,
@@ -1499,6 +1522,8 @@ impl App {
             recovery_throttles: log_throttle::RecoveryLogThrottles::new(),
             max_observed_externalize_slot: AtomicU64::new(0),
             max_verified_scp_slot: AtomicU64::new(0),
+            last_recovery_peer_gap: AtomicU64::new(u64::MAX),
+            recovery_consecutive_no_gap_progress: AtomicU32::new(0),
             ledger_tx_count: AtomicU64::new(0),
             max_tx_size_bytes: Arc::new(AtomicU32::new(
                 henyey_herder::flow_control::MAX_CLASSIC_TX_SIZE_BYTES,
@@ -2218,6 +2243,52 @@ impl App {
             .saturating_sub(current_ledger as u64)
     }
 
+    /// Update the #3204 peer-gap-shrink progress tracker for one Path-A
+    /// consensus-stuck tick and return whether peer-SCP back-fill is still
+    /// "making progress" for the purpose of suppressing the count-based
+    /// `recovery_exhausted` HardReset.
+    ///
+    /// "Progress" = the verified peer gap (`peer_gap`) STRICTLY decreased vs
+    /// the previous tick of this stuck episode. This is the ONLY admitted
+    /// signal — we deliberately do NOT treat "current_ledger advanced" as
+    /// progress, because current_ledger is what re-keys `stuck_start`
+    /// (`maybe_start_buffered_catchup` filters the snapshot on current_ledger).
+    /// Admitting it would reset the episode clock and defeat the 120s
+    /// wall-clock backstop (#2789), creating a no-escape wedge. peer_gap-shrink
+    /// never touches `stuck_start`, so the 120s ceiling stays armed whenever
+    /// current_ledger is pinned — the two anti-wedge escapes remain
+    /// independent.
+    ///
+    /// Cumulative encoding so a single noisy flat tick mid-shrink does not
+    /// escalate: we count CONSECUTIVE ticks WITHOUT a strict shrink, reset that
+    /// counter to 0 on any strict shrink, and report progress while the counter
+    /// is below `RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS`. The first tick of
+    /// an episode sees the `u64::MAX` sentinel as the prior gap, so it is NOT a
+    /// strict shrink (counter accrues from 0) — fail-safe toward escalation.
+    pub(super) fn update_recovery_gap_progress(&self, peer_gap: u64) -> bool {
+        let last_peer_gap = self.last_recovery_peer_gap.load(Ordering::Relaxed);
+        // The first tick of an episode has the u64::MAX sentinel as the prior
+        // gap → there is NO prior observation to compare against, so it is NOT
+        // a strict shrink (counter accrues from 0) — fail-safe toward
+        // escalation. Comparing against the sentinel directly would make the
+        // first tick spuriously look like a giant shrink and report progress.
+        let gap_shrank = last_peer_gap != u64::MAX && peer_gap < last_peer_gap;
+        self.last_recovery_peer_gap
+            .store(peer_gap, Ordering::Relaxed);
+
+        let no_gap_progress = if gap_shrank {
+            self.recovery_consecutive_no_gap_progress
+                .store(0, Ordering::Relaxed);
+            0
+        } else {
+            self.recovery_consecutive_no_gap_progress
+                .fetch_add(1, Ordering::Relaxed)
+                .saturating_add(1)
+        };
+
+        no_gap_progress < RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS
+    }
+
     /// Reset (or re-arm) the recovery attempt counter and snapshot the current
     /// SCP message count. See [`RecoveryResetMode`] for the two reset policies.
     ///
@@ -2245,6 +2316,14 @@ impl App {
                 self.max_verified_scp_slot.store(0, Ordering::Relaxed);
                 self.recovery_attempts_without_progress
                     .store(0, Ordering::SeqCst);
+                // Clear the #3204 peer-gap-shrink progress tracker — the node
+                // is caught up, so the next stall episode must start with a
+                // fresh "no prior observation" sentinel and a zeroed
+                // no-progress counter.
+                self.last_recovery_peer_gap
+                    .store(u64::MAX, Ordering::Relaxed);
+                self.recovery_consecutive_no_gap_progress
+                    .store(0, Ordering::Relaxed);
                 // Re-arm the onset diagnostic for the next stall episode.
                 self.recovery_episode_latch.reset();
             }
@@ -11470,6 +11549,113 @@ mod tests {
                 .load(Ordering::SeqCst),
             high_attempts,
             "fetch_max must not lower attempts below existing value"
+        );
+    }
+
+    /// #3204: the peer-gap-shrink progress tracker.
+    ///
+    /// - A strictly shrinking gap (19→15→12) keeps the consecutive-no-progress
+    ///   counter at 0 and reports `recovery_making_progress = true`.
+    /// - A flat gap (12 repeated) increments the counter once per tick; after
+    ///   `RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS` flat ticks it reaches the
+    ///   threshold and `recovery_making_progress` becomes false (escalation).
+    /// - Bounded oscillation (12→10→12→10) keeps the counter low because each
+    ///   strict shrink resets it, so progress is sustained.
+    #[tokio::test]
+    async fn test_recovery_gap_progress_counter() {
+        let (_dir, app) = make_app_for_peer_ahead_test().await;
+
+        // First tick: prior gap is the u64::MAX sentinel, so 19 is NOT a strict
+        // shrink — the counter accrues from 0 (value 1) but is still below the
+        // threshold (3), so progress is reported true while the gap then shrinks.
+        let first = app.update_recovery_gap_progress(19);
+        assert!(
+            first,
+            "first tick: counter=1 < {RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS} → still progress"
+        );
+
+        // Strictly shrinking 19→15→12 resets the counter to 0 each tick.
+        assert!(app.update_recovery_gap_progress(15));
+        assert_eq!(
+            app.recovery_consecutive_no_gap_progress
+                .load(Ordering::Relaxed),
+            0,
+            "strict shrink resets the no-progress counter"
+        );
+        assert!(app.update_recovery_gap_progress(12));
+        assert_eq!(
+            app.recovery_consecutive_no_gap_progress
+                .load(Ordering::Relaxed),
+            0
+        );
+
+        // Now the gap goes flat at 12: each tick is non-shrink, counter climbs.
+        assert!(
+            app.update_recovery_gap_progress(12),
+            "1 flat tick: counter=1 < 3 → still progress"
+        );
+        assert!(
+            app.update_recovery_gap_progress(12),
+            "2 flat ticks: counter=2 < 3 → still progress"
+        );
+        let third_flat = app.update_recovery_gap_progress(12);
+        assert_eq!(
+            app.recovery_consecutive_no_gap_progress
+                .load(Ordering::Relaxed),
+            RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS,
+            "3 flat ticks: counter reaches the escalation threshold"
+        );
+        assert!(
+            !third_flat,
+            "counter == threshold → recovery_making_progress is false (escalate)"
+        );
+
+        // A single strict shrink immediately re-enables progress (counter → 0).
+        assert!(app.update_recovery_gap_progress(11));
+        assert_eq!(
+            app.recovery_consecutive_no_gap_progress
+                .load(Ordering::Relaxed),
+            0
+        );
+
+        // Bounded oscillation 11→10→12→10: each strict shrink (10, then 10
+        // again from 12) resets the counter, the single up-tick (10→12) only
+        // bumps it to 1, so the counter never reaches the threshold and
+        // progress stays true throughout.
+        assert!(app.update_recovery_gap_progress(10)); // shrink → 0
+        assert!(app.update_recovery_gap_progress(12)); // grow  → 1 (< 3, progress)
+        assert!(app.update_recovery_gap_progress(10)); // shrink → 0
+        assert!(
+            app.recovery_consecutive_no_gap_progress
+                .load(Ordering::Relaxed)
+                < RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS,
+            "bounded oscillation keeps the counter below the threshold"
+        );
+    }
+
+    /// #3204: a Full reset clears the peer-gap-shrink tracker so the next stall
+    /// episode starts from the "no prior observation" sentinel with a zeroed
+    /// no-progress counter (`force_post_catchup_hard_reset` delegates here).
+    #[tokio::test]
+    async fn test_reset_recovery_attempts_clears_gap_progress_tracker() {
+        let (_dir, app) = make_app_for_peer_ahead_test().await;
+        // Dirty the tracker.
+        app.last_recovery_peer_gap.store(7, Ordering::Relaxed);
+        app.recovery_consecutive_no_gap_progress
+            .store(2, Ordering::Relaxed);
+
+        app.reset_recovery_attempts(RecoveryResetMode::Full);
+
+        assert_eq!(
+            app.last_recovery_peer_gap.load(Ordering::Relaxed),
+            u64::MAX,
+            "Full reset must restore the no-prior-observation sentinel"
+        );
+        assert_eq!(
+            app.recovery_consecutive_no_gap_progress
+                .load(Ordering::Relaxed),
+            0,
+            "Full reset must zero the no-progress counter"
         );
     }
 

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -782,6 +782,20 @@ pub(super) struct StuckSignals {
     /// `trigger_recovery_catchup`.
     #[allow(dead_code)]
     pub near_tip: bool,
+    /// When `true`, peer-SCP back-fill is demonstrably making progress: the
+    /// verified peer gap (`effective_peer_gap`) has strictly shrunk across the
+    /// last few Path-A ticks of this stuck episode, encoded cumulatively as
+    /// `recovery_consecutive_no_gap_progress < RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS`.
+    ///
+    /// Used by `decide_consensus_stuck_action` to SUPPRESS the count-based
+    /// `recovery_exhausted` HardReset (#3204) while #3199's peer-SCP back-fill
+    /// is shrinking the gap — restoring stellar-core's uncapped out-of-sync
+    /// recovery (`HerderImpl::outOfSyncRecovery`). It deliberately gates ONLY
+    /// the count cap; the 120s wall-clock backstop (#2789) and the tx_set
+    /// exhaustion escalation are independent and remain armed. The progress
+    /// signal is peer_gap-shrink ONLY (NOT current_ledger advance), so it never
+    /// touches `stuck_start` re-keying and cannot defeat the 120s ceiling.
+    pub recovery_making_progress: bool,
 }
 
 /// Actions to take when consensus is stuck.


### PR DESCRIPTION
Closes #3204

**CRITICAL consensus-liveness fix** — the third and (per the converged plan) decisive fix in the #1862 → #3187 → #3199 → #3204 arc. URGENT production consensus outage.

## Summary

The post-catchup archive-behind near-tip recovery hard-reset checked the count-based cap (`recovery_attempts >= MAX_POST_CATCHUP_RECOVERY_ATTEMPTS = 3`) **ahead of** the 120s wall-clock backstop and **with no regard to whether #3199's peer-SCP back-fill was making progress**. The per-stuck `recovery_attempts` counter is reset only on a hard reset or successful catchup — never on peer-SCP progress — so it hit the cap in ~40s and hard-reset (`ArchiveBehindRecoveryExhausted`) while back-fill was still shrinking the gap, discarding that progress and stalling for ~6min (observed gap growth 15 → 31 → 48).

**The change — progress-aware cap + zero-gap-progress counter:**
- New `App` tracker: `last_recovery_peer_gap: AtomicU64` (sentinel `u64::MAX` = no prior observation) + `recovery_consecutive_no_gap_progress: AtomicU32`, updated once per Path-A tick in `App::update_recovery_gap_progress(peer_gap)`. The counter **resets to 0 on any strict `effective_peer_gap` decrease** and **increments when the gap does NOT strictly shrink**. It reports `recovery_making_progress = (consecutive_no_gap_progress < RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS = 3)`.
- `decide_consensus_stuck_action`'s archive-behind arm changes ONLY from `recovery_exhausted` to `recovery_exhausted && !recovery_making_progress`. `would_hard_reset` and the #1843 cooldown fallback are unchanged.

## Anti-wedge independence (the wedge the planning refute pass caught)

The progress signal is **peer_gap-shrink ONLY** — deliberately NOT "current_ledger advanced". `current_ledger` is what re-keys `stuck_start` (`maybe_start_buffered_catchup` filters the snapshot on `current_ledger`); admitting it would reset the episode clock and defeat the 120s backstop, creating a no-escape wedge. peer_gap-shrink never touches `stuck_start`, so the two escapes stay **independent**:

1. **No-gap-progress across N (~30s):** counter reaches 3 → `HardReset(ArchiveBehindRecoveryExhausted)`. Catches the real #3204 stall (the gap GREW → never shrank → fires).
2. **120s wall-clock backstop (#2789), UNCHANGED:** `stuck_duration >= 120s` → `HardReset(ArchiveBehindStallWallClock)`. Pinned current_ledger + shrinking peer_gap → `stuck_start` stable → 120s ceiling still armed. Proven by `test_decide_archive_behind_wall_clock_backstop_fires_despite_gap_progress`.

Preserved: **#2789** (120s wall-clock), **#1862** (peer_gap >= checkpoint far-behind archive catchup, disjoint band), **#1843** (cooldown → AttemptRecovery), **#3199** (peer-SCP routing — this fix lets it keep running), **#3187** (near-tip detection).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3204#issuecomment-4636850345)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-app -- -D warnings` clean
- [x] `cargo test -p henyey-app` — 1016 lib + integration + doctests, 0 failures, incl. all #2789/#1862/#1843/#3199/#3187 preserved tests

## Regression test (kind: bug-fix)

- **Tests:** `catchup_impl::tests::test_decide_archive_behind_gap_progress_does_not_hard_reset` (core), `..._no_gap_progress_escalates`, `..._wall_clock_backstop_fires_despite_gap_progress`, `..._cooldown_falls_back_even_without_progress`, `test_decide_tx_set_exhausted_overrides_gap_progress`; `app::tests::test_recovery_gap_progress_counter`, `test_reset_recovery_attempts_clears_gap_progress_tracker`.
- **Pre-fix:** verified on main-equivalent logic (arm reverted to `recovery_exhausted`) — `test_decide_archive_behind_gap_progress_does_not_hard_reset` FAILED with `left: HardReset(ArchiveBehindRecoveryExhausted), right: AttemptRecovery`, and `..._wall_clock_backstop_fires_despite_gap_progress` FAILED (count cap fired before the 120s arm). `..._no_gap_progress_escalates` passed both pre and post (genuine stall escalates correctly).
- **Post-fix:** all PASS at `aa4a5db5c3d0b170e75635d3d045400c3e9b11ec`.

## Deviations from plan

- `do_bootstrap` is not present in this repo's `agent-worktree-contract.sh`; derived the do-role workspace inline via `require_home_data_path` under `~/data/<session>/do-3204/` as the instructions permit.
- The plan's helper math is implemented as `App::update_recovery_gap_progress` (extracted pure helper) so the counter is directly unit-testable per the plan's `test_recovery_gap_progress_counter` requirement.
- The `bug-fix` label did not exist; created it and applied `urgent` + `bug-fix`.
- Existing production-path test `test_no_previous_reset_routes_to_hard_reset` (single-tick immediate hard reset) was updated to the N-tick form: the count cap is now progress-gated, so a genuine-no-progress stall escalates after the no-progress budget lapses (~30s) rather than instantly. This is the intended behavior change, not a regression; the test now proves escape-1 still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)