### PR TITLE
Add --no-snapshot-write read-only mode to eval-alarms.py

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1141,6 +1141,14 @@ eval_result=$(python3 scripts/lib/eval-alarms.py \
     --state-dir "$HOME/data/$MONITOR_SESSION_ID/metrics")
 ```
 
+> **Caution (#3209):** This canonical per-tick run is invoked **exactly once** and
+> advances the streak/ratio snapshots. Any ad-hoc or repeat/diagnostic eval
+> invocation within the same tick MUST pass `--no-snapshot-write` — otherwise the
+> first run consumes the streak/ratio delta and the second run masks the alarm
+> (reports `delta=0`). Also: never pipe the evaluator through `2>&1` into a JSON
+> parser — telemetry is emitted on stderr, and merging it into stdout corrupts the
+> JSON parse. Capture stderr separately (`2>telemetry.log` or `2>/dev/null`).
+
 **Process the JSON output:**
 
 1. Parse `eval_result` as JSON.

--- a/scripts/lib/eval-alarms.py
+++ b/scripts/lib/eval-alarms.py
@@ -19,6 +19,7 @@ Outputs:
     stdout: JSON (schema_version=1) with alarms array + aggregate lines
     stderr: per-alarm telemetry (# alarm=NAME metric=METRIC series_matched=N state=STATE)
     Side effects: writes updated snapshot files in --state-dir
+                  (suppressed by --no-snapshot-write for a read-only dry-run)
 
 Exit codes:
     0 = success
@@ -40,6 +41,17 @@ except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 
 SCHEMA_VERSION = 1
+
+# When True (set by --no-snapshot-write in main()), write_snapshot() becomes a
+# no-op so the evaluator runs as a TRUE read-only dry-run: it evaluates against
+# the existing on-disk snapshots and emits identical JSON/telemetry, but
+# persists nothing. This is the single chokepoint for ALL stateful writes
+# (counter_streak_snapshot, ratio_snapshot, counter_dynamic_snapshot,
+# gauge_persistence, and the maybe_reset_counter_snapshot reset paths), so
+# gating it here suppresses every side effect at once — letting a diagnostic or
+# repeat invocation within a tick re-evaluate without consuming the delta.
+_NO_SNAPSHOT_WRITE = False
+
 VALID_KINDS = {
     "gauge", "gauge-ratio", "counter", "counter-dynamic",
     "counter-ratio", "histogram-p99", "counter-streak",
@@ -288,7 +300,16 @@ def read_snapshot(path: Path) -> dict[str, str]:
 
 
 def write_snapshot(path: Path, data: dict[str, str]) -> None:
-    """Write a key=value snapshot file atomically via rename."""
+    """Write a key=value snapshot file atomically via rename.
+
+    No-op when _NO_SNAPSHOT_WRITE is set (--no-snapshot-write): the in-memory
+    snapshot/persistence dicts the callers built are still updated locally —
+    harmless for this single-shot process since nothing reads them after exit —
+    but nothing is persisted, so the on-disk delta is not consumed. A future
+    in-process loop that re-reads state would need to revisit this.
+    """
+    if _NO_SNAPSHOT_WRITE:
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = [f"{k}={v}" for k, v in data.items()]
     tmp = path.with_suffix(".tmp")
@@ -1356,7 +1377,17 @@ def main() -> int:
     parser.add_argument("--prev", default=None, help="Path to prev.prom")
     parser.add_argument("--state-dir", default=None, help="Directory for snapshot files")
     parser.add_argument("--validate-only", action="store_true", help="Only validate schema, don't evaluate")
+    parser.add_argument(
+        "--no-snapshot-write",
+        action="store_true",
+        help="Evaluate without persisting any snapshot/state files (read-only "
+             "dry-run for diagnostic/repeat invocations within a tick)",
+    )
     args = parser.parse_args()
+
+    # Gate the single write_snapshot() chokepoint for the whole process.
+    global _NO_SNAPSHOT_WRITE
+    _NO_SNAPSHOT_WRITE = args.no_snapshot_write
 
     # Validate-only mode only needs --catalog
     if not args.validate_only:

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=321
+TAP_PLAN=325
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -3862,6 +3862,120 @@ except:
   fi
   rm -f "$tick_prom_148d"
   rm -rf "$state_dir_148d"
+
+  # Test 148e: --no-snapshot-write read-only dry-run (#3209).
+  # Regression for the double-run masking bug: the evaluator mutates its streak
+  # snapshot on EVERY run, so a second run within a tick compares the
+  # just-written snapshot against itself (delta consumed) and masks the
+  # recovery-stalled WARN that the first run fired (the #3206 alarm). The fix
+  # adds --no-snapshot-write so a diagnostic/repeat invocation re-evaluates
+  # against the existing on-disk snapshot without consuming the delta.
+  #
+  # Fixture mirrors 148c: pre-seed a PRE-restart snapshot (pid=1000), then feed
+  # a first post-restart observation (PID 2000, accrued stall 213) that fires
+  # recovery-stalled via the post_restart_absolute_threshold=50 path.
+  rs_state_of() {
+    # $1 = evaluator stdout JSON; prints the recovery-stalled alarm state.
+    echo "$1" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    for r in data.get('alarms', []):
+        if r.get('name') == 'recovery-stalled':
+            print(r.get('state', 'missing'))
+            break
+    else:
+        print('not-found')
+except:
+    print('parse-error')
+" 2>/dev/null || echo "parse-error"
+  }
+  seed_148e_snapshot() {
+    # $1 = state-dir; (re)write the PRE-restart snapshot fixture.
+    mkdir -p "$1/metrics"
+    cat > "$1/metrics/counter_streak_snapshot" <<'SNAP_148E'
+version=1
+pid=1000
+start_ticks=1000
+counter_value=0
+breach_streak=0
+SNAP_148E
+  }
+  local state_dir_148e tick_prom_148e
+  state_dir_148e=$(mktemp -d)
+  tick_prom_148e=$(mktemp)
+  cat > "$tick_prom_148e" <<'TICK_PROM_148E'
+henyey_recovery_stalled_tick_total{reason="forcing_catchup_behind"} 213
+TICK_PROM_148E
+
+  # Run 1 (no flag): the canonical per-tick run — fires AND advances the
+  # snapshot (consumes the delta).
+  seed_148e_snapshot "$state_dir_148e"
+  local out1_148e rs1_148e
+  out1_148e=$(MONITOR_MODE=validator UPTIME_SECONDS=900 WARMUP_TICKS_REMAINING=0 \
+    PID=2000 START_TICKS=2000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$tick_prom_148e" \
+    --state-dir "$state_dir_148e" 2>/dev/null) || true
+  rs1_148e=$(rs_state_of "$out1_148e")
+  if [[ "$rs1_148e" == "firing" ]]; then
+    tap_ok "eval-alarms: --no-snapshot-write run 1 (no flag) fires recovery-stalled (213 → firing)"
+  else
+    tap_not_ok "eval-alarms: --no-snapshot-write run 1 (no flag) fires recovery-stalled" \
+      "expected firing, got $rs1_148e"
+  fi
+
+  # Run 2 (no flag, SAME inputs, NO re-seed): documents the masking bug. The
+  # snapshot was advanced by run 1, so the delta is consumed and the alarm is
+  # masked (state != firing).
+  local out2_148e rs2_148e
+  out2_148e=$(MONITOR_MODE=validator UPTIME_SECONDS=900 WARMUP_TICKS_REMAINING=0 \
+    PID=2000 START_TICKS=2000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$tick_prom_148e" \
+    --state-dir "$state_dir_148e" 2>/dev/null) || true
+  rs2_148e=$(rs_state_of "$out2_148e")
+  if [[ "$rs2_148e" != "firing" ]]; then
+    tap_ok "eval-alarms: --no-snapshot-write run 2 (no flag) masks recovery-stalled (delta consumed → $rs2_148e)"
+  else
+    tap_not_ok "eval-alarms: --no-snapshot-write run 2 (no flag) masks recovery-stalled" \
+      "expected masked (delta consumed by run 1), got firing"
+  fi
+
+  # Run 3 (--no-snapshot-write) against a FRESH re-seed of the PRE-restart
+  # snapshot: the alarm must STILL fire AND the snapshot file must be left
+  # BYTE-unchanged (delta not consumed). These two are the decisive fix
+  # assertions. Fails on origin/main: --no-snapshot-write is an unknown arg,
+  # so parse_args() exits non-zero, out3 is empty, and rs3 != firing.
+  seed_148e_snapshot "$state_dir_148e"
+  local snap_before_148e
+  snap_before_148e=$(cat "$state_dir_148e/metrics/counter_streak_snapshot")
+  local out3_148e rs3_148e snap_after_148e
+  out3_148e=$(MONITOR_MODE=validator UPTIME_SECONDS=900 WARMUP_TICKS_REMAINING=0 \
+    PID=2000 START_TICKS=2000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$tick_prom_148e" \
+    --state-dir "$state_dir_148e" \
+    --no-snapshot-write 2>/dev/null) || true
+  rs3_148e=$(rs_state_of "$out3_148e")
+  if [[ "$rs3_148e" == "firing" ]]; then
+    tap_ok "eval-alarms: --no-snapshot-write run 3 (with flag) still fires recovery-stalled (213 → firing)"
+  else
+    tap_not_ok "eval-alarms: --no-snapshot-write run 3 (with flag) still fires recovery-stalled" \
+      "expected firing with --no-snapshot-write, got $rs3_148e (unknown flag on origin/main?)"
+  fi
+  snap_after_148e=$(cat "$state_dir_148e/metrics/counter_streak_snapshot")
+  if [[ "$snap_before_148e" == "$snap_after_148e" ]]; then
+    tap_ok "eval-alarms: --no-snapshot-write leaves counter_streak_snapshot byte-unchanged"
+  else
+    tap_not_ok "eval-alarms: --no-snapshot-write leaves counter_streak_snapshot byte-unchanged" \
+      "snapshot mutated despite --no-snapshot-write"
+  fi
+  rm -f "$tick_prom_148e"
+  rm -rf "$state_dir_148e"
 
   # Test 149: alarm-surfaces.toml file-local invariants + mirrored UIDs
   #           resolve to real Grafana alert UIDs in henyey-slo-alerts.yaml.


### PR DESCRIPTION
Closes #3209

## Summary

`scripts/lib/eval-alarms.py` persisted its streak/ratio snapshots as an unconditional side effect of every run, so a second invocation within a tick compared the just-written snapshot against itself (`delta=0`) and masked the streak/ratio alarms — including the #3206 `recovery-stalled` WARN. This adds a `--no-snapshot-write` argparse flag (`action="store_true"`, default False) that gates the single `write_snapshot()` chokepoint — the only filesystem write in the module — behind a module-level `_NO_SNAPSHOT_WRITE` flag. When set, the evaluator runs as a true read-only dry-run: identical JSON/telemetry output, no state persisted, so a diagnostic or repeat invocation re-evaluates against the existing on-disk snapshot without consuming the delta. Default-False keeps the canonical per-tick run byte-identical.

The SKILL.md change documents that the canonical eval runs exactly once (advancing state), that ad-hoc/repeat runs MUST pass `--no-snapshot-write`, and that the evaluator must never be piped through `2>&1` into a JSON parser (telemetry goes to stderr; merging corrupts the parse).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3209#issuecomment-4637764955)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — new Test 148e (4 assertions) passes; only the known-pre-existing pv-label-sync tests 144–147 fail on clean main (unrelated).
- [x] `python3 -c 'import ast; ast.parse(...)'` on eval-alarms.py
- [x] `python3 -m pytest scripts/ci/test_check_alarm_versions.py` — 23/23
- [x] `bash -n` + `zsh -n` on the harness
- [x] Normal (no-flag) run still writes snapshots and emits identical JSON (verified vs origin/main with `PYTHONHASHSEED=0`; the only run-to-run text delta is pre-existing set-ordering of the skipped-metrics list, non-deterministic on origin/main too).
- [x] cargo clippy (via pre-commit hook) passed

## Regression test

- **Test:** `scripts/test-monitor-skill-snippets.sh` Test 148e (`--no-snapshot-write` double-run, mirrors 148c `recovery-stalled` fixture)
- **Pre-fix:** committed as `e1f8063e` — verified FAILED: run 3 (with flag) reports `parse-error` (unknown argparse arg → `parse_args()` exits non-zero, empty output)
- **Post-fix:** verified PASSES after `324e23cf` — run 1 fires, run 2 (no flag) masks (delta consumed), run 3 (`--no-snapshot-write`) still fires AND leaves `counter_streak_snapshot` byte-unchanged (exact content compare, not mtime)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)