### PR TITLE
Fire recovery-stalled WARN on post-restart absolute forcing_catchup_behind stall

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1210,10 +1210,29 @@ a skip. Report `recovery_stalled: skipped (<reason>)`.
 - First tick after fresh start (no prior snapshot exists)
 
 On invalidation: write new snapshot with current counter value and
-`recovery_stalled_breach_streak=0`. Report `recovery_stalled: collecting baseline`.
-Do NOT evaluate burst or streak logic on invalidation ticks — this prevents
-false-firing the burst override on the first tick after a restart where the
-counter jumps from 0 to the current absolute value.
+`recovery_stalled_breach_streak=0`. Do NOT evaluate burst or streak (delta)
+logic on invalidation ticks — this prevents false-firing the burst override on
+the first tick after a restart where the counter jumps from 0 to the current
+absolute value.
+
+**Post-restart absolute-value fire (#3198):** After writing the fresh baseline,
+evaluate the *absolute* `recovery_stalled_behind` value that the reset would
+otherwise discard. If it meets `post_restart_absolute_threshold` (= `50`, from
+`metric-alarms.toml`), fire WARN once on this invalidation tick instead of
+reporting `collecting baseline`, and route through the Bug Filing Workflow.
+This closes the blind spot from #3197/#3198: a self-recovering
+`forcing_catchup_behind` stall that completes before the 15m clean-restart sync
+deadline (so check (2) never reports SYNC FAILURE) and accrues its entire burst
+across the single tick interval that straddles the baseline-reset tick (so the
+cross-tick streak/burst machine never observes an incrementing delta). The
+#3197 episode accrued 213 ticks; a clean restart reaching real-time sync
+promptly accrues only a handful (well under 50). The fresh baseline + 7200s
+cooldown prevent re-fire on subsequent ticks. The fire uses the absolute value,
+not a cross-tick delta — it is robust *across* the reset because it triggers
+*on* the reset. Both invalidation branches (PID/`start_ticks` change AND counter
+reset) are covered, so the absolute baseline is never silently discarded.
+Otherwise (absolute value below threshold, or threshold disabled): report
+`recovery_stalled: collecting baseline` as before.
 
 **Per-tick logic (not skipped AND not invalidated):**
 ```
@@ -1257,8 +1276,9 @@ to overall tick severity — the tick is considered unhealthy when any alert fir
 - `recovery_stalled: breach (delta=N, streak M/3)` — incrementing, below threshold
 - `recovery_stalled: WARNING delta=N (M ticks) — investigating` — streak ≥ 3
 - `recovery_stalled: WARNING delta=N (burst) — investigating` — immediate fire (delta ≥ 10)
+- `recovery_stalled: WARNING absolute=N (post-restart) — investigating` — post-restart absolute fire (absolute ≥ 50 on a baseline-reset tick, #3198)
 - `recovery_stalled: skipped (<reason>)` — metric missing or fetch failed
-- `recovery_stalled: collecting baseline` — first tick after restart/invalidation
+- `recovery_stalled: collecting baseline` — first tick after restart/invalidation (absolute value below the post-restart threshold)
 
 **Rendering precedence** (determines the `metrics_ratio:` line format):
 
@@ -1284,6 +1304,7 @@ Examples:
 - Building streak: `recovery_stalled: breach (delta=2, streak 1/3)`
 - Firing (streak): `recovery_stalled: WARNING delta=1 (3 ticks) — investigating`
 - Firing (burst): `recovery_stalled: WARNING delta=15 (burst) — investigating`
+- Firing (post-restart absolute, #3198): `recovery_stalled: WARNING absolute=213 (post-restart) — investigating`
 - Skipped: `recovery_stalled: skipped (metric missing)`
 - Baseline: `recovery_stalled: collecting baseline`
 

--- a/.claude/skills/shared/metric-alarms.toml
+++ b/.claude/skills/shared/metric-alarms.toml
@@ -706,6 +706,8 @@ burst_threshold = 10
 # episode accrued 213; a clean restart reaching real-time sync promptly accrues
 # only a handful. 0/absent disables the check.
 post_restart_absolute_threshold = 50
+baseline_version = 2  # bumped in #3198: add post_restart_absolute_threshold post-restart absolute fire
+semantic_change_date = "2026-06-06T00:00:00Z"
 severity = "WARN"
 gates = ["validator-only"]
 snapshot_file = "metrics/counter_streak_snapshot"

--- a/.claude/skills/shared/metric-alarms.toml
+++ b/.claude/skills/shared/metric-alarms.toml
@@ -698,6 +698,14 @@ labels = [{ key = "reason", value = "forcing_catchup_behind" }]
 delta_threshold = 1
 streak_threshold = 3
 burst_threshold = 10
+# Post-restart absolute-value fire (#3198). On a PID/start_ticks change (restart)
+# or a counter reset the streak baseline is re-collected and the cross-tick delta
+# machine is blind to a stall that accrued during startup/warmup. If the first
+# post-reset observation already shows an absolute value >= this threshold, fire
+# WARN once on the reset tick (independent of the 15m sync deadline). The #3197
+# episode accrued 213; a clean restart reaching real-time sync promptly accrues
+# only a handful. 0/absent disables the check.
+post_restart_absolute_threshold = 50
 severity = "WARN"
 gates = ["validator-only"]
 snapshot_file = "metrics/counter_streak_snapshot"

--- a/scripts/ci/check-alarm-versions.py
+++ b/scripts/ci/check-alarm-versions.py
@@ -29,6 +29,7 @@ SEMANTIC_FIELDS = frozenset({
     "op", "threshold", "multiplier", "min_absolute",
     "gates", "for_ticks",
     "burst_threshold", "delta_threshold", "streak_threshold",
+    "post_restart_absolute_threshold",
     "denominator", "denominator_metric", "denominator_sum",
     "denominator_extraction", "denominator_includes_numerator",
     "numerator", "numerator_metric", "numerator_sum", "numerator_extraction",

--- a/scripts/lib/eval-alarms.py
+++ b/scripts/lib/eval-alarms.py
@@ -970,6 +970,40 @@ def eval_counter_ratio(
         return make_result(alarm, "ok", value=round(ratio, 4), threshold=ratio_threshold, extra_values=ev)
 
 
+def maybe_post_restart_fire(alarm: dict, cur_val: float) -> dict | None:
+    """Post-restart absolute-value check for counter-streak alarms (#3198).
+
+    On a streak baseline reset (PID/start_ticks change, or a counter reset), the
+    cross-tick delta machine cannot observe a stall that accrued during a node's
+    startup/warmup window — the burst straddles the reset tick. This evaluates
+    the absolute counter value that the reset would otherwise discard: if it
+    meets `post_restart_absolute_threshold` (a positive value enables the check;
+    0/absent disables it), return a "firing" result keyed on the ABSOLUTE value
+    with a `post_restart` marker (streak/delta semantics are meaningless on a
+    fresh incarnation). Otherwise return None so the caller falls through to
+    "collecting_baseline".
+
+    Callers MUST write the fresh baseline snapshot BEFORE invoking this, so the
+    next tick's streak machine stays consistent regardless of the fire path.
+    """
+    threshold = alarm.get("post_restart_absolute_threshold", 0)
+    if not threshold or threshold <= 0:
+        return None
+    if cur_val < threshold:
+        return None
+    abs_val = int(cur_val)
+    return make_result(
+        alarm, "firing", value=abs_val, threshold=threshold,
+        extra_values={
+            "post_restart": True,
+            "value": abs_val,
+            "threshold": threshold,
+            "streak": 0,
+            "streak_threshold": alarm.get("streak_threshold", 3),
+        },
+    )
+
+
 def eval_counter_streak(
     alarm: dict,
     current: dict,
@@ -1001,7 +1035,13 @@ def eval_counter_streak(
         if snapshot.get("version") != "1":
             snapshot = {}
         elif snapshot.get("pid") != pid or snapshot.get("start_ticks") != start_ticks:
-            # Process identity changed — invalidate
+            # Process identity changed (restart) — invalidate the streak and
+            # re-collect baseline. The cross-tick delta machine is blind to a
+            # stall that accrued during startup/warmup because the burst spans
+            # the baseline-reset tick (see #3198). Write the fresh baseline
+            # snapshot FIRST so the next tick's streak machine stays consistent,
+            # THEN evaluate the discarded absolute value: if it already crosses
+            # post_restart_absolute_threshold, fire WARN once on this reset tick.
             new_snapshot = {
                 "version": "1",
                 "pid": pid,
@@ -1010,6 +1050,9 @@ def eval_counter_streak(
                 "breach_streak": "0",
             }
             write_snapshot(snapshot_path, new_snapshot)
+            post_restart = maybe_post_restart_fire(alarm, cur_val)
+            if post_restart is not None:
+                return post_restart
             return make_result(alarm, "collecting_baseline",
                                extra_values=ev_default)
 
@@ -1029,7 +1072,12 @@ def eval_counter_streak(
     prev_counter = int(snapshot.get("counter_value", "0"))
     streak = int(snapshot.get("breach_streak", "0"))
 
-    # Counter reset
+    # Counter reset (cur_val < prev_counter): the counter regressed without a
+    # PID change (e.g. metric re-registered). cur_val here is the POST-reset
+    # absolute value, not a delta — re-collect baseline. Mirror the PID-change
+    # branch: write the fresh baseline FIRST, then evaluate the discarded
+    # absolute value for a post-restart fire (#3198). The fire here uses the
+    # absolute value, so it is not double-counting a delta.
     if cur_val < prev_counter:
         new_snapshot = {
             "version": "1",
@@ -1039,6 +1087,9 @@ def eval_counter_streak(
             "breach_streak": "0",
         }
         write_snapshot(snapshot_path, new_snapshot)
+        post_restart = maybe_post_restart_fire(alarm, cur_val)
+        if post_restart is not None:
+            return post_restart
         return make_result(alarm, "collecting_baseline",
                            extra_values=ev_default)
 

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=316
+TAP_PLAN=319
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -1479,7 +1479,7 @@ run_tests() {
 
   # Test 41: TOML catalog file exists, is parseable, and contains recovery-stalled alarm
   # Extract recovery-stalled alarm constants from metric-alarms.toml
-  local streak_val burst_val delta_val snapshot_file mode_val metric_name metric_label
+  local streak_val burst_val delta_val post_restart_val snapshot_file mode_val metric_name metric_label
   # Use Python to extract the recovery-stalled alarm entry from the TOML
   local toml_extract
   toml_extract=$(python3 - "$constants_file" <<'PYEOF'
@@ -1495,6 +1495,7 @@ for a in data['alarm']:
         print('streak_val=' + str(a['streak_threshold']))
         print('burst_val=' + str(a['burst_threshold']))
         print('delta_val=' + str(a['delta_threshold']))
+        print('post_restart_val=' + str(a.get('post_restart_absolute_threshold', 0)))
         print('snapshot_file=' + a['snapshot_file'])
         print('metric_name=' + a['metric'])
         labels = a.get('labels', [])
@@ -1513,6 +1514,14 @@ PYEOF
   if [[ -n "$toml_extract" && "$toml_extract" != "NOT_FOUND" ]]; then
     eval "$toml_extract"
     tap_ok "metric-alarms: TOML exists and parseable (streak=$streak_val burst=$burst_val delta=$delta_val)"
+    # Test 41b: post-restart absolute threshold cross-validated against TOML (#3198).
+    # Keeps the inline SKILL.md literal (50) cross-validated against the catalog.
+    if [[ "$post_restart_val" == "50" ]]; then
+      tap_ok "metric-alarms: recovery-stalled post_restart_absolute_threshold == 50"
+    else
+      tap_not_ok "metric-alarms: recovery-stalled post_restart_absolute_threshold == 50" \
+        "expected post_restart_absolute_threshold=50, got '$post_restart_val'"
+    fi
   else
     tap_not_ok "metric-alarms: TOML exists and parseable" \
       "Failed to parse recovery-stalled alarm from metric-alarms.toml"
@@ -3679,6 +3688,107 @@ except:
   fi
   rm -f "$tick_prom_148b" "$prev_prom_148b"
   rm -rf "$state_dir_148b"
+
+  # Test 148c: recovery-stalled post-restart absolute-value fire (#3198).
+  # Scenario from #3197/#3198: a deploy restart changes the process PID. The
+  # monitor's first observation of the restarted process already shows a large
+  # forcing_catchup_behind value (213) accrued during startup/warmup. The
+  # streak machine would normally reset its baseline on the PID change and
+  # return "collecting_baseline" — silently discarding the absolute value. With
+  # post_restart_absolute_threshold=50 the discarded value is evaluated and the
+  # alarm fires WARN once. A clean restart (value 5, below threshold) must NOT
+  # fire.
+  local state_dir_148c
+  state_dir_148c=$(mktemp -d)
+  # Pre-seed a snapshot from the PRE-restart incarnation (pid=1000).
+  mkdir -p "$state_dir_148c/metrics"
+  cat > "$state_dir_148c/metrics/counter_streak_snapshot" <<'SNAP_148C'
+version=1
+pid=1000
+start_ticks=1000
+counter_value=0
+breach_streak=0
+SNAP_148C
+  local tick_prom_148c
+  tick_prom_148c=$(mktemp)
+  # First post-restart observation: PID changed to 2000, big accrued stall.
+  cat > "$tick_prom_148c" <<'TICK_PROM_148C'
+henyey_recovery_stalled_tick_total{reason="forcing_catchup_behind"} 213
+TICK_PROM_148C
+  local fire_out_148c
+  fire_out_148c=$(MONITOR_MODE=validator UPTIME_SECONDS=900 WARMUP_TICKS_REMAINING=0 \
+    PID=2000 START_TICKS=2000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$tick_prom_148c" \
+    --state-dir "$state_dir_148c" 2>/dev/null) || true
+  local rs_state_148c rs_postrestart_148c
+  rs_state_148c=$(echo "$fire_out_148c" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    for r in data.get('alarms', []):
+        if r.get('name') == 'recovery-stalled':
+            print(r.get('state', 'missing'))
+            break
+    else:
+        print('not-found')
+except:
+    print('parse-error')
+" 2>/dev/null || echo "parse-error")
+  if [[ "$rs_state_148c" == "firing" ]]; then
+    tap_ok "eval-alarms: recovery-stalled post-restart absolute fire (213 >= 50 → firing, not collecting_baseline)"
+  else
+    tap_not_ok "eval-alarms: recovery-stalled post-restart absolute fire" \
+      "expected firing on PID-change with value 213, got $rs_state_148c"
+  fi
+  rm -f "$tick_prom_148c"
+  rm -rf "$state_dir_148c"
+
+  # Test 148d: recovery-stalled clean restart below threshold does NOT fire.
+  local state_dir_148d
+  state_dir_148d=$(mktemp -d)
+  mkdir -p "$state_dir_148d/metrics"
+  cat > "$state_dir_148d/metrics/counter_streak_snapshot" <<'SNAP_148D'
+version=1
+pid=1000
+start_ticks=1000
+counter_value=0
+breach_streak=0
+SNAP_148D
+  local tick_prom_148d
+  tick_prom_148d=$(mktemp)
+  cat > "$tick_prom_148d" <<'TICK_PROM_148D'
+henyey_recovery_stalled_tick_total{reason="forcing_catchup_behind"} 5
+TICK_PROM_148D
+  local clean_out_148d rs_state_148d
+  clean_out_148d=$(MONITOR_MODE=validator UPTIME_SECONDS=900 WARMUP_TICKS_REMAINING=0 \
+    PID=2000 START_TICKS=2000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$tick_prom_148d" \
+    --state-dir "$state_dir_148d" 2>/dev/null) || true
+  rs_state_148d=$(echo "$clean_out_148d" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    for r in data.get('alarms', []):
+        if r.get('name') == 'recovery-stalled':
+            print(r.get('state', 'missing'))
+            break
+    else:
+        print('not-found')
+except:
+    print('parse-error')
+" 2>/dev/null || echo "parse-error")
+  if [[ "$rs_state_148d" == "collecting_baseline" ]]; then
+    tap_ok "eval-alarms: recovery-stalled clean restart below threshold (5 < 50 → collecting_baseline, no false-fire)"
+  else
+    tap_not_ok "eval-alarms: recovery-stalled clean restart below threshold" \
+      "expected collecting_baseline on PID-change with value 5, got $rs_state_148d"
+  fi
+  rm -f "$tick_prom_148d"
+  rm -rf "$state_dir_148d"
 
   # Test 149: alarm-surfaces.toml file-local invariants + mirrored UIDs
   #           resolve to real Grafana alert UIDs in henyey-slo-alerts.yaml.


### PR DESCRIPTION
Closes #3198

## Summary

A self-recovering `forcing_catchup_behind` stall that completes before the 15m clean-restart sync deadline (so check (2) never reports SYNC FAILURE) and accrues its entire burst across the single tick interval that straddles the check-12b baseline-reset tick was invisible to both check (2) and check (12b). The #3197 episode accrued 213 stall-ticks undetected. The `recovery-stalled` counter-streak alarm reset its streak baseline and returned `collecting_baseline` on a PID/`start_ticks` change (restart) or counter reset, discarding the absolute value without evaluating it.

This adds a post-restart absolute-value path (converged plan Option A): on **both** reset branches in `eval_counter_streak`, after writing the fresh baseline snapshot, the discarded absolute value is evaluated via `maybe_post_restart_fire`; if it meets `post_restart_absolute_threshold = 50` the alarm fires WARN once (keyed on the absolute value, with a `post_restart` marker) instead of `collecting_baseline`. The fresh baseline is written **before** the early return so the streak machine stays consistent next tick; the existing 7200s cooldown prevents re-fire. Normal same-incarnation streak/burst logic is unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3198#issuecomment-4637472572)

## Changes

- `.claude/skills/shared/metric-alarms.toml` — add `post_restart_absolute_threshold = 50` to the `recovery-stalled` block (severity stays WARN, cooldown 7200s).
- `scripts/lib/eval-alarms.py` — new `maybe_post_restart_fire` helper; invoked from both the PID/`start_ticks`-changed and the counter-reset branches of `eval_counter_streak` after the fresh baseline write. Unknown TOML field is allowlist-ignored by `validate_catalog`; `maybe_reset_counter_snapshot` only acts on `skipped`, so the firing baseline is preserved.
- `.claude/skills/monitor-tick/SKILL.md` — Check 12b "Invalidation" section documents the post-restart-absolute fire path and the #3197/#3198 blind spot; adds `recovery_stalled: WARNING absolute=N (post-restart)` status-line examples.
- `scripts/test-monitor-skill-snippets.sh` — new multi-tick eval-alarms tests (148c firing@213, 148d no-fire@5) and Test 41b cross-validating `post_restart_absolute_threshold == 50`.

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — new assertions pass; the only `not ok` (pv-label-sync 144–147) are pre-existing on origin/main and unrelated.
- [x] `python3 -c 'import ast; ast.parse(...)'` on eval-alarms.py — clean.
- [x] `metric-alarms.toml` parses; `eval-alarms.py --validate-only` accepts the new field (35 alarms valid).
- [x] `bash -n` + `zsh -n` clean on the test script.
- [x] Verified normal same-PID streak path still fires via streak (delta semantics, no `post_restart` marker) and all 35 alarms still evaluate.

## Regression test (TDD)

- **Test:** `scripts/test-monitor-skill-snippets.sh` — "recovery-stalled post-restart absolute fire" (148c), "post_restart_absolute_threshold == 50" (41b)
- **Pre-fix:** committed as `5e15d7bb` — verified FAILED: tests returned `collecting_baseline` on PID change (got `0` for the threshold).
- **Post-fix:** verified PASS after `8e5a83c8`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)