### PR TITLE
Auto-clear bundled-commit quarantine via resolved:<fix-sha> token

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1840,6 +1840,29 @@ Entries stay in the file as a historical log; they're harmless once their
 content is gone. The file can grow unboundedly over time if you want a
 deploy audit trail; trim it manually whenever convenient.
 
+**Bundled commits (`resolved:<fix-sha>`)** — the content-check above blocks
+if **any** hunk of the quarantined SHA still reverse-applies. A commit that
+**bundled** a harmful change with desirable ones (e.g. #3238 mixed a harmful
+`retain:false` with the benign `_rjem_malloc_conf` export + instrumentation)
+can never auto-clear after a **partial** revert: the benign hunks are
+intentionally kept on `origin/main`, so the per-hunk check stays
+`blocked_active` forever (the tick-199 false-block, #3256). For that case,
+stamp the entry once with the fix commit that resolved it:
+
+```bash
+source "$(git rev-parse --show-toplevel)/scripts/lib/deploy-quarantine.sh"
+# <fix-sha> is the commit that removed the harmful part (e.g. #3251).
+quarantine_resolve "$HOME/data/deploy_quarantine.txt" "$bad_sha" "$fix_sha"
+```
+
+This appends a `resolved:<fix-sha>` token to the entry. The gate **auto-clears**
+that entry once `<fix-sha>` is an ancestor of `origin/main` (i.e. the fix has
+merged) — no further per-tick action needed. It is **fail-safe**: a not-yet-
+merged fix, a malformed token, a self-resolution (`<fix-sha>` == `<bad_sha>`),
+or a git error all fall back to the per-hunk content-check (BLOCK). Stamping is
+a once-per-quarantine manual step today; automatic fix-SHA stamping is the
+follow-up #3258. `quarantine_remove` remains the override.
+
 **Manual removal** (still supported, occasionally useful — e.g. an entry
 that the content check can't decide cleanly because of a malformed diff
 or a binary file):

--- a/scripts/lib/deploy-quarantine.sh
+++ b/scripts/lib/deploy-quarantine.sh
@@ -12,6 +12,11 @@
 #   - Line-oriented, default-whitespace-separated fields
 #   - First field: 40 lowercase hex chars (commit SHA)
 #   - Remaining fields: optional free-text reason (single line)
+#   - An optional `resolved:<40-hex>` token MAY appear anywhere in the reason
+#     (token-boundary-anchored). It records the fix commit that resolves the
+#     quarantine: once that fix SHA is an ancestor of origin/main, the entry
+#     auto-clears (see check_quarantine_active). Additive — absent on legacy
+#     entries, which keep the per-hunk content-check as their backstop.
 #   - Lines starting with # (after optional whitespace) are comments
 #   - Blank/whitespace-only lines are skipped
 #   - CRLF is stripped during parsing
@@ -36,6 +41,11 @@ _DEPLOY_QUARANTINE_LOADED=1
 #
 # Sets globals:
 #   QUARANTINE_ENTRIES  - Newline-separated valid SHAs (order preserved)
+#   QUARANTINE_RESOLVED - Newline-separated resolved-fix SHAs, ONE PER ENTRY in
+#                         the SAME order as QUARANTINE_ENTRIES. A line is the
+#                         40-hex fix SHA when the entry carried a valid,
+#                         token-boundary-anchored `resolved:<sha>`, or "-" when
+#                         it did not. The two globals are index-aligned.
 #   QUARANTINE_WARNINGS - Comma-space-separated warning messages
 #
 # Returns:
@@ -45,6 +55,7 @@ _DEPLOY_QUARANTINE_LOADED=1
 parse_quarantine_file() {
   local file="$1"
   QUARANTINE_ENTRIES=""
+  QUARANTINE_RESOLVED=""
   QUARANTINE_WARNINGS=""
 
   # Missing or empty file: clear, no warnings
@@ -80,10 +91,29 @@ parse_quarantine_file() {
 
     # Validate: exactly 40 lowercase hex chars
     if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+      # Extract an optional `resolved:<40-hex>` token from the reason field.
+      # Anchored on token boundaries (start-or-whitespace before, end-or-
+      # whitespace after) so a substring like `unresolved:...` or a >40-hex
+      # blob never false-matches. Default "-" (no resolved annotation).
+      # Done via grep (not the `=~` capture array) so the extraction is
+      # identical under bash and zsh — zsh populates `$match`, not
+      # `$BASH_REMATCH`, for `[[ =~ ]]` capture groups (#3256).
+      local resolved="-" _resolved_tok
+      # `|| true`: grep exits 1 on no-match; the `|| true` keeps this from
+      # tripping a caller's `set -e`/`pipefail` (the no-token case is normal).
+      _resolved_tok="$(printf '%s' " $_rest " | grep -oE '[[:space:]]resolved:[0-9a-f]{40}[[:space:]]' | head -n1 || true)"
+      if [[ -n "$_resolved_tok" ]]; then
+        # Strip the leading-space + `resolved:` prefix and the trailing space.
+        _resolved_tok="${_resolved_tok#"${_resolved_tok%%[![:space:]]*}"}"
+        _resolved_tok="${_resolved_tok%"${_resolved_tok##*[![:space:]]}"}"
+        resolved="${_resolved_tok#resolved:}"
+      fi
       if [[ -n "$QUARANTINE_ENTRIES" ]]; then
         QUARANTINE_ENTRIES+=$'\n'"$sha"
+        QUARANTINE_RESOLVED+=$'\n'"$resolved"
       else
         QUARANTINE_ENTRIES="$sha"
+        QUARANTINE_RESOLVED="$resolved"
       fi
     else
       local warning="malformed: ${sha:0:12}"
@@ -240,12 +270,28 @@ _quarantine_any_hunk_present() {
 #
 # Algorithm per entry:
 #   1. If SHA is NOT an ancestor of origin/main → not deployed, skip.
-#   2. If SHA IS an ancestor → split its diff (`git diff sha^..sha`) into
-#      per-hunk patches and reverse-apply-check EACH hunk independently
-#      (`_quarantine_any_hunk_present`). The entry is ACTIVE (BLOCK) if ANY
-#      hunk still reverse-applies — i.e. at least one harmful hunk's content
-#      is still in the tree. It CLEARs only when ALL hunks fail to
-#      reverse-apply (genuinely reverted/removed).
+#   2. resolved-SHA auto-clear (#3256): if the entry carries a valid
+#      `resolved:<fix-sha>` token, the fix SHA is NOT the entry's own SHA
+#      (self-resolution guard), and that fix SHA is an ancestor of origin/main
+#      (`git merge-base --is-ancestor` → 0), the fix has genuinely landed →
+#      CLEAR this entry (skip the content-check). This is the ONLY way an
+#      annotated bundled-commit quarantine auto-clears while benign hunks of
+#      the same commit are intentionally retained (the tick-199 false-block:
+#      #3238 bundled a harmful `retain:false` hunk removed by #3251 with benign
+#      hunks kept on main; the per-hunk check below stays BLOCKED forever
+#      because the benign hunks legitimately reverse-apply). An operator/
+#      automation stamps `resolved:` once; the gate auto-clears on merge.
+#      FAIL-SAFE: a missing token, self-resolution, a not-yet-merged fix
+#      (`--is-ancestor` → 1), OR a git error on the resolved-ancestry check
+#      (rc>=128) all FALL THROUGH to the per-hunk content-check below — the
+#      resolved path can only CLEAR, never relax the existing backstop.
+#   3. If the entry was not auto-cleared by step 2 → split its diff
+#      (`git diff sha^..sha`) into per-hunk patches and reverse-apply-check
+#      EACH hunk independently (`_quarantine_any_hunk_present`). The entry is
+#      ACTIVE (BLOCK) if ANY hunk still reverse-applies — i.e. at least one
+#      harmful hunk's content is still in the tree. It CLEARs only when ALL
+#      hunks fail to reverse-apply (genuinely reverted/removed). This is the
+#      byte-for-byte #3253 backstop for every un-annotated entry.
 #
 #      Why per-hunk and not whole-commit (the #3248 fix): `git apply --check`
 #      is all-or-nothing, so the old whole-commit reverse-apply false-CLEARED
@@ -253,7 +299,7 @@ _quarantine_any_hunk_present() {
 #      of a multi-file quarantined commit — even though the harmful hunk was
 #      fully intact. Per-hunk isolates each hunk's presence. Per-FILE is
 #      insufficient (same-file drift still false-clears all-or-nothing).
-#   3. Hard git errors (rc>=128 from merge-base, missing parent), an empty or
+#   4. Hard git errors (rc>=128 from merge-base, missing parent), an empty or
 #      unparseable diff, or a non-empty diff yielding zero hunks all FAIL-SAFE
 #      toward BLOCK (a false block delays a deploy; a false clear re-crashes
 #      the validator).
@@ -292,8 +338,11 @@ check_quarantine_active() {
     return 1
   fi
 
-  local sha merge_base_rc present_rc
-  while IFS= read -r sha; do
+  # Iterate QUARANTINE_ENTRIES and the index-aligned QUARANTINE_RESOLVED in
+  # lockstep over two FDs. `read -r ... <&3 && read -r ... <&4` advances both
+  # streams one line per loop and behaves identically under bash and zsh.
+  local sha resolved merge_base_rc present_rc resolved_rc
+  while IFS= read -r sha <&3 && IFS= read -r resolved <&4; do
     [[ -z "$sha" ]] && continue
 
     # Step 1: ancestry check. If SHA isn't reachable, its content can't
@@ -318,7 +367,24 @@ check_quarantine_active() {
       continue
     fi
 
-    # Step 2: per-hunk content check. The SHA is an ancestor; ask whether ANY
+    # Step 2: resolved-SHA auto-clear (#3256). If this entry carries a valid
+    # `resolved:<fix-sha>` that is NOT its own SHA (self-resolution guard) and
+    # the fix SHA is an ancestor of origin/main, the fix has genuinely landed
+    # → CLEAR this entry. Every uncertain case (no token, self-resolution,
+    # not-yet-merged, git error) FALLS THROUGH to the per-hunk content-check
+    # below — the resolved path can only clear, never weaken the backstop.
+    if [[ "$resolved" =~ ^[0-9a-f]{40}$ && "$resolved" != "$sha" ]]; then
+      resolved_rc=0
+      git merge-base --is-ancestor "$resolved" origin/main 2>/dev/null || resolved_rc=$?
+      if [[ "$resolved_rc" -eq 0 ]]; then
+        # Fix commit is on main → the quarantine is resolved → CLEAR.
+        continue
+      fi
+      # resolved_rc == 1 (fix not yet merged) OR rc>=128 (git error): do NOT
+      # clear — fall through to the per-hunk content-check (fail-closed).
+    fi
+
+    # Step 3: per-hunk content check. The SHA is an ancestor; ask whether ANY
     # hunk of its diff still reverse-applies (harmful content present). rc 0 →
     # at least one hunk present → BLOCK. rc 1 → all hunks gone → CLEAR for this
     # entry. rc 2 → fail-safe (diff error / empty / zero hunks) → BLOCK.
@@ -344,7 +410,7 @@ check_quarantine_active() {
       return 0
     fi
     # present_rc == 1: every hunk failed to reverse-apply → content removed. Skip.
-  done <<< "$QUARANTINE_ENTRIES"
+  done 3<<< "$QUARANTINE_ENTRIES" 4<<< "$QUARANTINE_RESOLVED"
 
   # No active match
   QUARANTINE_STATUS="clear"
@@ -455,6 +521,83 @@ quarantine_remove() {
   # Atomic removal via tmp+mv
   local tmpfile="${file}.tmp"
   if ! awk -v sha="$sha" '$1 != sha' "$file" > "$tmpfile" 2>/dev/null; then
+    rm -f "$tmpfile" 2>/dev/null
+    return 2
+  fi
+
+  if ! mv "$tmpfile" "$file" 2>/dev/null; then
+    rm -f "$tmpfile" 2>/dev/null
+    return 2
+  fi
+
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# quarantine_resolve QUARANTINE_FILE SHA RESOLVED_SHA
+#
+# I/O: atomically stamps a `resolved:<RESOLVED_SHA>` token onto EVERY entry
+# whose first field is SHA. This records the fix commit that resolves the
+# quarantine; check_quarantine_active auto-clears the entry once RESOLVED_SHA
+# is an ancestor of origin/main (#3256). Idempotent: any pre-existing
+# `resolved:<...>` token on a matching entry is replaced (canonicalized to a
+# single token), so repeated calls converge. Non-matching entries are left
+# byte-for-byte unchanged. Mirrors quarantine_remove's atomic tmp+mv posture.
+#
+# Arguments:
+#   QUARANTINE_FILE - Path to deploy_quarantine.txt
+#   SHA             - 40 lowercase hex chars (the quarantined commit)
+#   RESOLVED_SHA    - 40 lowercase hex chars (the fix commit)
+#
+# Returns:
+#   0 — stamped, already stamped (no-op), SHA not present, or missing file
+#   1 — invalid SHA format (either argument), or self-resolution
+#       (SHA == RESOLVED_SHA — rejected; would defeat the gate)
+#   2 — I/O error (read, awk, or mv failure)
+# ─────────────────────────────────────────────────────────────────────────────
+quarantine_resolve() {
+  local file="$1" sha="$2" resolved="$3"
+
+  # Validate both SHAs.
+  if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+    return 1
+  fi
+  if [[ ! "$resolved" =~ ^[0-9a-f]{40}$ ]]; then
+    return 1
+  fi
+  # Self-resolution guard: a commit cannot resolve itself (it is always its own
+  # ancestor, which would permanently auto-clear the gate). Reject up front.
+  if [[ "$sha" == "$resolved" ]]; then
+    return 1
+  fi
+
+  # Missing file: nothing to stamp.
+  if [[ ! -e "$file" ]]; then
+    return 0
+  fi
+
+  # Unreadable file: cannot safely modify.
+  if [[ ! -r "$file" ]]; then
+    return 2
+  fi
+
+  # Atomic rewrite via tmp+mv. For every line whose first field == sha, strip
+  # any existing `resolved:<40hex>` token(s) and append the canonical one. The
+  # token boundary (leading space + trailing word-boundary) mirrors the parse
+  # regex so we never mangle a free-text reason.
+  local tmpfile="${file}.tmp"
+  if ! awk -v sha="$sha" -v resolved="$resolved" '
+    {
+      if ($1 == sha) {
+        # Remove any prior resolved:<40hex> token (boundary-anchored).
+        gsub(/[ \t]resolved:[0-9a-f]{40}([ \t]|$)/, " ", $0)
+        sub(/[ \t]+$/, "", $0)
+        print $0 " resolved:" resolved
+      } else {
+        print $0
+      }
+    }
+  ' "$file" > "$tmpfile" 2>/dev/null; then
     rm -f "$tmpfile" 2>/dev/null
     return 2
   fi

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=337
+TAP_PLAN=349
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -2403,6 +2403,212 @@ CANNED
     fi
   else
     tap_skip "quarantine-active: drift stays blocked — zsh recheck" "zsh not found"
+  fi
+
+  # ── Tests 78f-78j + 78r: resolved:<sha> auto-clear and its fail-safes (#3256) ─
+  # A bundled-commit quarantine (#3238) mixed a harmful hunk (removed by #3251)
+  # with benign hunks intentionally kept on main. The per-hunk content-check
+  # (78e) stays blocked_active FOREVER because the benign hunks legitimately
+  # reverse-apply — the tick-199 false-block. The fix: an additive
+  # `resolved:<fix-sha>` token auto-clears the entry once the fix SHA is an
+  # ancestor of origin/main. Every uncertain case (not-merged, malformed,
+  # self-resolution, git error) FALLS BACK to the per-hunk BLOCK (fail-safe).
+  #
+  # Mock strategy: reuse the `_Q_MODE=partial` canned diff (so the per-hunk
+  # content-check WOULD block — this is what makes 78f genuinely depend on the
+  # resolved short-circuit, not on the diff). A dedicated `git` mock dispatches
+  # `merge-base --is-ancestor <sha> origin/main` on the SHA being checked: the
+  # quarantined SHA ($sha1) is always an ancestor; the resolved/fix SHA is
+  # governed by `$_Q_RESOLVED_RC` (0 = merged, 1 = not yet, 128 = git error).
+  # `apply` is the partial-presence model: only the harmful hunk reverse-applies.
+  _q_resolved_git() {
+    case "$1" in
+      merge-base)
+        # Args: merge-base --is-ancestor <sha> origin/main → SHA is $3.
+        if [[ "$3" == "$sha1" ]]; then
+          return 0   # quarantined SHA is always deployed (ancestor)
+        fi
+        return "${_Q_RESOLVED_RC:-0}"  # fix SHA ancestry governed by the test
+        ;;
+      diff) _q_canned_diff_partial; return 0 ;;
+      apply)
+        local patch; patch="$(cat)"
+        if printf '%s' "$patch" | grep -qE 'GONE_HUNK_ONE_MARKER|GONE_HUNK_THREE_MARKER'; then
+          return 1
+        fi
+        if printf '%s' "$patch" | grep -q 'HARMFUL_RETAIN_FALSE_MARKER'; then
+          return 0
+        fi
+        return 1
+        ;;
+      *) return 0 ;;
+    esac
+  }
+
+  # ── Test 78f — bundled commit + surviving benign hunk + resolved-on-main → CLEAR
+  # FAILS on origin/main today (no `resolved` parsing → blocked_active, the
+  # tick-199 bug); PASSES after the resolved short-circuit lands.
+  printf '%s regression #3238 resolved:%s\n' "$sha1" "$sha2" > "$qdir/resolved_clear.txt"
+  _Q_RESOLVED_RC=0
+  git() { _q_resolved_git "$@"; }
+  local rc78f=0
+  check_quarantine_active "$qdir/resolved_clear.txt" || rc78f=$?
+  unset -f git
+  unset _Q_RESOLVED_RC
+  if [[ $rc78f -eq 1 && "$QUARANTINE_STATUS" == "clear" && -z "$QUARANTINED_MATCH" ]]; then
+    tap_ok "quarantine-active: bundled commit + resolved-on-main auto-clears (#3256)"
+  else
+    tap_not_ok "quarantine-active: bundled commit + resolved-on-main auto-clears (#3256)" \
+      "rc=$rc78f status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78g — resolved-SHA NOT yet on main → stays blocked (fail-safe) ─────
+  printf '%s regression #3238 resolved:%s\n' "$sha1" "$sha2" > "$qdir/resolved_unmerged.txt"
+  _Q_RESOLVED_RC=1
+  git() { _q_resolved_git "$@"; }
+  local rc78g=0
+  check_quarantine_active "$qdir/resolved_unmerged.txt" || rc78g=$?
+  unset -f git
+  unset _Q_RESOLVED_RC
+  if [[ $rc78g -eq 0 && "$QUARANTINE_STATUS" == "blocked_active" && "$QUARANTINED_MATCH" == "$sha1" ]]; then
+    tap_ok "quarantine-active: resolved-SHA not yet merged stays blocked (fail-safe)"
+  else
+    tap_not_ok "quarantine-active: resolved-SHA not yet merged stays blocked (fail-safe)" \
+      "rc=$rc78g status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78h — malformed resolved token → falls back to per-hunk BLOCK ──────
+  printf '%s regression #3238 resolved:notahex\n' "$sha1" > "$qdir/resolved_malformed.txt"
+  _Q_RESOLVED_RC=0
+  git() { _q_resolved_git "$@"; }
+  local rc78h=0
+  check_quarantine_active "$qdir/resolved_malformed.txt" || rc78h=$?
+  unset -f git
+  unset _Q_RESOLVED_RC
+  if [[ $rc78h -eq 0 && "$QUARANTINE_STATUS" == "blocked_active" && "$QUARANTINED_MATCH" == "$sha1" ]]; then
+    tap_ok "quarantine-active: malformed resolved token falls back to per-hunk block"
+  else
+    tap_not_ok "quarantine-active: malformed resolved token falls back to per-hunk block" \
+      "rc=$rc78h status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78i — self-resolution (resolved == own SHA) → BLOCK ────────────────
+  # A commit is always its own ancestor, so resolved:<own-sha> would
+  # permanently auto-clear. The guard rejects it → per-hunk block governs.
+  printf '%s regression #3238 resolved:%s\n' "$sha1" "$sha1" > "$qdir/resolved_self.txt"
+  _Q_RESOLVED_RC=0
+  git() { _q_resolved_git "$@"; }
+  local rc78i=0
+  check_quarantine_active "$qdir/resolved_self.txt" || rc78i=$?
+  unset -f git
+  unset _Q_RESOLVED_RC
+  if [[ $rc78i -eq 0 && "$QUARANTINE_STATUS" == "blocked_active" && "$QUARANTINED_MATCH" == "$sha1" ]]; then
+    tap_ok "quarantine-active: self-resolution (resolved==own sha) is rejected, stays blocked"
+  else
+    tap_not_ok "quarantine-active: self-resolution (resolved==own sha) is rejected, stays blocked" \
+      "rc=$rc78i status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78j — git error on resolved-ancestry check → BLOCK (fail-closed) ───
+  printf '%s regression #3238 resolved:%s\n' "$sha1" "$sha2" > "$qdir/resolved_giterr.txt"
+  _Q_RESOLVED_RC=128
+  git() { _q_resolved_git "$@"; }
+  local rc78j=0
+  check_quarantine_active "$qdir/resolved_giterr.txt" || rc78j=$?
+  unset -f git
+  unset _Q_RESOLVED_RC
+  if [[ $rc78j -eq 0 && "$QUARANTINE_STATUS" == "blocked_active" && "$QUARANTINED_MATCH" == "$sha1" ]]; then
+    tap_ok "quarantine-active: git error on resolved-ancestry falls back to block (fail-closed)"
+  else
+    tap_not_ok "quarantine-active: git error on resolved-ancestry falls back to block (fail-closed)" \
+      "rc=$rc78j status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78k — parse extracts resolved token (token-boundary-anchored) ──────
+  # `unresolved:<40hex>` must NOT false-match; a real `resolved:<40hex>` must.
+  printf '%s reason unresolved:%s\n%s reason resolved:%s\n' \
+    "$sha1" "$sha2" "$sha2" "$sha1" > "$qdir/resolved_parse.txt"
+  parse_quarantine_file "$qdir/resolved_parse.txt"
+  local expected_resolved
+  expected_resolved=$(printf '%s\n%s' "-" "$sha1")
+  if [[ "$QUARANTINE_RESOLVED" == "$expected_resolved" ]]; then
+    tap_ok "quarantine-parse: resolved token extracted, unresolved: substring ignored"
+  else
+    tap_not_ok "quarantine-parse: resolved token extracted, unresolved: substring ignored" \
+      "resolved='$QUARANTINE_RESOLVED' expected='$expected_resolved'"
+  fi
+
+  # ── Test 78l — quarantine_resolve stamps token onto matching entry ──────────
+  local resolve_file="$qdir/resolve_stamp.txt"
+  printf '%s regression #3238\n%s other entry\n' "$sha1" "$sha2" > "$resolve_file"
+  quarantine_resolve "$resolve_file" "$sha1" "$sha2"
+  local rc78l=$?
+  parse_quarantine_file "$resolve_file"
+  local stamped_resolved
+  stamped_resolved=$(printf '%s\n%s' "$sha2" "-")
+  if [[ $rc78l -eq 0 && "$QUARANTINE_RESOLVED" == "$stamped_resolved" ]] \
+     && grep -q "^$sha1 regression #3238 resolved:$sha2$" "$resolve_file" \
+     && grep -q "^$sha2 other entry$" "$resolve_file"; then
+    tap_ok "quarantine-resolve: stamps resolved:<sha> onto matching entry, others untouched"
+  else
+    tap_not_ok "quarantine-resolve: stamps resolved:<sha> onto matching entry, others untouched" \
+      "rc=$rc78l resolved='$QUARANTINE_RESOLVED' contents='$(cat "$resolve_file")'"
+  fi
+
+  # ── Test 78m — quarantine_resolve is idempotent (no duplicate token) ────────
+  quarantine_resolve "$resolve_file" "$sha1" "$sha2"
+  local rc78m=$?
+  local token_count
+  token_count=$(grep -o "resolved:$sha2" "$resolve_file" | wc -l)
+  if [[ $rc78m -eq 0 && "$token_count" -eq 1 ]]; then
+    tap_ok "quarantine-resolve: second call is idempotent (single token)"
+  else
+    tap_not_ok "quarantine-resolve: second call is idempotent (single token)" \
+      "rc=$rc78m token_count=$token_count contents='$(cat "$resolve_file")'"
+  fi
+
+  # ── Test 78n — quarantine_resolve replaces a stale resolved token ───────────
+  local sha3="cccccccccccccccccccccccccccccccccccccccc"
+  quarantine_resolve "$resolve_file" "$sha1" "$sha3"
+  local rc78n=$?
+  if [[ $rc78n -eq 0 ]] \
+     && grep -q "^$sha1 regression #3238 resolved:$sha3$" "$resolve_file" \
+     && ! grep -q "resolved:$sha2" "$resolve_file"; then
+    tap_ok "quarantine-resolve: re-stamp canonicalizes to the new fix SHA"
+  else
+    tap_not_ok "quarantine-resolve: re-stamp canonicalizes to the new fix SHA" \
+      "rc=$rc78n contents='$(cat "$resolve_file")'"
+  fi
+
+  # ── Test 78o — quarantine_resolve rejects self-resolution (rc 1) ────────────
+  local rc78o=0
+  quarantine_resolve "$resolve_file" "$sha1" "$sha1" || rc78o=$?
+  if [[ $rc78o -eq 1 ]]; then
+    tap_ok "quarantine-resolve: self-resolution (sha==resolved) returns 1"
+  else
+    tap_not_ok "quarantine-resolve: self-resolution (sha==resolved) returns 1" "rc=$rc78o"
+  fi
+
+  # ── Test 78p — quarantine_resolve rejects invalid SHA (rc 1) ────────────────
+  local rc78p=0
+  quarantine_resolve "$resolve_file" "$sha1" "not-a-sha" || rc78p=$?
+  local rc78p2=0
+  quarantine_resolve "$resolve_file" "bad" "$sha2" || rc78p2=$?
+  if [[ $rc78p -eq 1 && $rc78p2 -eq 1 ]]; then
+    tap_ok "quarantine-resolve: invalid SHA (either arg) returns 1"
+  else
+    tap_not_ok "quarantine-resolve: invalid SHA (either arg) returns 1" \
+      "resolved-bad=$rc78p sha-bad=$rc78p2"
+  fi
+
+  # ── Test 78q — quarantine_resolve on missing file is a no-op (rc 0) ─────────
+  local rc78q=0
+  quarantine_resolve "$qdir/no_such_resolve.txt" "$sha1" "$sha2" || rc78q=$?
+  if [[ $rc78q -eq 0 && ! -e "$qdir/no_such_resolve.txt" ]]; then
+    tap_ok "quarantine-resolve: missing file is a no-op (rc 0, no file created)"
+  else
+    tap_not_ok "quarantine-resolve: missing file is a no-op (rc 0, no file created)" \
+      "rc=$rc78q exists=$([ -e "$qdir/no_such_resolve.txt" ] && echo yes || echo no)"
   fi
 
   # ── Test 79: check_quarantine_active — git error on ancestry (fail-closed) ─

--- a/scripts/test-shell-lib-cross-shell.sh
+++ b/scripts/test-shell-lib-cross-shell.sh
@@ -70,7 +70,7 @@ expected_funcs_for() {
     dedup-filing.sh)
       echo "dedup_load dedup_prune dedup_check dedup_record dedup_remove dedup_update_field dedup_write" ;;
     deploy-quarantine.sh)
-      echo "parse_quarantine_file check_quarantine_active check_quarantine_ancestry quarantine_append quarantine_remove" ;;
+      echo "parse_quarantine_file check_quarantine_active check_quarantine_ancestry quarantine_append quarantine_remove quarantine_resolve" ;;
     monitor-decisions.sh)
       echo "check_session_wiped check_long_stale_session detect_crash_state cleanup_guard" ;;
     review-pr-merge.sh)


### PR DESCRIPTION
Closes #3256

## Summary

The deploy-quarantine per-hunk content-check (#3253) blocks indefinitely when a quarantined commit **bundled** a harmful change with desirable ones and only the harmful part was reverted: the benign hunks legitimately still reverse-apply, so the entry stays `blocked_active` forever (the tick-199 false-block — #3238 mixed a harmful `retain:false` removed by #3251 with the benign `_rjem_malloc_conf` export + instrumentation, intentionally kept on main).

This adds **Option 4 (resolved_sha)**: an additive, token-boundary-anchored `resolved:<fix-sha>` annotation on a quarantine entry. In `check_quarantine_active`, an entry whose `resolved` fix-SHA is an **ancestor of origin/main** (genuinely merged) **auto-clears** — restoring autonomous deploy after a partial revert.

**The per-hunk content-check (#3253) is preserved byte-for-byte for every un-annotated entry.** The resolved path can only CLEAR, never weaken the backstop. Every uncertain case **falls back to BLOCK** (fail-safe toward the existing posture):
- missing / malformed `resolved` token → per-hunk content-check governs
- self-resolution (`resolved` == the quarantined SHA itself) → rejected → BLOCK
- fix not yet an ancestor of origin/main → BLOCK until it merges
- git error on the resolved-ancestry check (rc>=128) → fail-closed → BLOCK

The only auto-clear path requires an explicit, valid, genuinely-merged fix SHA — a strictly stronger signal than "all hunks gone". Token parsing uses `grep` (not the `=~` capture array) so it is identical under bash and zsh (zsh populates `$match`, not `$BASH_REMATCH`).

A new `quarantine_resolve FILE SHA RESOLVED_SHA` helper (atomic tmp+mv, idempotent, self-resolution + invalid-SHA rejected, missing-file no-op) stamps the field.

This restores autonomy for the **manual-stamp case** (operator stamps `resolved:` once → auto-clears on merge). Full auto-identification of the fix SHA is the carved-out follow-up **#3258** — not implemented here.

**Operator design fork (per the converged plan):** Option 4 v1 has the operator stamp `resolved:` once per bundled quarantine (vs. status quo: re-clear via `quarantine_remove` every blocked tick). Fully-automatic stamping (monitor-tick identifying the fix SHA itself) is #3258.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3256#issuecomment-4665889405)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — all new tests (78f–78q) pass; only the 4 pre-existing `pv-label-sync` failures remain (present on clean origin/main, unrelated)
- [x] `bash scripts/test-shell-lib-cross-shell.sh` — passes; `quarantine_resolve` now asserted defined under bash + zsh
- [x] `bash -n` + `zsh -n` clean on `deploy-quarantine.sh` + both harnesses
- [x] TAP_PLAN bumped (337 → 349, +12 new tests; pre-existing emitted/plan drift preserved)

## Regression test (kind: bug-fix)

- **Test:** `scripts/test-monitor-skill-snippets.sh` — *quarantine-active: bundled commit + resolved-on-main auto-clears (#3256)* (test 78f)
- **Pre-fix:** committed as `485225cb` — verified FAILED on origin/main lib: `not ok ... bundled commit + resolved-on-main auto-clears (#3256)` (no `resolved` parsing → `blocked_active`, the tick-199 bug)
- **Post-fix:** verified PASSES after `6c8de88b`
- **Fail-safe guards (78g–78j):** resolved-not-merged / malformed / self-resolution / git-error → all stay `blocked_active` (pass on both origin/main and the fix — they lock in the fail-safe posture)

## Deviations from plan

- Exposed the parsed token via the index-aligned `QUARANTINE_RESOLVED` global (one line per entry, `-` when absent) and iterate it lockstep with `QUARANTINE_ENTRIES` over two FDs (bash+zsh safe), as the plan specified.
- Resolved-token extraction uses `grep` rather than `[[ =~ ]]` capture groups for true bash/zsh parity (zsh does not populate `$BASH_REMATCH`). Functionally equivalent to the plan's token-boundary-anchored regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)