### PR TITLE
Skip archive-done job cleanly when PROJECT_BOARD_TOKEN is absent

### DIFF
--- a/.github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh
+++ b/.github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh
@@ -13,6 +13,15 @@
 #        Runs with SKIP_PREFLIGHT=1 and --dry-run, mocking the gh binary so
 #        no network call is made. Asserts exit 0 and no ERROR: in output.
 #        Covers the happy path with the probe bypassed.
+#   3. test_preflight_still_fails_loudly_when_token_present_but_unscoped
+#        Pins the don't-mask-real-failures contract for issue #3224: when a
+#        token IS present but lacks org-project scope (the GraphQL probe
+#        returns "Could not resolve to a ProjectV2"), the script must still
+#        exit non-zero with the structured "ERROR: GH_TOKEN lacks org project
+#        scope" message. The #3224 fix makes the *workflow* skip the archive
+#        step only when the secret is ABSENT; a present-but-unscoped/revoked
+#        token must NOT be silently turned into a skip — the script must keep
+#        failing loudly so a real misconfiguration is surfaced, not masked.
 #
 # Usage:
 #   bash .github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh
@@ -127,10 +136,64 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Test 3: token present but unscoped → still fails loudly (don't mask real
+# failures). Regression for issue #3224.
+# ---------------------------------------------------------------------------
+test_preflight_still_fails_loudly_when_token_present_but_unscoped() {
+  local name="test_preflight_still_fails_loudly_when_token_present_but_unscoped"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  # Mock `gh` to simulate a present-but-unscoped/revoked token: the org
+  # ProjectV2 probe fails with the opaque "Could not resolve to a ProjectV2"
+  # GraphQL error. This is the path the #3224 workflow gate does NOT skip
+  # (the secret IS present, so the YAML `if:` lets the step run); the script
+  # must therefore keep failing loudly with a structured exit 1.
+  cat >"$tmpdir/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock gh: simulate the present-but-unscoped-token GraphQL failure.
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+  echo "gh: Could not resolve to a ProjectV2 with the number 2." >&2
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$tmpdir/gh"
+
+  # A NON-EMPTY GH_TOKEN models "token present" — the exact condition the
+  # workflow gate treats as "do not skip". The probe is NOT bypassed
+  # (SKIP_PREFLIGHT unset), so the real pre-flight runs.
+  local output
+  local exit_code
+  output=$(PATH="$tmpdir:$PATH" GH_TOKEN="ghp_present_but_unscoped" \
+           bash "$TARGET_SCRIPT" --dry-run 2>&1)
+  exit_code=$?
+
+  if [ "$exit_code" -eq 0 ]; then
+    echo "FAIL: $name — expected non-zero exit (real failure must not be masked), got 0"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return
+  fi
+
+  if ! grep -q "ERROR: GH_TOKEN lacks org project scope" <<<"$output"; then
+    echo "FAIL: $name — output missing structured 'ERROR: GH_TOKEN lacks org project scope'"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return
+  fi
+
+  echo "PASS: $name"
+  PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests.
 # ---------------------------------------------------------------------------
 test_preflight_fails_with_bad_token
 test_preflight_succeeds_with_dry_run
+test_preflight_still_fails_loudly_when_token_present_but_unscoped
 
 echo
 echo "Results: ${PASSED} passed, ${FAILED} failed"

--- a/.github/workflows/archive-done.yml
+++ b/.github/workflows/archive-done.yml
@@ -43,19 +43,35 @@ jobs:
       # org-level ProjectV2 scope required by archive-stale-done.sh. That
       # requires a fine-grained PAT with Projects:Read+Write on
       # stellar-experimental, set as the PROJECT_BOARD_TOKEN secret.
+      # `secrets.*` cannot be used in step/job `if:` expressions, so this guard
+      # maps PROJECT_BOARD_TOKEN's presence into a step OUTPUT (`present`), which
+      # IS usable in a later `if:`. When the secret is absent we emit a `::notice::`
+      # (not `::warning::`) with the operator action — a clean skip should look
+      # clean in the run log, not alarming.
       - name: Check PROJECT_BOARD_TOKEN secret
+        id: check_token
         env:
           HAS_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN != '' }}
         run: |
+          echo "present=$HAS_TOKEN" >> "$GITHUB_OUTPUT"
           if [ "$HAS_TOKEN" != "true" ]; then
-            echo "::warning::PROJECT_BOARD_TOKEN secret is not configured; falling back to GITHUB_TOKEN, which lacks org-level ProjectV2 scope. The next step will fail with a diagnostic message. See issue #2777."
+            echo "::notice::PROJECT_BOARD_TOKEN secret is not configured; skipping the archive step (the job will conclude success). To enable archiving, create a fine-grained PAT with Projects:Read+Write on stellar-experimental and store it as the PROJECT_BOARD_TOKEN org secret. See issue #3224."
           else
-            echo "PROJECT_BOARD_TOKEN is configured."
+            echo "PROJECT_BOARD_TOKEN is configured; the archive step will run."
           fi
 
+      # Gated on the secret-presence OUTPUT only — NOT on the script's success.
+      # A step skipped via `if:` does NOT fail the job, so when the secret is
+      # absent the run concludes `success` (this is what ends the deploy-gate
+      # CI-signal pollution). When the secret IS present the step runs against
+      # PROJECT_BOARD_TOKEN directly; the doomed `|| secrets.GITHUB_TOKEN`
+      # fallback is dropped because GITHUB_TOKEN structurally lacks org-project
+      # scope. A present-but-unscoped/revoked token still runs here and fails
+      # loudly via the script's pre-flight exit 1 (don't mask real failures).
       - name: Run archive-stale-done.sh
+        if: steps.check_token.outputs.present == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN }}
         run: |
           DAYS="${{ inputs.days || '2' }}"
           DRY_RUN="${{ inputs.dry_run && '--dry-run' || '' }}"


### PR DESCRIPTION
Closes #3224

## Summary

The scheduled **Archive Done Project Items** workflow has hard-failed on `main` every day, all with `ERROR: GH_TOKEN lacks org project scope`. The job ran `archive-stale-done.sh` with `${{ secrets.PROJECT_BOARD_TOKEN || secrets.GITHUB_TOKEN }}`; when the secret is absent it fell back to `GITHUB_TOKEN`, which structurally lacks org-level ProjectV2 scope, so the pre-flight probe aborted with `exit 1`. These daily failures polluted the deploy gate's `gh run list --branch main --limit 3` CI-green scan, deferring binary-impact deploys as `ci-red`.

This PR makes the job conclude **success** (archive step skipped) when the secret is absent, ending the pollution. It does **not** archive anything by itself — see the operator action below for what actually enables archiving.

## (a) Autonomous fix in this PR — skip clean when the secret is absent

`.github/workflows/archive-done.yml`:
- The guard step `Check PROJECT_BOARD_TOKEN secret` gets `id: check_token` and emits a step output: `echo "present=$HAS_TOKEN" >> "$GITHUB_OUTPUT"` (`HAS_TOKEN` is `${{ secrets.PROJECT_BOARD_TOKEN != '' }}`, so `present` is `true`/`false`). `secrets.*` can't be referenced in an `if:`, but **step outputs can**.
- The archive step is gated with `if: steps.check_token.outputs.present == 'true'`. A step skipped via `if:` does **not** fail the job, so when the secret is absent the run concludes `success` — not failure, not error. This is what ends the deploy-gate pollution.
- The archive step's `GH_TOKEN` switches to `${{ secrets.PROJECT_BOARD_TOKEN }}`, **dropping** the `|| secrets.GITHUB_TOKEN` fallback (the fallback could never carry org-project scope).
- The skip path now emits `::notice::` (not `::warning::`) so a clean skip looks clean in the run log.

`.github/skills/shared/scripts/archive-stale-done.sh`: **unchanged.** The skip is decided in YAML, where secret-presence is knowable. The script keeps its pre-flight `exit 1` on real errors.

**Result matrix:**
- **Secret absent** → guard green, `::notice::`, `present=false`, archive step **skipped**, job concludes **success**.
- **Secret present + properly scoped** → `present=true`, archive runs for real (no further workflow edit needed).
- **Secret present but unscoped/revoked** → `present=true`, step runs, script pre-flight fails loudly with `exit 1` + structured error (a real misconfig is surfaced, not masked).

### Don't-mask-real-failures safeguard

The skip is keyed **only** on `secrets.PROJECT_BOARD_TOKEN == ''` (absence) via the step output, never on the script's success. `continue-on-error` is deliberately NOT used. A new regression test pins this contract:

- **Test:** `.github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh::test_preflight_still_fails_loudly_when_token_present_but_unscoped` — a non-empty `GH_TOKEN` whose ProjectV2 probe returns `Could not resolve to a ProjectV2` must still `exit 1` with `ERROR: GH_TOKEN lacks org project scope`.
- Verified to **FAIL** against a simulated masking regression (script turned to `exit 0` on the unscoped path) and **PASS** against the current (unchanged) script. The existing tests (`test_preflight_fails_with_bad_token`, `test_preflight_succeeds_with_dry_run`) are preserved and still pass.

## (b) Operator action that ENABLES archiving (NOT done in this PR)

This PR only stops the CI pollution. To actually run archiving, the operator must:

1. Create/rotate a **fine-grained PAT** with **Projects: Read and write** on the `stellar-experimental` org.
2. Store it as the **`PROJECT_BOARD_TOKEN`** org secret (Settings → Secrets and variables → Actions → org secret available to this repo).

Once the secret lands, `present=true` and the job archives for real with **no further workflow edit**. This is the same PAT-scope class as the known org **Discussions: Write** gap that makes `/daily-summary` posts fail FORBIDDEN — the operator may want to provision both on one fine-grained PAT.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3224#issuecomment-4647093817)

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/archive-done.yml"))'` → YAML OK
- [x] `actionlint .github/workflows/archive-done.yml` → clean (actionlint v1.7.7)
- [x] `bash -n` + `zsh -n` on `archive-stale-done.sh` → OK
- [x] `bash .github/skills/shared/scripts/tests/test-archive-stale-done-auth.sh` → 3 passed, 0 failed (incl. new loud-failure test)
- [x] cargo fmt + clippy clean (pre-commit hook)

## Regression test

- **Test:** `test-archive-stale-done-auth.sh::test_preflight_still_fails_loudly_when_token_present_but_unscoped`
- **Guard verification:** FAILS on a masking regression (script `exit 0` on unscoped path), PASSES on current script behavior. The workflow skip-conclusion is verified by YAML validity + actionlint + GHA `if:`-skip semantics (a skipped step does not fail its job).

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)