### PR TITLE
Auto-stamp resolved:<fix-sha> on bundled-commit quarantines

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1574,6 +1574,14 @@ Otherwise enter the deploy path:
    ```bash
    # --- Quarantine gate ---
    source "$(git rev-parse --show-toplevel)/scripts/lib/deploy-quarantine.sh"
+   # Auto-stamp resolved:<fix-sha> on any bundled-commit quarantine whose
+   # recorded crash issue (`regression #N`) has a MERGED closing PR (#3258).
+   # WRITE-ONLY + best-effort: it only ADDS a `resolved:` token (never clears);
+   # any gh/network failure or open PR leaves the entry un-stamped. The clear
+   # decision stays SOLELY with check_quarantine_active below, which re-gates
+   # every stamp with `git merge-base --is-ancestor`. So a wrong/premature
+   # stamp is still BLOCKED, and `|| true` keeps a gh hiccup from aborting.
+   quarantine_autostamp "$HOME/data/deploy_quarantine.txt" || true
    check_quarantine_active "$HOME/data/deploy_quarantine.txt"
    if [ $? -eq 0 ]; then
      case "$QUARANTINE_STATUS" in
@@ -1846,8 +1854,28 @@ if **any** hunk of the quarantined SHA still reverse-applies. A commit that
 `retain:false` with the benign `_rjem_malloc_conf` export + instrumentation)
 can never auto-clear after a **partial** revert: the benign hunks are
 intentionally kept on `origin/main`, so the per-hunk check stays
-`blocked_active` forever (the tick-199 false-block, #3256). For that case,
-stamp the entry once with the fix commit that resolved it:
+`blocked_active` forever (the tick-199 false-block, #3256).
+
+**Automatic stamping (#3258).** For the common case — the auto-quarantine path
+records the crash issue # in the entry's reason (`regression #N`, written by
+§3d) — the deploy gate now stamps `resolved:<fix-sha>` **automatically every
+tick**, via `quarantine_autostamp` run immediately before
+`check_quarantine_active` (section 10's quarantine gate above). It follows
+GitHub's **structured** linkage — not free-text commit-message scanning: parse
+`#N` from the reason → ask GitHub which **MERGED** PR closed #N
+(`closedByPullRequestsReferences`) → take that PR's `mergeCommit.oid`. So once
+the fix PR merges, the entry auto-clears on the next tick with **no operator
+action**. `quarantine_autostamp` is **write-only and best-effort**: it only
+ADDS a `resolved:` token (never clears), and any gh/network/parse failure, an
+open (non-MERGED) PR, a missing issue #, or a self-resolution leaves the entry
+un-stamped — so the per-hunk content-check governs that entry. The clear
+decision stays **solely** with `check_quarantine_active`, which independently
+re-gates every stamp with `git merge-base --is-ancestor` — a wrong/premature
+stamp is still BLOCKED.
+
+**Manual stamping (fallback).** If the entry has no recorded issue # (e.g. a
+hand-added quarantine), or the fix landed without a closing PR, stamp it once
+yourself with the fix commit that resolved it:
 
 ```bash
 source "$(git rev-parse --show-toplevel)/scripts/lib/deploy-quarantine.sh"
@@ -1859,9 +1887,8 @@ This appends a `resolved:<fix-sha>` token to the entry. The gate **auto-clears**
 that entry once `<fix-sha>` is an ancestor of `origin/main` (i.e. the fix has
 merged) — no further per-tick action needed. It is **fail-safe**: a not-yet-
 merged fix, a malformed token, a self-resolution (`<fix-sha>` == `<bad_sha>`),
-or a git error all fall back to the per-hunk content-check (BLOCK). Stamping is
-a once-per-quarantine manual step today; automatic fix-SHA stamping is the
-follow-up #3258. `quarantine_remove` remains the override.
+or a git error all fall back to the per-hunk content-check (BLOCK).
+`quarantine_remove` remains the override.
 
 **Manual removal** (still supported, occasionally useful — e.g. an entry
 that the content check can't decide cleanly because of a malformed diff

--- a/scripts/lib/deploy-quarantine.sh
+++ b/scripts/lib/deploy-quarantine.sh
@@ -46,6 +46,16 @@ _DEPLOY_QUARANTINE_LOADED=1
 #                         40-hex fix SHA when the entry carried a valid,
 #                         token-boundary-anchored `resolved:<sha>`, or "-" when
 #                         it did not. The two globals are index-aligned.
+#   QUARANTINE_REASONS  - Newline-separated reason text (everything after the
+#                         SHA on the entry's line), ONE PER ENTRY in the SAME
+#                         order as QUARANTINE_ENTRIES — index-aligned with both
+#                         QUARANTINE_ENTRIES and QUARANTINE_RESOLVED. A bare-SHA
+#                         entry (no reason) contributes an EMPTY line so the
+#                         lockstep three-FD read in quarantine_autostamp never
+#                         skews. Reasons are single-line by construction
+#                         (quarantine_append strips \n\t\r), so newline-joining
+#                         is lossless. Used by quarantine_autostamp to recover
+#                         the recorded crash issue # (`regression #N`, #3258).
 #   QUARANTINE_WARNINGS - Comma-space-separated warning messages
 #
 # Returns:
@@ -56,6 +66,7 @@ parse_quarantine_file() {
   local file="$1"
   QUARANTINE_ENTRIES=""
   QUARANTINE_RESOLVED=""
+  QUARANTINE_REASONS=""
   QUARANTINE_WARNINGS=""
 
   # Missing or empty file: clear, no warnings
@@ -111,9 +122,11 @@ parse_quarantine_file() {
       if [[ -n "$QUARANTINE_ENTRIES" ]]; then
         QUARANTINE_ENTRIES+=$'\n'"$sha"
         QUARANTINE_RESOLVED+=$'\n'"$resolved"
+        QUARANTINE_REASONS+=$'\n'"$_rest"
       else
         QUARANTINE_ENTRIES="$sha"
         QUARANTINE_RESOLVED="$resolved"
+        QUARANTINE_REASONS="$_rest"
       fi
     else
       local warning="malformed: ${sha:0:12}"
@@ -606,6 +619,152 @@ quarantine_resolve() {
     rm -f "$tmpfile" 2>/dev/null
     return 2
   fi
+
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _quarantine_issue_in_reason REASON
+#
+# Read-only, pure (no subprocess). Echoes the FIRST GitHub issue number `#N`
+# found in REASON, or nothing if there is none. The crash issue # is recorded
+# by monitor-tick §3d as `regression #<issue>` in the entry's reason; #3260's
+# parser preserves arbitrary reason text. The parse EXCLUDES any `resolved:`
+# token span first (Critic A on #3258): a `resolved:<40-hex>` token contains no
+# `#`, so a hex digit-run can never be mis-read as an issue#, but we strip the
+# token span explicitly so the contract holds even if the token convention
+# changes. A single grep (no `=~` capture array, so the extraction is identical
+# under bash and zsh — zsh populates `$match`, not `$BASH_REMATCH`).
+# ─────────────────────────────────────────────────────────────────────────────
+_quarantine_issue_in_reason() {
+  local reason="$1"
+  # Excise any resolved:<40-hex> token span (boundary-anchored), so we never
+  # scan inside it for a `#N`. Replace with a space to keep word boundaries.
+  reason="$(printf '%s' " $reason " | sed -E 's/[[:space:]]resolved:[0-9a-f]{40}([[:space:]])/ \1/g')"
+  # First `#<digits>` occurrence. `grep -oE` + head emits just the matched
+  # token; strip the leading `#`. `|| true` keeps a no-match (grep rc=1) from
+  # tripping a caller's set -e/pipefail.
+  local tok
+  tok="$(printf '%s' "$reason" | grep -oE '#[0-9]+' | head -n1 || true)"
+  [[ -n "$tok" ]] && printf '%s' "${tok#\#}"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _quarantine_fix_sha_for_issue ISSUE_NUMBER
+#
+# gh subprocess (best-effort, read-only). Resolves the merge-commit SHA of the
+# MERGED PR that closed ISSUE_NUMBER, via GitHub's STRUCTURED linkage — NOT
+# free-text commit-message scanning:
+#   1. `gh issue view N --json closedByPullRequestsReferences` → the PR numbers
+#      GitHub authoritatively records as closing issue N (issue-scoped: immune
+#      to any global PR-list recency window — Critic A on #3258).
+#   2. For each such PR, `gh pr view P --json state,mergeCommit` and take
+#      `.mergeCommit.oid` ONLY when `.state == "MERGED"` (an open/draft PR has
+#      a null mergeCommit and must never stamp — fail-safe).
+# Echoes the first valid 40-hex merge SHA found, or nothing. Any `gh`/network/
+# parse failure → echoes nothing (caller skips → no stamp → #3260's gate
+# governs). The `--jq` shapes here are EXACTLY what the production code consumes
+# and what the snippet-test `gh` mock must mirror (Critic A).
+# ─────────────────────────────────────────────────────────────────────────────
+_quarantine_fix_sha_for_issue() {
+  local issue="$1"
+  local repo="${QUARANTINE_GH_REPO:-stellar-experimental/henyey}"
+  local prs pr sha
+
+  # Issue-side linkage: the PR numbers that close this issue (one per line).
+  prs="$(gh issue view "$issue" --repo "$repo" \
+           --json closedByPullRequestsReferences \
+           --jq '.closedByPullRequestsReferences[]?.number' 2>/dev/null)" || return 0
+  [[ -z "$prs" ]] && return 0
+
+  while IFS= read -r pr; do
+    [[ -z "$pr" ]] && continue
+    # Merge SHA, ONLY when the PR is MERGED (else --jq emits nothing).
+    sha="$(gh pr view "$pr" --repo "$repo" \
+             --json state,mergeCommit \
+             --jq 'select(.state=="MERGED") | .mergeCommit.oid' 2>/dev/null)" || continue
+    if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+      printf '%s' "$sha"
+      return 0
+    fi
+  done <<< "$prs"
+
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# quarantine_autostamp QUARANTINE_FILE
+#
+# Best-effort, full-autonomy auto-stamping (#3258). For each entry NOT already
+# carrying a `resolved:` token, follow GitHub's structured linkage to the
+# merge-commit SHA of the MERGED PR that closed the entry's recorded crash
+# issue (`regression #N`, written by monitor-tick §3d), and stamp it via the
+# existing #3260 `quarantine_resolve`.
+#
+# This function is WRITE-ONLY and STRICTLY MONOTONIC: it can only ADD a
+# `resolved:` token (delegating to quarantine_resolve, which is atomic tmp+mv,
+# idempotent, and self-resolution-guarded). It NEVER removes or weakens an
+# entry, and it contains NO clear logic. The SOLE clear authority remains
+# `check_quarantine_active` (#3260), which independently re-gates every stamp
+# with `git merge-base --is-ancestor <resolved> origin/main`. Therefore a
+# wrong / unmerged / premature stamp is still BLOCKED by that ancestor gate,
+# and a missing stamp leaves the per-hunk content-check in charge — a
+# catastrophic auto-clear of a still-harmful tree is unreachable by
+# construction. `check_quarantine_active` is intentionally NOT modified.
+#
+# FAIL-OPEN toward NOT-stamping: a missing/unparseable issue #, no closing PR,
+# an open (non-MERGED) PR, a self-resolution, or ANY gh/network/parse error
+# all skip that entry (leave it un-stamped). The function never aborts the tick.
+#
+# Call this ONCE PER TICK, BEFORE check_quarantine_active.
+#
+# Arguments:
+#   QUARANTINE_FILE - Path to deploy_quarantine.txt
+#
+# Env (optional):
+#   QUARANTINE_GH_REPO - owner/name for gh queries (default
+#                        stellar-experimental/henyey)
+#
+# Returns:
+#   0 — always (best-effort; per-entry failures are silently skipped). Never
+#       aborts; never propagates a gh/parse error.
+# ─────────────────────────────────────────────────────────────────────────────
+quarantine_autostamp() {
+  local file="$1"
+
+  # Missing/empty/unreadable file: nothing to stamp. (check_quarantine_active
+  # independently handles the unreadable case as fail-closed BLOCK.)
+  [[ -e "$file" && -s "$file" && -r "$file" ]] || return 0
+
+  parse_quarantine_file "$file" || return 0
+  [[ -z "$QUARANTINE_ENTRIES" ]] && return 0
+
+  # Iterate the three index-aligned globals in lockstep over three FDs. The
+  # `read <&3 && read <&4 && read <&5` pattern advances all streams one line
+  # per loop and behaves identically under bash and zsh (#3256).
+  local sha resolved reason issue fix_sha
+  while IFS= read -r sha <&3 && IFS= read -r resolved <&4 && IFS= read -r reason <&5; do
+    [[ -z "$sha" ]] && continue
+    # Already stamped → leave untouched, do NOT query gh (idempotent + cheap).
+    [[ "$resolved" != "-" ]] && continue
+
+    # Recover the crash issue # from the reason. No `#N` → skip (the gate's
+    # per-hunk content-check governs this entry).
+    issue="$(_quarantine_issue_in_reason "$reason")"
+    [[ -z "$issue" ]] && continue
+
+    # Resolve the merged fix SHA via structured GitHub linkage (best-effort).
+    fix_sha="$(_quarantine_fix_sha_for_issue "$issue")"
+    # No merged closing PR, open PR, or any gh error → skip (no stamp).
+    [[ "$fix_sha" =~ ^[0-9a-f]{40}$ ]] || continue
+    # Self-resolution guard (also enforced by quarantine_resolve): a commit
+    # cannot resolve itself. Skip rather than let quarantine_resolve reject.
+    [[ "$fix_sha" == "$sha" ]] && continue
+
+    # WRITE-ONLY stamp. Any rc from quarantine_resolve is non-fatal here —
+    # best-effort; the gate still governs. `|| true` keeps set -e happy.
+    quarantine_resolve "$file" "$sha" "$fix_sha" || true
+  done 3<<< "$QUARANTINE_ENTRIES" 4<<< "$QUARANTINE_RESOLVED" 5<<< "$QUARANTINE_REASONS"
 
   return 0
 }

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=349
+TAP_PLAN=355
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -2609,6 +2609,155 @@ CANNED
   else
     tap_not_ok "quarantine-resolve: missing file is a no-op (rc 0, no file created)" \
       "rc=$rc78q exists=$([ -e "$qdir/no_such_resolve.txt" ] && echo yes || echo no)"
+  fi
+
+  # ── Tests 78s-78x: quarantine_autostamp — issue→merged-PR→merge-SHA (#3258) ─
+  # quarantine_autostamp follows GitHub's STRUCTURED linkage: it parses the
+  # crash-issue number `#N` already recorded in the entry's reason (`regression
+  # #N`, written by monitor-tick §3d), asks GitHub which MERGED PR closed #N
+  # (`gh issue view N --json closedByPullRequestsReferences` → per-PR `gh pr
+  # view <pr> --json state,mergeCommit`), and stamps `resolved:<mergeCommit.oid>`
+  # via the existing #3260 quarantine_resolve. It is WRITE-ONLY and best-effort:
+  # any gh/network/parse failure, an open (non-MERGED) PR, or a missing/absent
+  # issue# → it skips that entry (no stamp), so #3260's gate governs unchanged.
+  #
+  # FAIL-SAFE: autostamp NEVER clears. The sole clear authority remains #3260's
+  # check_quarantine_active, which independently requires the stamped SHA be an
+  # ancestor of origin/main. A wrong/unmerged/premature stamp still BLOCKs.
+  #
+  # gh mock: matches the REAL --jq output shapes (Critic A) —
+  #   `gh issue view N --json closedByPullRequestsReferences --jq
+  #      '.closedByPullRequestsReferences[]?.number'`  → newline-separated PR #s
+  #   `gh pr view P --json state,mergeCommit --jq
+  #      'select(.state=="MERGED") | .mergeCommit.oid'` → merge SHA or empty.
+  # Driven by env: _GH_PR_FOR_ISSUE (PR# closing N or empty), _GH_PR_STATE
+  # (MERGED / OPEN), _GH_PR_MERGESHA (the merge oid), _GH_RC (non-zero → error).
+  _q_autostamp_gh() {
+    if [[ "${_GH_RC:-0}" -ne 0 ]]; then return "${_GH_RC}"; fi
+    case "$1" in
+      issue)
+        # gh issue view N --repo R --json closedByPullRequestsReferences --jq '...'
+        # Real --jq emits one PR number per line (empty when none).
+        [[ -n "${_GH_PR_FOR_ISSUE:-}" ]] && printf '%s\n' "$_GH_PR_FOR_ISSUE"
+        return 0
+        ;;
+      pr)
+        # gh pr view P --repo R --json state,mergeCommit --jq 'select(.state=="MERGED")|.mergeCommit.oid'
+        # Real --jq emits the oid only when state==MERGED, else nothing.
+        if [[ "${_GH_PR_STATE:-MERGED}" == "MERGED" ]]; then
+          printf '%s\n' "${_GH_PR_MERGESHA:-}"
+        fi
+        return 0
+        ;;
+      *) return 0 ;;
+    esac
+  }
+
+  # ── Test 78s — END-TO-END (#3258→#3260): reason #N + merged closing PR →
+  #   autostamp stamps resolved:<mergeSha>, then the gate AUTO-CLEARS.
+  # FAILS on origin/main today (no quarantine_autostamp → entry stays
+  # blocked_active, the tick-199 false-block); PASSES after this lands.
+  printf '%s regression #3238\n' "$sha1" > "$qdir/autostamp_e2e.txt"
+  _GH_PR_FOR_ISSUE=3251 _GH_PR_STATE=MERGED _GH_PR_MERGESHA="$sha2"
+  gh() { _q_autostamp_gh "$@"; }
+  local rc78s_stamp=0
+  quarantine_autostamp "$qdir/autostamp_e2e.txt" || rc78s_stamp=$?
+  unset -f gh
+  # Verify the stamp landed.
+  parse_quarantine_file "$qdir/autostamp_e2e.txt"
+  local stamped78s="$QUARANTINE_RESOLVED"
+  # Now the gate: sha1 ancestor + benign hunk present (partial), but resolved
+  # sha2 is on main → CLEAR. Reuse the resolved-aware git mock (sha2 merged).
+  _Q_RESOLVED_RC=0
+  git() { _q_resolved_git "$@"; }
+  local rc78s=0
+  check_quarantine_active "$qdir/autostamp_e2e.txt" || rc78s=$?
+  unset -f git
+  unset _Q_RESOLVED_RC
+  unset _GH_PR_FOR_ISSUE _GH_PR_STATE _GH_PR_MERGESHA
+  if [[ "$stamped78s" == "$sha2" && $rc78s -eq 1 && "$QUARANTINE_STATUS" == "clear" && -z "$QUARANTINED_MATCH" ]]; then
+    tap_ok "quarantine-autostamp: reason #N + merged PR → stamps resolved:<sha>, gate auto-clears (#3258→#3260)"
+  else
+    tap_not_ok "quarantine-autostamp: reason #N + merged PR → stamps resolved:<sha>, gate auto-clears (#3258→#3260)" \
+      "stamped='$stamped78s' rc=$rc78s status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78t — no `#N` in reason → no stamp (gate's per-hunk check governs) ─
+  printf '%s regression no-issue-number\n' "$sha1" > "$qdir/autostamp_noissue.txt"
+  _GH_PR_FOR_ISSUE=3251 _GH_PR_STATE=MERGED _GH_PR_MERGESHA="$sha2"
+  gh() { _q_autostamp_gh "$@"; }
+  quarantine_autostamp "$qdir/autostamp_noissue.txt" || true
+  unset -f gh
+  unset _GH_PR_FOR_ISSUE _GH_PR_STATE _GH_PR_MERGESHA
+  parse_quarantine_file "$qdir/autostamp_noissue.txt"
+  if [[ "$QUARANTINE_RESOLVED" == "-" ]]; then
+    tap_ok "quarantine-autostamp: reason without #N is not stamped (per-hunk gate governs)"
+  else
+    tap_not_ok "quarantine-autostamp: reason without #N is not stamped (per-hunk gate governs)" \
+      "resolved='$QUARANTINE_RESOLVED' contents='$(cat "$qdir/autostamp_noissue.txt")'"
+  fi
+
+  # ── Test 78u — closing PR is OPEN (state != MERGED) → no stamp (fail-safe) ──
+  printf '%s regression #3238\n' "$sha1" > "$qdir/autostamp_open.txt"
+  _GH_PR_FOR_ISSUE=3251 _GH_PR_STATE=OPEN _GH_PR_MERGESHA="$sha2"
+  gh() { _q_autostamp_gh "$@"; }
+  quarantine_autostamp "$qdir/autostamp_open.txt" || true
+  unset -f gh
+  unset _GH_PR_FOR_ISSUE _GH_PR_STATE _GH_PR_MERGESHA
+  parse_quarantine_file "$qdir/autostamp_open.txt"
+  if [[ "$QUARANTINE_RESOLVED" == "-" ]]; then
+    tap_ok "quarantine-autostamp: open (non-MERGED) closing PR is not stamped (fail-safe)"
+  else
+    tap_not_ok "quarantine-autostamp: open (non-MERGED) closing PR is not stamped (fail-safe)" \
+      "resolved='$QUARANTINE_RESOLVED' contents='$(cat "$qdir/autostamp_open.txt")'"
+  fi
+
+  # ── Test 78v — gh error (rc!=0) → no stamp, function does not abort ────────
+  printf '%s regression #3238\n' "$sha1" > "$qdir/autostamp_gherr.txt"
+  _GH_RC=1 _GH_PR_FOR_ISSUE=3251 _GH_PR_STATE=MERGED _GH_PR_MERGESHA="$sha2"
+  gh() { _q_autostamp_gh "$@"; }
+  local rc78v=0
+  quarantine_autostamp "$qdir/autostamp_gherr.txt" || rc78v=$?
+  unset -f gh
+  unset _GH_RC _GH_PR_FOR_ISSUE _GH_PR_STATE _GH_PR_MERGESHA
+  parse_quarantine_file "$qdir/autostamp_gherr.txt"
+  if [[ "$QUARANTINE_RESOLVED" == "-" && $rc78v -eq 0 ]]; then
+    tap_ok "quarantine-autostamp: gh error skips entry, returns without abort (best-effort)"
+  else
+    tap_not_ok "quarantine-autostamp: gh error skips entry, returns without abort (best-effort)" \
+      "rc=$rc78v resolved='$QUARANTINE_RESOLVED' contents='$(cat "$qdir/autostamp_gherr.txt")'"
+  fi
+
+  # ── Test 78w — entry already stamped → unchanged, gh is NOT invoked ────────
+  printf '%s regression #3238 resolved:%s\n' "$sha1" "$sha2" > "$qdir/autostamp_idem.txt"
+  local _gh_called78w=0
+  gh() { _gh_called78w=1; _q_autostamp_gh "$@"; }
+  _GH_PR_FOR_ISSUE=3251 _GH_PR_STATE=MERGED _GH_PR_MERGESHA="cccccccccccccccccccccccccccccccccccccccc"
+  quarantine_autostamp "$qdir/autostamp_idem.txt" || true
+  unset -f gh
+  unset _GH_PR_FOR_ISSUE _GH_PR_STATE _GH_PR_MERGESHA
+  parse_quarantine_file "$qdir/autostamp_idem.txt"
+  if [[ "$QUARANTINE_RESOLVED" == "$sha2" && "$_gh_called78w" -eq 0 ]]; then
+    tap_ok "quarantine-autostamp: already-stamped entry is unchanged, no gh call (idempotent)"
+  else
+    tap_not_ok "quarantine-autostamp: already-stamped entry is unchanged, no gh call (idempotent)" \
+      "resolved='$QUARANTINE_RESOLVED' gh_called=$_gh_called78w contents='$(cat "$qdir/autostamp_idem.txt")'"
+  fi
+
+  # ── Test 78x — self-resolution (merge SHA == quarantined SHA) → not stamped ─
+  # quarantine_resolve rejects sha==resolved; autostamp delegates that guard.
+  printf '%s regression #3238\n' "$sha1" > "$qdir/autostamp_self.txt"
+  _GH_PR_FOR_ISSUE=3251 _GH_PR_STATE=MERGED _GH_PR_MERGESHA="$sha1"
+  gh() { _q_autostamp_gh "$@"; }
+  quarantine_autostamp "$qdir/autostamp_self.txt" || true
+  unset -f gh
+  unset _GH_PR_FOR_ISSUE _GH_PR_STATE _GH_PR_MERGESHA
+  parse_quarantine_file "$qdir/autostamp_self.txt"
+  if [[ "$QUARANTINE_RESOLVED" == "-" ]]; then
+    tap_ok "quarantine-autostamp: self-resolution (merge sha == quarantined sha) is not stamped"
+  else
+    tap_not_ok "quarantine-autostamp: self-resolution (merge sha == quarantined sha) is not stamped" \
+      "resolved='$QUARANTINE_RESOLVED' contents='$(cat "$qdir/autostamp_self.txt")'"
   fi
 
   # ── Test 79: check_quarantine_active — git error on ancestry (fail-closed) ─

--- a/scripts/test-shell-lib-cross-shell.sh
+++ b/scripts/test-shell-lib-cross-shell.sh
@@ -70,7 +70,7 @@ expected_funcs_for() {
     dedup-filing.sh)
       echo "dedup_load dedup_prune dedup_check dedup_record dedup_remove dedup_update_field dedup_write" ;;
     deploy-quarantine.sh)
-      echo "parse_quarantine_file check_quarantine_active check_quarantine_ancestry quarantine_append quarantine_remove quarantine_resolve" ;;
+      echo "parse_quarantine_file check_quarantine_active check_quarantine_ancestry quarantine_append quarantine_remove quarantine_resolve quarantine_autostamp" ;;
     monitor-decisions.sh)
       echo "check_session_wiped check_long_stale_session detect_crash_state cleanup_guard" ;;
     review-pr-merge.sh)
@@ -297,6 +297,54 @@ if [[ "$HAVE_ZSH" -eq 1 ]]; then
   assert_merge_flags_separated zsh zsh
 else
   skip "merge-flag-separation[zsh]: --squash and --admin arrive as distinct args" "zsh not installed"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Assertion group 5.5: quarantine-autostamp-roundtrip-both-shells (#3258).
+#   quarantine_autostamp parses the crash issue # from an entry's reason,
+#   queries gh for the merged closing PR's merge SHA, and stamps resolved:<sha>
+#   via quarantine_resolve. Its inner loop reads THREE index-aligned globals in
+#   lockstep over FDs 3/4/5 — the highest cross-shell risk in the new code.
+#   This roundtrip mocks `gh` (so no network), runs autostamp under each shell
+#   from a foreign cwd, and asserts the resolved token was stamped onto the
+#   entry. The gh mock mirrors the real --jq shapes: issue-view emits the PR #,
+#   pr-view emits the 40-hex merge SHA only when state==MERGED.
+# ─────────────────────────────────────────────────────────────────────────────
+assert_autostamp_roundtrip() {
+  local shbin="$1" shname="$2"
+  local qfile="$SCRATCH/autostamp-$shname.txt"
+  local bad="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  local fix="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  printf '%s regression #4242\n' "$bad" > "$qfile"
+  # Mock gh: issue view → PR number; pr view → merge SHA (state==MERGED).
+  local code="
+    source '$LIB_DIR/deploy-quarantine.sh' || exit 3;
+    gh() {
+      case \"\$1\" in
+        issue) printf '%s\n' 707 ;;
+        pr) printf '%s\n' '$fix' ;;
+        *) return 0 ;;
+      esac
+    };
+    quarantine_autostamp '$qfile';
+    parse_quarantine_file '$qfile';
+    printf '%s' \"\$QUARANTINE_RESOLVED\"
+  "
+  run_in_shell "$shbin" "$code"
+  local label="quarantine-autostamp-roundtrip[$shname]: reason #N → stamps resolved:<merge-sha>"
+  if [[ "$_RC" -ne 0 ]]; then
+    notok "$label" "rc=$_RC" "stderr: $_STDERR"; return
+  fi
+  if [[ "$_STDOUT" != "$fix" ]]; then
+    notok "$label" "expected resolved: $fix" "got: '$_STDOUT'"; return
+  fi
+  ok "$label"
+}
+assert_autostamp_roundtrip bash bash
+if [[ "$HAVE_ZSH" -eq 1 ]]; then
+  assert_autostamp_roundtrip zsh zsh
+else
+  skip "quarantine-autostamp-roundtrip[zsh]: reason #N → stamps resolved:<merge-sha>" "zsh not installed"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #3258

## Summary

Completes the **full-autonomy half** of #3256. monitor-tick now stamps `resolved:<fix-sha>` on a bundled-commit quarantine **automatically, every tick**, restoring autonomous deployment after a partial revert without an operator step.

**Strategy 1 — authoritative GitHub issue→merged-PR→merge-SHA linkage (not heuristic message-scanning).** The auto-quarantine path already records the crash issue # in the entry's reason (`regression #N`, monitor-tick §3d), and #3260's parser preserves that text. `quarantine_autostamp` recovers `#N`, asks GitHub which **MERGED** PR closed it (`closedByPullRequestsReferences`, issue-scoped — immune to any global PR-list recency window), and takes that PR's `mergeCommit.oid`. This is the **inverse and structured** form of the rejected #3256 "option 3" (guessing the fix commit by scanning new main commits for `Fixes #N`) — no guessing; GitHub answers authoritatively in both directions.

## Fail-safe (the whole safety argument)

`quarantine_autostamp` is **write-only and monotonic** — it can ONLY add a `resolved:` token (delegating to #3260's atomic, idempotent, self-resolution-guarded `quarantine_resolve`). It contains **no clear logic**. `check_quarantine_active` (#3260) remains the **sole clear authority** and independently re-gates every stamp with `git merge-base --is-ancestor <resolved> origin/main`. Therefore:

- Wrong / unmerged / premature stamp → still **BLOCKED** by the ancestor gate.
- No stamp (no `#N`, no closing PR, open PR, gh error, self-resolution) → per-hunk content-check governs (status-quo BLOCK).
- The only clear path is a SHA GitHub says closed the crash issue **AND** that is genuinely on main.

A catastrophic auto-clear of a still-harmful tree is **unreachable by construction**. `check_quarantine_active` is **untouched**.

## Changes

- `scripts/lib/deploy-quarantine.sh`
  - `parse_quarantine_file`: new `QUARANTINE_REASONS` global, index-aligned with `QUARANTINE_ENTRIES`/`QUARANTINE_RESOLVED` (three-FD lockstep, bash+zsh safe).
  - `quarantine_autostamp FILE` (best-effort): per un-stamped entry, parse `#N` from the reason (excluding any `resolved:` token span — Critic A), resolve the merged closing PR's merge SHA via `gh` (issue-scoped; per-PR `state==MERGED` guard so an open PR never stamps), and stamp via `quarantine_resolve`. Any gh/network/parse failure → skip; never aborts the tick.
- `.claude/skills/monitor-tick/SKILL.md`: wire `quarantine_autostamp` into §10's deploy gate immediately before `check_quarantine_active`; document automatic issue-linked stamping (manual `quarantine_resolve` retained as fallback).
- `scripts/test-shell-lib-cross-shell.sh`: assert `quarantine_autostamp` defined under bash+zsh + a behavioral roundtrip (mocked `gh`) exercising the three-FD lockstep loop.
- `scripts/test-monitor-skill-snippets.sh`: 6 new mocked-`gh` tests; `TAP_PLAN` bumped.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3258#issuecomment-4666092431)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — 6 new autostamp tests pass; all #3260 resolved tests still pass (gate unchanged). The only failures are 4 **pre-existing** `pv-label-sync` tests, confirmed failing on clean `origin/main` and unrelated to this change.
- [x] `bash scripts/test-shell-lib-cross-shell.sh` — all 27 pass (incl. the new autostamp roundtrip under bash+zsh).
- [x] `bash -n` + `zsh -n` clean on `deploy-quarantine.sh` and the cross-shell harness.
- [x] `cargo fmt --check` + `cargo clippy` (pre-commit hook, passed).

## New coverage (kind: feature)

- **End-to-end (#3258→#3260):** quarantined bundled commit with `regression #N` whose fix-PR merged → `quarantine_autostamp` stamps `resolved:<merge-sha>` → `check_quarantine_active` then auto-clears (that SHA is an ancestor of main). Committed first as `7baefd2f`, verified **FAILED** on main (`quarantine_autostamp` undefined), **PASSES** after `84735a8e`.
- no `#N` in reason → no stamp; open (non-MERGED) PR → no stamp; `gh` error → no stamp/no abort; already-stamped → unchanged + no `gh` call; self-resolution → not stamped.
- The `gh` mock mirrors the real `closedByPullRequestsReferences` / `state`+`mergeCommit` `--jq` output shapes (Critic A).

## Deviations from plan

None. (Pre-existing: `test-monitor-skill-snippets.sh` emits 4 more TAP lines than `TAP_PLAN` declared even before this PR — out of scope; the harness keys off failures, not the plan count.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)