### PR TITLE
Skip/re-baseline counter-delta alarms on a gap-stale monitor baseline

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -929,6 +929,36 @@ against a node that is in real-time sync with age=2s).
      reason=`no scrape_identity` or `scrape_identity malformed`.
      This handles rollout (existing sessions have prev.prom but no
      scrape_identity), manual deletion, and corruption.
+   - **Gap-staleness check (`PREV_SCRAPE_AGE_SECONDS`, #3246):** the identity
+     check above only catches a *process* change (PID/`start_ticks`). It does
+     NOT catch the case where the monitor **loop** stalled across a long
+     wall-clock gap while the validator **process survived** — same PID, so
+     `PREV_PROM_INVALID=false`, but `prev.prom`/the snapshot baseline is now
+     hours old. The counter-delta would then be computed across the whole gap
+     and false-fire as an acute burst (the headline tick-184 `recovery-stalled`
+     case). Compute `prev_scrape_age = now − timestamp(scrape_identity)` from
+     the `timestamp=` field of `scrape_identity` (which describes the process
+     that produced `prev.prom`) and export it for the evaluator:
+     ```bash
+     # prev_ts = ISO8601 timestamp from the EXISTING scrape_identity (the one
+     # describing prev.prom), read BEFORE the fresh write below. If the file is
+     # absent/malformed/has no timestamp, leave the age unknown (-1) — that case
+     # is already covered by PREV_PROM_INVALID, and an unknown age is treated as
+     # NOT stale (fail-safe).
+     PREV_TS=$(awk -F= '/^timestamp=/{print $2}' \
+       /home/tomer/data/$MONITOR_SESSION_ID/metrics/scrape_identity 2>/dev/null)
+     if [ -n "$PREV_TS" ]; then
+       PREV_EPOCH=$(date -u -d "$PREV_TS" +%s 2>/dev/null || echo "")
+       NOW_EPOCH=$(date -u +%s)
+       if [ -n "$PREV_EPOCH" ]; then
+         export PREV_SCRAPE_AGE_SECONDS=$(( NOW_EPOCH - PREV_EPOCH ))
+       else
+         export PREV_SCRAPE_AGE_SECONDS=-1
+       fi
+     else
+       export PREV_SCRAPE_AGE_SECONDS=-1
+     fi
+     ```
    - Write fresh identity file:
      ```bash
      printf "version=1\npid=%s\nstart_ticks=%s\ntimestamp=%s\n" \
@@ -963,6 +993,23 @@ against a node that is in real-time sync with age=2s).
      Independence is safe: each check reads PID/start_ticks from `/proc` and
      compares against its own snapshot.
 
+   **Gap-stale baseline (`PREV_SCRAPE_AGE_SECONDS`, #3246):** derived in the
+   evaluator as `gap_stale = age >= 0 and age >= GAP_STALE_THRESHOLD_SECONDS`
+   (default `3600` ≈ 3× the nominal ~20-min tick). This is the **distinct**
+   same-PID-old-baseline case: PID-change (#3206) trips `PREV_PROM_INVALID`
+   FIRST; gap-stale is sequenced AFTER the identity check, so the two are never
+   double-handled. Applied **asymmetrically** by alarm family:
+   - **prev.prom families** (counter, counter-dynamic, histogram-p99): **SKIP**
+     the acute fire this tick with a `gap-stale (prev age Xh)` reason — `prev.prom`
+     is recomputed from the file each tick, so no persisted baseline to reseed.
+   - **snapshot families** (counter-ratio, counter-streak — incl. the headline
+     `recovery-stalled` burst): **RE-BASELINE** — rewrite the snapshot with
+     current values and reset the streak to `0` (reusing the counter-reset path),
+     because these snapshots PERSIST across ticks; a plain skip would leave the
+     stale baseline and fire on the NEXT tick.
+   - **Age-unknown (`-1`/absent)** is treated as NOT stale (fail-safe; a truly
+     missing identity is already covered by `PREV_PROM_INVALID`).
+
 6. **Counter reset handling**: for any counter, if `current < prev`, treat
    `delta = current` (defense-in-depth for within-incarnation counter resets).
 
@@ -988,6 +1035,7 @@ against a node that is in real-time sync with age=2s).
    ARCHIVE_VERSION=1
    TICK_SKIPPED=${TICK_SKIPPED:-false}
    PREV_PROM_INVALID=${PREV_PROM_INVALID:-false}
+   PREV_SCRAPE_AGE_SECONDS=${PREV_SCRAPE_AGE_SECONDS:--1}
    WARMUP_TICKS_REMAINING=${WARMUP_TICKS_REMAINING:-0}
    FRESH_START=${FRESH_START:-no}
    CRASH_RECOVERY=${CRASH_RECOVERY:-no}
@@ -1126,6 +1174,7 @@ catalog for per-alarm gates and the evaluator source for edge-case behavior.
 ```bash
 # Set env vars from checks 3/10 state:
 export PREV_PROM_INVALID=...     # true/false from scrape_identity check
+export PREV_SCRAPE_AGE_SECONDS=... # prev.prom/snapshot age in seconds (gap-stale, #3246); -1/unset = unknown
 export WARMUP_TICKS_REMAINING=... # 0/1/2 from restart detection
 export FRESH_START=...            # yes/no
 export CRASH_RECOVERY=...        # yes/no

--- a/scripts/lib/eval-alarms.py
+++ b/scripts/lib/eval-alarms.py
@@ -7,6 +7,14 @@ Usage:
 
 Inputs (env vars):
     PREV_PROM_INVALID   true/false (default: false)
+    PREV_SCRAPE_AGE_SECONDS  wall-clock age of the prev.prom/snapshot baseline,
+                        in seconds (default/absent/-1: unknown ⇒ not stale).
+                        When >= GAP_STALE_THRESHOLD_SECONDS the baseline is
+                        "gap-stale" (see #3246): the monitor LOOP stalled across
+                        a long wall-clock gap while the validator PROCESS
+                        survived, so the same-PID baseline is hours old and the
+                        counter-delta would false-fire as an acute burst.
+    GAP_STALE_THRESHOLD_SECONDS  gap-stale threshold (default: 3600 ≈ 3× tick).
     WARMUP_TICKS_REMAINING  0/1/2 (default: 0)
     FRESH_START         yes/no (default: no)
     CRASH_RECOVERY      yes/no (default: no)
@@ -554,16 +562,31 @@ def eval_gauge_ratio(
         return make_result(alarm, "ok", value=round(ratio, 4), threshold=threshold)
 
 
+def gap_stale_reason(age_hours: float) -> str:
+    """Skip reason for a gap-stale prev.prom baseline (#3246)."""
+    return f"gap-stale (prev age {age_hours}h)"
+
+
 def eval_counter(
     alarm: dict,
     current: dict,
     prev: dict,
     prev_prom_invalid: bool,
     warmup_remaining: int,
+    gap_stale: bool = False,
+    gap_stale_age_hours: float = 0,
 ) -> dict:
     """Evaluate a counter alarm."""
     if prev_prom_invalid:
         return make_result(alarm, "skipped", skip_reason="PREV_PROM_INVALID")
+    # Gap-stale (#3246): prev.prom is same-PID but hours old, so cur-prev spans
+    # the whole loop gap and would false-fire. prev.prom is recomputed from the
+    # file each tick, so a plain SKIP is sufficient — no persisted baseline to
+    # re-seed (contrast the snapshot families, which must re-baseline). Checked
+    # AFTER prev_prom_invalid so a PID change is never double-handled.
+    if gap_stale:
+        return make_result(alarm, "skipped",
+                           skip_reason=gap_stale_reason(gap_stale_age_hours))
 
     metric = alarm.get("metric")
     metric_sum_list = alarm.get("metric_sum")
@@ -608,12 +631,23 @@ def eval_counter_dynamic(
     state_dir: Path,
     prev_prom_invalid: bool,
     warmup_remaining: int,
+    gap_stale: bool = False,
+    gap_stale_age_hours: float = 0,
 ) -> dict:
     """Evaluate a counter-dynamic alarm (threshold = multiplier × prior delta)."""
     ev_default = default_extra_values(alarm, "counter-dynamic")
 
     if prev_prom_invalid:
         return make_result(alarm, "skipped", skip_reason="PREV_PROM_INVALID",
+                           extra_values=ev_default)
+    # Gap-stale (#3246): skip BEFORE the prior-delta snapshot write below — the
+    # gap-spanning delta must not be stored as next tick's prior_delta, which
+    # would poison the dynamic threshold. prev.prom is recomputed each tick, so
+    # SKIP (not re-baseline) suffices. Checked after prev_prom_invalid so a PID
+    # change is never double-handled.
+    if gap_stale:
+        return make_result(alarm, "skipped",
+                           skip_reason=gap_stale_reason(gap_stale_age_hours),
                            extra_values=ev_default)
 
     metric_sum_list = alarm["metric_sum"]
@@ -684,12 +718,21 @@ def eval_histogram_p99(
     current: dict,
     prev: dict,
     prev_prom_invalid: bool,
+    gap_stale: bool = False,
+    gap_stale_age_hours: float = 0,
 ) -> dict:
     """Evaluate a histogram-p99 alarm with mean fallback."""
     ev_default = default_extra_values(alarm, "histogram-p99")
 
     if prev_prom_invalid:
         return make_result(alarm, "skipped", skip_reason="PREV_PROM_INVALID",
+                           extra_values=ev_default)
+    # Gap-stale (#3246): the count/sum/bucket deltas all span the loop gap, so
+    # SKIP. prev.prom is recomputed each tick (no persisted baseline to reseed).
+    # Checked after prev_prom_invalid so a PID change is never double-handled.
+    if gap_stale:
+        return make_result(alarm, "skipped",
+                           skip_reason=gap_stale_reason(gap_stale_age_hours),
                            extra_values=ev_default)
 
     metric = alarm["metric"]
@@ -813,6 +856,7 @@ def eval_counter_ratio(
     fresh_start: bool,
     crash_recovery: bool,
     uptime: int,
+    gap_stale: bool = False,
 ) -> dict:
     """Evaluate a counter-ratio alarm with streak detection.
 
@@ -940,6 +984,23 @@ def eval_counter_ratio(
         write_snapshot(snapshot_path, snapshot)
         return make_result(alarm, "collecting_baseline", extra_values=ev_default)
 
+    # Gap-stale (#3246): the snapshot baseline is SAME-PID (the identity check
+    # above passed) but hours old — the monitor loop stalled across a long
+    # wall-clock gap while the process survived. Unlike the prev.prom families
+    # (which recompute their baseline from the file each tick and can simply
+    # SKIP), this snapshot PERSISTS across ticks, so a plain skip would leave
+    # the stale baseline and fire on the NEXT tick. RE-BASELINE instead: rewrite
+    # the snapshot to current values and reset the streak to "0" — the exact
+    # path used on a counter reset above. Sequenced after the identity check, so
+    # a PID change (#3206) is handled by the snapshot reset there and never
+    # double-handled here.
+    if gap_stale:
+        snapshot[prev_num_key] = str(int(cur_num))
+        snapshot[prev_den_key] = str(int(cur_den))
+        snapshot[streak_key] = "0"
+        write_snapshot(snapshot_path, snapshot)
+        return make_result(alarm, "collecting_baseline", extra_values=ev_default)
+
     num_delta = cur_num - prev_num
     den_delta = cur_den - prev_den
 
@@ -1031,6 +1092,7 @@ def eval_counter_streak(
     state_dir: Path,
     pid: str,
     start_ticks: str,
+    gap_stale: bool = False,
 ) -> dict:
     """Evaluate a counter-streak alarm.
 
@@ -1111,6 +1173,31 @@ def eval_counter_streak(
         post_restart = maybe_post_restart_fire(alarm, cur_val)
         if post_restart is not None:
             return post_restart
+        return make_result(alarm, "collecting_baseline",
+                           extra_values=ev_default)
+
+    # Gap-stale (#3246): the snapshot baseline is SAME-PID (the identity check
+    # above passed) but hours old — the monitor loop stalled across a long
+    # wall-clock gap while the process survived. The headline tick-184
+    # recovery-stalled false-fire lives here: counter jumped 0→703 over the gap,
+    # delta >= burst_threshold would fire WARN as an acute burst. RE-BASELINE
+    # instead: rewrite the snapshot to the current value and reset the streak to
+    # "0" (mirrors the counter-reset branch above) — this snapshot PERSISTS
+    # across ticks, so a plain skip would leave the stale baseline and fire on
+    # the NEXT tick. Unlike the PID-change / counter-reset branches, do NOT
+    # invoke maybe_post_restart_fire: gap-stale is not a restart — the counts
+    # accrued across normal operation, not a startup burst, so the absolute
+    # value must not acute-fire. Sequenced after the identity check, so a PID
+    # change (#3206) is handled there and never double-handled here.
+    if gap_stale:
+        new_snapshot = {
+            "version": "1",
+            "pid": pid,
+            "start_ticks": start_ticks,
+            "counter_value": str(int(cur_val)),
+            "breach_streak": "0",
+        }
+        write_snapshot(snapshot_path, new_snapshot)
         return make_result(alarm, "collecting_baseline",
                            extra_values=ev_default)
 
@@ -1416,6 +1503,24 @@ def main() -> int:
 
     # Read env vars
     prev_prom_invalid = os.environ.get("PREV_PROM_INVALID", "false").lower() == "true"
+    # Gap-staleness (#3246): the baseline (prev.prom for the file families,
+    # the persisted PID/start_ticks snapshot for the snapshot families) is
+    # SAME-PID-but-old when the monitor loop stalled across a long wall-clock
+    # gap while the process survived. PID-change (#3206) is handled FIRST via
+    # PREV_PROM_INVALID / the snapshot PID-mismatch reset; gap-stale is the
+    # distinct same-PID case, sequenced AFTER (never double-handled). Age -1 /
+    # absent ⇒ unknown ⇒ NOT stale (fail-safe; truly-missing identity is
+    # already covered by PREV_PROM_INVALID).
+    try:
+        prev_scrape_age = int(os.environ.get("PREV_SCRAPE_AGE_SECONDS", "-1"))
+    except ValueError:
+        prev_scrape_age = -1
+    try:
+        gap_stale_threshold = int(os.environ.get("GAP_STALE_THRESHOLD_SECONDS", "3600"))
+    except ValueError:
+        gap_stale_threshold = 3600
+    gap_stale = prev_scrape_age >= 0 and prev_scrape_age >= gap_stale_threshold
+    gap_stale_age_hours = round(prev_scrape_age / 3600.0, 1) if gap_stale else 0
     warmup_remaining = int(os.environ.get("WARMUP_TICKS_REMAINING", "0"))
     fresh_start = os.environ.get("FRESH_START", "no").lower() == "yes"
     crash_recovery = os.environ.get("CRASH_RECOVERY", "no").lower() == "yes"
@@ -1474,18 +1579,22 @@ def main() -> int:
             elif kind == "gauge-ratio":
                 result = eval_gauge_ratio(alarm, current, persistence_state, prev_prom_invalid)
             elif kind == "counter":
-                result = eval_counter(alarm, current, prev, prev_prom_invalid, warmup_remaining)
+                result = eval_counter(alarm, current, prev, prev_prom_invalid, warmup_remaining,
+                                      gap_stale, gap_stale_age_hours)
             elif kind == "counter-dynamic":
-                result = eval_counter_dynamic(alarm, current, prev, state_dir, prev_prom_invalid, warmup_remaining)
+                result = eval_counter_dynamic(alarm, current, prev, state_dir, prev_prom_invalid, warmup_remaining,
+                                              gap_stale, gap_stale_age_hours)
             elif kind == "histogram-p99":
-                result = eval_histogram_p99(alarm, current, prev, prev_prom_invalid)
+                result = eval_histogram_p99(alarm, current, prev, prev_prom_invalid,
+                                            gap_stale, gap_stale_age_hours)
             elif kind == "counter-ratio":
                 result = eval_counter_ratio(
                     alarm, current, prev, state_dir, pid, start_ticks_val,
-                    fresh_start, crash_recovery, uptime,
+                    fresh_start, crash_recovery, uptime, gap_stale,
                 )
             elif kind == "counter-streak":
-                result = eval_counter_streak(alarm, current, state_dir, pid, start_ticks_val)
+                result = eval_counter_streak(alarm, current, state_dir, pid, start_ticks_val,
+                                             gap_stale)
             else:
                 result = make_result(alarm, "skipped", skip_reason=f"unknown kind: {kind}")
 

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=331
+TAP_PLAN=337
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -3257,6 +3257,26 @@ MOCK_BINARY
       "One or more of current.prom, prev.prom, scrape_identity missing from state table or not labeled check 12"
   fi
 
+  # Test 140: gap-staleness (#3246) documented in Check 12 — the identity section
+  # must compute prev_scrape_age from the timestamp field, export
+  # PREV_SCRAPE_AGE_SECONDS, name the gap-stale rule, and state the default
+  # threshold. The env var must also appear in the evaluator-invocation list.
+  if echo "$identity_section" | grep -Fq 'prev_scrape_age' \
+     && echo "$identity_section" | grep -Fq 'PREV_SCRAPE_AGE_SECONDS' \
+     && echo "$identity_section" | grep -Fq 'gap-stale' \
+     && echo "$identity_section" | grep -Fq '3600'; then
+    tap_ok "scrape-identity: gap-stale rule documented (prev_scrape_age, PREV_SCRAPE_AGE_SECONDS, gap-stale, 3600)"
+  else
+    tap_not_ok "scrape-identity: gap-stale rule documented" \
+      "identity section missing one of: prev_scrape_age, PREV_SCRAPE_AGE_SECONDS, gap-stale, 3600"
+  fi
+  if grep -Fq 'export PREV_SCRAPE_AGE_SECONDS' "$tick_file"; then
+    tap_ok "scrape-identity: PREV_SCRAPE_AGE_SECONDS in evaluator-invocation env list"
+  else
+    tap_not_ok "scrape-identity: PREV_SCRAPE_AGE_SECONDS in evaluator-invocation env list" \
+      "no 'export PREV_SCRAPE_AGE_SECONDS' in $tick_file"
+  fi
+
   fi  # end identity_section guard
 
   # Clean up all background processes from lifecycle tests
@@ -4256,6 +4276,200 @@ TICK_PROM_148E
   fi
   rm -f "$tick_prom_148e"
   rm -rf "$state_dir_148e"
+
+  # ── Tests 148f–148i: gap-staleness (#3246) ──────────────────────────────────
+  # When the monitor LOOP stalls for a long wall-clock gap but the validator
+  # PROCESS survives (same PID/start_ticks), the prev.prom / snapshot baseline
+  # stays valid by identity but becomes hours old. The counter-delta is then
+  # computed across the whole gap → false acute-burst alarms. The fix derives a
+  # gap_stale signal from PREV_SCRAPE_AGE_SECONDS >= GAP_STALE_THRESHOLD_SECONDS
+  # (default 3600) and applies it asymmetrically: prev.prom-family alarms SKIP
+  # (the file baseline is recomputed each tick); snapshot-family alarms
+  # RE-BASELINE (the snapshot persists across ticks).
+  local alarm_state_of
+  alarm_state_of() {
+    # $1 = evaluator stdout JSON, $2 = alarm name; prints the alarm state.
+    echo "$1" | python3 -c "
+import json, sys
+name = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+    for r in data.get('alarms', []):
+        if r.get('name') == name:
+            print(r.get('state', 'missing'))
+            break
+    else:
+        print('not-found')
+except:
+    print('parse-error')
+" "$2" 2>/dev/null || echo "parse-error"
+  }
+  local alarm_skipreason_of
+  alarm_skipreason_of() {
+    # $1 = evaluator stdout JSON, $2 = alarm name; prints the alarm skip_reason.
+    echo "$1" | python3 -c "
+import json, sys
+name = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+    for r in data.get('alarms', []):
+        if r.get('name') == name:
+            print(r.get('skip_reason', ''))
+            break
+    else:
+        print('not-found')
+except:
+    print('parse-error')
+" "$2" 2>/dev/null || echo "parse-error"
+  }
+
+  # Shared counter fixture: a valid prev.prom baseline (same incarnation, no
+  # PREV_PROM_INVALID) with a large delta on the `lost-sync` counter (op >= 1).
+  # The delta would normally fire — the only difference between 148f and 148g is
+  # the prev-scrape age.
+  local gap_prev_prom gap_cur_prom
+  gap_prev_prom=$(mktemp)
+  gap_cur_prom=$(mktemp)
+  cat > "$gap_prev_prom" <<'GAP_PREV'
+stellar_herder_lost_sync_total 100
+GAP_PREV
+  cat > "$gap_cur_prom" <<'GAP_CUR'
+stellar_herder_lost_sync_total 117
+GAP_CUR
+
+  # Test 148f: counter gap-stale skip. prev age 12h (43200s) >= threshold ⇒ the
+  # delta=17 lost-sync alarm must NOT acute-fire; it is skipped with a gap-stale
+  # reason. FAILS pre-fix (no gap_stale logic ⇒ fires).
+  local state_dir_148f out_148f
+  state_dir_148f=$(mktemp -d)
+  out_148f=$(MONITOR_MODE=validator UPTIME_SECONDS=99999 WARMUP_TICKS_REMAINING=0 \
+    PREV_PROM_INVALID=false PREV_SCRAPE_AGE_SECONDS=43200 \
+    PID=3366449 START_TICKS=5000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$gap_cur_prom" \
+    --prev "$gap_prev_prom" \
+    --state-dir "$state_dir_148f" 2>/dev/null) || true
+  local ls_state_148f ls_reason_148f
+  ls_state_148f=$(alarm_state_of "$out_148f" "lost-sync")
+  ls_reason_148f=$(alarm_skipreason_of "$out_148f" "lost-sync")
+  if [[ "$ls_state_148f" == "skipped" && "$ls_reason_148f" == *"gap-stale"* ]]; then
+    tap_ok "eval-alarms: counter gap-stale skip (prev age 12h ⇒ lost-sync skipped, reason '$ls_reason_148f', not firing)"
+  else
+    tap_not_ok "eval-alarms: counter gap-stale skip" \
+      "expected skipped+gap-stale, got state=$ls_state_148f reason=$ls_reason_148f"
+  fi
+  rm -rf "$state_dir_148f"
+
+  # Test 148g: counter normal interval still fires. Same fixture, prev age 20min
+  # (1200s) < threshold ⇒ the delta=17 alarm STILL fires. Guards against
+  # over-skipping. Passes both pre- and post-fix (no gap_stale at 1200s).
+  local state_dir_148g out_148g ls_state_148g
+  state_dir_148g=$(mktemp -d)
+  out_148g=$(MONITOR_MODE=validator UPTIME_SECONDS=99999 WARMUP_TICKS_REMAINING=0 \
+    PREV_PROM_INVALID=false PREV_SCRAPE_AGE_SECONDS=1200 \
+    PID=3366449 START_TICKS=5000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$gap_cur_prom" \
+    --prev "$gap_prev_prom" \
+    --state-dir "$state_dir_148g" 2>/dev/null) || true
+  ls_state_148g=$(alarm_state_of "$out_148g" "lost-sync")
+  if [[ "$ls_state_148g" == "firing" ]]; then
+    tap_ok "eval-alarms: counter normal interval still fires (prev age 20m ⇒ lost-sync firing)"
+  else
+    tap_not_ok "eval-alarms: counter normal interval still fires" \
+      "expected firing at 1200s prev age, got $ls_state_148g"
+  fi
+  rm -rf "$state_dir_148g"
+  rm -f "$gap_prev_prom" "$gap_cur_prom"
+
+  # Test 148h: recovery-stalled burst gap-stale RE-BASELINE (the headline
+  # tick-184 case). A valid SAME-PID snapshot baseline (pid=3366449) with a burst
+  # delta (counter jumped 0 → 703 across the gap). With prev age 12h >= threshold
+  # the alarm must RE-BASELINE — return collecting_baseline (NOT firing) AND
+  # rewrite the snapshot to the current counter value with breach_streak=0, so
+  # next tick's delta is small. A plain skip would leave the stale baseline and
+  # fire on the NEXT tick — that's why snapshot-family re-baselines. FAILS pre-fix
+  # (delta=703 >= burst_threshold ⇒ firing). NB: same PID, so this is the
+  # distinct-from-#3206 case — the identity check passes, #3206's PID-mismatch
+  # reset never triggers; gap-staleness is what re-baselines here.
+  local state_dir_148h tick_prom_148h
+  state_dir_148h=$(mktemp -d)
+  cat > "$state_dir_148h/counter_streak_snapshot" <<'SNAP_148H'
+version=1
+pid=3366449
+start_ticks=5000
+counter_value=0
+breach_streak=0
+SNAP_148H
+  tick_prom_148h=$(mktemp)
+  cat > "$tick_prom_148h" <<'TICK_PROM_148H'
+henyey_recovery_stalled_tick_total{reason="forcing_catchup_behind"} 703
+TICK_PROM_148H
+  local out_148h rs_state_148h
+  out_148h=$(MONITOR_MODE=validator UPTIME_SECONDS=99999 WARMUP_TICKS_REMAINING=0 \
+    PREV_PROM_INVALID=false PREV_SCRAPE_AGE_SECONDS=43200 \
+    PID=3366449 START_TICKS=5000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$tick_prom_148h" \
+    --state-dir "$state_dir_148h" 2>/dev/null) || true
+  rs_state_148h=$(rs_state_of "$out_148h")
+  local snap_cv_148h snap_streak_148h
+  snap_cv_148h=$(grep '^counter_value=' "$state_dir_148h/counter_streak_snapshot" | cut -d= -f2)
+  snap_streak_148h=$(grep '^breach_streak=' "$state_dir_148h/counter_streak_snapshot" | cut -d= -f2)
+  if [[ "$rs_state_148h" == "collecting_baseline" \
+        && "$snap_cv_148h" == "703" && "$snap_streak_148h" == "0" ]]; then
+    tap_ok "eval-alarms: recovery-stalled burst gap-stale re-baseline (703 ⇒ collecting_baseline, snapshot reseeded to 703 streak 0, not firing)"
+  else
+    tap_not_ok "eval-alarms: recovery-stalled burst gap-stale re-baseline" \
+      "expected collecting_baseline + snapshot reseed (cv=703 streak=0), got state=$rs_state_148h cv=$snap_cv_148h streak=$snap_streak_148h"
+  fi
+  rm -f "$tick_prom_148h"
+  rm -rf "$state_dir_148h"
+
+  # Test 148i: counter-ratio gap-stale RE-BASELINE. A valid same-PID ratio
+  # snapshot baseline with a breaching ratio across the gap must re-baseline
+  # (collecting_baseline) and reset the streak to 0, rather than advancing the
+  # streak toward a fire. Uses `pending-too-old-ratio` (min_volume=100).
+  # FAILS pre-fix (the breaching ratio advances the streak → breach/firing).
+  local state_dir_148i tick_prom_148i
+  state_dir_148i=$(mktemp -d)
+  cat > "$state_dir_148i/ratio_snapshot" <<'SNAP_148I'
+version=1
+pid=3366449
+start_ticks=5000
+pending-too-old-ratio_numerator=0
+pending-too-old-ratio_denominator=0
+pending-too-old-ratio_streak=2
+SNAP_148I
+  tick_prom_148i=$(mktemp)
+  # num jumps 0→900, den 0→1000 across the gap → ratio 0.9 (breaching), den_delta
+  # 1000 >= min_volume 100.
+  cat > "$tick_prom_148i" <<'TICK_PROM_148I'
+stellar_herder_pending_too_old_total 900
+stellar_herder_pending_received_total 1000
+TICK_PROM_148I
+  local out_148i pt_state_148i
+  out_148i=$(MONITOR_MODE=validator UPTIME_SECONDS=99999 WARMUP_TICKS_REMAINING=0 \
+    PREV_PROM_INVALID=false PREV_SCRAPE_AGE_SECONDS=43200 \
+    PID=3366449 START_TICKS=5000 \
+    python3 "$eval_script" \
+    --catalog "$catalog_file" \
+    --current "$tick_prom_148i" \
+    --state-dir "$state_dir_148i" 2>/dev/null) || true
+  pt_state_148i=$(alarm_state_of "$out_148i" "pending-too-old-ratio")
+  local ratio_streak_148i
+  ratio_streak_148i=$(grep '^pending-too-old-ratio_streak=' "$state_dir_148i/ratio_snapshot" | cut -d= -f2)
+  if [[ "$pt_state_148i" == "collecting_baseline" && "$ratio_streak_148i" == "0" ]]; then
+    tap_ok "eval-alarms: counter-ratio gap-stale re-baseline (breaching ratio ⇒ collecting_baseline, streak reset 0)"
+  else
+    tap_not_ok "eval-alarms: counter-ratio gap-stale re-baseline" \
+      "expected collecting_baseline + streak 0, got state=$pt_state_148i streak=$ratio_streak_148i"
+  fi
+  rm -f "$tick_prom_148i"
+  rm -rf "$state_dir_148i"
 
   # Test 149: alarm-surfaces.toml file-local invariants + mirrored UIDs
   #           resolve to real Grafana alert UIDs in henyey-slo-alerts.yaml.


### PR DESCRIPTION
Closes #3246

## Summary

When the monitor loop stalls across a long wall-clock gap but the validator process survives (same PID/start_ticks), check-12's identity check (`PREV_PROM_INVALID`) stays `false`, so the counter-delta is computed across the entire gap and false-fires as an acute burst (the headline tick-184 `recovery-stalled` WARN with delta=703). This adds a baseline-age (gap-stale) signal to the evaluator and applies it asymmetrically by alarm family.

## Approach

- **SKILL (`.claude/skills/monitor-tick/SKILL.md`):** check-12 step 5 now computes `prev_scrape_age = now − timestamp(scrape_identity)` and exports `PREV_SCRAPE_AGE_SECONDS`. Documents the gap-stale rule, the default threshold, the env var in the evaluator-invocation list, and the archive metadata sidecar.
- **Evaluator (`scripts/lib/eval-alarms.py`):** derives `gap_stale = age >= 0 and age >= GAP_STALE_THRESHOLD_SECONDS` (default `3600`), sequenced **after** the PID-identity check so #3206's PID-change case is never double-handled. Applied asymmetrically:
  - **prev.prom families** (`eval_counter`, `eval_counter_dynamic`, `eval_histogram_p99`) → **SKIP** the acute fire with a `gap-stale (prev age Xh)` reason. The `eval_counter_dynamic` guard precedes its prior-delta snapshot write so the gap-spanning delta is not stored.
  - **snapshot families** (`eval_counter_ratio`, `eval_counter_streak` — the headline) → **RE-BASELINE** (rewrite snapshot + reset streak to `0`, reusing the counter-reset path), because snapshots persist across ticks.
  - **Age-unknown (`-1`/absent)** → not stale (fail-safe; truly-missing identity is already covered by `PREV_PROM_INVALID`).

## Distinctness from #3206

#3206 handles the PID-change (restart) case via `PREV_PROM_INVALID` / the snapshot PID-mismatch reset. Gap-stale is the **distinct** same-PID-but-old-baseline case: the identity check passes, so #3206's logic never triggers. Gap-stale is sequenced strictly after the identity check in every evaluator, so a PID change is handled there and never double-handled.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3246#issuecomment-4665719912)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — all new tests pass (the only remaining failures, pv-label-sync 152–155, are pre-existing on origin/main and unrelated)
- [x] `python3 -c 'import ast; ast.parse(open("scripts/lib/eval-alarms.py").read())'`
- [x] `python3 -m pytest scripts/ci/test_check_alarm_versions.py` — 23 passed
- [x] `check-alarm-versions.py` green (no TOML change ⇒ no `baseline_version` bump)
- [x] `bash -n` + `zsh -n` clean

## Regression test

- **Tests:** `scripts/test-monitor-skill-snippets.sh` — 148f (counter skip), 148g (normal interval still fires), 148h (recovery-stalled re-baseline), 148i (counter-ratio re-baseline) + 2 SKILL-doc assertions.
- **Pre-fix:** committed as `5d076e5eb04ac0ccbd2dabd51230bc5c8a31ef58` — 148f/148h/148i and the doc tests FAILED on origin/main (e.g. counter skip got `state=firing`; streak got `firing` instead of `collecting_baseline`).
- **Post-fix:** all PASS after `b9600969f4cba56ba88d9adb17a614e103077bd4`. 148g (normal ~20-min interval) fires both pre- and post-fix, guarding against over-skipping.

## Deviations from plan

None. (Plan line-number references were ~20 lines off from the current file; logic placement matches the plan's described anchors.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)