### PR TITLE
Cap apply fan-out in restore_from_has_parallel (lever D)

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -902,9 +902,14 @@ impl App {
             let arc = bucket_manager.load_bucket(hash)?;
             Ok(Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone()))
         };
-        let mut bucket_list =
-            BucketList::restore_from_has_parallel(&live_hash_pairs, &live_next_states, load_bucket)
-                .map_err(|e| anyhow::anyhow!("Failed to restore live bucket list: {}", e))?;
+        let restore_fan_out = self.config.buckets.restore_apply_fan_out_cap();
+        let mut bucket_list = BucketList::restore_from_has_parallel(
+            &live_hash_pairs,
+            &live_next_states,
+            load_bucket,
+            restore_fan_out,
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to restore live bucket list: {}", e))?;
         bucket_list.set_bucket_dir(bucket_dir.clone());
         bucket_list.set_ledger_seq(lcl_seq);
         henyey_ledger::log_startup_memory("after_restore_bucket_list");
@@ -973,6 +978,7 @@ impl App {
                 &hot_hash_pairs,
                 &hot_next_states,
                 load_hot,
+                self.config.buckets.restore_apply_fan_out_cap(),
             )
             .map_err(|e| anyhow::anyhow!("Failed to restore hot archive: {}", e))?;
 
@@ -1249,9 +1255,13 @@ impl App {
             Ok(std::sync::Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone()))
         };
 
-        let mut bucket_list =
-            BucketList::restore_from_has_parallel(&live_hash_pairs, &live_next_states, load_bucket)
-                .map_err(|e| anyhow::anyhow!("Failed to restore live bucket list: {}", e))?;
+        let mut bucket_list = BucketList::restore_from_has_parallel(
+            &live_hash_pairs,
+            &live_next_states,
+            load_bucket,
+            self.config.buckets.restore_apply_fan_out_cap(),
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to restore live bucket list: {}", e))?;
 
         let bucket_dir = self.bucket_manager.bucket_dir().to_path_buf();
         bucket_list.set_bucket_dir(bucket_dir.clone());
@@ -1305,6 +1315,7 @@ impl App {
                 &hot_hash_pairs,
                 &hot_next_states,
                 load_hot,
+                self.config.buckets.restore_apply_fan_out_cap(),
             )
             .map_err(|e| anyhow::anyhow!("Failed to restore hot archive: {}", e))?;
 

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -831,6 +831,31 @@ pub struct BucketConfig {
     #[serde(default = "default_scan_thread_count")]
     pub scan_thread_count: usize,
 
+    /// Maximum number of bucket-materialization workers that may run
+    /// concurrently during parallel restore (`restore_from_has_parallel`).
+    ///
+    /// Caps the cold-catchup live-allocation spike (#3245/#3235): on a fresh
+    /// catchup henyey spawns up to ~22 concurrent `load_bucket` workers, each
+    /// with a large transient working set (streaming index build, XDR parse
+    /// buffers, small buckets loaded fully into RAM). The peak ≈ the sum of all
+    /// concurrent workers' transient sets. Capping concurrency to `k` bounds
+    /// the spike (≈ `base + k × per-worker-live`) at the cost of restore
+    /// wall-clock.
+    ///
+    /// `0` (the default) means **unbounded** — the historical behavior, a true
+    /// no-op with zero regression. A non-zero `k` caps concurrent
+    /// materialization to `k` via a counting semaphore acquired around the
+    /// load. Bounding concurrency does NOT change the restored state: the
+    /// `bucketListHash` is byte-identical for every value of `k` (assembly is
+    /// indexed by level, independent of scheduling order).
+    ///
+    /// On a 32 GB host, `restore_apply_fan_out = 6` caps the peak at ~19 GB
+    /// (≤20 GB margin) for ~+30s of catchup time. Aligns with stellar-core,
+    /// which bounds apply/index concurrency via the configurable
+    /// `WORKER_THREADS`; henyey's unbounded fan-out was the outlier.
+    #[serde(default = "default_restore_apply_fan_out")]
+    pub restore_apply_fan_out: usize,
+
     /// Disable on-disk bucket garbage collection (forensic / debugging
     /// kill-switch).
     ///
@@ -848,6 +873,24 @@ fn default_scan_thread_count() -> usize {
     4
 }
 
+/// Default fan-out cap for parallel restore: `0` = unbounded (current
+/// behavior, zero regression). See [`BucketConfig::restore_apply_fan_out`].
+fn default_restore_apply_fan_out() -> usize {
+    0
+}
+
+impl BucketConfig {
+    /// The restore fan-out cap as an `Option<usize>` suitable for
+    /// `restore_from_has_parallel`: `0` maps to `None` (unbounded), any
+    /// non-zero `k` to `Some(k)`.
+    pub fn restore_apply_fan_out_cap(&self) -> Option<usize> {
+        match self.restore_apply_fan_out {
+            0 => None,
+            k => Some(k),
+        }
+    }
+}
+
 impl Default for BucketConfig {
     fn default() -> Self {
         Self {
@@ -855,6 +898,7 @@ impl Default for BucketConfig {
             cache_size: default_bucket_cache_size(),
             bucket_list_db: BucketListDbConfig::default(),
             scan_thread_count: default_scan_thread_count(),
+            restore_apply_fan_out: default_restore_apply_fan_out(),
             disable_bucket_gc: false,
         }
     }
@@ -2624,6 +2668,48 @@ disable_bucket_gc = true
             config.buckets.disable_bucket_gc,
             "disable_bucket_gc = true must parse to true"
         );
+    }
+
+    #[test]
+    fn test_restore_apply_fan_out_default_is_unbounded() {
+        // #3245: restore_apply_fan_out defaults to 0 == unbounded == current
+        // behavior (a true no-op, zero regression). The operator sets a
+        // non-zero cap (e.g. 6) at deploy on a memory-constrained host.
+        assert_eq!(
+            BucketConfig::default().restore_apply_fan_out,
+            0,
+            "restore_apply_fan_out must default to 0 (unbounded)"
+        );
+        assert_eq!(
+            BucketConfig::default().restore_apply_fan_out_cap(),
+            None,
+            "the default (0) must map to None (no cap engaged)"
+        );
+
+        // Absent from TOML => default unbounded.
+        let toml_str = r#"
+[network]
+passphrase = "Test SDF Network ; September 2015"
+
+[buckets]
+directory = "buckets"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.buckets.restore_apply_fan_out, 0);
+        assert_eq!(config.buckets.restore_apply_fan_out_cap(), None);
+
+        // A non-zero value round-trips and maps to Some(k).
+        let toml_str_capped = r#"
+[network]
+passphrase = "Test SDF Network ; September 2015"
+
+[buckets]
+directory = "buckets"
+restore_apply_fan_out = 6
+"#;
+        let config: AppConfig = toml::from_str(toml_str_capped).unwrap();
+        assert_eq!(config.buckets.restore_apply_fan_out, 6);
+        assert_eq!(config.buckets.restore_apply_fan_out_cap(), Some(6));
     }
 
     #[test]

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -2657,10 +2657,21 @@ impl BucketList {
     /// * `hashes` - Vec of (curr_hash, snap_hash) pairs for each level
     /// * `next_states` - Vec of pending merge states for each level
     /// * `load_bucket` - Thread-safe function to load a bucket from its hash
+    /// * `fan_out` - Optional cap on the number of workers that may *materialize*
+    ///   a bucket (`load_bucket`) concurrently. `None` (or `Some(0)`) is the
+    ///   default: unbounded, byte-for-byte the historical behavior — all
+    ///   workers materialize at once. `Some(k)` caps concurrent materialization
+    ///   to `k` via a counting semaphore ([`FanOutLimiter`]) acquired *around
+    ///   the `load_bucket` calls*. The permit bounds the transient
+    ///   per-load working set (the cold-catchup spike, #3235), NOT the resident
+    ///   base — assembled buckets stay live regardless of `k`. The restored
+    ///   `BucketList` and its `hash()` are identical for every `fan_out` value:
+    ///   assembly indexes results by level, independent of scheduling order.
     pub fn restore_from_has_parallel<F>(
         hashes: &[(Hash256, Hash256)],
         next_states: &[Option<PendingMergeState>],
         load_bucket: F,
+        fan_out: Option<usize>,
     ) -> Result<Self>
     where
         F: Fn(&Hash256) -> Result<Bucket> + Send + Sync,
@@ -2681,6 +2692,11 @@ impl BucketList {
         }
 
         let load_bucket = &load_bucket;
+
+        // Bound concurrent bucket materialization (the cold-catchup spike, #3245).
+        // Unbounded by default (`None`/`Some(0)`) → no-op, current behavior.
+        let limiter = crate::FanOutLimiter::from_cap(fan_out);
+        let limiter = &limiter;
 
         // Collect (level_index, output_hash) for levels with completed merge outputs.
         // Skip zero-hash outputs as a belt-and-suspenders defense; parse_next_states()
@@ -2704,6 +2720,12 @@ impl BucketList {
                     s.spawn(move || -> Result<(usize, Bucket, Bucket)> {
                         let level_start = std::time::Instant::now();
 
+                        // Acquire a permit around materialization so at most
+                        // `fan_out` workers build buckets at once (no-op when
+                        // unbounded). Held across both loads (the level
+                        // worker's transient working set); released on drop
+                        // after the buckets are built and returned.
+                        let _permit = limiter.acquire();
                         let curr = load_or_sentinel_shared(curr_hash, load_bucket)?;
                         let snap = load_or_sentinel_shared(snap_hash, load_bucket)?;
 
@@ -2733,6 +2755,10 @@ impl BucketList {
                         i,
                         s.spawn(move || -> Result<Bucket> {
                             let t = std::time::Instant::now();
+                            // Same permit gate as the level workers — the
+                            // output bucket (e.g. level 10's ~47M-entry merge
+                            // result) is a heavy materialization.
+                            let _permit = limiter.acquire();
                             let bucket = load_and_verify_shared(&hash, load_bucket)?;
                             tracing::info!(
                                 level = i,
@@ -4853,7 +4879,8 @@ mod tests {
         let next_states = vec![None; BUCKET_LIST_LEVELS];
 
         let loader = make_loader(vec![bucket0_curr, bucket1_curr]);
-        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, loader).unwrap();
+        let bl =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None).unwrap();
 
         assert_eq!(bl.levels().len(), BUCKET_LIST_LEVELS);
 
@@ -4895,7 +4922,8 @@ mod tests {
         next_states[0] = Some(PendingMergeState::Output(ho));
 
         let loader = make_loader(vec![bucket_curr, bucket_out]);
-        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, loader).unwrap();
+        let bl =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None).unwrap();
 
         assert!(
             bl.levels()[0].next.is_some(),
@@ -4924,7 +4952,8 @@ mod tests {
         let next_states = vec![None; BUCKET_LIST_LEVELS]; // all CLEAR
 
         let loader = make_loader(vec![bucket]);
-        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, loader).unwrap();
+        let bl =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None).unwrap();
 
         for i in 0..BUCKET_LIST_LEVELS {
             assert!(
@@ -4971,31 +5000,123 @@ mod tests {
         let bl_seq =
             BucketList::restore_from_has(&hashes, &next_states, |h| loader_seq(h)).unwrap();
 
-        let loader_par = make_loader(all_buckets);
-        let bl_par =
-            BucketList::restore_from_has_parallel(&hashes, &next_states, loader_par).unwrap();
+        // Parametrize the parallel restore over the fan-out cap (#3245):
+        // unbounded (None / Some(0)), and capped to 1, 2, 4. EVERY value must
+        // produce a BYTE-IDENTICAL BucketList — same entries, same level.next
+        // presence, and crucially the same bl.hash() — because capping
+        // concurrency only changes HOW MANY workers materialize at once, not
+        // WHAT is assembled or the assembly order (results are indexed by
+        // level). This is the byte-identical-state proof.
+        let seq_hash = bl_seq.hash();
+        for fan_out in [None, Some(0), Some(1), Some(2), Some(4)] {
+            let loader_par = make_loader(all_buckets.clone());
+            let bl_par =
+                BucketList::restore_from_has_parallel(&hashes, &next_states, loader_par, fan_out)
+                    .unwrap();
 
-        // All entries should be reachable from both
-        for i in 1u8..=4 {
-            let key = make_account_key([i; 32]);
-            let seq_result = bl_seq.get(&key).unwrap();
-            let par_result = bl_par.get(&key).unwrap();
+            // Byte-identical restored state: bucketListHash must match the
+            // sequential restore regardless of fan-out.
             assert_eq!(
-                seq_result.is_some(),
-                par_result.is_some(),
-                "entry [{}; 32] presence mismatch between sequential and parallel restore",
-                i
+                bl_par.hash(),
+                seq_hash,
+                "bl.hash() differs for fan_out={:?} — capping concurrency must \
+                 not change the restored state",
+                fan_out
             );
+
+            // All entries should be reachable from both.
+            for i in 1u8..=4 {
+                let key = make_account_key([i; 32]);
+                let seq_result = bl_seq.get(&key).unwrap();
+                let par_result = bl_par.get(&key).unwrap();
+                assert_eq!(
+                    seq_result.is_some(),
+                    par_result.is_some(),
+                    "entry [{}; 32] presence mismatch (fan_out={:?})",
+                    i,
+                    fan_out
+                );
+            }
+
+            // level.next presence must match.
+            for i in 0..BUCKET_LIST_LEVELS {
+                assert_eq!(
+                    bl_seq.levels()[i].next.is_some(),
+                    bl_par.levels()[i].next.is_some(),
+                    "level {} next presence mismatch (fan_out={:?})",
+                    i,
+                    fan_out
+                );
+            }
         }
+    }
 
-        // level.next presence must match
-        for i in 0..BUCKET_LIST_LEVELS {
-            assert_eq!(
-                bl_seq.levels()[i].next.is_some(),
-                bl_par.levels()[i].next.is_some(),
-                "level {} next presence mismatch between sequential and parallel restore",
-                i
-            );
+    #[test]
+    fn test_restore_from_has_parallel_respects_fan_out_cap() {
+        // Verify the semaphore actually bounds concurrency: with fan_out =
+        // Some(2) over more than 2 non-empty levels, no more than 2 loader
+        // closures may execute simultaneously. We instrument the loader with an
+        // atomic concurrent-counter + max-seen, and sleep inside it so that an
+        // unbounded restore would reliably overlap >2 loads.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc as StdArc;
+
+        // Build distinct curr buckets for several levels so multiple loader
+        // calls run concurrently.
+        let n_levels = 6usize;
+        let buckets: Vec<Bucket> = (0..n_levels)
+            .map(|i| {
+                let entry = make_account_entry([(i as u8) + 1; 32], (i as i64 + 1) * 100);
+                Bucket::from_entries(vec![BucketListEntry::Liveentry(entry)]).unwrap()
+            })
+            .collect();
+
+        let mut hashes = vec![(Hash256::ZERO, Hash256::ZERO); BUCKET_LIST_LEVELS];
+        for (i, b) in buckets.iter().enumerate() {
+            hashes[i] = (b.hash(), Hash256::ZERO);
+        }
+        let next_states = vec![None; BUCKET_LIST_LEVELS];
+
+        // Map hash -> bucket for the instrumented loader.
+        let by_hash: std::collections::HashMap<Hash256, Bucket> =
+            buckets.iter().map(|b| (b.hash(), b.clone())).collect();
+
+        let current = StdArc::new(AtomicUsize::new(0));
+        let max_seen = StdArc::new(AtomicUsize::new(0));
+        let current_c = StdArc::clone(&current);
+        let max_seen_c = StdArc::clone(&max_seen);
+
+        let loader = move |h: &Hash256| -> Result<Bucket> {
+            if h.is_zero() {
+                // Sentinel path doesn't materialize a real bucket; don't count.
+                return Ok(Bucket::empty());
+            }
+            let now = current_c.fetch_add(1, Ordering::SeqCst) + 1;
+            max_seen_c.fetch_max(now, Ordering::SeqCst);
+            // Hold "inside the load" briefly so concurrent loads actually overlap.
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let b = by_hash
+                .get(h)
+                .cloned()
+                .expect("instrumented loader: unknown hash");
+            current_c.fetch_sub(1, Ordering::SeqCst);
+            Ok(b)
+        };
+
+        let cap = 2usize;
+        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, loader, Some(cap))
+            .unwrap();
+
+        assert_eq!(current.load(Ordering::SeqCst), 0, "all loads completed");
+        assert!(
+            max_seen.load(Ordering::SeqCst) <= cap,
+            "max concurrent loads {} exceeded fan_out cap {}",
+            max_seen.load(Ordering::SeqCst),
+            cap
+        );
+        // Sanity: the buckets were actually materialized.
+        for (i, b) in buckets.iter().enumerate() {
+            assert_eq!(bl.levels()[i].curr.hash(), b.hash());
         }
     }
 
@@ -5005,9 +5126,12 @@ mod tests {
         let next_states = vec![None; BUCKET_LIST_LEVELS];
         let too_short = vec![(Hash256::ZERO, Hash256::ZERO); 5]; // < BUCKET_LIST_LEVELS
 
-        let result = BucketList::restore_from_has_parallel(&too_short, &next_states, |_| {
-            unreachable!("should not call loader")
-        });
+        let result = BucketList::restore_from_has_parallel(
+            &too_short,
+            &next_states,
+            |_| unreachable!("should not call loader"),
+            None,
+        );
         assert!(result.is_err(), "should return error for wrong level count");
     }
 
@@ -5023,8 +5147,9 @@ mod tests {
 
         let next_states = vec![None; BUCKET_LIST_LEVELS];
 
-        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, make_loader(vec![]))
-            .unwrap();
+        let bl =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, make_loader(vec![]), None)
+                .unwrap();
 
         assert_eq!(bl.levels()[0].curr.hash(), *Hash256::empty_hash());
         assert_eq!(bl.levels()[0].curr.len(), 0);
@@ -5060,8 +5185,9 @@ mod tests {
 
         let next_states = vec![None; BUCKET_LIST_LEVELS];
 
-        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, make_loader(vec![]))
-            .unwrap();
+        let bl =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, make_loader(vec![]), None)
+                .unwrap();
 
         assert_eq!(bl.levels()[0].curr.hash(), *Hash256::empty_hash());
         assert_eq!(bl.levels()[0].curr.len(), 0);
@@ -5534,7 +5660,7 @@ mod tests {
         let next_states = vec![None; BUCKET_LIST_LEVELS];
 
         let loader = make_wrong_hash_loader(correct_bucket, wrong_bucket);
-        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, loader);
+        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None);
         assert!(matches!(result, Err(BucketError::HashMismatch { .. })));
     }
 
@@ -5607,7 +5733,8 @@ mod tests {
             }
         };
 
-        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, combined_loader);
+        let result =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, combined_loader, None);
         assert!(matches!(result, Err(BucketError::HashMismatch { .. })));
     }
 
@@ -5621,9 +5748,12 @@ mod tests {
         });
         assert!(result.is_err());
 
-        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, |_| {
-            unreachable!("should not call loader")
-        });
+        let result = BucketList::restore_from_has_parallel(
+            &hashes,
+            &next_states,
+            |_| unreachable!("should not call loader"),
+            None,
+        );
         assert!(result.is_err());
     }
 
@@ -5637,9 +5767,12 @@ mod tests {
         });
         assert!(result.is_err());
 
-        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, |_| {
-            unreachable!("should not call loader")
-        });
+        let result = BucketList::restore_from_has_parallel(
+            &hashes,
+            &next_states,
+            |_| unreachable!("should not call loader"),
+            None,
+        );
         assert!(result.is_err());
     }
 
@@ -5761,7 +5894,7 @@ mod tests {
             )))
         };
 
-        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, loader);
+        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None);
         assert!(
             result.is_err(),
             "restore_from_has_parallel must fail when state-1 output bucket is missing"
@@ -5812,7 +5945,7 @@ mod tests {
         next_states[1] = Some(PendingMergeState::Output(output_hash));
 
         let loader = make_loader(vec![output_bucket]);
-        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, loader);
+        let result = BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None);
         assert!(
             result.is_ok(),
             "restore should succeed when all buckets are present: {:?}",
@@ -5947,7 +6080,8 @@ mod tests {
         next_states[0] = Some(PendingMergeState::Output(ho));
 
         let loader = make_loader(vec![bucket_curr, bucket_out]);
-        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, loader).unwrap();
+        let bl =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None).unwrap();
 
         let referenced = bl.all_referenced_hashes();
 
@@ -6001,7 +6135,8 @@ mod tests {
         next_states[0] = Some(PendingMergeState::Output(Hash256::ZERO));
 
         let loader = make_loader(vec![bucket]);
-        let bl = BucketList::restore_from_has_parallel(&hashes, &next_states, loader).unwrap();
+        let bl =
+            BucketList::restore_from_has_parallel(&hashes, &next_states, loader, None).unwrap();
 
         assert!(
             bl.levels()[0].next.is_none(),
@@ -6287,6 +6422,7 @@ mod tests {
             &has_hashes,
             &has_next_states,
             move |h: &Hash256| loader_ref(h),
+            None,
         )
         .unwrap();
         bl_restored.set_ledger_seq(restore_ledger);
@@ -6510,9 +6646,13 @@ mod tests {
                 Bucket::from_xdr_file_disk_backed(&path)
             }
         };
-        let mut bl_restored =
-            BucketList::restore_from_has_parallel(&has_hashes, &has_next_states, disk_loader_clone)
-                .unwrap();
+        let mut bl_restored = BucketList::restore_from_has_parallel(
+            &has_hashes,
+            &has_next_states,
+            disk_loader_clone,
+            None,
+        )
+        .unwrap();
         bl_restored.set_ledger_seq(restore_ledger);
 
         // Set bucket_dir to enable disk-backed merges (the production condition)

--- a/crates/bucket/src/fan_out_limiter.rs
+++ b/crates/bucket/src/fan_out_limiter.rs
@@ -1,0 +1,233 @@
+//! Bounded-concurrency limiter for parallel bucket restore (issue #3245).
+//!
+//! [`FanOutLimiter`] is a small counting semaphore used to cap how many
+//! bucket-materialization workers may run concurrently inside the
+//! `std::thread::scope` of `BucketList::restore_from_has_parallel` and its
+//! hot-archive twin.
+//!
+//! The cold-catchup memory peak (#3235) is dominated by the *transient*
+//! working set of concurrent `load_bucket` calls (streaming index builds, XDR
+//! parse buffers, small buckets loaded fully into RAM). Spawning the worker
+//! threads is cheap; the RAM lives in the bucket materialization. So callers
+//! spawn all workers but acquire a permit from this limiter *around the
+//! `load_bucket` materialization*, bounding the concurrent live working set —
+//! the spike — without changing the resident base or the restored state.
+//!
+//! When constructed with [`FanOutLimiter::unbounded`] (the default,
+//! representing current behavior), [`FanOutLimiter::acquire`] is a no-op: no
+//! permit accounting happens and all workers materialize concurrently exactly
+//! as before. This is what keeps `restore_apply_fan_out`'s default a true
+//! zero-regression no-op.
+//!
+//! Built on `parking_lot::{Mutex, Condvar}` (already a dependency) rather than
+//! a hand-rolled `std::sync::Condvar` loop to avoid lost-wakeup mistakes. The
+//! permit is RAII: [`FanOutPermit`] releases on drop and wakes one waiter.
+
+use parking_lot::{Condvar, Mutex};
+
+/// A counting semaphore bounding concurrent bucket materialization.
+///
+/// Cheap to clone-by-reference (used as `&FanOutLimiter` across scoped
+/// threads). `unbounded()` disables all accounting for the default
+/// (current-behavior) path.
+#[derive(Debug)]
+pub struct FanOutLimiter {
+    /// `None` = unbounded (no cap, no accounting — current behavior).
+    /// `Some((mutex<available_permits>, condvar))` = bounded to `k`.
+    inner: Option<(Mutex<usize>, Condvar)>,
+}
+
+impl FanOutLimiter {
+    /// Construct an unbounded limiter: [`acquire`](Self::acquire) never blocks
+    /// and does no accounting. This is the default / current behavior.
+    pub fn unbounded() -> Self {
+        Self { inner: None }
+    }
+
+    /// Construct a limiter from an optional cap.
+    ///
+    /// * `None` → [`unbounded`](Self::unbounded) (current behavior, no-op).
+    /// * `Some(0)` → also unbounded (a zero cap is meaningless; treat as "no
+    ///   cap" so a misconfigured `restore_apply_fan_out = 0` can never
+    ///   deadlock the restore by handing out zero permits).
+    /// * `Some(k)` with `k >= 1` → at most `k` concurrent permits.
+    pub fn from_cap(cap: Option<usize>) -> Self {
+        match cap {
+            None | Some(0) => Self::unbounded(),
+            Some(k) => Self::bounded(k),
+        }
+    }
+
+    /// Construct a limiter bounded to `k` concurrent permits.
+    ///
+    /// `k` is clamped to a minimum of 1 to avoid a zero-permit deadlock.
+    pub fn bounded(k: usize) -> Self {
+        let k = k.max(1);
+        Self {
+            inner: Some((Mutex::new(k), Condvar::new())),
+        }
+    }
+
+    /// Whether this limiter actually bounds concurrency (vs. the unbounded
+    /// no-op). Used by tests and for the doc-comment invariant.
+    pub fn is_bounded(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Acquire one permit, blocking until one is available.
+    ///
+    /// Returns a RAII [`FanOutPermit`] that releases the permit on drop. For an
+    /// unbounded limiter this returns immediately with a no-op permit.
+    pub fn acquire(&self) -> FanOutPermit<'_> {
+        if let Some((mutex, condvar)) = &self.inner {
+            let mut available = mutex.lock();
+            while *available == 0 {
+                condvar.wait(&mut available);
+            }
+            *available -= 1;
+        }
+        FanOutPermit { limiter: self }
+    }
+
+    /// Release one permit and wake a single waiter. Called by `FanOutPermit`'s
+    /// `Drop`; not public.
+    fn release(&self) {
+        if let Some((mutex, condvar)) = &self.inner {
+            let mut available = mutex.lock();
+            *available += 1;
+            // Wake exactly one waiter — one permit became available.
+            condvar.notify_one();
+        }
+    }
+}
+
+/// RAII permit from [`FanOutLimiter::acquire`]. Releases on drop.
+#[derive(Debug)]
+pub struct FanOutPermit<'a> {
+    limiter: &'a FanOutLimiter,
+}
+
+impl Drop for FanOutPermit<'_> {
+    fn drop(&mut self) {
+        self.limiter.release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_unbounded_is_not_bounded_and_never_blocks() {
+        let limiter = FanOutLimiter::unbounded();
+        assert!(!limiter.is_bounded());
+        // Acquire many permits concurrently without releasing — must not block.
+        let _p1 = limiter.acquire();
+        let _p2 = limiter.acquire();
+        let _p3 = limiter.acquire();
+        // If acquire blocked on the unbounded path this test would hang.
+    }
+
+    #[test]
+    fn test_from_cap_none_is_unbounded() {
+        assert!(!FanOutLimiter::from_cap(None).is_bounded());
+    }
+
+    #[test]
+    fn test_from_cap_zero_is_unbounded_no_deadlock() {
+        // A misconfigured cap of 0 must not deadlock — treated as unbounded.
+        let limiter = FanOutLimiter::from_cap(Some(0));
+        assert!(!limiter.is_bounded());
+        let _p1 = limiter.acquire();
+        let _p2 = limiter.acquire();
+    }
+
+    #[test]
+    fn test_from_cap_some_is_bounded() {
+        assert!(FanOutLimiter::from_cap(Some(2)).is_bounded());
+        assert!(FanOutLimiter::bounded(2).is_bounded());
+    }
+
+    #[test]
+    fn test_bounded_limits_max_concurrency() {
+        // With k=2 and N workers each holding the permit while bumping a shared
+        // max-concurrent counter, the observed max must never exceed 2.
+        let k = 2;
+        let n_workers = 16;
+        let limiter = Arc::new(FanOutLimiter::bounded(k));
+        let current = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|s| {
+            for _ in 0..n_workers {
+                let limiter = Arc::clone(&limiter);
+                let current = Arc::clone(&current);
+                let max_seen = Arc::clone(&max_seen);
+                s.spawn(move || {
+                    let _permit = limiter.acquire();
+                    let now = current.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_seen.fetch_max(now, Ordering::SeqCst);
+                    // Hold the permit a moment so contention is real.
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    current.fetch_sub(1, Ordering::SeqCst);
+                    // permit released on drop here
+                });
+            }
+        });
+
+        assert_eq!(current.load(Ordering::SeqCst), 0);
+        assert!(
+            max_seen.load(Ordering::SeqCst) <= k,
+            "max concurrent {} exceeded cap {}",
+            max_seen.load(Ordering::SeqCst),
+            k
+        );
+        // Sanity: with 16 workers and k=2 we should actually reach the cap.
+        assert!(max_seen.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[test]
+    fn test_bounded_k1_serializes() {
+        // k=1 means strictly one worker at a time.
+        let limiter = Arc::new(FanOutLimiter::bounded(1));
+        let current = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+
+        std::thread::scope(|s| {
+            for _ in 0..8 {
+                let limiter = Arc::clone(&limiter);
+                let current = Arc::clone(&current);
+                let max_seen = Arc::clone(&max_seen);
+                s.spawn(move || {
+                    let _permit = limiter.acquire();
+                    let now = current.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_seen.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(2));
+                    current.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+        });
+
+        assert_eq!(max_seen.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_all_workers_complete_under_cap() {
+        // Every worker must eventually run (no starvation / lost wakeup).
+        let limiter = Arc::new(FanOutLimiter::bounded(3));
+        let completed = Arc::new(AtomicUsize::new(0));
+        std::thread::scope(|s| {
+            for _ in 0..50 {
+                let limiter = Arc::clone(&limiter);
+                let completed = Arc::clone(&completed);
+                s.spawn(move || {
+                    let _permit = limiter.acquire();
+                    completed.fetch_add(1, Ordering::SeqCst);
+                });
+            }
+        });
+        assert_eq!(completed.load(Ordering::SeqCst), 50);
+    }
+}

--- a/crates/bucket/src/hot_archive.rs
+++ b/crates/bucket/src/hot_archive.rs
@@ -1284,10 +1284,17 @@ impl HotArchiveBucketList {
     /// * `hashes` - Vec of (curr_hash, snap_hash) pairs for each level
     /// * `next_states` - Pending merge state for each level
     /// * `load_bucket` - Thread-safe function to load a HotArchiveBucket by hash
+    /// * `fan_out` - Optional cap on concurrent bucket materialization, mirroring
+    ///   [`BucketList::restore_from_has_parallel`](crate::BucketList::restore_from_has_parallel).
+    ///   `None`/`Some(0)` = unbounded (current behavior). The restored
+    ///   `hash()` is identical for every `fan_out` value. (The hot archive is
+    ///   small/cheap relative to the live BL — this knob is threaded here for
+    ///   symmetry; the catchup memory win is on the live BucketList.)
     pub fn restore_from_has_parallel<F>(
         hashes: &[(Hash256, Hash256)],
         next_states: &[Option<PendingMergeState>],
         load_bucket: F,
+        fan_out: Option<usize>,
     ) -> Result<Self>
     where
         F: Fn(&Hash256) -> Result<HotArchiveBucket> + Send + Sync,
@@ -1308,6 +1315,11 @@ impl HotArchiveBucketList {
         }
 
         let load_bucket = &load_bucket;
+
+        // Bound concurrent materialization (#3245). Unbounded by default.
+        let limiter = crate::FanOutLimiter::from_cap(fan_out);
+        let limiter = &limiter;
+
         let levels = std::thread::scope(|s| -> Result<Vec<HotArchiveBucketLevel>> {
             let handles: Vec<_> = hashes
                 .iter()
@@ -1315,6 +1327,9 @@ impl HotArchiveBucketList {
                 .enumerate()
                 .map(|(i, ((curr_hash, snap_hash), state))| {
                     s.spawn(move || -> Result<HotArchiveBucketLevel> {
+                        // Permit held across this level's materialization
+                        // (curr + snap + optional output); released on drop.
+                        let _permit = limiter.acquire();
                         let curr = load_hot_or_sentinel_shared(curr_hash, load_bucket)?;
 
                         let snap = load_hot_or_sentinel_shared(snap_hash, load_bucket)?;
@@ -2395,7 +2410,8 @@ mod tests {
             }
         };
 
-        let result = HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, loader);
+        let result =
+            HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, loader, None);
         assert!(matches!(result, Err(BucketError::HashMismatch { .. })));
     }
 
@@ -2485,8 +2501,12 @@ mod tests {
             }
         };
 
-        let result =
-            HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, combined_loader);
+        let result = HotArchiveBucketList::restore_from_has_parallel(
+            &hashes,
+            &next_states,
+            combined_loader,
+            None,
+        );
         assert!(matches!(result, Err(BucketError::HashMismatch { .. })));
     }
 
@@ -2500,9 +2520,12 @@ mod tests {
         });
         assert!(result.is_err());
 
-        let result = HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, |_| {
-            unreachable!("should not call loader")
-        });
+        let result = HotArchiveBucketList::restore_from_has_parallel(
+            &hashes,
+            &next_states,
+            |_| unreachable!("should not call loader"),
+            None,
+        );
         assert!(result.is_err());
     }
 
@@ -2516,9 +2539,12 @@ mod tests {
         });
         assert!(result.is_err());
 
-        let result = HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, |_| {
-            unreachable!("should not call loader")
-        });
+        let result = HotArchiveBucketList::restore_from_has_parallel(
+            &hashes,
+            &next_states,
+            |_| unreachable!("should not call loader"),
+            None,
+        );
         assert!(result.is_err());
     }
 
@@ -2686,7 +2712,8 @@ mod tests {
         };
 
         let bl =
-            HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, loader).unwrap();
+            HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, loader, None)
+                .unwrap();
 
         for level in bl.levels() {
             assert!(level.curr.hash().is_zero());
@@ -2739,7 +2766,8 @@ mod tests {
             )))
         };
 
-        let result = HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, loader);
+        let result =
+            HotArchiveBucketList::restore_from_has_parallel(&hashes, &next_states, loader, None);
         assert!(
             result.is_err(),
             "hot archive parallel restore must fail when state-1 output bucket is missing"

--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -99,6 +99,7 @@ mod disk_bucket;
 mod entry;
 mod error;
 mod eviction;
+mod fan_out_limiter;
 mod future_bucket;
 mod hot_archive;
 mod index;
@@ -130,6 +131,7 @@ pub use bucket::Bucket;
 pub use bucket_list::{
     BucketLevel, BucketList, BucketListStats, PendingMergeState, BUCKET_LIST_LEVELS,
 };
+pub use fan_out_limiter::{FanOutLimiter, FanOutPermit};
 
 // ============================================================================
 // Disk-backed storage


### PR DESCRIPTION
Closes #3245

## Summary

Ships the `restore_apply_fan_out` knob (`BucketConfig`). **Default `0` = unbounded = current behavior — a true no-op by default, zero regression.** A non-zero `k` caps how many bucket-materialization workers run concurrently during parallel restore, via a counting semaphore acquired *around the `load_bucket` materialization* (not the thread spawn), bounding the cold-catchup live-allocation spike (#3235/#3235) at the cost of restore wall-clock.

The **operator sets `restore_apply_fan_out=6` at deploy** on the 32 GB host (~19 GB peak, +~30s catchup, ≤20 GB margin) per the quantified table in #3245. No default change is baked in here.

**Byte-identical restored state across all k:** capping concurrency only changes *how many* workers materialize at once, not *what* is assembled or the assembly order — `level_results` is indexed by level `i` and `output_map` is keyed by level index, both independent of scheduling. The parametrized-k test below proves the `bucketListHash` is identical for every fan-out value. The state-affecting merge restart in `restart_merges_from_has` is untouched.

**Parity-aligning:** stellar-core bounds apply/index concurrency via the configurable `WORKER_THREADS` (default 11, 1–1000) and assembles the bucket list serially; henyey's unbounded ~22-way fan-out was the outlier. This knob moves toward parity; the restored hash is concurrency-independent in both.

**Operator-verify:** re-measure `henyey_startup_peak_anon_rss_mb` with `restore_apply_fan_out=6` set.

## Changes

- `crates/app/src/config.rs` — add `restore_apply_fan_out: usize` to `BucketConfig` (default `0` = unbounded) + `restore_apply_fan_out_cap() -> Option<usize>` (0→None).
- `crates/bucket/src/fan_out_limiter.rs` (new) — `FanOutLimiter`, a small counting semaphore on `parking_lot::{Mutex, Condvar}` (no lost-wakeup risk; no reusable primitive existed). `unbounded()`/`from_cap(None|Some(0))` → no-op `acquire()`.
- `crates/bucket/src/bucket_list.rs` — `restore_from_has_parallel` takes `fan_out: Option<usize>`; each worker acquires a permit around its `load_*` materialization.
- `crates/bucket/src/hot_archive.rs` — same `fan_out` param on the hot-archive twin (symmetry; the live BL is where the win is).
- `crates/app/src/app/ledger_close.rs` — pass `self.config.buckets.restore_apply_fan_out_cap()` at all four restore call sites.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3245#issuecomment-4661757144)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-bucket -p henyey-app -- -D warnings (clean)
- [x] cargo test -p henyey-bucket — 501+32+5+6 pass
- [x] cargo test -p henyey-app (config test) passes; app tests compile

New coverage:
- `bucket_list::tests::test_restore_from_has_parallel_matches_sequential` — **parametrized over fan_out = None / Some(0) / Some(1) / Some(2) / Some(4)**, asserts `bl.hash()` is byte-identical to the sequential restore for every k (the byte-identical-state proof).
- `bucket_list::tests::test_restore_from_has_parallel_respects_fan_out_cap` — instrumented loader with atomic max-concurrent counter; with `Some(2)` over 6 non-empty levels, asserts max-seen ≤ 2 (semaphore actually bounds concurrency).
- `config::tests::test_restore_apply_fan_out_default_is_unbounded` — default `0` maps to `None` (no cap engaged); non-zero round-trips through TOML to `Some(k)`.
- `fan_out_limiter::tests::*` — unbounded never blocks, cap-of-0 is unbounded (no deadlock), bounded limits/serializes concurrency, no starvation.

## Deviations from plan

- The plan named the new tests `test_restore_from_has_parallel_fan_out_cap_matches_unbounded`; I instead **extended the existing `test_restore_from_has_parallel_matches_sequential` to parametrize over k** (as the task instruction directed), which subsumes that assertion and also pins equality against the sequential restore. Same coverage, narrower diff.
- Config field landed in `crates/app/src/config.rs` (where `scan_thread_count` actually lives), not `crates/common/src/config.rs` as the path hint suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)