### PR TITLE
Instrument startup/catchup peak RSS

### DIFF
--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -507,6 +507,12 @@ metric_catalog! {
             => "Current SCP ballot phase of the tracking slot (0=unknown, 1=prepare, 2=confirm, 3=externalize)";
         SCP_MEMORY_CUMULATIVE_STATEMENTS = "stellar_scp_memory_cumulative_statements"
             => "Total SCP statements currently held in memory (decreases after slot purging)";
+
+        // Startup/catchup peak RSS (issue #3226). Set once when the startup
+        // sampler stops, before the event loop's first ledger close. Covers the
+        // restore + catchup window that the `% 64` ledger-close report misses.
+        STARTUP_PEAK_ANON_RSS_MB = "henyey_startup_peak_anon_rss_mb"
+            => "Peak anonymous RSS (MB) observed during startup restore + catchup";
     }
 
     gauges_no_prereg {
@@ -2030,6 +2036,35 @@ mod tests {
         assert!(
             output.contains("stellar_protocol_version"),
             "stellar_protocol_version not found in rendered metrics"
+        );
+    }
+
+    /// Issue #3226: the startup peak-anon-RSS gauge is in the gauge catalog and
+    /// pre-registered at 0 (so dashboards render it before the sampler stops).
+    /// Mirrors the #3168 eviction-catalog test pattern.
+    #[test]
+    fn test_startup_peak_gauge_in_catalog() {
+        let gauge_names: HashSet<&str> = ALL_GAUGE_NAMES.iter().copied().collect();
+        assert!(
+            gauge_names.contains("henyey_startup_peak_anon_rss_mb"),
+            "henyey_startup_peak_anon_rss_mb missing from gauge catalog"
+        );
+        let prereg: HashSet<&str> = ALL_PREREGISTERED_GAUGE_NAMES.iter().copied().collect();
+        assert!(
+            prereg.contains("henyey_startup_peak_anon_rss_mb"),
+            "henyey_startup_peak_anon_rss_mb must be pre-registered at 0"
+        );
+    }
+
+    #[test]
+    fn test_startup_peak_gauge_preregistered_at_zero() {
+        let handle = ensure_test_recorder();
+        describe_metrics();
+        register_label_series();
+        let output = handle.render();
+        assert!(
+            output.contains("henyey_startup_peak_anon_rss_mb"),
+            "henyey_startup_peak_anon_rss_mb not found in rendered metrics"
         );
     }
 

--- a/crates/app/src/run_cmd.rs
+++ b/crates/app/src/run_cmd.rs
@@ -47,6 +47,7 @@ use crate::compat_http::CompatServer;
 use crate::config::AppConfig;
 use crate::http::{QueryServer, StatusServer};
 use henyey_history::CatchupRunMode;
+use henyey_ledger::peak_rss_sampler::{Phase as StartupPhase, StartupPeakRssSampler};
 
 /// Node running mode determining behavior and consensus participation.
 ///
@@ -370,6 +371,17 @@ fn print_startup_info(app: &App, options: &RunOptions) {
 
 /// Run the main application loop.
 async fn run_main_loop(app: Arc<App>, options: RunOptions) -> anyhow::Result<()> {
+    // Observability (#3226): sample peak anonymous RSS across the startup
+    // restore + catchup window — the region the `% 64` ledger-close memory
+    // report misses (that report only fires once replay is underway, after the
+    // restore peak has already been released). The sampler runs a single
+    // background std::thread (tokio-independent) that polls RssAnon ~1/s and
+    // tracks a running max; it shares no mutable state with the close/consensus
+    // path and has zero effect on hashes/timing. `mut` so we can tag the phase
+    // and stop it before the event loop is spawned (below), where the peak is
+    // published to the `henyey_startup_peak_anon_rss_mb` gauge.
+    let mut startup_rss_sampler = StartupPeakRssSampler::start();
+
     // Check for force-scp flag (standalone single-node bootstrap).
     // When set, skip all catchup and restore the node directly from DB state.
     let force_scp = app.check_force_scp().await;
@@ -419,6 +431,9 @@ async fn run_main_loop(app: Arc<App>, options: RunOptions) -> anyhow::Result<()>
             tracing::info!("Watcher mode: skipping catchup");
         } else {
             tracing::info!("Node is behind, starting catchup");
+
+            // Tag subsequent peak samples as the catchup phase (#3226).
+            startup_rss_sampler.set_phase(StartupPhase::Catchup);
 
             // Start overlay network BEFORE catchup to receive tx_sets during catchup.
             // This helps bridge the gap between catchup checkpoint and live consensus.
@@ -477,6 +492,17 @@ async fn run_main_loop(app: Arc<App>, options: RunOptions) -> anyhow::Result<()>
             app.refresh_max_tx_size_bytes().await;
         }
     }
+
+    // Stop the startup peak-RSS sampler (#3226) BEFORE the event loop is
+    // spawned, so the reported peak covers exactly the restore + catchup window
+    // and never overlaps with the `% 64` ledger-close report. stop() joins the
+    // sampler thread (no leak), emits the greppable
+    // `startup_peak_anon_rss_mb=<N> phase=<peak-phase>` one-liner, and returns
+    // the peak in bytes; publish it as a gauge. On non-Linux / read error this
+    // is 0 (no panic), inheriting ProcessMemory::capture()'s contract.
+    let startup_peak_bytes = startup_rss_sampler.stop();
+    let startup_peak_mb = startup_peak_bytes as f64 / (1024.0 * 1024.0);
+    crate::metrics::STARTUP_PEAK_ANON_RSS_MB.set(startup_peak_mb);
 
     // Start the sync recovery manager for consensus stuck detection
     app.start_sync_recovery();

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -82,6 +82,7 @@ pub mod offer;
 pub mod offer_store;
 pub mod p23_hot_archive_bug;
 mod p23_hot_archive_bug_data;
+pub mod peak_rss_sampler;
 mod prepare_liabilities;
 mod snapshot;
 mod soroban_state;
@@ -111,6 +112,7 @@ pub use manager::{
     LedgerManagerConfig,
 };
 pub use memory_report::log_startup_memory;
+pub use peak_rss_sampler::{Phase as StartupPhase, StartupPeakRssSampler};
 pub use snapshot::{
     EntriesLookupFn, EntryLookupFn, LedgerSnapshot, PoolShareTrustlinesByAccountFn,
     SnapshotBuilder, SnapshotHandle,

--- a/crates/ledger/src/peak_rss_sampler.rs
+++ b/crates/ledger/src/peak_rss_sampler.rs
@@ -1,0 +1,431 @@
+//! Startup/catchup peak anonymous-RSS sampler.
+//!
+//! The periodic memory report ([`crate::memory_report::MemoryReport`]) only
+//! emits from the ledger-close path, gated on `ledger_seq % 64 == 0`
+//! (`crates/ledger/src/manager.rs`). That hook runs *after* the node is
+//! already replaying ledgers — by which point the startup/catchup restore peak
+//! (HAS download + parallel bucket apply + cache scan) has already been
+//! released. As a result the binding memory peak during startup is invisible:
+//! a memory-constrained host learns it exceeded the RAM ceiling only by getting
+//! OOM-killed.
+//!
+//! [`StartupPeakRssSampler`] closes that gap. It runs a single background
+//! `std::thread` (tokio-independent, like the heartbeat pattern) that polls the
+//! process's anonymous RSS roughly once per second, tracking an atomic running
+//! maximum and the phase that was current when each new maximum was recorded.
+//! When [`StartupPeakRssSampler::stop`] is called (once, after catchup returns
+//! and before the event loop is spawned) it joins the thread, emits a greppable
+//! `startup_peak_anon_rss_mb=<N> phase=<peak-phase>` one-liner, and returns the
+//! peak in bytes so the caller can publish it as a Prometheus gauge.
+//!
+//! # Observability-only contract
+//!
+//! The sampler reads `/proc/self/status` (via the existing
+//! [`crate::memory_report::ProcessMemory::capture`] parser) and atomics ONLY.
+//! It shares no mutable state with the ledger-close / consensus path, performs
+//! no allocation on the hot path, and has zero effect on hashes, timing, or any
+//! observable protocol behavior. Off-Linux (or on a `/proc` read error) the
+//! value-source degrades to 0 — the sampler records peak 0 and never panics,
+//! inheriting `ProcessMemory::capture()`'s degrade-to-zero contract.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use tracing::info;
+
+use crate::memory_report::ProcessMemory;
+
+/// Default poll interval for the background sampler thread.
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Startup phase attributed to a sampled peak.
+///
+/// The coarse `Startup`/`Catchup` split is the must-have signal (settable from
+/// the `run_main_loop` orchestrator alone). The finer `BucketApply`/`CacheScan`
+/// tags are nice-to-have refinements set at the existing `log_startup_memory`
+/// checkpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Phase {
+    /// Generic startup / state-restore window (before catchup is entered).
+    Startup = 0,
+    /// Parallel bucket-list restore (`restore_from_has_parallel`).
+    BucketApply = 1,
+    /// In-memory cache scan + pending merges (`scan_level_pairs_for_caches`).
+    CacheScan = 2,
+    /// History catchup (HAS download + apply).
+    Catchup = 3,
+}
+
+impl Phase {
+    fn from_u8(v: u8) -> Phase {
+        match v {
+            1 => Phase::BucketApply,
+            2 => Phase::CacheScan,
+            3 => Phase::Catchup,
+            _ => Phase::Startup,
+        }
+    }
+
+    /// Stable, greppable string tag for the phase (used in the summary line).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Phase::Startup => "startup",
+            Phase::BucketApply => "bucket-apply",
+            Phase::CacheScan => "cache-scan",
+            Phase::Catchup => "catchup",
+        }
+    }
+}
+
+/// Shared, lock-free state between the sampler thread and the controlling
+/// threads. Only the sampler thread writes `peak_bytes` / `peak_phase`;
+/// `current_phase` is written by [`StartupPeakRssSampler::set_phase`] from
+/// arbitrary threads and read by the sampler thread.
+#[derive(Debug)]
+struct SamplerState {
+    /// Running maximum anonymous RSS in bytes.
+    peak_bytes: AtomicU64,
+    /// Phase index that was current when `peak_bytes` was last raised.
+    peak_phase: AtomicU8,
+    /// Phase index currently in effect (written by `set_phase`).
+    current_phase: AtomicU8,
+    /// Shutdown flag — the thread breaks its loop once this is set.
+    stopping: AtomicBool,
+}
+
+impl SamplerState {
+    fn new() -> Self {
+        SamplerState {
+            peak_bytes: AtomicU64::new(0),
+            peak_phase: AtomicU8::new(Phase::Startup as u8),
+            current_phase: AtomicU8::new(Phase::Startup as u8),
+            stopping: AtomicBool::new(false),
+        }
+    }
+}
+
+/// A background peak-anon-RSS sampler scoped to the startup/catchup window.
+///
+/// Construct + start with [`StartupPeakRssSampler::start`] (default `/proc`
+/// value-source) or [`StartupPeakRssSampler::start_with_source`] (injected
+/// value-source, for tests). Tag phases with [`StartupPeakRssSampler::set_phase`].
+/// Finish with [`StartupPeakRssSampler::stop`], which joins the thread, logs the
+/// one-liner, and returns the peak in bytes. `stop` is idempotent; a `Drop`
+/// fallback guarantees the thread is joined even if `stop` is never called, so
+/// the sampler can never outlive the startup window.
+pub struct StartupPeakRssSampler {
+    state: Arc<SamplerState>,
+    handle: Option<JoinHandle<()>>,
+    /// Whether the summary one-liner has already been emitted (idempotency).
+    stopped: bool,
+}
+
+impl StartupPeakRssSampler {
+    /// Build a sampler WITHOUT spawning a background thread. Tests drive
+    /// [`StartupPeakRssSampler::sample_once`] directly, so the peak/phase logic
+    /// is exercised deterministically with no sleeps and no thread races.
+    #[cfg(test)]
+    fn for_test() -> Self {
+        StartupPeakRssSampler {
+            state: Arc::new(SamplerState::new()),
+            handle: None,
+            stopped: false,
+        }
+    }
+
+    /// Start a sampler backed by the real `/proc/self/status` parser
+    /// ([`ProcessMemory::capture`]). Off-Linux this reports 0 with no panic.
+    pub fn start() -> Self {
+        Self::start_with_source(|| ProcessMemory::capture().anon_rss_bytes)
+    }
+
+    /// Start a sampler over an injectable value-source returning the current
+    /// anonymous RSS in bytes. The background thread calls
+    /// [`StartupPeakRssSampler::sample_once`] once per [`POLL_INTERVAL`].
+    ///
+    /// The injected source makes the peak/phase logic deterministically
+    /// unit-testable without reading `/proc`.
+    pub fn start_with_source<F>(value_source: F) -> Self
+    where
+        F: Fn() -> u64 + Send + 'static,
+    {
+        let state = Arc::new(SamplerState::new());
+        let thread_state = Arc::clone(&state);
+        let handle = std::thread::Builder::new()
+            .name("startup-rss-sampler".to_string())
+            .spawn(move || {
+                // Take an immediate sample so a short startup window still
+                // records a non-zero peak before the first sleep elapses.
+                loop {
+                    sample_once_impl(&thread_state, &value_source);
+                    if thread_state.stopping.load(Ordering::Acquire) {
+                        break;
+                    }
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+            })
+            .expect("failed to spawn startup-rss-sampler thread");
+
+        StartupPeakRssSampler {
+            state,
+            handle: Some(handle),
+            stopped: false,
+        }
+    }
+
+    /// Set the phase attributed to subsequent peak samples. Callable from any
+    /// thread (lock-free single atomic store).
+    pub fn set_phase(&self, phase: Phase) {
+        self.state
+            .current_phase
+            .store(phase as u8, Ordering::Release);
+    }
+
+    /// The phase currently in effect (for tests / introspection).
+    pub fn current_phase(&self) -> Phase {
+        Phase::from_u8(self.state.current_phase.load(Ordering::Acquire))
+    }
+
+    /// Take a single poll step against the given value-source: read the current
+    /// RSS, update the running max, and — only if the max was just raised —
+    /// record the current phase as the peak-phase. Exposed for deterministic,
+    /// non-racy unit tests; the background thread calls the same logic in a
+    /// sleep loop.
+    pub fn sample_once<F: Fn() -> u64>(&self, value_source: &F) {
+        sample_once_impl(&self.state, value_source);
+    }
+
+    /// Current recorded peak in bytes.
+    pub fn peak_bytes(&self) -> u64 {
+        self.state.peak_bytes.load(Ordering::Acquire)
+    }
+
+    /// Phase recorded at the time the peak was reached.
+    pub fn peak_phase(&self) -> Phase {
+        Phase::from_u8(self.state.peak_phase.load(Ordering::Acquire))
+    }
+
+    /// Stop the sampler: signal shutdown, join the background thread, emit the
+    /// greppable summary one-liner, and return the peak in bytes.
+    ///
+    /// Idempotent — a second call (or the `Drop` fallback) is a no-op that does
+    /// not re-emit the log line or re-join.
+    pub fn stop(&mut self) -> u64 {
+        let peak = self.peak_bytes();
+        if self.stopped {
+            return peak;
+        }
+        self.stopped = true;
+
+        self.state.stopping.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            // join failure (thread panic) must not abort startup — the sampler
+            // is observability-only.
+            let _ = handle.join();
+        }
+
+        let peak = self.peak_bytes();
+        let phase = self.peak_phase();
+        // Emit as an integer field so it renders unquoted (`...=777`) for clean
+        // grepping, mirroring the numeric memory-report fields.
+        let peak_mb = (peak as f64 / (1024.0 * 1024.0)).round() as u64;
+        info!(
+            startup_peak_anon_rss_mb = peak_mb,
+            phase = phase.as_str(),
+            "Startup peak RSS summary"
+        );
+        peak
+    }
+}
+
+impl Drop for StartupPeakRssSampler {
+    fn drop(&mut self) {
+        // Fallback: if stop() was never called, ensure the thread is joined so
+        // it can never outlive the sampler. We do NOT emit the summary line
+        // here — that is reserved for an explicit stop().
+        self.state.stopping.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// The single poll step, shared by the background thread and `sample_once`.
+///
+/// Reads the current RSS via the value-source, raises the running max, and —
+/// only when the max was just raised — records the current phase as the
+/// peak-phase. The current-phase atomic is read AFTER the max is confirmed to
+/// have increased and only by the writer of the peak, so the recorded
+/// peak/peak-phase pair is always self-consistent.
+fn sample_once_impl<F: Fn() -> u64>(state: &SamplerState, value_source: &F) {
+    let sample = value_source();
+    let prev = state.peak_bytes.fetch_max(sample, Ordering::AcqRel);
+    if sample > prev {
+        let phase = state.current_phase.load(Ordering::Acquire);
+        state.peak_phase.store(phase, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
+
+    /// A value-source driven by a fixed, in-order list of samples. Each call
+    /// returns the next value (clamping at the last). Lets tests drive
+    /// `sample_once` deterministically without a real `/proc` read or a racy
+    /// free-running thread.
+    fn scripted_source(samples: Vec<u64>) -> impl Fn() -> u64 {
+        let idx = AtomicUsize::new(0);
+        let samples = Arc::new(samples);
+        move || {
+            let i = idx.fetch_add(1, Ordering::SeqCst);
+            let s = &samples;
+            *s.get(i).or_else(|| s.last()).unwrap_or(&0)
+        }
+    }
+
+    fn mb(v: u64) -> u64 {
+        v * 1024 * 1024
+    }
+
+    /// A sampler with no background thread, for deterministic `sample_once`
+    /// driving.
+    fn idle_sampler() -> StartupPeakRssSampler {
+        StartupPeakRssSampler::for_test()
+    }
+
+    #[test]
+    fn test_peak_tracks_max_of_injected_samples() {
+        let mut s = idle_sampler();
+        let src = scripted_source(vec![mb(100), mb(500), mb(300), mb(450)]);
+        for _ in 0..4 {
+            s.sample_once(&src);
+        }
+        assert_eq!(s.peak_bytes(), mb(500), "peak must be the max sample");
+        let _ = s.stop();
+    }
+
+    #[test]
+    fn test_peak_records_phase_at_peak() {
+        let mut s = idle_sampler();
+        // bucket-apply @ 500 (the peak), then cache-scan @ 300 (below peak).
+        s.set_phase(Phase::BucketApply);
+        let src_hi = scripted_source(vec![mb(500)]);
+        s.sample_once(&src_hi);
+        s.set_phase(Phase::CacheScan);
+        let src_lo = scripted_source(vec![mb(300)]);
+        s.sample_once(&src_lo);
+        assert_eq!(s.peak_bytes(), mb(500));
+        assert_eq!(
+            s.peak_phase(),
+            Phase::BucketApply,
+            "peak-phase must reflect the phase current when the max was set"
+        );
+        let _ = s.stop();
+    }
+
+    #[test]
+    fn test_phase_transition_updates_current_phase() {
+        let mut s = idle_sampler();
+        assert_eq!(s.current_phase(), Phase::Startup);
+        s.set_phase(Phase::BucketApply);
+        assert_eq!(s.current_phase(), Phase::BucketApply);
+        s.set_phase(Phase::CacheScan);
+        assert_eq!(s.current_phase(), Phase::CacheScan);
+        s.set_phase(Phase::Catchup);
+        assert_eq!(s.current_phase(), Phase::Catchup);
+        let _ = s.stop();
+    }
+
+    #[test]
+    fn test_peak_zero_when_source_zero() {
+        // Non-Linux / error path: value-source returns 0 throughout.
+        let mut s = idle_sampler();
+        let src = scripted_source(vec![0, 0, 0]);
+        for _ in 0..3 {
+            s.sample_once(&src);
+        }
+        assert_eq!(s.peak_bytes(), 0);
+        // stop() must not panic and must report peak 0.
+        assert_eq!(s.stop(), 0);
+    }
+
+    #[test]
+    fn test_stop_idempotent() {
+        let mut s = idle_sampler();
+        let src = scripted_source(vec![mb(123)]);
+        s.sample_once(&src);
+        let first = s.stop();
+        let second = s.stop();
+        assert_eq!(first, mb(123));
+        assert_eq!(second, mb(123), "second stop() returns the same peak");
+        // Drop after stop() must not panic / double-join (covered by going out
+        // of scope at end of test).
+    }
+
+    #[test]
+    fn test_background_thread_joins_cleanly() {
+        // Smoke test of the real threaded path with a non-zero source: stop()
+        // must join without leaking the thread.
+        let mut s = StartupPeakRssSampler::start_with_source(|| mb(42));
+        // Give the thread a chance to take at least one sample.
+        std::thread::sleep(Duration::from_millis(50));
+        let peak = s.stop();
+        assert!(peak >= mb(42), "thread should have sampled the source");
+    }
+
+    /// Verify `stop()` emits the greppable `startup_peak_anon_rss_mb=` /
+    /// `phase=` summary line, in both structured and Text-rendered form
+    /// (mirrors the `memory_report` field tests).
+    #[test]
+    fn test_summary_line_format() {
+        use std::io;
+        use tracing::subscriber::with_default;
+        use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
+
+        #[derive(Clone)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        impl io::Write for BufWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let buf_clone = buf.clone();
+        let fmt_layer = fmt::layer()
+            .with_writer(move || -> Box<dyn io::Write> { Box::new(BufWriter(buf_clone.clone())) })
+            .with_ansi(false)
+            .with_target(true);
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new("info"))
+            .with(fmt_layer);
+
+        with_default(subscriber, || {
+            let mut s = idle_sampler();
+            s.set_phase(Phase::BucketApply);
+            let src = scripted_source(vec![mb(777)]);
+            s.sample_once(&src);
+            let _ = s.stop();
+        });
+
+        let output = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            output.contains("startup_peak_anon_rss_mb=777"),
+            "summary line must render startup_peak_anon_rss_mb=<N>. Got: {output}"
+        );
+        assert!(
+            output.contains("phase=\"bucket-apply\"") || output.contains("phase=bucket-apply"),
+            "summary line must render the peak phase. Got: {output}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3226

## Summary

Adds a background peak-anonymous-RSS sampler that covers the startup-restore + catchup window — the region the `% 64` ledger-close memory report misses (that report only fires once replay is underway, after the restore peak has already been released). On stop it emits a greppable `startup_peak_anon_rss_mb=<N> phase=<peak-phase>` one-liner and publishes a new pre-registered `henyey_startup_peak_anon_rss_mb` Prometheus gauge. This makes the catchup peak — the binding risk on a 32 GB/no-swap box — directly observable, supporting verification of the #2901/#3216 catchup-OOM fix.

## Design

- **Sampler** (`crates/ledger/src/peak_rss_sampler.rs`, new): `StartupPeakRssSampler` runs a single tokio-independent `std::thread` that polls `RssAnon` ~1/s via the existing `ProcessMemory::capture()` parser, tracking an `AtomicU64` running max and the `AtomicU8` phase current at the peak. Abstracted over an injectable value-source (`start_with_source` / `sample_once`) so the peak/phase logic is unit-testable deterministically without reading `/proc`. `stop()` is idempotent, joins the thread, logs the one-liner, and returns the peak in bytes; `Drop` is a join fallback so the thread can never outlive the startup window.
- **Bracket** (`crates/app/src/run_cmd.rs` `run_main_loop`): started at the top (before `load_last_known_ledger`), phase tagged `catchup` at catchup entry, stopped before the event loop is spawned (before `start_sync_recovery` / `app.run()`), then the peak is published to the gauge. Strictly before the first event-loop ledger close — no overlap with the `% 64` report.
- **Metric** (`crates/app/src/metrics.rs`): `STARTUP_PEAK_ANON_RSS_MB = "henyey_startup_peak_anon_rss_mb"` added to the `gauges {}` block (auto-included in `ALL_GAUGE_NAMES`, pre-registered at 0).

## Observability-only / no-leak

The sampler reads `/proc` + atomics ONLY; it shares no mutable state with the close/consensus path and has zero effect on hashes, timing, or any observable protocol behavior. The thread is cleanly joined on `stop()` (with a `Drop` fallback). Off-Linux degrades to peak 0 / gauge 0 / no panic, inheriting `ProcessMemory::capture()`'s contract.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3226#issuecomment-4649806316)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (pre-commit hook) clean on changed code
- [x] `cargo test -p henyey-ledger -p henyey-app` passes incl. new tests

New coverage (all passing):
- `peak_rss_sampler::tests::test_peak_tracks_max_of_injected_samples`
- `test_peak_records_phase_at_peak`
- `test_phase_transition_updates_current_phase`
- `test_peak_zero_when_source_zero`
- `test_summary_line_format`
- `test_stop_idempotent`
- `test_background_thread_joins_cleanly`
- `metrics::tests::test_startup_peak_gauge_in_catalog`
- `metrics::tests::test_startup_peak_gauge_preregistered_at_zero`

## Deviations from plan

- **Fine phase tags (`bucket-apply`/`cache-scan`) in `ledger_close.rs` were not wired** — these were explicitly nice-to-have per Critic C, "only if the wiring stays cheap." The `log_startup_memory` checkpoints (ledger_close.rs:905/1003) live inside App methods on the restore path with no sampler in scope; threading the handle through would require signature churn across the bucket-restore path, which Critic C said to avoid. The must-have (peak value + coarse `startup`/`catchup` phase, set from `run_main_loop`) is delivered. A process-global phase channel could add the fine tags later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)