### PR TITLE
Source heard_from_quorum from the SCP ballot flag (#3250)

### DIFF
--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -1199,7 +1199,16 @@ impl App {
                     // Check quorum status - use latest_ext if available since we have
                     // actual SCP messages for that slot, otherwise fall back to tracking_slot
                     let quorum_check_slot = if latest_ext > 0 { latest_ext } else { tracking_slot };
-                    let heard_from_quorum = self.herder.heard_from_quorum(quorum_check_slot);
+                    // heard_from_quorum reports the SCP ballot protocol's per-slot
+                    // flag (parity with stellar-core's BallotProtocol::mHeardFromQuorum:
+                    // includes the local node, and is set for slots the node only
+                    // *followed* via a quorum of EXTERNALIZE). The henyey-only
+                    // SlotQuorumTracker never records the local node and only reaches a
+                    // v-blocking subset for an already-externalized followed slot, so
+                    // it gets stuck false after a restart while the qset is healthy
+                    // (#3250). The tracker is still the source for is_v_blocking /
+                    // out-of-sync recovery accounting (#1874).
+                    let heard_from_quorum = self.herder.scp_heard_from_quorum(quorum_check_slot);
                     let is_v_blocking = self.herder.is_v_blocking(quorum_check_slot);
 
                     let scp_sent = self.scp_messages_sent.load(Ordering::Relaxed);
@@ -1231,12 +1240,18 @@ impl App {
                     );
                     scp_messages_last_heartbeat = scp_messages_received;
 
-                    // Warn if we haven't heard from quorum for a while
-                    if self.is_validator && !heard_from_quorum && peers > 0 {
+                    // Warn if we are not even hearing from a v-blocking set, which
+                    // is the real partition signal. stellar-core keys partition /
+                    // recovery off v-blocking, never off heardFromQuorum — a node
+                    // that is v-blocking is demonstrably hearing from its quorum at
+                    // the ballot level, so gating this WARN on !heard_from_quorum
+                    // produced a false "network partition" warning every heartbeat
+                    // after a restart (#3250). Gate on !is_v_blocking instead.
+                    if self.is_validator && !is_v_blocking && peers > 0 {
                         tracing::warn!(
                             tracking_slot,
-                            is_v_blocking,
-                            "Have not heard from quorum - may be experiencing network partition"
+                            heard_from_quorum,
+                            "Have not heard from a v-blocking set - may be experiencing network partition"
                         );
                     }
 
@@ -1284,10 +1299,14 @@ impl App {
                     }
 
                     // Out-of-sync recovery: purge old slots when we're too far behind.
-                    // This mirrors stellar-core's outOfSyncRecovery() behavior.
-                    // When we have v-blocking slots that are >100 ahead of older slots,
-                    // purge the old slots to free memory and allow recovery.
-                    if !self.herder.state().can_receive_scp() || !heard_from_quorum {
+                    // This mirrors stellar-core's outOfSyncRecovery() behavior, which
+                    // keys off gotVBlocking (HerderImpl.cpp:521) — never off
+                    // heardFromQuorum. out_of_sync_recovery() itself early-returns
+                    // when Tracking and otherwise scans v-blocking slots. Gating the
+                    // call on !heard_from_quorum (the previously-stuck tracker flag)
+                    // spuriously triggered recovery on a healthy node after a restart
+                    // (#3250); drop that disjunct to match core.
+                    if !self.herder.state().can_receive_scp() {
                         if let Some(purge_slot) = self.herder.out_of_sync_recovery() {
                             tracing::info!(
                                 purge_slot,

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -2678,7 +2678,12 @@ impl App {
             peer_count: self.peer_count().await,
             pending_envelopes: herder_stats.pending_envelopes,
             cached_tx_sets: herder_stats.cached_tx_sets,
-            heard_from_quorum: self.herder.heard_from_quorum(quorum_slot),
+            // Source from the SCP ballot protocol's per-slot flag so this matches
+            // the /info qset `heard` view by construction (parity with
+            // stellar-core's getJsonQuorumInfo→ret["heard"]). The henyey-only
+            // SlotQuorumTracker excludes the local node and gets stuck false for a
+            // followed slot after a restart (#3250); is_v_blocking still uses it.
+            heard_from_quorum: self.herder.scp_heard_from_quorum(quorum_slot),
             is_v_blocking: self.herder.is_v_blocking(quorum_slot),
             slot: slot_state.map(Into::into),
             consensus_trigger_timer_fires: self
@@ -5078,7 +5083,41 @@ mod tests {
         // Verify quorum tracking methods are callable
         let slot = app.herder.tracking_slot().get();
         let _heard = app.herder.heard_from_quorum(slot);
+        let _scp_heard = app.herder.scp_heard_from_quorum(slot);
         let _blocking = app.herder.is_v_blocking(slot);
+    }
+
+    /// Regression test for #3250: the debug-stats / heartbeat `heard_from_quorum`
+    /// is sourced from the SCP ballot protocol's per-slot flag (which matches the
+    /// /info qset `heard` view), NOT the henyey-only SlotQuorumTracker. The two
+    /// must agree for the slot the stats query.
+    #[tokio::test]
+    async fn test_debug_stats_heard_from_quorum_matches_scp_ballot_flag() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+
+        let app = App::new(config).await.unwrap();
+
+        let stats = app.simulation_debug_stats().await;
+
+        // The stats slot is the same quorum_slot used to compute heard_from_quorum.
+        let quorum_slot = stats
+            .tracking_slot
+            .get()
+            .max(stats.current_ledger as u64 + 1)
+            .max(1);
+
+        // Source of truth: the SCP per-slot ballot flag (parity with core's
+        // BallotProtocol::mHeardFromQuorum). The debug-stats field must equal it
+        // exactly — by construction now that both read scp_heard_from_quorum.
+        let scp_flag = app.herder.scp_heard_from_quorum(quorum_slot);
+        assert_eq!(
+            stats.heard_from_quorum, scp_flag,
+            "debug-stats heard_from_quorum must mirror the SCP ballot flag (#3250)"
+        );
     }
 
     #[tokio::test]

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1470,6 +1470,32 @@ impl Herder {
         tracker.has_quorum(slot, |node_id| self.scp_driver.get_quorum_set(node_id))
     }
 
+    /// Report `heard_from_quorum` from the SCP ballot protocol's per-slot flag.
+    ///
+    /// This is the parity-faithful source for the heartbeat / `/info`
+    /// telemetry, mirroring stellar-core's per-slot
+    /// `BallotProtocol::mHeardFromQuorum` (`stellar-core/src/scp/BallotProtocol.cpp:2192`).
+    /// Unlike [`Self::heard_from_quorum`] (the henyey-only `SlotQuorumTracker`),
+    /// the SCP flag (1) includes the local node — core's `LocalNode::isQuorum`
+    /// always counts the local node's own `mLatestEnvelopes` entry, while the
+    /// tracker never records self (self-messages are skipped in
+    /// `process_verified` before `record_envelope`); and (2) is set for every
+    /// slot the node has a ballot for, including a slot the node only *followed*
+    /// via a quorum of CONFIRM/EXTERNALIZE (`set_state_from_envelope` →
+    /// `advance_slot` → `check_heard_from_quorum`). The tracker, by contrast,
+    /// only reaches a v-blocking subset for an already-externalized slot the
+    /// node free-rode (#1862/#3199/#3205), so it gets stuck `false` after a
+    /// restart while `qset.agree` is healthy — the #3250 triad.
+    ///
+    /// `SlotQuorumTracker` is intentionally left untouched (it remains the
+    /// source for `is_v_blocking` / recovery accounting per #1874).
+    pub fn scp_heard_from_quorum(&self, slot: SlotIndex) -> bool {
+        self.scp
+            .get_slot_state(slot)
+            .map(|s| s.heard_from_quorum)
+            .unwrap_or(false)
+    }
+
     /// Check whether we have a v-blocking set for a slot.
     pub fn is_v_blocking(&self, slot: SlotIndex) -> bool {
         self.slot_quorum_tracker.read().is_v_blocking(slot)
@@ -7232,6 +7258,170 @@ mod tests {
         assert!(
             has_externalize,
             "SCP should emit its own EXTERNALIZE message"
+        );
+    }
+
+    /// Regression test for #3250: a node that *follows* a quorum of EXTERNALIZE
+    /// for slot N (without nominating, as after a restart) reports
+    /// `scp_heard_from_quorum(N) == true` (the parity-faithful SCP ballot flag,
+    /// which includes the local node), while the henyey-only `SlotQuorumTracker`
+    /// path `heard_from_quorum(N)` reproduces the issue's stuck-`false` triad.
+    ///
+    /// Fails on main: there is no `scp_heard_from_quorum` accessor, and the
+    /// tracker-based `heard_from_quorum` returns false for the followed
+    /// externalized slot (only a v-blocking remote subset accumulates; the
+    /// local node is never recorded). Passes after the fix.
+    #[test]
+    fn test_scp_heard_from_quorum_true_for_followed_externalized_slot() {
+        // 2-of-2 quorum (local + one remote). The node receives a single remote
+        // EXTERNALIZE for `slot` and *follows* it — the local node emits its own
+        // EXTERNALIZE on the same value, the slot externalizes, and the SCP
+        // per-slot ballot flag (which counts the local node, parity with core
+        // LocalNode::isQuorum) is set. The henyey-only tracker only ever records
+        // the single remote (the local node is skipped at herder.rs:1965), so it
+        // sees just 1 of the 2-of-2 quorum → the stuck-false side of the #3250
+        // triad (is_v_blocking=true, scp heard=true, tracker heard=false).
+        let local_secret = SecretKey::from_seed(&[7u8; 32]);
+        let local_public = local_secret.public_key();
+        let local_node_id = node_id_from_public_key(&local_public);
+
+        let remote_secret = SecretKey::from_seed(&[1u8; 32]);
+        let remote_public = remote_secret.public_key();
+        let remote_node_id = node_id_from_public_key(&remote_public);
+
+        let quorum_set = ScpQuorumSet {
+            threshold: 2,
+            validators: vec![local_node_id.clone(), remote_node_id.clone()]
+                .try_into()
+                .unwrap(),
+            inner_sets: vec![].try_into().unwrap(),
+        };
+
+        let config = HerderConfig {
+            is_validator: true,
+            node_public_key: local_public,
+            local_quorum_set: Some(quorum_set.clone()),
+            ..HerderConfig::default()
+        };
+
+        let herder = Herder::with_secret_key(
+            config,
+            SecretKey::from_seed(&[7u8; 32]),
+            make_default_lm(),
+            TimerManagerHandle::no_op(),
+        );
+        herder.start_syncing();
+        herder.bootstrap(0);
+
+        herder
+            .quorum_tracker
+            .write()
+            .expand(&remote_node_id, quorum_set.clone())
+            .unwrap();
+
+        let slot = herder.tracking_slot().get();
+
+        // Follow a remote EXTERNALIZE for `slot` (the node does not nominate —
+        // this mirrors the post-restart free-ride path).
+        let env = make_signed_externalize_from(slot, &herder, &remote_secret);
+        assert_eq!(herder.receive_scp_envelope(env), EnvelopeState::Valid);
+
+        // The slot externalized via SCP, so the per-slot ballot flag is set.
+        assert!(
+            herder.scp().is_slot_externalized(slot),
+            "slot should externalize after following a quorum EXTERNALIZE"
+        );
+
+        // The parity-faithful SCP flag is TRUE for the followed slot.
+        assert!(
+            herder.scp_heard_from_quorum(slot),
+            "scp_heard_from_quorum must be true for a followed externalized slot (#3250)"
+        );
+
+        // The old tracker path yields the stuck-false side of the triad: it never
+        // recorded the local node, so the single remote envelope does not satisfy
+        // the 2-of-2 quorum from the tracker's perspective.
+        assert!(
+            !herder.heard_from_quorum(slot),
+            "tracker-based heard_from_quorum reproduces the stuck-false #3250 triad"
+        );
+    }
+
+    /// Regression test for #3250: the SCP `heard_from_quorum` flag does not
+    /// require the local node to appear in `SlotQuorumTracker.slot_nodes` (it
+    /// never can — `process_verified` skips self-messages before
+    /// `record_envelope` at herder.rs:1965). A 2-of-2 (local + one remote)
+    /// quorum that externalizes via a single remote EXTERNALIZE is TRUE under
+    /// the SCP flag (the local node is counted by the ballot protocol) but
+    /// FALSE under the tracker (local node absent → only 1 of 2 recorded).
+    #[test]
+    fn test_scp_heard_from_quorum_independent_of_local_node_record() {
+        let local_secret = SecretKey::from_seed(&[7u8; 32]);
+        let local_public = local_secret.public_key();
+        let local_node_id = node_id_from_public_key(&local_public);
+
+        let remote_secret = SecretKey::from_seed(&[1u8; 32]);
+        let remote_public = remote_secret.public_key();
+        let remote_node_id = node_id_from_public_key(&remote_public);
+
+        let quorum_set = ScpQuorumSet {
+            threshold: 2,
+            validators: vec![local_node_id.clone(), remote_node_id.clone()]
+                .try_into()
+                .unwrap(),
+            inner_sets: vec![].try_into().unwrap(),
+        };
+
+        let config = HerderConfig {
+            is_validator: true,
+            node_public_key: local_public,
+            local_quorum_set: Some(quorum_set.clone()),
+            ..HerderConfig::default()
+        };
+
+        let herder = Herder::with_secret_key(
+            config,
+            SecretKey::from_seed(&[7u8; 32]),
+            make_default_lm(),
+            TimerManagerHandle::no_op(),
+        );
+        herder.start_syncing();
+        herder.bootstrap(0);
+
+        herder
+            .quorum_tracker
+            .write()
+            .expand(&remote_node_id, quorum_set.clone())
+            .unwrap();
+
+        let slot = herder.tracking_slot().get();
+
+        // Follow the single remote EXTERNALIZE. With a 2-of-2 qset that includes
+        // the local node, the ballot protocol counts the local node and the
+        // remote → quorum; the tracker only ever has the remote.
+        let env = make_signed_externalize_from(slot, &herder, &remote_secret);
+        assert_eq!(herder.receive_scp_envelope(env), EnvelopeState::Valid);
+
+        assert!(
+            herder.scp_heard_from_quorum(slot),
+            "scp_heard_from_quorum counts the local node (parity with core LocalNode::isQuorum)"
+        );
+
+        // The local node is never in the tracker's slot_nodes (self-message skip),
+        // so the tracker cannot reach a 2-of-2 quorum from the single remote.
+        assert!(
+            !herder.heard_from_quorum(slot),
+            "tracker excludes the local node (herder.rs:1965) → 2-of-2 qset stuck false"
+        );
+    }
+
+    /// `scp_heard_from_quorum` returns false for a slot with no SCP state.
+    #[test]
+    fn test_scp_heard_from_quorum_missing_slot_is_false() {
+        let herder = make_test_herder();
+        assert!(
+            !herder.scp_heard_from_quorum(999_999),
+            "scp_heard_from_quorum must be false for an unknown slot"
         );
     }
 


### PR DESCRIPTION
Closes #3250

## Summary

After a restart the heartbeat field `heard_from_quorum` got stuck `false` indefinitely (and fired a recurring false "may be experiencing network partition" WARN) on a node that was demonstrably validating with a healthy quorum (`qset.agree=21`, `is_v_blocking=true`).

Root cause: the heartbeat/`/info` read the henyey-only `SlotQuorumTracker`, which (1) never records the **local node** (`process_verified` skips self-messages at `herder.rs:1965` before `record_envelope`), and (2) was queried for `latest_ext`, an already-externalized slot the node only *followed* — once a slot externalizes peers stop resending PREPARE/CONFIRM and only a **v-blocking** subset of EXTERNALIZE is needed to accept it (#1862). So the tracker reaches v-blocking but not a full remote quorum → the exact observed triad (`is_v_blocking=true`, `heard_from_quorum=false`, `agree=21`).

The fix routes the `heard_from_quorum` *signal* to the SCP ballot protocol's per-slot flag, the exact mirror of stellar-core's `BallotProtocol::mHeardFromQuorum` (`BallotProtocol.cpp:2192`) — it counts the local node and is set for every slot the node has a ballot for, including a followed/externalized slot. The two other consumers are decoupled to match core (which keys neither off `heardFromQuorum`): the partition WARN now gates on `!is_v_blocking`, and the out-of-sync-recovery gate drops the `|| !heard_from_quorum` disjunct (core's `outOfSyncRecovery` keys off `gotVBlocking`, `HerderImpl.cpp:521`).

`SlotQuorumTracker` is preserved verbatim for `is_v_blocking` / `get_v_blocking_slots` / `out_of_sync_recovery` (#1874, #3199/#3205, pipeline-order tests). Only the `heard_from_quorum` source changes.

This fixes the telemetry / partition-WARN / recovery-gate divergence. It does **NOT** fix the post-restart consensus stall — that is the #3199/#3205 recovery-routing arc, tracked separately as **#3252** (WAD here).

## Delegation + rewiring

- `crates/herder/src/herder.rs:1492` — new `pub fn scp_heard_from_quorum(slot) -> bool` = `self.scp.get_slot_state(slot).map(|s| s.heard_from_quorum).unwrap_or(false)`. Existing `heard_from_quorum` (tracker), `is_v_blocking`, `out_of_sync_recovery` left untouched.
- `crates/app/src/app/lifecycle.rs:1202` (heartbeat) — `heard_from_quorum` sourced from `scp_heard_from_quorum(quorum_check_slot)`; `is_v_blocking` still from the tracker.
- `crates/app/src/app/lifecycle.rs:~1243` (partition WARN) — gated on `!is_v_blocking`.
- `crates/app/src/app/lifecycle.rs:~1302` (out-of-sync-recovery gate) — `!can_receive_scp() || !heard_from_quorum` → `!can_receive_scp()`.
- `crates/app/src/app/mod.rs:2683` (`/info`/debug-stats) — `heard_from_quorum` sourced from `scp_heard_from_quorum(quorum_slot)`, so it agrees with `qset.heard` by construction.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3250#issuecomment-4663764188)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (lib) clean for henyey-herder / henyey-app / henyey-scp
- [x] `cargo test -p henyey-herder` — 1185 lib tests pass (incl. pipeline-order with test-support, #1874)
- [x] `cargo test -p henyey-app --lib` — 1022 pass (incl. new `/info` test)
- [x] `cargo test -p henyey-scp` — all pass

## Regression test (bug-fix)

- **Tests:** `crates/herder/src/herder.rs::test_scp_heard_from_quorum_true_for_followed_externalized_slot`, `::test_scp_heard_from_quorum_independent_of_local_node_record`, `::test_scp_heard_from_quorum_missing_slot_is_false`, plus `crates/app/src/app/mod.rs::test_debug_stats_heard_from_quorum_matches_scp_ballot_flag`.
- **Pre-fix:** committed as `1475d77d`. Verified FAILED (with `scp_heard_from_quorum` temporarily delegating to the tracker) on the two followed-slot tests with the issue's exact triad: `scp_heard_from_quorum must be true for a followed externalized slot (#3250)` while the tracker yields false (is_v_blocking=true, heard=false).
- **Post-fix:** verified PASSES after `e576ec3c`.

## Preserved (no regression)

- `SlotQuorumTracker` untouched; `is_v_blocking` / `out_of_sync_recovery` unchanged.
- `test_issue_1874_heard_from_quorum_survives_*` pass.
- `crates/herder/tests/scp_envelope_pipeline_order.rs` (`dependency_blocked_envelope_does_not_count_toward_heard_from_quorum_until_ready`) passes unchanged — stays on the tracker method.
- No #1862 / #3199 / #3205 regression.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)