### PR TITLE
Stop monitor state from dirtying repo tree and blocking deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,22 @@ crates/*/ledger/[0-9a-f][0-9a-f]/
 crates/*/results/[0-9a-f][0-9a-f]/
 crates/*/scp/[0-9a-f][0-9a-f]/
 crates/*/transactions/[0-9a-f][0-9a-f]/
+
+# Monitor/evaluator scratch state (#3201, defense in depth).
+# These leak into the tracked repo-root metrics/ dir when monitor-tick or
+# eval-alarms.py runs with a relative --state-dir from repo-root cwd, dirtying
+# the working tree and hard-blocking the deploy gate. Anchor with a leading '/'
+# so ONLY the repo-root metrics/ dir is matched — the tracked dashboards
+# (metrics/henyey-dashboard.json, ...) and any crates/*/metrics are unaffected.
+/metrics/current.prom
+/metrics/prev.prom
+/metrics/gauge_persistence
+/metrics/scrape_identity
+/metrics/counter_streak_snapshot
+/metrics/ratio_snapshot
+/metrics/counter_dynamic_snapshot
+/metrics/anomaly_cooldown.json
+/metrics/archive/
 scripts/lib/__pycache__/
 .alarm-regression-filing.lock
 .alarm-regression-filed.json

--- a/scripts/lib/eval-alarms.py
+++ b/scripts/lib/eval-alarms.py
@@ -1400,6 +1400,18 @@ def main() -> int:
     prev = parse_prom(prev_path)
 
     state_dir = Path(args.state_dir)
+    # Reject a relative --state-dir (#3201). A relative path resolves against the
+    # caller's cwd; when invoked from the repo root with e.g. `--state-dir metrics`
+    # it drops state files (gauge_persistence, scrape_identity, ...) into the
+    # tracked metrics/ dir, dirtying the working tree and hard-blocking the deploy
+    # gate. Reject (not abspath) — abspath("metrics") from the repo root still
+    # lands in the tree, so only rejection forces an absolute path under ~/data.
+    if not state_dir.is_absolute():
+        print(
+            f"ERROR: --state-dir must be an absolute path, got relative: {args.state_dir}",
+            file=sys.stderr,
+        )
+        return 1
     state_dir.mkdir(parents=True, exist_ok=True)
 
     # Persistence state for gauge for_ticks

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=319
+TAP_PLAN=321
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -3123,6 +3123,79 @@ PYEOF
     fi
   else
     tap_not_ok "eval-alarms: --validate-only" \
+      "Missing eval-alarms.py or metric-alarms.toml"
+  fi
+
+  # Test 146a (regression #3201): monitor/evaluator state files under repo-root
+  # metrics/ are ignored by .gitignore so a stray write can't dirty the tree and
+  # hard-block the deploy gate. The anchored (leading-/) block must NOT ignore
+  # the tracked dashboards in metrics/ nor any crates/*/metrics path.
+  #
+  # check-ignore must run from the repo root (the .gitignore anchors are
+  # repo-root-relative). Names enumerated here EXACTLY match the .gitignore
+  # block (deduped); archive/ is a directory entry, checked via a path under it.
+  local ci_ok=true ci_detail=""
+  local stray_names=(
+    "current.prom"
+    "prev.prom"
+    "gauge_persistence"
+    "scrape_identity"
+    "counter_streak_snapshot"
+    "ratio_snapshot"
+    "counter_dynamic_snapshot"
+    "anomaly_cooldown.json"
+    "archive/some-file"
+  )
+  local n
+  for n in "${stray_names[@]}"; do
+    if ! git -C "$REPO_ROOT" check-ignore -q "metrics/$n"; then
+      ci_ok=false
+      ci_detail+="metrics/$n NOT ignored; "
+    fi
+  done
+  # Over-broad-pattern guard: the tracked dashboard must NOT be ignored.
+  if git -C "$REPO_ROOT" check-ignore -q "metrics/henyey-dashboard.json"; then
+    ci_ok=false
+    ci_detail+="metrics/henyey-dashboard.json IS ignored (over-broad); "
+  fi
+  # The anchored block must not leak into crate-local metrics dirs.
+  if git -C "$REPO_ROOT" check-ignore -q "crates/foo/metrics/gauge_persistence"; then
+    ci_ok=false
+    ci_detail+="crates/foo/metrics/gauge_persistence IS ignored (anchor leaked); "
+  fi
+  if [[ "$ci_ok" == "true" ]]; then
+    tap_ok "gitignore: monitor state under /metrics is ignored; tracked dashboards are not"
+  else
+    tap_not_ok "gitignore: monitor state under /metrics is ignored; tracked dashboards are not" \
+      "$ci_detail"
+  fi
+
+  # Test 146b (regression #3201): eval-alarms.py rejects a RELATIVE --state-dir.
+  # A relative `--state-dir metrics` resolves against the repo-root cwd and drops
+  # state files (gauge_persistence, ...) into the tracked metrics/ dir. The guard
+  # must reject (not abspath) with a non-zero exit and write nothing. Run in a
+  # subshell cd'd into a temp dir so the test itself can never dirty the repo.
+  if [[ -f "$eval_script" && -f "$catalog_file" ]]; then
+    local rel_tmp rel_current rel_rc
+    rel_tmp=$(mktemp -d)
+    rel_current="$rel_tmp/current.prom"
+    echo "# empty" > "$rel_current"
+    rel_rc=0
+    (
+      cd "$rel_tmp" || exit 99
+      MONITOR_MODE=validator UPTIME_SECONDS=900 WARMUP_TICKS_REMAINING=0 \
+        python3 "$eval_script" --catalog "$catalog_file" \
+        --current "$rel_current" --state-dir metrics >/dev/null 2>&1
+    ) || rel_rc=$?
+    if [[ "$rel_rc" -ne 0 && ! -e "$rel_tmp/metrics/gauge_persistence" && ! -d "$rel_tmp/metrics" ]]; then
+      tap_ok "eval-alarms: relative --state-dir is rejected (non-zero exit, nothing written)"
+    else
+      tap_not_ok "eval-alarms: relative --state-dir is rejected (non-zero exit, nothing written)" \
+        "rc=$rel_rc; metrics dir exists: $([[ -d "$rel_tmp/metrics" ]] && echo yes || echo no)"
+    fi
+    rm -rf "$rel_tmp"
+  else
+    tap_not_ok "eval-alarms: relative --state-dir is rejected (non-zero exit, nothing written)" \
       "Missing eval-alarms.py or metric-alarms.toml"
   fi
 


### PR DESCRIPTION
Closes #3201

## Summary

Monitor/evaluator state files can leak into the repo's tracked `metrics/` dir (via a relative `--state-dir` slip from the repo-root cwd), dirtying the working tree and hard-blocking **all** validator deploys (the deploy gate aborts on any `git status --porcelain` output). This is a belt-and-suspenders fix:

- **`.gitignore`** — an anchored block (`/metrics/...`, leading `/`) ignoring the leaked monitor state files (`gauge_persistence`, `scrape_identity`, `current.prom`, `prev.prom`, `counter_streak_snapshot`, `ratio_snapshot`, `counter_dynamic_snapshot`, `anomaly_cooldown.json`, `archive/`). The leading `/` anchors to repo root so the tracked dashboards (`metrics/henyey-dashboard.json`, ...) and any `crates/*/metrics` are unaffected.
- **`scripts/lib/eval-alarms.py` `main()`** — reject a relative `--state-dir` (print error to stderr + `return 1`) right after `state_dir = Path(args.state_dir)`, before `mkdir`. Reject, not abspath: `abspath("metrics")` from the repo-root cwd still lands in the tree, so only rejection forces an absolute path under `~/data`.

The deploy-gate dirty-tree check is left **strict** (the converged plan declined the issue's optional allowlist — keep the gate as a fail-safe). The documented monitor-tick caller (`.claude/skills/monitor-tick/SKILL.md` L1141) already passes an absolute `--state-dir "$HOME/data/$MONITOR_SESSION_ID/metrics"`, and all in-repo `eval-alarms.py` callers use absolute paths (`$HOME/data/...` or `mktemp -d`), so the new guard only trips a mis-invocation — no live caller change needed.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3201#issuecomment-4637476903)

## Test plan

- [x] cargo fmt --check (pre-commit)
- [x] cargo clippy --all -- -D warnings (pre-commit)
- [x] `scripts/test-monitor-skill-snippets.sh` — two new regression tests pass (146a gitignore, 146b relative state-dir rejected)
- [x] `python3 -c 'import ast; ast.parse(...)'` on eval-alarms.py — OK
- [x] `python3 -m pytest scripts/ci/test_check_alarm_versions.py` — 23/23 still pass
- [x] absolute `--state-dir` run still works (exit 0, valid JSON, state written under the absolute dir); `git status --porcelain` shows no stray metrics files

## Regression test (kind: bug-fix)

- **Test:** `scripts/test-monitor-skill-snippets.sh` — "gitignore: monitor state under /metrics is ignored; tracked dashboards are not" and "eval-alarms: relative --state-dir is rejected (non-zero exit, nothing written)"
- **Pre-fix:** committed as `e0c844b2` — verified FAILED: all `metrics/<name>` NOT ignored (no .gitignore block); relative-state-dir run exits 0 and creates the metrics dir
- **Post-fix:** verified PASSES after `e51d9ae0`

Note: 4 pre-existing `pv-label-sync` failures (tests 144-147) exist on `origin/main` (43c13198) unrelated to this change — verified by running the suite on a pristine `origin/main` worktree.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)