### PR TITLE
Make deploy-quarantine content-check per-hunk (fix false-clear on unrelated drift)

### DIFF
--- a/scripts/lib/deploy-quarantine.sh
+++ b/scripts/lib/deploy-quarantine.sh
@@ -100,6 +100,131 @@ parse_quarantine_file() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# _quarantine_split_hunks
+#
+# Read-only filter. Reads a unified `git diff` on stdin and emits it split into
+# one self-contained patch per hunk on stdout, with each per-hunk patch
+# terminated by a NUL byte (so callers can iterate with `read -r -d ''` even
+# when a patch body contains blank lines). Each emitted patch carries the full
+# per-file header (`diff --git`/`old mode`/`new mode`/`index`/`---`/`+++`/etc.)
+# that preceded the `@@` hunk, so it is independently apply-checkable.
+#
+# We split per-HUNK (not per-file) deliberately: when a quarantined commit's
+# harmful hunk and an unrelated drifted hunk live in the SAME file, a per-file
+# patch is still all-or-nothing under `git apply --check` and would false-clear
+# (the drifted hunk fails → the whole file's patch fails). Per-hunk is the
+# minimal granularity that isolates "is THIS harmful hunk still present?".
+#
+# `filterdiff` is not installed, so this is a small awk program. It tracks the
+# current file header (everything from a `diff --git` line up to and including
+# the `+++` line) and, on each `@@` line, emits header + that single hunk's
+# body (up to the next `@@` or `diff --git`), NUL-terminated. Binary stanzas,
+# pure mode/rename changes, and other no-`@@` content produce zero hunks (no
+# false "applies"); the caller's fail-safe covers the zero-hunk case.
+# ─────────────────────────────────────────────────────────────────────────────
+_quarantine_split_hunks() {
+  awk '
+    function flush_hunk() {
+      if (in_hunk) {
+        printf "%s%s", header, hunk
+        printf "%c", 0
+        hunk = ""
+        in_hunk = 0
+      }
+    }
+    /^diff --git / {
+      flush_hunk()
+      header = $0 "\n"
+      in_header = 1
+      next
+    }
+    # File-header lines accumulate into header until the first @@.
+    in_header && /^@@/ {
+      in_header = 0
+    }
+    in_header {
+      header = header $0 "\n"
+      next
+    }
+    /^@@/ {
+      # New hunk for the current file: emit the previous one first.
+      flush_hunk()
+      in_hunk = 1
+      hunk = $0 "\n"
+      next
+    }
+    {
+      if (in_hunk) hunk = hunk $0 "\n"
+    }
+    END { flush_hunk() }
+  '
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _quarantine_any_hunk_present SHA
+#
+# Read-only + git subprocess. Splits `git diff <sha>^..<sha>` into per-hunk
+# patches and reverse-apply-checks EACH hunk independently. Returns:
+#   0 — at least one hunk still reverse-applies (harmful content PRESENT → BLOCK)
+#   1 — every hunk fails to reverse-apply (content genuinely removed → CLEAR)
+#   2 — fail-safe: `git diff` errored, produced no output, or produced output
+#       from which no hunks could be parsed (treat as PRESENT → BLOCK)
+#
+# FAIL-SAFE direction: this gate guards deploys of a binary already proven to
+# crash the validator. A false BLOCK only delays a deploy (recoverable); a
+# false CLEAR re-crashes the node (catastrophic). So every uncertain case errs
+# toward BLOCK. The per-hunk loop captures each hunk's rc WITHOUT letting a
+# non-zero (expected: rejected hunk) abort under a caller's `set -e`.
+#
+# OVER-BLOCK is INTENTIONAL: "any hunk present → block" keeps a commit with
+# MIXED harmful+benign hunks blocked while a BENIGN hunk survives (e.g. #3238
+# added both `retain:false` (harmful) AND the `_rjem_malloc_conf` export
+# (benign — #3251 keeps it); after the harmful line is removed, the benign
+# export remains, so this stays blocked). This is fail-safe and by design: the
+# content-check is a BACKSTOP — the operator removes the quarantine ENTRY once
+# a fix is verified. We deliberately do NOT try to auto-distinguish
+# harmful-vs-benign hunks (that is the rejected content-signature approach,
+# which would require per-entry harmful-line identification + a schema change).
+# ─────────────────────────────────────────────────────────────────────────────
+_quarantine_any_hunk_present() {
+  local sha="$1"
+  local diff_out diff_rc=0
+
+  # Capture the full commit diff. A hard git error (missing parent, etc.) or
+  # empty output is fail-safe → PRESENT.
+  diff_out="$(git diff "${sha}^..${sha}" 2>/dev/null)" || diff_rc=$?
+  if [[ "$diff_rc" -ne 0 ]]; then
+    return 2
+  fi
+  if [[ -z "$diff_out" ]]; then
+    return 2
+  fi
+
+  local any_present=0 n_hunks=0 patch
+  # Iterate NUL-delimited per-hunk patches. `read -r -d ''` keeps blank lines
+  # inside a hunk intact and behaves identically under bash and zsh.
+  while IFS= read -r -d '' patch; do
+    [[ -z "$patch" ]] && continue
+    n_hunks=$((n_hunks + 1))
+    # rc=1 (hunk rejected) is NORMAL — must not abort the loop under set -e.
+    if printf '%s' "$patch" | git apply --check --reverse 2>/dev/null; then
+      any_present=1
+    fi
+  done < <(printf '%s\n' "$diff_out" | _quarantine_split_hunks)
+
+  # Non-empty diff but zero hunks parsed (pure rename/mode/binary, or a parser
+  # gap): fail-safe → PRESENT. Never silently treat "couldn't parse" as CLEAR.
+  if [[ "$n_hunks" -eq 0 ]]; then
+    return 2
+  fi
+
+  if [[ "$any_present" -eq 1 ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # check_quarantine_active QUARANTINE_FILE
 #
 # Read-only + git subprocess. Determines if any quarantined SHA's *content*
@@ -115,13 +240,23 @@ parse_quarantine_file() {
 #
 # Algorithm per entry:
 #   1. If SHA is NOT an ancestor of origin/main → not deployed, skip.
-#   2. If SHA IS an ancestor → emit its diff via `git diff sha^..sha` and
-#      test reverse-apply via `git apply --check --reverse`. Success means
-#      the bad lines are still in the tree (BLOCK). Failure (rejected hunks,
-#      missing files, context mismatch) means the bad code has been removed
-#      or moved (CLEAR for this entry).
-#   3. Hard git errors (rc>=128 from merge-base, rc>=128 from `git diff`
-#      itself, missing parent) fail-closed: BLOCK with a warning.
+#   2. If SHA IS an ancestor → split its diff (`git diff sha^..sha`) into
+#      per-hunk patches and reverse-apply-check EACH hunk independently
+#      (`_quarantine_any_hunk_present`). The entry is ACTIVE (BLOCK) if ANY
+#      hunk still reverse-applies — i.e. at least one harmful hunk's content
+#      is still in the tree. It CLEARs only when ALL hunks fail to
+#      reverse-apply (genuinely reverted/removed).
+#
+#      Why per-hunk and not whole-commit (the #3248 fix): `git apply --check`
+#      is all-or-nothing, so the old whole-commit reverse-apply false-CLEARED
+#      whenever a LATER unrelated commit drifted the context of ANY one hunk
+#      of a multi-file quarantined commit — even though the harmful hunk was
+#      fully intact. Per-hunk isolates each hunk's presence. Per-FILE is
+#      insufficient (same-file drift still false-clears all-or-nothing).
+#   3. Hard git errors (rc>=128 from merge-base, missing parent), an empty or
+#      unparseable diff, or a non-empty diff yielding zero hunks all FAIL-SAFE
+#      toward BLOCK (a false block delays a deploy; a false clear re-crashes
+#      the validator).
 #
 # Arguments:
 #   QUARANTINE_FILE - Path to deploy_quarantine.txt
@@ -157,7 +292,7 @@ check_quarantine_active() {
     return 1
   fi
 
-  local sha merge_base_rc apply_rc
+  local sha merge_base_rc present_rc
   while IFS= read -r sha; do
     [[ -z "$sha" ]] && continue
 
@@ -183,21 +318,32 @@ check_quarantine_active() {
       continue
     fi
 
-    # Step 2: content check. The SHA is an ancestor; ask whether its diff
-    # would still reverse-apply cleanly. If YES, the offending lines are
-    # in the current tree → BLOCK. If NO (rejected hunks, missing files,
-    # context drift) the bad code is no longer present → CLEAR for this
-    # entry.
-    apply_rc=0
-    git diff "${sha}^..${sha}" 2>/dev/null | git apply --check --reverse 2>/dev/null || apply_rc=$?
+    # Step 2: per-hunk content check. The SHA is an ancestor; ask whether ANY
+    # hunk of its diff still reverse-applies (harmful content present). rc 0 →
+    # at least one hunk present → BLOCK. rc 1 → all hunks gone → CLEAR for this
+    # entry. rc 2 → fail-safe (diff error / empty / zero hunks) → BLOCK.
+    present_rc=0
+    _quarantine_any_hunk_present "$sha" || present_rc=$?
 
-    if [[ "$apply_rc" -eq 0 ]]; then
-      # Reverse-apply works → content still present → BLOCK
+    if [[ "$present_rc" -eq 0 ]]; then
+      # At least one hunk's harmful content is still present → BLOCK.
       QUARANTINE_STATUS="blocked_active"
       QUARANTINED_MATCH="$sha"
       return 0
     fi
-    # rc != 0: bad code has been reverted or otherwise removed. Skip.
+    if [[ "$present_rc" -ge 2 ]]; then
+      # Fail-safe: could not confidently determine absence → BLOCK.
+      local warning="content-check-indeterminate: ${sha:0:8} (rc=$present_rc)"
+      if [[ -n "$QUARANTINE_WARNINGS" ]]; then
+        QUARANTINE_WARNINGS+=", $warning"
+      else
+        QUARANTINE_WARNINGS="$warning"
+      fi
+      QUARANTINE_STATUS="blocked_active"
+      QUARANTINED_MATCH="$sha"
+      return 0
+    fi
+    # present_rc == 1: every hunk failed to reverse-apply → content removed. Skip.
   done <<< "$QUARANTINE_ENTRIES"
 
   # No active match

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -2107,11 +2107,29 @@ except Exception as e:
   fi
 
   # ── Test 77: check_quarantine_active — ancestor + content still applied ────
-  # New semantics: ancestor by itself is not enough; the bad commit's diff
-  # must still reverse-apply cleanly. Mock both git calls to return 0
-  # (ancestor: true, apply: clean).
+  # New semantics: ancestor by itself is not enough; at least one hunk of the
+  # bad commit's diff must still reverse-apply. Mock `diff` to emit a real
+  # single-hunk diff (so the per-hunk splitter parses one hunk) and `apply` to
+  # report it still reverse-applies (rc 0).
   printf '%s regression\n' "$sha1" > "$qdir/ancestor.txt"
-  git() { return 0; }
+  git() {
+    case "$1" in
+      merge-base) return 0 ;;
+      diff)
+        cat <<'CANNED'
+diff --git a/f.rs b/f.rs
+index 1111111..2222222 100644
+--- a/f.rs
++++ b/f.rs
+@@ -1,2 +1,3 @@ mod m {
++    still_present
+ }
+CANNED
+        return 0 ;;
+      apply) return 0 ;;  # hunk still reverse-applies → present
+      *) return 0 ;;
+    esac
+  }
   local rc77=0
   check_quarantine_ancestry "$qdir/ancestor.txt" || rc77=$?
   unset -f git
@@ -2136,13 +2154,23 @@ except Exception as e:
   fi
 
   # ── Test 78b: check_quarantine_active — ancestor but content reverted ──────
-  # Ancestor (rc=0) but apply --check --reverse fails (rc=1) → CLEAR.
-  # Mock dispatches on first arg: merge-base returns 0, apply returns 1.
+  # Ancestor (rc=0); `diff` emits a real single-hunk diff but the only hunk
+  # fails to reverse-apply (rc=1) → all hunks gone → CLEAR.
   printf '%s regression\n' "$sha1" > "$qdir/reverted.txt"
   git() {
     case "$1" in
       merge-base) return 0 ;;  # ancestor
-      diff)       return 0 ;;  # diff command emits output (pipe through)
+      diff)
+        cat <<'CANNED'
+diff --git a/f.rs b/f.rs
+index 1111111..2222222 100644
+--- a/f.rs
++++ b/f.rs
+@@ -1,2 +1,3 @@ mod m {
++    reverted_away
+ }
+CANNED
+        return 0 ;;
       apply)      return 1 ;;  # patch rejected → content gone
       *)          return 0 ;;
     esac

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=327
+TAP_PLAN=331
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -2155,6 +2155,226 @@ except Exception as e:
   else
     tap_not_ok "quarantine-active: ancestor + content-reverted returns 1 (auto-clear)" \
       "rc=$rc78b status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Tests 78c/78d/78e/78c-zsh: per-hunk reverse-apply (#3248) ──────────────
+  # Regression cluster for the false-clear bug fixed in #3248. The OLD code
+  # piped the whole-commit diff into a SINGLE `git apply --check --reverse`,
+  # which is all-or-nothing: a later unrelated commit drifting the context of
+  # ANY one hunk of a multi-file quarantined commit makes the entire
+  # reverse-apply fail → the gate reports CLEAR even though the harmful hunk
+  # (e.g. retain:false) is fully intact in HEAD. The fix splits the diff
+  # per-hunk and BLOCKS if ANY hunk still reverse-applies.
+  #
+  # Mock strategy (validated): mock `git diff sha^..sha` to emit a canned
+  # multi-hunk, multi-file diff; mock `git apply` to read the per-hunk patch
+  # off stdin and dispatch on the hunk's content marker — a "harmful" hunk
+  # still reverse-applies (rc 0), a "drifted/removed" hunk does not (rc 1).
+  # The mock therefore behaves identically whether it receives the whole-commit
+  # diff (old code: sees the drifted hunk → rejects all) or a single-hunk patch
+  # (new code: judges each hunk independently). This is what makes 78c FAIL on
+  # origin/main and PASS after the per-hunk rewrite.
+
+  # Canned 2-file, 2-hunk diff for a quarantined commit. Hunk 1 (main.rs) is
+  # the harmful retain:false line; hunk 2 (memory_report.rs) is the unrelated
+  # hunk a later commit drifted.
+  _q_canned_diff_drift() {
+    cat <<'CANNED'
+diff --git a/crates/henyey/src/main.rs b/crates/henyey/src/main.rs
+index 1111111..2222222 100644
+--- a/crates/henyey/src/main.rs
++++ b/crates/henyey/src/main.rs
+@@ -114,3 +114,4 @@ fn configure_allocator() {
+     let _ = unsafe { &_rjem_malloc_conf };
++    HARMFUL_RETAIN_FALSE_MARKER
+     let cfg = Config::load();
+     run(cfg)
+diff --git a/crates/ledger/src/memory_report.rs b/crates/ledger/src/memory_report.rs
+index 3333333..4444444 100644
+--- a/crates/ledger/src/memory_report.rs
++++ b/crates/ledger/src/memory_report.rs
+@@ -356,3 +356,4 @@ impl MemoryReport {
+     let total = self.heap + self.stack;
++    DRIFTED_UNRELATED_MARKER
+     report.emit(total);
+ }
+CANNED
+  }
+
+  # 3-hunk single-file diff for the partial-presence fail-safe case. Only the
+  # MIDDLE hunk still reverse-applies; the surrounding two are gone.
+  _q_canned_diff_partial() {
+    cat <<'CANNED'
+diff --git a/crates/henyey/src/cfg.rs b/crates/henyey/src/cfg.rs
+index aaaaaaa..bbbbbbb 100644
+--- a/crates/henyey/src/cfg.rs
++++ b/crates/henyey/src/cfg.rs
+@@ -10,2 +10,3 @@ mod top {
++    GONE_HUNK_ONE_MARKER
+ }
+@@ -40,2 +41,3 @@ mod mid {
++    HARMFUL_RETAIN_FALSE_MARKER
+ }
+@@ -90,2 +92,3 @@ mod bot {
++    GONE_HUNK_THREE_MARKER
+ }
+CANNED
+  }
+
+  # Per-hunk-aware `git` mock. `diff` emits the named canned diff; `apply`
+  # reads the patch off stdin and faithfully models `git apply --check`'s
+  # ALL-OR-NOTHING semantics: it succeeds (rc 0) only if EVERY hunk in the
+  # patch reverse-applies. A "harmful" hunk (HARMFUL_RETAIN_FALSE_MARKER)
+  # reverse-applies; a "drifted/removed" hunk (any *_MARKER that is NOT the
+  # harmful one) does NOT (a later commit moved its context). So the mock
+  # returns 0 iff the patch carries the harmful marker AND carries no
+  # drifted/gone marker. This is the crux of the #3248 repro:
+  #   - OLD code pipes the WHOLE 2-hunk diff into ONE apply → the patch
+  #     contains BOTH the harmful AND the drifted marker → rc 1 → false CLEAR.
+  #   - NEW code feeds each hunk separately → the harmful hunk alone → rc 0
+  #     → BLOCK.
+  # `merge-base` reports ancestor. `$_Q_MODE` selects the canned diff; if
+  # `$_Q_APPLY_ALL_FAIL` is set, every patch is rejected (genuine-revert).
+  _q_perhunk_git() {
+    case "$1" in
+      merge-base) return 0 ;;
+      diff)
+        case "${_Q_MODE:-drift}" in
+          partial) _q_canned_diff_partial ;;
+          *)       _q_canned_diff_drift ;;
+        esac
+        return 0
+        ;;
+      apply)
+        local patch
+        patch="$(cat)"
+        if [[ -n "${_Q_APPLY_ALL_FAIL:-}" ]]; then
+          return 1
+        fi
+        # All-or-nothing: any drifted/gone marker present → whole apply fails.
+        if printf '%s' "$patch" | grep -qE 'DRIFTED_UNRELATED_MARKER|GONE_HUNK_ONE_MARKER|GONE_HUNK_THREE_MARKER'; then
+          return 1
+        fi
+        if printf '%s' "$patch" | grep -q 'HARMFUL_RETAIN_FALSE_MARKER'; then
+          return 0   # only the harmful hunk → reverse-applies → present
+        fi
+        return 1     # no harmful content → rejected
+        ;;
+      *) return 0 ;;
+    esac
+  }
+
+  # ── Test 78c — drift → still-active (the #3248 bug; FAILS on origin/main) ───
+  printf '%s regression #3238\n' "$sha1" > "$qdir/drift.txt"
+  _Q_MODE=drift
+  unset _Q_APPLY_ALL_FAIL
+  git() { _q_perhunk_git "$@"; }
+  local rc78c=0
+  check_quarantine_active "$qdir/drift.txt" || rc78c=$?
+  unset -f git
+  unset _Q_MODE
+  if [[ $rc78c -eq 0 && "$QUARANTINE_STATUS" == "blocked_active" && "$QUARANTINED_MATCH" == "$sha1" ]]; then
+    tap_ok "quarantine-active: unrelated-hunk drift stays blocked (#3248 per-hunk)"
+  else
+    tap_not_ok "quarantine-active: unrelated-hunk drift stays blocked (#3248 per-hunk)" \
+      "rc=$rc78c status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78d — genuine full revert → clear ─────────────────────────────────
+  # ALL hunks fail to reverse-apply (the bad commit was genuinely reverted).
+  printf '%s regression #3238\n' "$sha1" > "$qdir/revert.txt"
+  _Q_MODE=drift
+  _Q_APPLY_ALL_FAIL=1
+  git() { _q_perhunk_git "$@"; }
+  local rc78d=0
+  check_quarantine_active "$qdir/revert.txt" || rc78d=$?
+  unset -f git
+  unset _Q_MODE _Q_APPLY_ALL_FAIL
+  if [[ $rc78d -eq 1 && "$QUARANTINE_STATUS" == "clear" && -z "$QUARANTINED_MATCH" ]]; then
+    tap_ok "quarantine-active: all hunks gone → clear (per-hunk all-gone path)"
+  else
+    tap_not_ok "quarantine-active: all hunks gone → clear (per-hunk all-gone path)" \
+      "rc=$rc78d status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78e — partial presence (fail-safe) → active ───────────────────────
+  # Same-file 3-hunk commit; only the middle (harmful) hunk survives. Per-file
+  # granularity would false-clear here (the whole file's patch fails); per-hunk
+  # correctly blocks. Encodes the fail-safe-toward-quarantined principle.
+  printf '%s regression #3238\n' "$sha1" > "$qdir/partial.txt"
+  _Q_MODE=partial
+  unset _Q_APPLY_ALL_FAIL
+  git() { _q_perhunk_git "$@"; }
+  local rc78e=0
+  check_quarantine_active "$qdir/partial.txt" || rc78e=$?
+  unset -f git
+  unset _Q_MODE
+  if [[ $rc78e -eq 0 && "$QUARANTINE_STATUS" == "blocked_active" && "$QUARANTINED_MATCH" == "$sha1" ]]; then
+    tap_ok "quarantine-active: partial same-file presence stays blocked (fail-safe)"
+  else
+    tap_not_ok "quarantine-active: partial same-file presence stays blocked (fail-safe)" \
+      "rc=$rc78e status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78c-zsh — cross-shell recheck of the drift case ───────────────────
+  # The awk hunk-splitter + the `while read`/rc-capture loop must behave
+  # identically under zsh (the orchestrator runs under zsh). Re-run the 78c
+  # drift scenario inside a `zsh -c` subprocess. Gated on zsh availability.
+  if command -v zsh >/dev/null 2>&1; then
+    printf '%s regression #3238\n' "$sha1" > "$qdir/drift_zsh.txt"
+    local zsh_out
+    zsh_out=$(zsh -c '
+      emulate -L zsh
+      source "$1/scripts/lib/deploy-quarantine.sh"
+      git() {
+        case "$1" in
+          merge-base) return 0 ;;
+          diff)
+            cat <<CANNED
+diff --git a/crates/henyey/src/main.rs b/crates/henyey/src/main.rs
+index 1111111..2222222 100644
+--- a/crates/henyey/src/main.rs
++++ b/crates/henyey/src/main.rs
+@@ -114,3 +114,4 @@ fn configure_allocator() {
+     let _ = unsafe { \&_rjem_malloc_conf };
++    HARMFUL_RETAIN_FALSE_MARKER
+     let cfg = Config::load();
+     run(cfg)
+diff --git a/crates/ledger/src/memory_report.rs b/crates/ledger/src/memory_report.rs
+index 3333333..4444444 100644
+--- a/crates/ledger/src/memory_report.rs
++++ b/crates/ledger/src/memory_report.rs
+@@ -356,3 +356,4 @@ impl MemoryReport {
+     let total = self.heap + self.stack;
++    DRIFTED_UNRELATED_MARKER
+     report.emit(total);
+ }
+CANNED
+            return 0 ;;
+          apply)
+            local patch
+            patch="$(cat)"
+            if print -r -- "$patch" | grep -qE DRIFTED_UNRELATED_MARKER; then
+              return 1
+            fi
+            if print -r -- "$patch" | grep -q HARMFUL_RETAIN_FALSE_MARKER; then
+              return 0
+            fi
+            return 1 ;;
+          *) return 0 ;;
+        esac
+      }
+      rc=0
+      check_quarantine_active "$2" || rc=$?
+      print -r -- "rc=$rc status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+    ' -- "$REPO_ROOT" "$qdir/drift_zsh.txt")
+    if [[ "$zsh_out" == "rc=0 status=blocked_active match=$sha1" ]]; then
+      tap_ok "quarantine-active: drift stays blocked — zsh recheck"
+    else
+      tap_not_ok "quarantine-active: drift stays blocked — zsh recheck" "got: '$zsh_out'"
+    fi
+  else
+    tap_skip "quarantine-active: drift stays blocked — zsh recheck" "zsh not found"
   fi
 
   # ── Test 79: check_quarantine_active — git error on ancestry (fail-closed) ─


### PR DESCRIPTION
Closes #3248

## Summary

`check_quarantine_active` in `scripts/lib/deploy-quarantine.sh` decided "is the bad commit's content still present?" by piping the **whole-commit** diff into a single `git diff sha^..sha | git apply --check --reverse`. `git apply --check` is all-or-nothing, so a later unrelated commit that drifted the context of **any one hunk** of a multi-file quarantined commit made the entire reverse-apply fail — and the gate concluded "content removed → CLEAR" even though the harmful hunk was fully intact. This false-cleared the #3238 crash commit after #3244 drifted `crates/ledger/src/memory_report.rs`, which would have let the autonomous deploy loop redeploy a binary already proven to crash the validator.

This replaces the whole-commit reverse-apply with a **per-hunk** one:
- `_quarantine_split_hunks` (awk) splits `git diff sha^..sha` into one self-contained, NUL-terminated patch per hunk, each carrying its full `diff --git`/`index`/`---`/`+++` file header (`filterdiff` is not installed). Splitting is **per-hunk, not per-file** — same-file drift still false-clears under per-file all-or-nothing.
- `_quarantine_any_hunk_present` reverse-apply-checks each hunk independently. **BLOCK if ANY hunk still applies; CLEAR only when ALL hunks fail** (genuinely removed).

### Fail-safe direction (it is a deploy safety gate)
A false block only delays a deploy (recoverable); a false clear re-crashes the validator (catastrophic). So every uncertain case errs toward **blocked**: `git diff` error, empty diff, or a non-empty diff that yields **zero parsed hunks** (pure rename/mode/binary, or a parser gap) all return BLOCK. The per-hunk loop captures each hunk's rc **without** aborting under `set -e` (rc=1 / rejected hunk is normal).

### Over-block is intentional and documented
Per-hunk "any hunk present → block" means a commit with **mixed harmful+benign hunks** stays blocked while a benign hunk survives — e.g. #3238 added both `retain:false` (harmful) **and** the `_rjem_malloc_conf` export (benign, which #3251 keeps); after the harmful line is removed the benign export remains, so #3238 stays `blocked_active` until the operator removes the quarantine **entry**. This is **intentional and fail-safe**, not a bug: the content-check is a *backstop*; the operator clears the entry once a fix is verified. We deliberately do **not** try to auto-distinguish harmful-vs-benign hunks — that is the rejected content-signature approach (per-entry harmful-line identification + a file-format/schema change = broader scope + operator burden). See the code comments on `_quarantine_any_hunk_present` and the issue implementation note.

Unchanged: the ancestry pre-filter, the `blocked_unreadable` / `blocked_git_error` fail-closed paths, all globals (`QUARANTINE_STATUS`/`QUARANTINED_MATCH`/`QUARANTINE_WARNINGS`), the return codes, and the `check_quarantine_ancestry` backward-compat alias — so all monitor-tick/monitor-loop call sites work without modification.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3248#issuecomment-4662441522)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — all quarantine tests pass (only the 4 pre-existing `pv-label-sync` failures remain, present on clean origin/main, unrelated to this change).
- [x] `bash -n` + `zsh -n` clean on `deploy-quarantine.sh` and the test harness.
- [x] awk splitter verified on a **real** multi-file commit (18963635 / #3238): 10 `@@` hunks → 10 per-hunk patches; per-hunk reverse-apply finds 7 still present.
- [x] End-to-end real-git proof: with 18963635 quarantined, the **old** whole-commit reverse-apply fails on `memory_report.rs:358` (the exact #3248 symptom) → would CLEAR; the **new** code reports `blocked_active`.

## Regression test (kind: bug-fix)

- **Tests:** `scripts/test-monitor-skill-snippets.sh` — 78c (drift→still-active), 78d (genuine-revert→clear), 78e (partial-presence→active, fail-safe), 78c-zsh (cross-shell).
- **Pre-fix:** committed as `7ae7cbf6` — 78c / 78e / 78c-zsh verified **FAILED** on origin/main (whole-commit `git apply` sees the drifted hunk → non-zero → `clear`); 78d passes on both.
- **Post-fix:** all four verified **PASS** after `191e3856`.

Mock strategy (per plan): mock `git diff` to emit a canned multi-hunk/multi-file diff; mock `git apply` to model `git apply --check`'s all-or-nothing semantics per patch (a drifted-marker hunk fails the whole patch), so the mock behaves identically whether handed the whole-commit diff (old code) or a single-hunk patch (new code) — which is what makes 78c fail-pre / pass-post.

## Deviations from plan

None. (The plan's status names, return codes, and call-site compatibility are all preserved. Existing tests 77 and 78b were updated to emit real canned diffs so they exercise the new per-hunk path rather than relying on the now-fail-safe empty-diff behavior — a test-fidelity update, not a semantic deviation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)