### PR TITLE
De-double counter-streak snapshot path and reconcile check-12b doc schema

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1190,9 +1190,8 @@ Format:
 version=1
 pid=<PID>
 start_ticks=<field 22 from /proc/$PID/stat>
-timestamp=<ISO8601>
-recovery_stalled_behind=<value>
-recovery_stalled_breach_streak=<N>
+counter_value=<value>
+breach_streak=<N>
 ```
 
 **PID/start_ticks check (always, even on skip):** Before evaluating skip
@@ -1206,25 +1205,25 @@ counters to a pre-restart baseline.
 - `/metrics` returns "recorder not installed"
 - `forcing_catchup_behind` label missing from the scrape
 
-On skip: write snapshot preserving existing `recovery_stalled_behind` value (or
-0 if no prior snapshot) with `recovery_stalled_breach_streak=0`. Next healthy
+On skip: write snapshot preserving existing `counter_value` value (or
+0 if no prior snapshot) with `breach_streak=0`. Next healthy
 tick compares against preserved value — does NOT enter "collecting baseline" after
 a skip. Report `recovery_stalled: skipped (<reason>)`.
 
 **Invalidation (reset streak AND enter "collecting baseline"):**
 - PID or `start_ticks` changed (process restart) — checked before skip conditions
 - Snapshot malformed, missing fields, or `version` ≠ `1`
-- Current `recovery_stalled_behind` value < previous (counter reset)
+- Current `counter_value` value < previous (counter reset)
 - First tick after fresh start (no prior snapshot exists)
 
 On invalidation: write new snapshot with current counter value and
-`recovery_stalled_breach_streak=0`. Do NOT evaluate burst or streak (delta)
+`breach_streak=0`. Do NOT evaluate burst or streak (delta)
 logic on invalidation ticks — this prevents false-firing the burst override on
 the first tick after a restart where the counter jumps from 0 to the current
 absolute value.
 
 **Post-restart absolute-value fire (#3198):** After writing the fresh baseline,
-evaluate the *absolute* `recovery_stalled_behind` value that the reset would
+evaluate the *absolute* `counter_value` value that the reset would
 otherwise discard. If it meets `post_restart_absolute_threshold` (= `50`, from
 `metric-alarms.toml`), fire WARN once on this invalidation tick instead of
 reporting `collecting baseline`, and route through the Bug Filing Workflow.
@@ -1244,19 +1243,19 @@ Otherwise (absolute value below threshold, or threshold disabled): report
 
 **Per-tick logic (not skipped AND not invalidated):**
 ```
-delta = current(recovery_stalled_behind) - prev(recovery_stalled_behind)
+delta = current(counter_value) - prev(counter_value)
 
 if delta >= 10:
     # Immediate-fire override: large burst indicates sustained stalling.
     # Do NOT reset streak — keep incrementing; cooldown (7200s) handles dedup.
-    recovery_stalled_breach_streak += 1
+    breach_streak += 1
     → fire WARN, route through Bug Filing Workflow
 elif delta >= 1:
-    recovery_stalled_breach_streak += 1
-    if recovery_stalled_breach_streak >= 3:
+    breach_streak += 1
+    if breach_streak >= 3:
         → fire WARN, route through Bug Filing Workflow
 else:  # delta == 0
-    recovery_stalled_breach_streak = 0
+    breach_streak = 0
 ```
 
 Note: after skipped ticks where the counter value was preserved, the first

--- a/.claude/skills/shared/metric-alarms.toml
+++ b/.claude/skills/shared/metric-alarms.toml
@@ -706,11 +706,11 @@ burst_threshold = 10
 # episode accrued 213; a clean restart reaching real-time sync promptly accrues
 # only a handful. 0/absent disables the check.
 post_restart_absolute_threshold = 50
-baseline_version = 2  # bumped in #3198: add post_restart_absolute_threshold post-restart absolute fire
-semantic_change_date = "2026-06-06T00:00:00Z"
+baseline_version = 3  # bumped in #3222: de-double snapshot_file (metrics/ prefix removed → bare filename)
+semantic_change_date = "2026-06-07T00:00:00Z"
 severity = "WARN"
 gates = ["validator-only"]
-snapshot_file = "metrics/counter_streak_snapshot"
+snapshot_file = "counter_streak_snapshot"
 cooldown_key = "henyey_recovery_stalled_tick_total{reason=\"forcing_catchup_behind\"}"
 cooldown_seconds = 7200
 filing_title = "metrics: henyey_recovery_stalled_tick_total{reason=\"forcing_catchup_behind\"} — sustained breach"

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -3804,9 +3804,10 @@ except:
   # fire.
   local state_dir_148c
   state_dir_148c=$(mktemp -d)
-  # Pre-seed a snapshot from the PRE-restart incarnation (pid=1000).
-  mkdir -p "$state_dir_148c/metrics"
-  cat > "$state_dir_148c/metrics/counter_streak_snapshot" <<'SNAP_148C'
+  # Pre-seed a snapshot from the PRE-restart incarnation (pid=1000). The catalog
+  # snapshot_file is the BARE name (#3222), so the evaluator resolves it directly
+  # under --state-dir (no 'metrics/' subdir).
+  cat > "$state_dir_148c/counter_streak_snapshot" <<'SNAP_148C'
 version=1
 pid=1000
 start_ticks=1000
@@ -3852,8 +3853,7 @@ except:
   # Test 148d: recovery-stalled clean restart below threshold does NOT fire.
   local state_dir_148d
   state_dir_148d=$(mktemp -d)
-  mkdir -p "$state_dir_148d/metrics"
-  cat > "$state_dir_148d/metrics/counter_streak_snapshot" <<'SNAP_148D'
+  cat > "$state_dir_148d/counter_streak_snapshot" <<'SNAP_148D'
 version=1
 pid=1000
 start_ticks=1000
@@ -3922,9 +3922,10 @@ except:
 " 2>/dev/null || echo "parse-error"
   }
   seed_148e_snapshot() {
-    # $1 = state-dir; (re)write the PRE-restart snapshot fixture.
-    mkdir -p "$1/metrics"
-    cat > "$1/metrics/counter_streak_snapshot" <<'SNAP_148E'
+    # $1 = state-dir; (re)write the PRE-restart snapshot fixture. The catalog
+    # snapshot_file is the BARE name (#3222), so the evaluator resolves it
+    # directly under --state-dir (no 'metrics/' subdir).
+    cat > "$1/counter_streak_snapshot" <<'SNAP_148E'
 version=1
 pid=1000
 start_ticks=1000
@@ -3982,7 +3983,7 @@ TICK_PROM_148E
   # so parse_args() exits non-zero, out3 is empty, and rs3 != firing.
   seed_148e_snapshot "$state_dir_148e"
   local snap_before_148e
-  snap_before_148e=$(cat "$state_dir_148e/metrics/counter_streak_snapshot")
+  snap_before_148e=$(cat "$state_dir_148e/counter_streak_snapshot")
   local out3_148e rs3_148e snap_after_148e
   out3_148e=$(MONITOR_MODE=validator UPTIME_SECONDS=900 WARMUP_TICKS_REMAINING=0 \
     PID=2000 START_TICKS=2000 \
@@ -3998,7 +3999,7 @@ TICK_PROM_148E
     tap_not_ok "eval-alarms: --no-snapshot-write run 3 (with flag) still fires recovery-stalled" \
       "expected firing with --no-snapshot-write, got $rs3_148e (unknown flag on origin/main?)"
   fi
-  snap_after_148e=$(cat "$state_dir_148e/metrics/counter_streak_snapshot")
+  snap_after_148e=$(cat "$state_dir_148e/counter_streak_snapshot")
   if [[ "$snap_before_148e" == "$snap_after_148e" ]]; then
     tap_ok "eval-alarms: --no-snapshot-write leaves counter_streak_snapshot byte-unchanged"
   else

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=325
+TAP_PLAN=327
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -1646,6 +1646,37 @@ PYEOF
   else
     tap_not_ok "check-12b-semantics: metric label from TOML in both specs" \
       "Expected '$metric_label' in both Check 12b section and monitor-loop table"
+  fi
+
+  # Test 53b: recovery-stalled snapshot_file is a BARE filename (no '/'), matching
+  # sibling snapshots (ratio_snapshot / counter_dynamic_snapshot). The evaluator
+  # resolves snapshot_path = Path(state_dir) / snapshot_file and the SKILL invokes
+  # it with --state-dir .../metrics, so any 'metrics/' prefix here doubles the path
+  # (.../metrics/metrics/counter_streak_snapshot). See #3222. A directory prefix is
+  # invalid; the bare name resolves single-level under --state-dir. Substring greps
+  # (Tests 44/48) do NOT catch the doubling because the bare name is a substring of
+  # the doubled path — hence this dedicated structural assertion.
+  if [[ "$snapshot_file" != */* && "$snapshot_file" == "counter_streak_snapshot" ]]; then
+    tap_ok "metric-alarms: recovery-stalled snapshot_file is bare filename ($snapshot_file)"
+  else
+    tap_not_ok "metric-alarms: recovery-stalled snapshot_file is bare filename" \
+      "snapshot_file must be the bare name 'counter_streak_snapshot' (no '/' prefix), got '$snapshot_file' — a directory prefix doubles the resolved path under --state-dir .../metrics (#3222)"
+  fi
+
+  # Test 53c: check-12b Format block documents the evaluator's ACTUAL snapshot
+  # schema. eval-alarms.py writes version/pid/start_ticks/counter_value/breach_streak
+  # (no timestamp). The check-12b prose must use counter_value / breach_streak and
+  # must NOT contain the drifted field names recovery_stalled_behind /
+  # recovery_stalled_breach_streak / timestamp. See #3222.
+  if echo "$check_12b_section" | grep -Fq 'counter_value' \
+     && echo "$check_12b_section" | grep -Fq 'breach_streak' \
+     && ! echo "$check_12b_section" | grep -Fq 'recovery_stalled_behind' \
+     && ! echo "$check_12b_section" | grep -Fq 'recovery_stalled_breach_streak' \
+     && ! echo "$check_12b_section" | grep -Fq 'timestamp'; then
+    tap_ok "check-12b-semantics: doc snapshot schema matches evaluator (counter_value/breach_streak)"
+  else
+    tap_not_ok "check-12b-semantics: doc snapshot schema matches evaluator (counter_value/breach_streak)" \
+      "Check 12b prose must use 'counter_value'/'breach_streak' and must NOT contain 'recovery_stalled_behind', 'recovery_stalled_breach_streak', or 'timestamp' (drifted from eval-alarms.py schema, #3222)"
   fi
 
   # ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #3222

## Summary

The `recovery-stalled` counter-streak alarm's `snapshot_file` in `metric-alarms.toml` carried a spurious `metrics/` prefix. The evaluator resolves `Path(state_dir) / snapshot_file` and the monitor-tick SKILL invokes it with `--state-dir .../metrics`, so the prefix produced a doubled path (`.../metrics/metrics/counter_streak_snapshot`). This PR drops the prefix to the bare `counter_streak_snapshot` (matching siblings `ratio_snapshot` / `counter_dynamic_snapshot`) and reconciles the drifted check-12b documentation to the evaluator's actual snapshot schema.

**Fix 1 — path-doubling:** `metric-alarms.toml` `snapshot_file = "metrics/counter_streak_snapshot"` → `"counter_streak_snapshot"`. No evaluator change (the default arg was already bare; only the catalog override carried the prefix). `baseline_version` bumped 2 → 3 because `snapshot_file` is a semantic field per `check-alarm-versions.py`; `semantic_change_date` updated.

**Fix 2 — doc reconciliation:** the check-12b Format block + prose used drifted field names. Reconciled to what `eval-alarms.py` actually writes: `recovery_stalled_behind` → `counter_value`, `recovery_stalled_breach_streak` → `breach_streak`, and removed `timestamp` (the evaluator never writes or reads it). The state-machine logic prose is untouched. The state-files table and the Snapshot-file absolute path already documented the correct single-level path, so they were left as-is.

### One-time effect on a running monitor (expected, harmless)

On the next tick after this lands, the active baseline path moves from the doubled location to the un-doubled one. The first read hits an empty/orphan path → one `collecting_baseline` tick → normal streak evaluation resumes the following tick. No alarm is lost — a single collecting tick is the normal post-restart behavior. The stale doubled-path file is operator housekeeping, not part of this change.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3222#issuecomment-4644237092)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — new tests pass; only the 4 pre-existing `pv-label-sync` failures remain (identical on clean `origin/main`, unrelated to #3222)
- [x] `python3 -m pytest scripts/ci/test_check_alarm_versions.py` — 23 passed
- [x] `python3 -m pytest scripts/lib/test_eval_alarms_counter_reset.py` — 15 passed (incl. `test_counter_streak_custom_snapshot_file`, unchanged)
- [x] `python3 scripts/ci/check-alarm-versions.py` old vs new — 0 errors, 0 warnings after the `baseline_version` bump
- [x] `python3 -c 'import tomllib; ...'` (tomli fallback) — catalog parses
- [x] `bash -n` + `zsh -n` on the harness — clean

## Regression test (kind: bug-fix)

- **Tests:** `scripts/test-monitor-skill-snippets.sh` — (1) recovery-stalled `snapshot_file` is a bare filename (no `/`); (2) check-12b Format block matches the evaluator schema (`counter_value`/`breach_streak`, no `recovery_stalled_behind`/`recovery_stalled_breach_streak`/`timestamp`).
- **Pre-fix:** committed as `e05ee88e90c0b193c698df8f531075ac4942b94a` — verified FAILED (`not ok 81`, `not ok 82`).
- **Post-fix:** verified PASS after `6ddd5ffaa6c9f7f05b78864a85c8e735874b3707` (`ok 81`, `ok 82`).
- Note: existing Tests 44/48 use substring-grep that does NOT catch the doubling (the bare name is a substring of the doubled path) — hence the dedicated structural assertions. TAP_PLAN bumped 325 → 327.

## Deviations from plan

- Updated the `148c`/`148d`/`148e` eval-alarms harness fixtures to seed the snapshot at the un-doubled path. These tests exercise the **real** catalog, so they hardcoded the doubled path and would have broken on Fix 1; reseeding at the bare path keeps them green and consistent with the fix. (The pytest `test_counter_streak_custom_snapshot_file`, which uses a synthetic prefixed path, was correctly left untouched.)
- Bumped `baseline_version` 2 → 3 + `semantic_change_date` per the version-check validator's guidance (same as #3206 did for the previous semantic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)