### PR TITLE
Lock numeric-upgrade positivity parity with core

### DIFF
--- a/crates/herder/SPEC_ADHERENCE.md
+++ b/crates/herder/SPEC_ADHERENCE.md
@@ -663,6 +663,16 @@ excluded. SHOULD claims and operational defaults excluded.
     paths implement the per-type rules (Version monotonic + ≤
     `LEDGER_PROTOCOL_VERSION`; BaseFee/BaseReserve ≠ 0; Flags mask + V18;
     Config V20+ + ledger-resolves-and-valid; MaxSorobanTxSetSize V20+).
+  - **§15.4-5 (numeric upgrade positivity) — WAD/core-consistent:** matches
+    core, no positivity check per `stellar-core/src/herder/Upgrades.cpp:591-631`.
+    Only `BaseFee != 0` and `BaseReserve != 0` are enforced; `MaxTxSetSize`
+    accepts any size (incl. zero) and `MaxSorobanTxSetSize` accepts any size
+    (incl. zero) once protocol ≥ `SOROBAN_PROTOCOL_VERSION`. The earlier
+    spec-adherence finding (#3050) flagged an over-broad "MUST be a positive
+    integer" claim in `HERDER_SPEC.md` that was since corrected to match core;
+    henyey already matched core in both validation paths, so no validation-code
+    change was required. Parity is locked by
+    `test_numeric_upgrade_zero_accepted_matches_core` (`scp_driver.rs`).
   - **Status:** Full.
 
 - **§16.5 (MUST)** `removeUpgrades` + per-step expiration clear (default 15

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -6462,6 +6462,61 @@ mod tests {
         );
     }
 
+    /// Parity-lock for #3050 (HERDER §15.4-5: numeric upgrade positivity), via
+    /// the ledger-state-aware `ScpDriver::is_valid_upgrade_for_apply` path.
+    ///
+    /// stellar-core `Upgrades::isValidForApply`
+    /// (`stellar-core/src/herder/Upgrades.cpp:591-631`) applies NO positivity
+    /// check: only `BaseFee != 0` / `BaseReserve != 0` are enforced; `MaxTxSetSize`
+    /// and `MaxSorobanTxSetSize` accept any size (incl. zero), with the Soroban
+    /// variant additionally gated on protocol ≥ 20. henyey already matches core.
+    /// This test passes today and would fail only if a spurious positivity check
+    /// were added (as the old spec wrongly demanded). Companion to
+    /// `upgrades::test_numeric_upgrade_zero_accepted_matches_core`, which locks
+    /// the no-ledger-state path.
+    #[test]
+    fn test_numeric_upgrade_zero_accepted_matches_core() {
+        let lm = make_default_lm();
+
+        // MaxTxSetSize: any size, incl. zero (core "any size is allowed").
+        assert!(
+            ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::MaxTxSetSize(0), 25, &lm),
+            "MaxTxSetSize(0) must be VALID per core — no positivity check"
+        );
+        assert!(
+            ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::MaxTxSetSize(1), 25, &lm),
+            "MaxTxSetSize(1) must be VALID"
+        );
+
+        // MaxSorobanTxSetSize: any size at protocol >= 20; gated below 20.
+        assert!(
+            ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::MaxSorobanTxSetSize(0), 20, &lm),
+            "MaxSorobanTxSetSize(0) must be VALID at protocol >= 20 per core"
+        );
+        assert!(
+            !ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::MaxSorobanTxSetSize(0), 19, &lm),
+            "MaxSorobanTxSetSize(0) must be INVALID below protocol 20 (protocol gate)"
+        );
+
+        // BaseFee / BaseReserve: the ONLY non-zero checks.
+        assert!(
+            !ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::BaseFee(0), 25, &lm),
+            "BaseFee(0) must be INVALID"
+        );
+        assert!(
+            !ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::BaseReserve(0), 25, &lm),
+            "BaseReserve(0) must be INVALID"
+        );
+        assert!(
+            ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::BaseFee(1), 25, &lm),
+            "BaseFee(1) must be VALID"
+        );
+        assert!(
+            ScpDriver::is_valid_upgrade_for_apply(&LedgerUpgrade::BaseReserve(1), 25, &lm),
+            "BaseReserve(1) must be VALID"
+        );
+    }
+
     /// Regression test for AUDIT-220 / issue #2157: validate_value_against_local_state
     /// must not allow a value to reach Valid without full tx-set content validation.
     ///

--- a/crates/herder/src/upgrades.rs
+++ b/crates/herder/src/upgrades.rs
@@ -966,6 +966,84 @@ mod tests {
         assert_eq!(validity, UpgradeValidity::Invalid);
     }
 
+    /// Parity-lock for #3050 (HERDER §15.4-5: numeric upgrade positivity).
+    ///
+    /// stellar-core `Upgrades::isValidForApply`
+    /// (`stellar-core/src/herder/Upgrades.cpp:591-631`) applies NO positivity
+    /// check to the numeric upgrades: only `BaseFee != 0` and `BaseReserve != 0`
+    /// are enforced; `MaxTxSetSize` accepts any size (incl. zero) and
+    /// `MaxSorobanTxSetSize` accepts any size (incl. zero) once protocol ≥
+    /// `SOROBAN_PROTOCOL_VERSION` (20). henyey already matches core in both
+    /// validation paths. This test passes today and locks that parity — a future
+    /// spurious "must be a positive integer" check (as the old spec wrongly
+    /// demanded) would make it fail.
+    #[test]
+    fn test_numeric_upgrade_zero_accepted_matches_core() {
+        use stellar_xdr::curr::WriteXdr;
+
+        fn encode(upgrade: LedgerUpgrade) -> UpgradeType {
+            UpgradeType(
+                upgrade
+                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            )
+        }
+
+        // --- MaxTxSetSize: any size, incl. zero (core "any size is allowed") ---
+        let (validity, _) = is_valid_for_apply(&encode(LedgerUpgrade::MaxTxSetSize(0)), 25, 25);
+        assert_eq!(
+            validity,
+            UpgradeValidity::Valid,
+            "MaxTxSetSize(0) must be VALID per core — no positivity check"
+        );
+        let (validity, _) = is_valid_for_apply(&encode(LedgerUpgrade::MaxTxSetSize(1)), 25, 25);
+        assert_eq!(
+            validity,
+            UpgradeValidity::Valid,
+            "MaxTxSetSize(1) must be VALID"
+        );
+
+        // --- MaxSorobanTxSetSize: any size at protocol >= 20; gated below 20 ---
+        let (validity, _) =
+            is_valid_for_apply(&encode(LedgerUpgrade::MaxSorobanTxSetSize(0)), 20, 25);
+        assert_eq!(
+            validity,
+            UpgradeValidity::Valid,
+            "MaxSorobanTxSetSize(0) must be VALID at protocol >= 20 per core — no positivity check"
+        );
+        let (validity, _) =
+            is_valid_for_apply(&encode(LedgerUpgrade::MaxSorobanTxSetSize(0)), 19, 25);
+        assert_eq!(
+            validity,
+            UpgradeValidity::Invalid,
+            "MaxSorobanTxSetSize(0) must be INVALID below protocol 20 (protocol gate)"
+        );
+
+        // --- BaseFee / BaseReserve: the ONLY non-zero checks ---
+        let (validity, _) = is_valid_for_apply(&encode(LedgerUpgrade::BaseFee(0)), 25, 25);
+        assert_eq!(
+            validity,
+            UpgradeValidity::Invalid,
+            "BaseFee(0) must be INVALID"
+        );
+        let (validity, _) = is_valid_for_apply(&encode(LedgerUpgrade::BaseReserve(0)), 25, 25);
+        assert_eq!(
+            validity,
+            UpgradeValidity::Invalid,
+            "BaseReserve(0) must be INVALID"
+        );
+        let (validity, _) = is_valid_for_apply(&encode(LedgerUpgrade::BaseFee(1)), 25, 25);
+        assert_eq!(validity, UpgradeValidity::Valid, "BaseFee(1) must be VALID");
+        let (validity, _) = is_valid_for_apply(&encode(LedgerUpgrade::BaseReserve(1)), 25, 25);
+        assert_eq!(
+            validity,
+            UpgradeValidity::Valid,
+            "BaseReserve(1) must be VALID"
+        );
+    }
+
     #[test]
     fn test_upgrade_to_string() {
         assert_eq!(


### PR DESCRIPTION
Closes #3050

## Summary

henyey's numeric-upgrade validation already matches stellar-core `Upgrades::isValidForApply` (`stellar-core/src/herder/Upgrades.cpp:591-631`) byte-for-byte: only `BaseFee != 0` and `BaseReserve != 0` are enforced; `MaxTxSetSize` accepts any size and `MaxSorobanTxSetSize` accepts any size once protocol ≥ `SOROBAN_PROTOCOL_VERSION` (20). There is **no positivity check** in core, and none in henyey — both validation paths (`ScpDriver::is_valid_upgrade_for_apply` and `upgrades::is_valid_for_apply`) delegate to the single shared `henyey_common::upgrade_valid_for_apply_non_config`. So **no validation-code change** is made.

The spec drift that triggered the §15.4-5 audit finding ("Numeric upgrades ... MUST be a positive integer") was **already corrected** in a prior `stellar-specs` regeneration: the submodule pin on `main` (`baf511a4`) has §16.3 reading `BaseFee/BaseReserve != 0`, `MaxTxSetSize` any size, `MaxSorobanTxSetSize` V20+ any size — matching core. No "positive integer" wording remains anywhere in the spec, so **no submodule edit or pin bump is required**.

This PR therefore lands the remaining two parts of the converged plan:
- A WAD/core-consistent note under `crates/herder/SPEC_ADHERENCE.md` §16.3 recording the §15.4-5 finding as resolved (matches core, no positivity check per `Upgrades.cpp:591-631`).
- A parity-lock test that pins the current correct behavior across both validation paths, so a future spurious positivity check would fail it.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3050#issuecomment-4650048447)

## Test plan

- [x] cargo fmt --check (clean)
- [x] cargo test -p henyey-herder — 1182 + 2 pass, 0 failures; incl. new `test_numeric_upgrade_zero_accepted_matches_core` in both `upgrades.rs` and `scp_driver.rs`
- [x] clippy: change introduces no new warnings (the 10 pre-existing herder lints + 1 common lint are toolchain-drift from local rust-1.95.0 and present identically on clean `origin/main`; not touched by this docs+test PR)

The parity-lock test asserts: `MaxTxSetSize(0)` VALID; `MaxSorobanTxSetSize(0)` VALID at protocol ≥ 20 and INVALID below 20; `BaseFee(0)`/`BaseReserve(0)` INVALID; `BaseFee(1)`/`BaseReserve(1)`/`MaxTxSetSize(1)` VALID.

## Deviations from plan

- **No `stellar-specs/HERDER_SPEC.md` edit / no submodule pin bump.** The plan's step 1 (rewrite §15.4 item 5 + bump the pin) is a **no-op**: the spec on `origin/main` (pin `baf511a4`) was already regenerated to match core and contains no positivity claim. The §15.4-5 over-broad text no longer exists. Verified by grep (no "positive integer"/"positive value" anywhere in `stellar-specs/`) and by reading §16.3, which now transcribes core exactly. Submodule pin left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)