### PR TITLE
jemalloc: add retain:false to malloc_conf to lower cold-catchup RSS peak

### DIFF
--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -3605,6 +3605,42 @@ mod tests {
         assert!(matches!(cli.command, Commands::Info));
     }
 
+    /// Pins the compiled-in jemalloc `malloc_conf` so a future edit cannot
+    /// silently drop one of the memory-return knobs.
+    ///
+    /// The full RSS-peak effect is operator-verified on a real cold catchup
+    /// (via `henyey_startup_peak_anon_rss_mb`, #3228); this offline test only
+    /// asserts the config string carries the four intended knobs and is
+    /// NUL-terminated (jemalloc requires the trailing C-string NUL). Gated on
+    /// `feature = "jemalloc"` to match the static's own cfg — the symbol does
+    /// not exist without the feature. See #3235 / #3232.
+    #[cfg(feature = "jemalloc")]
+    #[test]
+    fn test_malloc_conf_carries_decay_and_retain_knobs() {
+        let conf = super::malloc_conf;
+
+        // Must be NUL-terminated: jemalloc parses it as a C string.
+        assert_eq!(
+            conf.last(),
+            Some(&0u8),
+            "malloc_conf must end with the NUL terminator"
+        );
+
+        let conf_str = std::str::from_utf8(conf).expect("malloc_conf must be valid UTF-8");
+
+        for knob in [
+            "background_thread:true",
+            "dirty_decay_ms:1000",
+            "muzzy_decay_ms:1000",
+            "retain:false",
+        ] {
+            assert!(
+                conf_str.contains(knob),
+                "malloc_conf is missing knob `{knob}`; got `{conf_str}`"
+            );
+        }
+    }
+
     #[test]
     fn test_cli_run_command() {
         let cli = Cli::parse_from(["rs-stellar-core", "run", "--validator"]);

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -73,10 +73,28 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // - background_thread: purge dirty/muzzy pages asynchronously
 // - dirty_decay_ms=1000: return dirty pages to OS after 1s (default 10s)
 // - muzzy_decay_ms=1000: decommit muzzy pages after 1s (default 10s)
+// - retain=false: munmap freed virtual extents instead of retaining them.
+//   jemalloc's 5.0+ default is retain=true, which holds freed extents as
+//   retained virtual memory for fast reuse. During a multi-minute cold-catchup
+//   apply, the large transient working sets (HAS buffers, parallel bucket-apply
+//   scratch, cache-scan structures) are allocated and freed in churn; with
+//   retain=true the resident high-water stays inflated by the cumulative
+//   retained footprint. retain=false munmaps each freed extent, so — combined
+//   with the 1s decay + background_thread above — freed memory is returned to
+//   the OS continuously (~1s behind frees), bounding the *instantaneous* anon-RSS
+//   peak that is the binding constraint on a 32 GB / no-swap host.
+//   Tradeoff (honest): heap *growth* must re-mmap from the OS (syscall +
+//   first-touch fault) rather than recommitting a retained extent — a small
+//   steady-state alloc-path cost, assessed amortized for a validator whose
+//   steady-state RSS is dominated by stable, once-allocated caches/ledger state
+//   (infrequent growth events). Operator-authorized per #3233 / #3235.
+//   See #3235 / #3232. Catchup-scoped mallctl purge is the documented fallback
+//   if re-measurement shows steady-state regression.
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
-pub static malloc_conf: &[u8] = b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000\0";
+pub static malloc_conf: &[u8] =
+    b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000,retain:false\0";
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Closes #3235

## Summary

Append `,retain:false` to henyey's compiled-in jemalloc `malloc_conf` static (`crates/henyey/src/main.rs`), keeping the existing aggressive `background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000`. `retain:false` munmaps freed virtual extents rather than retaining them for reuse (jemalloc 5.0+ defaults to `retain:true`); combined with the existing 1s decay + background thread, freed memory is returned to the OS continuously (~1s behind frees) throughout the multi-minute cold-catchup apply churn — bounding the **instantaneous** anon-RSS peak that is the binding constraint on a 32 GB / no-swap host.

This is a **pure allocator memory-return policy** change. The only file touched is `crates/henyey/src/main.rs` (the `malloc_conf` static + its doc-comment + one unit test). No consensus / ledger / hash / XDR / SCP code is touched — zero effect on allocation contents, byte layout, ordering, or any observable protocol behavior.

## Notes on the change

- **(a)** The diff is `+,retain:false` appended to the existing `malloc_conf`. We **kept 1000ms decay** and did **NOT** adopt the issue's literal `5000ms` proposal — 5000ms returns pages *later* than the shipping 1000ms and would regress the peak (per triage). `retain:false` is the one genuinely-new lever.
- **(b)** The throughput tradeoff is **real but small and amortized** (the issue's \"no throughput cost\" claim was imprecise): `retain:false` forces heap *growth* to re-`mmap` from the OS (syscall + first-touch fault) rather than recommitting a retained extent. For a validator whose steady-state RSS (~18 GB) is dominated by stable, once-allocated caches/ledger state, growth events are infrequent in steady state, so the cost is amortized — and the operator pre-authorized this lever (#3233 / #3235).
- **(c)** The offline unit test pins the config string (so a future edit can't silently drop a knob). The **full RSS-peak effect is OPERATOR-verified** via `henyey_startup_peak_anon_rss_mb` (#3228) on a cold mainnet catchup. This lever is **additive** to the merged A/B levers (#3234) and **may not reach ≤24 GB alone**.
- **(d)** A **catchup-scoped mallctl purge** (transient per-arena `purge` / `dirty_decay_ms:0` via `tikv_jemalloc_ctl::raw`) is the documented **fallback** if re-measurement shows a steady-state regression — not implemented here (it's a weaker, one-shot lever against the instantaneous peak and materially more code for an S issue).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3235#issuecomment-4653642376)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p henyey -- -D warnings` clean
- [x] `cargo build -p henyey` (default features incl. jemalloc) compiles **and links** — the `malloc_conf` symbol export still links correctly; the embedded config string (`background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000,retain:false`) is present in the linked binary.
- [x] `cargo test -p henyey` passes (49 unit + integration tests), including the new `test_malloc_conf_carries_decay_and_retain_knobs`.

## New coverage

- **Test:** `crates/henyey/src/main.rs::tests::test_malloc_conf_carries_decay_and_retain_knobs` (`#[cfg(feature = \"jemalloc\")]`)
- **Pre-change:** committed as `d04c8045` — verified **FAILED** with: `malloc_conf is missing knob \`retain:false\``.
- **Post-change:** verified **PASSES** after `570aafe2`.
- Asserts the compiled-in static carries all four knobs (`background_thread:true`, `dirty_decay_ms:1000`, `muzzy_decay_ms:1000`, `retain:false`) and ends with the NUL terminator.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)