### PR TITLE
Drop retain:false from malloc_conf — fix jemalloc munmap VMA-exhaustion crash (#3247)

### DIFF
--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -113,8 +113,11 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[export_name = "_rjem_malloc_conf"]
-pub static malloc_conf: &[u8] =
-    b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000,retain:false\0";
+// NOTE: retain:false was REMOVED (#3247) — once live (via the #3238 symbol fix) it
+// made jemalloc munmap freed extents, exhausting vm.max_map_count during
+// warm-restart bucket-restore churn and crashing the validator. Decay knobs are
+// kept: under the default retain:true they return dirty pages via madvise (no VMA splits).
+pub static malloc_conf: &[u8] = b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000\0";
 
 use std::path::{Path, PathBuf};
 
@@ -3654,7 +3657,7 @@ mod tests {
     /// not exist without the feature. See #3235 / #3232.
     #[cfg(feature = "jemalloc")]
     #[test]
-    fn test_malloc_conf_carries_decay_and_retain_knobs() {
+    fn test_malloc_conf_carries_decay_knobs_and_omits_retain_false() {
         let conf = super::malloc_conf;
 
         // Must be NUL-terminated: jemalloc parses it as a C string.
@@ -3666,11 +3669,16 @@ mod tests {
 
         let conf_str = std::str::from_utf8(conf).expect("malloc_conf must be valid UTF-8");
 
+        // retain:false must NOT be present - it caused jemalloc munmap VMA exhaustion (#3247).
+        assert!(
+            !conf_str.contains("retain:false"),
+            "malloc_conf must NOT contain retain:false (it caused the VMA-exhaustion crash, #3247)"
+        );
+
         for knob in [
             "background_thread:true",
             "dirty_decay_ms:1000",
             "muzzy_decay_ms:1000",
-            "retain:false",
         ] {
             assert!(
                 conf_str.contains(knob),

--- a/crates/henyey/tests/jemalloc_config.rs
+++ b/crates/henyey/tests/jemalloc_config.rs
@@ -41,8 +41,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[export_name = "_rjem_malloc_conf"]
-pub static malloc_conf: &[u8] =
-    b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000,retain:false\0";
+pub static malloc_conf: &[u8] = b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000\0";
 
 /// Reads jemalloc's effective options via `mallctl` and asserts they match the
 /// values in henyey's `malloc_conf`. This is the real proof the config is
@@ -59,13 +58,19 @@ fn test_jemalloc_config_is_applied_at_runtime() {
     // definitely initialized before we query its options.
     let _warm = vec![0u8; 4096];
 
-    // `opt.retain`: default `true`; henyey sets `retain:false`.
+    // `opt.retain`: jemalloc's 64-bit-Linux default is `true`. henyey
+    // intentionally leaves it at that default: `retain:false` was dropped in
+    // #3247 because it munmaps freed extents and exhausts `vm.max_map_count`
+    // during high-churn warm-restart bucket-list restore, crashing the
+    // validator. Under `retain:true` the decay knobs still return dirty pages
+    // via `madvise` (no VMA splits). This asserts `retain:false` is NOT live.
     let retain: bool = unsafe { raw::read(b"opt.retain\0") }.expect("read opt.retain via mallctl");
     assert!(
-        !retain,
-        "jemalloc opt.retain must be false (henyey sets retain:false). \
-         Got retain={retain}. If true, jemalloc is running DEFAULTS — the \
-         malloc_conf export is NOT being read (wrong symbol name?)."
+        retain,
+        "jemalloc opt.retain must be true (the default; henyey must NOT set \
+         retain:false — it caused munmap/VMA exhaustion, #3247). \
+         Got retain={retain}. If false, the harmful retain:false knob has been \
+         reintroduced into malloc_conf."
     );
 
     // `opt.dirty_decay_ms`: default 10000; henyey sets 1000.


### PR DESCRIPTION
## URGENT regression fix — validator crash

**#3238 activated `retain:false` for the first time** (by fixing the `malloc_conf`→`_rjem_malloc_conf` symbol). The now-live `retain:false` **crashed the production validator** during warm-restart bucket-list restore:
```
<jemalloc>: Error in munmap(): Cannot allocate memory   ×153,195
```
RSS ≈ **731 MB**, **34 GB free** → NOT OOM. It's **kernel VMA-table exhaustion**: `retain:false` munmaps freed extents; the restore churn splits VMAs past `vm.max_map_count` (65530) → `munmap()` returns ENOMEM → abort. Auto-recovered by rollback to `24615fb5`; HEAD quarantined.

## Fix
Drop `retain:false` → jemalloc's `retain:true` default (extents retained, no VMA explosion). **Keep** the #3238 symbol fix + `background_thread:true` + `dirty_decay_ms/muzzy_decay_ms:1000`: under `retain:true` the decay returns dirty pages via `madvise` (operates within existing mappings, **never splits a VMA**) — RSS benefit kept, zero VMA risk. Only `retain:false` was the killer.

`malloc_conf` = `background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000`.

## Tests
- Runtime-assert test (`tests/jemalloc_config.rs`) now asserts `opt.retain==true` + `decay==1000` via mallctl — **passes** (`test_jemalloc_config_is_applied_at_runtime ... ok`). Re-proves the #3238 symbol fix AND confirms retain:false isn't live.
- Pin test renamed `test_malloc_conf_carries_decay_knobs_and_omits_retain_false` — asserts the string omits `retain:false` (guard against re-introduction) + still carries the decay/background_thread knobs.

## Operator-verify
Deploy; warm-restart bucket-restore completes with zero `Error in munmap()`, reaches Validating; #3244 logs `opt_retain=true`.

Closes #3247

🤖 Generated with [Claude Code](https://claude.com/claude-code)