### PR TITLE
De-flake custom_bucket_directory_survives_genesis_publish_and_restore

### DIFF
--- a/crates/app/src/app/publish.rs
+++ b/crates/app/src/app/publish.rs
@@ -686,6 +686,34 @@ mod tests {
         }
     }
 
+    /// Re-open an `App` against a just-dropped `App`'s db directory, tolerating the
+    /// sub-millisecond fd-close-vs-reopen window on the fs2 advisory db lockfile.
+    ///
+    /// `App::new` (→ `acquire_db_lock`) is intentionally single-shot in production so
+    /// real cross-process lock contention fails fast. This helper is TEST-ONLY: the
+    /// drop-then-reopen-same-db-dir-in-process pattern is unique to these tests, and
+    /// under CI scheduling pressure the first `App::new` can race the dropped app's
+    /// lockfile fd close (`mod.rs:1579` "database is locked"). We retry only on that
+    /// specific lock error with a short backoff and a bounded deadline; any OTHER
+    /// error is surfaced immediately so we never mask a real failure, and a lock that
+    /// genuinely never releases still panics with the original lockfile error rather
+    /// than hanging. Mirrors the bounded-poll idiom of `wait_for_publish_*` above.
+    async fn reopen_app_after_drop(config: crate::config::AppConfig) -> App {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match App::new(config.clone()).await {
+                Ok(app) => return app,
+                Err(e) if e.to_string().contains("database is locked") => {
+                    if tokio::time::Instant::now() >= deadline {
+                        panic!("App::new never re-acquired the db lock within deadline: {e}");
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(e) => panic!("App::new failed with non-lock error: {e}"),
+            }
+        }
+    }
+
     #[test]
     fn app_runtime_does_not_reconstruct_bucket_manager_from_config() {
         let app_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/app");
@@ -980,7 +1008,7 @@ mod tests {
         } = fixture;
         drop(app);
 
-        let second_app = App::new(config).await.unwrap();
+        let second_app = reopen_app_after_drop(config).await;
         assert_eq!(
             second_app.load_last_known_ledger().await.unwrap(),
             RestoreResult::Restored


### PR DESCRIPTION
Closes #3211

## Summary

De-flakes the test `custom_bucket_directory_survives_genesis_publish_and_restore`, which intermittently panicked with `database is locked (lockfile: .../henyey.lock)` on `origin/main` CI under scheduling pressure.

The test is the only place that drops an `App` and re-opens `App::new` against the **same** db directory **inside one process**. Production never does this (a node restart is a fresh process; the OS reclaims the prior fds/flock on exit, and the consensus hard-reset keeps the held `_db_lock` rather than dropping+reopening). Under CI load, the first `App::new` can race the just-dropped app's fs2 advisory lockfile fd close (the sole producer of the `"database is locked"` string is `acquire_db_lock`).

The fix adds a **test-only** helper `reopen_app_after_drop` that retries `App::new` only while the error contains `"database is locked"`, with a 10ms backoff and a bounded ~2s deadline, surfacing any other error immediately. It mirrors the existing `wait_for_publish_*` bounded-poll idiom in the same file.

**Production `App::new` / `acquire_db_lock` are UNCHANGED — they remain single-shot fail-fast, preserving real cross-process lock-contention detection.** The retry lives strictly in the test module. The test's original assertions (`RestoreResult::Restored`, custom `bucket_dir`, derived-dir bucket count == 0) are unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3211#issuecomment-4638292059)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (CI-equivalent; clean — verified via pre-commit hook)
- [x] cargo test -p henyey-app custom_bucket_directory_survives_genesis_publish_and_restore — passes 10/10 runs (deterministic)
- [x] cargo test -p henyey-app — full suite green (1016 + integration tests passed)

## Regression test (kind: test-only)

The de-flaked test **is** the deliverable. Per the converged plan, a deterministic pre-fix repro is not possible — the failure is a sub-millisecond, load-dependent fd-close-vs-reopen window, and forcing it would require artificially holding the lockfile fd, which production code does not expose. The regression is captured by the **structural** removal of the zero-tolerance single-shot reopen (replaced by a bounded poll that absorbs the window).

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)