### PR TITLE
Make post-close consensus trigger arm-only to match stellar-core

### DIFF
--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -409,10 +409,10 @@ impl App {
     /// production sites so it stays a faithful mirror of what they do.
     #[cfg(test)]
     pub(super) async fn post_close_trigger_and_arm(&self) {
-        // Trigger consensus immediately after a successful close.
-        self.try_trigger_consensus().await;
-        // Arm the event-driven trigger for the *next* ledger (#2702), the henyey
-        // analog of `lastClosedLedgerIncreased` → `setupTriggerNextLedger`.
+        // Arm-only (#3014): no immediate `try_trigger_consensus()` — the armed
+        // `TriggerNextLedger` timer is the sole nomination scheduler, matching
+        // stellar-core's arm-only `lastClosedLedgerIncreased`
+        // (HerderImpl.cpp:1218-1233).
         self.setup_trigger_next_ledger().await;
     }
 

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -401,6 +401,21 @@ impl App {
     /// Self-gates on `manual_close` (stellar-core skips `async_wait` under
     /// MANUAL_CLOSE, HerderImpl.cpp:1298-1303) and on `is_tracking`. Always
     /// cancels any prior trigger timer for the next slot before re-arming.
+    /// Test-only mirror of the post-close consensus-trigger subsequence run at
+    /// the two production post-close sites (`lifecycle.rs` select-loop close
+    /// completion and the `try_apply_buffered_ledgers` burst helper). The
+    /// regression test `test_post_close_arms_trigger_without_immediate_nomination`
+    /// asserts on this canonical sequence; it is edited in lockstep with the two
+    /// production sites so it stays a faithful mirror of what they do.
+    #[cfg(test)]
+    pub(super) async fn post_close_trigger_and_arm(&self) {
+        // Trigger consensus immediately after a successful close.
+        self.try_trigger_consensus().await;
+        // Arm the event-driven trigger for the *next* ledger (#2702), the henyey
+        // analog of `lastClosedLedgerIncreased` → `setupTriggerNextLedger`.
+        self.setup_trigger_next_ledger().await;
+    }
+
     pub(super) async fn setup_trigger_next_ledger(&self) {
         // Parity: MANUAL_CLOSE skips arming the trigger timer.
         if self.config.node.manual_close {
@@ -3050,6 +3065,96 @@ mod tests {
         assert!(
             !pump,
             "SCP nomination timeout must not signal a close-pipeline pump"
+        );
+    }
+
+    /// #3014: the post-close path must be **arm-only** — it arms the
+    /// `TriggerNextLedger` timer but must NOT call `try_trigger_consensus`
+    /// synchronously. This mirrors stellar-core's `lastClosedLedgerIncreased`
+    /// (HerderImpl.cpp:1218-1233), which calls only `setupTriggerNextLedger`;
+    /// the immediate fire happens via the timer's `triggerTime < now` clamp.
+    ///
+    /// Discrimination: the test bootstraps the steady-state regime where
+    /// `prepare_start(last_slot)` is `None` (cold start), so the trigger-time
+    /// gate inside `try_trigger_consensus` does NOT block. This is the only
+    /// regime that distinguishes pre/post: a fast/solo close already self-gates
+    /// on `origin/main` and would prove nothing.
+    ///
+    /// - Pre-fix (`origin/main`): the post-close sequence ran
+    ///   `try_trigger_consensus().await` immediately, so `consensus_trigger_attempts`
+    ///   incremented synchronously — this assertion FAILS.
+    /// - Post-fix: the post-close sequence is arm-only, so the counter does NOT
+    ///   move until the armed timer fires and is handled — this assertion PASSES.
+    #[tokio::test(start_paused = true)]
+    async fn test_post_close_arms_trigger_without_immediate_nomination() {
+        let (_dir, app) = mk_validator_app().await;
+
+        // Bootstrap at ledger 1 → tracking, LCL 1, next slot 2. prepare_start(1)
+        // is None on cold start, so the trigger-time gate in
+        // try_trigger_consensus does NOT block — the steady-state regime that
+        // discriminates pre/post.
+        app.herder.bootstrap(1);
+        assert!(app.herder.is_tracking());
+        assert!(
+            app.herder.prepare_start(1).is_none(),
+            "test precondition: prepare_start(LCL) must be None so the \
+             trigger-time gate does not block (the only regime that \
+             discriminates pre/post)"
+        );
+
+        let attempts_before = app.consensus_trigger_attempts.load(Ordering::Relaxed);
+
+        // Run the exact post-close subsequence the production sites run.
+        app.post_close_trigger_and_arm().await;
+
+        // (a) The post-close arm must NOT have triggered nomination
+        // synchronously. FAILS on origin/main (immediate try_trigger_consensus
+        // bumps the counter before any timer fires); PASSES post-fix.
+        assert_eq!(
+            app.consensus_trigger_attempts.load(Ordering::Relaxed),
+            attempts_before,
+            "post-close must be arm-only: try_trigger_consensus must NOT run \
+             synchronously (parity: lastClosedLedgerIncreased is arm-only)"
+        );
+
+        // (b) A TriggerNextLedger timer was armed for slot == current_ledger + 1.
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        let mut rx = app.scp_timer_rx.lock().await;
+        // prepare_start is None → delay is only ctValidityOffset (0) → fires
+        // effectively immediately under paused time.
+        tokio::time::advance(std::time::Duration::from_secs(2)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        let delivered = rx
+            .try_recv()
+            .expect("expected a TriggerNextLedger timer event to be delivered");
+        assert_eq!(
+            delivered.timer_type,
+            henyey_herder::TimerType::TriggerNextLedger
+        );
+        assert_eq!(
+            delivered.slot, 2,
+            "armed trigger timer must target current_ledger + 1"
+        );
+        drop(rx);
+
+        // (c) Handling the fired TriggerNextLedger event triggers nomination
+        // (attempts increments) and signals the close-pipeline pump — proving
+        // the trigger moved from immediate to timer-driven without losing
+        // close→nominate liveness.
+        let pump = app.handle_scp_timer_event(delivered).await;
+        assert!(
+            pump,
+            "a fired TriggerNextLedger event must signal the caller to pump the close pipeline"
+        );
+        assert_eq!(
+            app.consensus_trigger_attempts.load(Ordering::Relaxed),
+            attempts_before + 1,
+            "handling the armed TriggerNextLedger event must trigger nomination \
+             (timer-driven, not immediate)"
         );
     }
 }

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -1879,11 +1879,12 @@ impl App {
         // this burst.  This mirrors the reset done in the pending_close
         // handler at the end of the select-loop chain.
         if success {
-            // Trigger consensus immediately after close, matching stellar-core.
-            // Both validators and watchers participate (HERDER §5.2).
-            self.try_trigger_consensus().await;
-            // Arm the event-driven trigger for the next ledger (#2702), the
-            // henyey analog of lastClosedLedgerIncreased → setupTriggerNextLedger.
+            // Arm the event-driven trigger for the next ledger (#2702/#3014),
+            // the henyey analog of stellar-core's arm-only
+            // `lastClosedLedgerIncreased` → `setupTriggerNextLedger`
+            // (HerderImpl.cpp:1218-1233). No immediate `try_trigger_consensus()`
+            // here — the armed `TriggerNextLedger` timer is the sole nomination
+            // scheduler (its fire path carries the close-pipeline pump signal).
             self.setup_trigger_next_ledger().await;
 
             *self.last_externalized_at.write().await = self.clock.now();

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -533,19 +533,24 @@ impl App {
                         self.set_phase_sub(super::phase::PHASE_6_9_MAYBE_PUBLISH_HISTORY);
                         self.maybe_publish_history().await;
 
-                        // Trigger consensus immediately after a successful close.
-                        // Both validators and watchers participate: validators
-                        // nominate; watchers build/cache the next-slot tx set
-                        // (parity: HERDER §5.2).
-                        self.set_phase_sub(super::phase::PHASE_6_10_TRY_TRIGGER_CONSENSUS);
-                        self.try_trigger_consensus().await;
-
                         // Arm the event-driven trigger for the *next* ledger
-                        // (#2702). This is the henyey analog of stellar-core's
-                        // `lastClosedLedgerIncreased` → `setupTriggerNextLedger`:
-                        // a close just advanced LCL, so schedule the next
-                        // nomination via a single-shot timer instead of relying
-                        // on the 1-second poll.
+                        // (#2702/#3014). A close just advanced LCL, so schedule
+                        // the next nomination via a single-shot
+                        // `TriggerNextLedger` timer. This is the henyey analog of
+                        // stellar-core's `lastClosedLedgerIncreased` →
+                        // `setupTriggerNextLedger` (HerderImpl.cpp:1218-1233),
+                        // which is **arm-only**: it does NOT call
+                        // `try_trigger_consensus()` synchronously here. The
+                        // immediate fire happens via the timer's
+                        // `triggerTime < now` clamp (in steady state the delay
+                        // clamps to ~0, so the timer fires on the next event-loop
+                        // iteration), and the timer-fire path carries the
+                        // close-pipeline pump signal the inline call lacked
+                        // (preserving the solo self-externalize cold-start). Both
+                        // validators and watchers participate via the fired timer
+                        // (parity: HERDER §5.2). The 1-second maintenance tick
+                        // remains as the safety-net backstop.
+                        self.set_phase_sub(super::phase::PHASE_6_10_TRY_TRIGGER_CONSENSUS);
                         self.setup_trigger_next_ledger().await;
 
                         // Drain SCP + fetch response channels.


### PR DESCRIPTION
Closes #3014

## Summary

Aligns henyey's post-close consensus-trigger cadence to stellar-core's arm-only `HerderImpl::lastClosedLedgerIncreased` (HerderImpl.cpp:1218-1233). The two post-close sites previously called `try_trigger_consensus().await` immediately **and then** `setup_trigger_next_ledger().await`; core only arms the timer (the immediate fire happens via the timer's `triggerTime < now` clamp). This removes the immediate call at both sites, leaving the armed event-driven `TriggerNextLedger` timer as the sole nomination scheduler.

`try_trigger_consensus` already self-gates on the identical trigger-time boundary (`prepare_start + expected_close`, clamp-to-now, `ctValidityOffset`; consensus.rs:238-281), so the immediate call provably could not nominate earlier than core's timer — the change is **timing-equivalent today** (a refactor, not a behavior change). Liveness is preserved in all regimes: steady-state (delay clamps to ~0, timer fires next event-loop iteration), fast/solo close (immediate call was already a gated no-op; timer waits correctly), and cold-start solo self-externalize (the timer-fire path carries the close-pipeline pump signal the inline call lacked). The 1-second maintenance tick is retained as the safety-net backstop.

Two removals:
- `crates/app/src/app/lifecycle.rs:541` — immediate `try_trigger_consensus().await` (kept the arm).
- `crates/app/src/app/ledger_close.rs:1884` — immediate call in the `#[cfg(test)]` `try_apply_buffered_ledgers` burst helper (kept the arm).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3014#issuecomment-4650074241)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (pre-commit hook scope) — clean
- [x] cargo test -p henyey-app — 1017 lib + integration + doctests pass, 0 failures (incl. all trigger/timer-event/buffered-ledger/consensus-liveness tests)

## Regression test

- **Test:** `crates/app/src/app/consensus.rs::test_post_close_arms_trigger_without_immediate_nomination`
- **Pre-fix:** committed as `d5256cd1` — verified FAILED with: `assertion left == right failed ... left: 1, right: 0` (the immediate `try_trigger_consensus` bumped `consensus_trigger_attempts` synchronously in the steady-state regime where `prepare_start` is None).
- **Post-fix:** verified PASSES after `ec06ab21` — `consensus_trigger_attempts` does not move on the post-close arm; a `TriggerNextLedger` timer is delivered with `slot == current_ledger + 1`; handling it triggers nomination (count advances) and signals the pump.

## Deviations from plan

None. The plan offered "drive `try_apply_buffered_ledgers` OR add a tiny test-only helper"; this PR uses a `#[cfg(test)]` `post_close_trigger_and_arm` helper that mirrors the production post-close sequence and is edited in lockstep with the two production sites, keeping the pre/post discrimination explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)