### PR TITLE
Widen at-tip hard-reset suppression to Stale/Cold caches

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -6459,10 +6459,16 @@ mod tests {
         );
     }
 
-    /// When archive is ConfirmedBehind but cache is Stale, the guard
-    /// must NOT fire — ProbeAhead should proceed to discover truth.
+    /// #3262: When archive is ConfirmedBehind AND cache is Stale at/below
+    /// current_ledger AND peers confirm we are at-or-near tip (peer_gap <
+    /// HARD_RESET_GAP_ESCALATION), the hard reset must be SUPPRESSED and
+    /// routed to peer-SCP — NOT escalated to a spurious ProbeAhead archive
+    /// probe. This is the exact spurious-probe scenario from #3262: at the
+    /// live tip the published archive lags (10s urgent TTL → Stale between
+    /// refreshes), so the Fresh-only suppression on main bypassed and the
+    /// node spawned a futile ProbeAhead. Fails on main (counter increments).
     #[tokio::test]
-    async fn test_hard_reset_not_suppressed_stale_cache() {
+    async fn test_hard_reset_suppressed_stale_cache_at_tip() {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
         let config = crate::config::ConfigBuilder::new()
@@ -6476,6 +6482,161 @@ mod tests {
             .scp_driver()
             .record_externalized(5050, Default::default(), None);
         app.herder.scp_driver().publish_externalized(5050);
+
+        // peer_gap=5 (below HARD_RESET_GAP_ESCALATION=12) — peers confirm
+        // we are at/near tip, so this is the at-tip suppression window.
+        app.max_verified_scp_slot
+            .store(u64::from(current_ledger) + 5, Ordering::Relaxed);
+
+        {
+            let mut guard = app.archive_recovery_status.write().await;
+            *guard = ArchiveRecoveryStatus::ConfirmedBehind {
+                backoff_until: None,
+            };
+        }
+        // seed_stale makes the cache return Stale at/below current_ledger.
+        app.archive_checkpoint_cache.seed_stale(current_ledger);
+
+        app.start_instant = std::time::Instant::now() - std::time::Duration::from_secs(500);
+
+        let counter_before = app.post_catchup_hard_reset_total.load(Ordering::Relaxed);
+
+        let result = app
+            .force_post_catchup_hard_reset(
+                current_ledger,
+                HardResetReason::ArchiveBehindStallWallClock,
+            )
+            .await;
+
+        // Suppression must fire — returns None, no probe.
+        assert!(result.is_none(), "suppression guard should return None");
+
+        // Counter must NOT increment (no ProbeAhead spawned).
+        assert_eq!(
+            app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
+            counter_before,
+            "counter must not increment when Stale-at-tip suppression fires (#3262)"
+        );
+
+        // Status stays ConfirmedBehind (not cleared).
+        assert!(
+            app.archive_recovery_snapshot().await.is_confirmed_behind(),
+            "archive_recovery_status must remain ConfirmedBehind after suppression"
+        );
+
+        // Cooldown armed; peer-SCP route taken instead of the probe.
+        assert!(
+            app.last_hard_reset_offset.load(Ordering::Relaxed) > 0,
+            "cooldown must be armed after suppression"
+        );
+
+        // Livelock timer must NOT be armed (guard is before livelock).
+        assert_eq!(
+            app.hard_reset_livelock_start.load(Ordering::Relaxed),
+            0,
+            "livelock timer must not be armed on suppression"
+        );
+    }
+
+    /// #3262: When archive is ConfirmedBehind AND cache is Cold AND peers
+    /// confirm we are at-or-near tip (peer_gap < HARD_RESET_GAP_ESCALATION),
+    /// the hard reset must be SUPPRESSED and routed to peer-SCP — NOT
+    /// escalated to a spurious ProbeAhead. A Cold cache with peers confirming
+    /// tip means a refresh is in flight and there is nothing to catch up to.
+    /// Fails on main (counter increments — Cold falls through to ProbeAhead).
+    #[tokio::test]
+    async fn test_hard_reset_suppressed_cold_cache_at_tip() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let mut app = App::new(config).await.unwrap();
+
+        let current_ledger: u32 = 5_000;
+
+        app.herder
+            .scp_driver()
+            .record_externalized(5050, Default::default(), None);
+        app.herder.scp_driver().publish_externalized(5050);
+
+        // peer_gap=5 (< HARD_RESET_GAP_ESCALATION=12) — peers confirm tip.
+        app.max_verified_scp_slot
+            .store(u64::from(current_ledger) + 5, Ordering::Relaxed);
+
+        {
+            let mut guard = app.archive_recovery_status.write().await;
+            *guard = ArchiveRecoveryStatus::ConfirmedBehind {
+                backoff_until: None,
+            };
+        }
+        // Do NOT seed cache — leaves it Cold.
+
+        app.start_instant = std::time::Instant::now() - std::time::Duration::from_secs(500);
+
+        let counter_before = app.post_catchup_hard_reset_total.load(Ordering::Relaxed);
+
+        let result = app
+            .force_post_catchup_hard_reset(
+                current_ledger,
+                HardResetReason::ArchiveBehindStallWallClock,
+            )
+            .await;
+
+        // Suppression must fire — returns None, no probe.
+        assert!(result.is_none(), "suppression guard should return None");
+
+        // Counter must NOT increment (no ProbeAhead spawned).
+        assert_eq!(
+            app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
+            counter_before,
+            "counter must not increment when Cold-at-tip suppression fires (#3262)"
+        );
+
+        // Status stays ConfirmedBehind (not cleared).
+        assert!(
+            app.archive_recovery_snapshot().await.is_confirmed_behind(),
+            "archive_recovery_status must remain ConfirmedBehind after suppression"
+        );
+
+        // Cooldown armed; peer-SCP route taken instead of the probe.
+        assert!(
+            app.last_hard_reset_offset.load(Ordering::Relaxed) > 0,
+            "cooldown must be armed after suppression"
+        );
+
+        // Livelock timer must NOT be armed.
+        assert_eq!(
+            app.hard_reset_livelock_start.load(Ordering::Relaxed),
+            0,
+            "livelock timer must not be armed on suppression"
+        );
+    }
+
+    /// #1862 (re-pointed from `test_hard_reset_not_suppressed_stale_cache`):
+    /// When archive is ConfirmedBehind with a Stale cache AND peers are
+    /// verifiably far ahead (peer_gap >= HARD_RESET_GAP_ESCALATION), the
+    /// suppression must NOT fire — the Stale cache may have published a new
+    /// checkpoint and the node is genuinely behind the network, so it must
+    /// proceed to the ProbeAhead "discover truth" archive catchup (#1862).
+    #[tokio::test]
+    async fn test_hard_reset_not_suppressed_stale_cache_when_peers_ahead() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let mut app = App::new(config).await.unwrap();
+
+        let current_ledger: u32 = 5_000;
+
+        app.herder
+            .scp_driver()
+            .record_externalized(5050, Default::default(), None);
+        app.herder.scp_driver().publish_externalized(5050);
+
+        // Verified peers far ahead: peer_gap = 50 >= HARD_RESET_GAP_ESCALATION.
+        app.max_verified_scp_slot.store(5050, Ordering::Relaxed);
 
         {
             let mut guard = app.archive_recovery_status.write().await;
@@ -6496,18 +6657,23 @@ mod tests {
             .await;
 
         assert!(result.is_none()); // test app, spawn returns None anyway
-                                   // Key: counter DID increment (guard didn't fire, function proceeded).
+                                   // Key: counter DID increment (guard didn't fire — peers ahead, #1862
+                                   // ProbeAhead path proceeds).
         assert_eq!(
             app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
             1,
-            "counter should increment (stale cache — guard must not fire)"
+            "counter should increment (stale cache + peers ahead — guard must not fire, #1862)"
         );
     }
 
-    /// When archive is ConfirmedBehind but cache is Cold, the guard
-    /// must NOT fire.
+    /// #1862 (re-pointed from `test_hard_reset_not_suppressed_cold_cache`):
+    /// When archive is ConfirmedBehind with a Cold cache AND peers are
+    /// verifiably far ahead (peer_gap >= HARD_RESET_GAP_ESCALATION), the
+    /// suppression must NOT fire — the node is genuinely behind the network
+    /// and must proceed to the ProbeAhead "discover truth" archive catchup
+    /// (#1862).
     #[tokio::test]
-    async fn test_hard_reset_not_suppressed_cold_cache() {
+    async fn test_hard_reset_not_suppressed_cold_cache_when_peers_ahead() {
         let dir = tempfile::tempdir().expect("temp dir");
         let db_path = dir.path().join("rs-stellar-test.db");
         let config = crate::config::ConfigBuilder::new()
@@ -6521,6 +6687,9 @@ mod tests {
             .scp_driver()
             .record_externalized(5050, Default::default(), None);
         app.herder.scp_driver().publish_externalized(5050);
+
+        // Verified peers far ahead: peer_gap = 50 >= HARD_RESET_GAP_ESCALATION.
+        app.max_verified_scp_slot.store(5050, Ordering::Relaxed);
 
         {
             let mut guard = app.archive_recovery_status.write().await;
@@ -6543,7 +6712,7 @@ mod tests {
         assert_eq!(
             app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
             1,
-            "counter should increment (cold cache — guard must not fire)"
+            "counter should increment (cold cache + peers ahead — guard must not fire, #1862)"
         );
     }
 

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -1481,31 +1481,49 @@ impl App {
         // (suppressed resets must not arm the fatal timer), BEFORE step 1
         // (which clears the flag we read).
         //
-        // Fresh cache only: Stale means refresh in-flight (archive may have
-        // published). Cold means no data (must probe). Leave
-        // archive_recovery_status as ConfirmedBehind so decision function stays
-        // in the archive_behind branch where cooldown → AttemptRecovery.
+        // #3262 (widening): suppress on "not-known-ahead while peers confirm
+        // tip" rather than "Fresh-and-behind" only. At the live tip the
+        // published archive always lags the network, so is_confirmed_behind()
+        // is the normal steady state and the archive cache cycles through
+        // Fresh/Stale/Cold (urgent-mode TTL is 10s — between refreshes
+        // get_cached() returns Stale). The old Fresh-only predicate let the
+        // Stale/Cold windows fall through to a futile ProbeAhead archive probe
+        // that errors "not ahead of min_ledger" — spurious churn at tip. The
+        // widened predicate suppresses for:
+        //   - Fresh(v) if v <= current_ledger  (today's behavior)
+        //   - Stale(v) if v <= current_ledger  (NEW)
+        //   - Cold                              (NEW — no value to compare; a
+        //     refresh is in flight and peers confirm there is nothing ahead)
+        // A known-ahead cache (Fresh|Stale with v > current_ledger) still
+        // falls through to ProbeAhead: that is a legitimate catchup target
+        // (#1862). archive_recovery_status stays ConfirmedBehind so the
+        // decision function stays in the archive_behind branch where cooldown
+        // → AttemptRecovery.
         //
-        // #2789 (narrowing): only suppress when the validator is at-or-near
-        // the network tip. Peer-gap is read from verified SCP evidence
-        // (max_verified_scp_slot, via effective_peer_gap) rather than from
-        // the herder's latest_externalized — when the node is stuck waiting
-        // for tx_sets, latest_externalized stays at LCL while
+        // #2789 gate (preserved): only suppress when the validator is
+        // at-or-near the network tip. Peer-gap is read from verified SCP
+        // evidence (max_verified_scp_slot, via effective_peer_gap) rather than
+        // from the herder's latest_externalized — when the node is stuck
+        // waiting for tx_sets, latest_externalized stays at LCL while
         // max_verified_scp_slot reflects the network tip. When peers are
         // clearly ahead (peer_gap >= HARD_RESET_GAP_ESCALATION = 12), the
-        // suppression blocks the only state-changing recovery path and
-        // leaves the validator wedged for ~90s. Falling through to the
-        // hard-reset+ProbeAhead path is bounded by the 60s cooldown and the
-        // livelock circuit-breaker, and the spawn_catchup state transition
-        // to CatchingUp itself breaks the wedge.
+        // suppression never fires and the hard-reset+ProbeAhead path proceeds
+        // exactly as before — preserving the #1862 far-behind archive catchup
+        // and the #2789 anti-wedge contract (the peer_gap >= 12 gate is the
+        // henyey analogue of core's "LCL has fallen behind the network"
+        // condition; core has no archive-probe-at-tip path).
         let peer_gap = self.effective_peer_gap(current_ledger);
+        let cache_not_known_ahead = match self.get_cached_archive_checkpoint_nonblocking() {
+            CacheResult::Fresh(v) | CacheResult::Stale(v) => v <= current_ledger,
+            // Cold has no value — the v <= current_ledger comparison is
+            // vacuous; with peers confirming tip there is nothing to catch
+            // up to, so a Cold cache is treated as not-known-ahead.
+            CacheResult::Cold => true,
+        };
         let suppress_archive_behind_at_tip =
             self.archive_recovery_snapshot().await.is_confirmed_behind()
                 && peer_gap < HARD_RESET_GAP_ESCALATION
-                && matches!(
-                    self.get_cached_archive_checkpoint_nonblocking(),
-                    CacheResult::Fresh(v) if v <= current_ledger
-                );
+                && cache_not_known_ahead;
 
         if suppress_archive_behind_at_tip {
             // Record cooldown so decision function routes to AttemptRecovery.
@@ -1528,10 +1546,11 @@ impl App {
                     gap = current_gap,
                     peer_gap,
                     ?reason,
-                    "Hard reset suppressed: archive confirmed behind with fresh \
-                     cache at/below current_ledger AND peers within \
-                     HARD_RESET_GAP_ESCALATION — cooldown armed, requesting \
-                     SCP state from peers (#2713, narrowed by #2789)"
+                    "Hard reset suppressed: archive confirmed behind with a \
+                     not-known-ahead cache (Fresh/Stale at/below current_ledger, \
+                     or Cold) AND peers within HARD_RESET_GAP_ESCALATION — \
+                     cooldown armed, requesting SCP state from peers \
+                     (#2713, narrowed by #2789, widened by #3262)"
                 );
             } else {
                 tracing::debug!(
@@ -1540,7 +1559,7 @@ impl App {
                     gap = current_gap,
                     peer_gap,
                     ?reason,
-                    "Hard reset suppressed (#2713) (repeated)"
+                    "Hard reset suppressed (#2713/#3262) (repeated)"
                 );
             }
 
@@ -4282,6 +4301,13 @@ mod tests {
         // Set tx_set_all_peers_exhausted.
         app.tx_set_all_peers_exhausted.store(true, Ordering::SeqCst);
 
+        // Peers verifiably far ahead (peer_gap = 50 >= HARD_RESET_GAP_ESCALATION)
+        // so the #3262 at-tip suppression does NOT fire and the genuine
+        // hard-reset execution path (eviction, state-clearing, counters)
+        // runs — this test exercises that path, not the at-tip suppression.
+        app.max_verified_scp_slot
+            .store(u64::from(current_ledger) + 50, Ordering::Relaxed);
+
         // Arm archive_recovery_status with backoff.
         {
             let mut guard = app.archive_recovery_status.write().await;
@@ -5099,19 +5125,22 @@ mod tests {
         );
     }
 
-    /// #1844 control (updated for #3204): without a previous hard reset (no
-    /// cooldown), the same scenario routes to HardReset(RecoveryExhausted) —
-    /// but only once the peer-gap-shrink progress suppression has lapsed.
+    /// #1844 control (updated for #3204; re-pointed for #3262): without a
+    /// previous hard reset (no cooldown), the same scenario routes to
+    /// HardReset(RecoveryExhausted) — but only once the peer-gap-shrink
+    /// progress suppression has lapsed.
     ///
-    /// In this scenario there is NO peer-ahead evidence (max_verified_scp_slot
-    /// stays 0 → effective_peer_gap == 0, flat across ticks), so the verified
-    /// peer gap never strictly shrinks. Per #3204 the count-based cap is
-    /// suppressed while back-fill might be making progress and re-arms only
-    /// after RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS consecutive non-shrink
-    /// ticks (escape-1, ~30s). So the HardReset now fires on the Nth tick, not
-    /// the 1st — proving the genuine-no-progress stall still escalates (the
-    /// anti-wedge guarantee), just bounded by the no-progress budget instead of
-    /// an instantaneous count cap.
+    /// Peers are verifiably far ahead (max_verified_scp_slot = 50 →
+    /// effective_peer_gap == 50 >= HARD_RESET_GAP_ESCALATION), so the #3262
+    /// at-tip suppression does NOT fire and this genuinely-behind stall must
+    /// still escalate (the anti-wedge guarantee). The peer gap is FLAT at 50
+    /// across ticks, so it never strictly shrinks. Per #3204 the count-based
+    /// cap is suppressed while back-fill might be making progress and re-arms
+    /// only after RECOVERY_ZERO_PROGRESS_ESCALATION_ATTEMPTS consecutive
+    /// non-shrink ticks (escape-1, ~30s). So the HardReset fires on the Nth
+    /// tick, not the 1st — proving the genuine-no-progress stall still
+    /// escalates, just bounded by the no-progress budget instead of an
+    /// instantaneous count cap.
     #[tokio::test]
     async fn test_no_previous_reset_routes_to_hard_reset() {
         use std::sync::atomic::Ordering;
@@ -5119,11 +5148,17 @@ mod tests {
 
         let (_dir, app) = mk_app_for_cooldown_livelock_scenario().await;
 
+        // Peers verifiably far ahead (peer_gap = 50 >= HARD_RESET_GAP_ESCALATION)
+        // so the #3262 at-tip suppression does not fire — the node is
+        // genuinely behind the network and must escalate.
+        app.max_verified_scp_slot.store(50, Ordering::Relaxed);
+
         // last_hard_reset_offset stays at 0 (default) → "no previous reset"
         // → cooldown is inactive → HardReset fires once progress lapses.
 
         // Drive the no-progress counter to its escalation threshold. The peer
-        // gap is flat at 0 (no peer evidence), so each tick is a non-shrink.
+        // gap is flat at 50 (peers ahead, no shrink), so each tick is a
+        // non-shrink.
         // Re-arm the schedule timer between ticks so each one is schedule_due,
         // and re-seed the stuck state because the prior tick's AttemptRecovery
         // increments recovery_attempts (kept at/above the cap here).
@@ -6305,6 +6340,12 @@ mod tests {
         let current_ledger: u32 = 0;
         // latest_externalized is None → unwrap_or(0), so latest_ext == 0.
 
+        // Peers verifiably ahead (peer_gap = 50 >= HARD_RESET_GAP_ESCALATION)
+        // so the #3262 at-tip suppression does NOT fire — this test verifies
+        // the latest_ext==0 startup exclusion of the at-tip exact-equality
+        // guard, so the reset must proceed past the suppression.
+        app.max_verified_scp_slot.store(50, Ordering::Relaxed);
+
         {
             let mut guard = app.archive_recovery_status.write().await;
             *guard = ArchiveRecoveryStatus::ConfirmedBehind {
@@ -6351,6 +6392,13 @@ mod tests {
             .scp_driver()
             .record_externalized(5_010, Default::default(), None);
         app.herder.scp_driver().publish_externalized(5_010);
+
+        // Peers verifiably far ahead (peer_gap = 50 >= HARD_RESET_GAP_ESCALATION)
+        // so the #3262 at-tip suppression does NOT fire and the Behind case
+        // proceeds to the genuine hard reset (this test exercises the
+        // proceed-when-behind path, not at-tip suppression).
+        app.max_verified_scp_slot
+            .store(u64::from(current_ledger) + 50, Ordering::Relaxed);
 
         {
             let mut guard = app.archive_recovery_status.write().await;


### PR DESCRIPTION
Closes #3262

## Summary

Kills the spurious `HardResetEscalation`/`ProbeAhead` catchup probes that fire while the node is at tip and validating. At the live tip the published history archive always lags the network, so `is_confirmed_behind()` is the normal steady state and the archive-checkpoint cache cycles Fresh/Stale/Cold (urgent-mode TTL = 10s, `archive_cache.rs:47`). The #2789 suppression in `force_post_catchup_hard_reset` only fired for `Fresh`-and-behind caches, so the Stale/Cold windows fell through to a futile `ProbeAhead` archive probe that errors `not ahead of min_ledger` — flapping `Catching Up <-> Validating` every few minutes.

This widens the suppression predicate in `force_post_catchup_hard_reset` (`crates/app/src/app/catchup_impl.rs`) from "Fresh-and-behind" to **"not-known-ahead while peers confirm tip"**. When `is_confirmed_behind() && peer_gap < HARD_RESET_GAP_ESCALATION` (12), suppress (route to peer-SCP via `request_scp_state_and_record()`, return `None` — no probe) for:
- `Fresh(v) if v <= current_ledger` (today's behavior — kept),
- `Stale(v) if v <= current_ledger` (NEW),
- `Cold` (NEW — no value, vacuously not-known-ahead).

Known-ahead caches (`v > current_ledger`) and peers-ahead (`peer_gap >= 12`) **still fall through to ProbeAhead**, preserving the #1862 far-behind archive catchup. `force_post_catchup_hard_reset` is the single chokepoint through which all three escalation entry points funnel, so this one change covers every trigger.

## Recovery-arc preservation

- **#1862** far-behind archive catchup — `peer_gap >= 12` → probe proceeds (unchanged; covered by the re-pointed tests).
- **#3199/#3205** near-tip peer-SCP — strengthened (more at-tip cases now route through `request_scp_state_and_record`).
- **#2789** anti-wedge — the `peer_gap >= 12` gate is the exact discriminator; the genuine-stuck-peers-ahead path still escalates. `test_hard_reset_not_suppressed_when_peers_ahead` / `test_recovery_loop_unwedges_when_peers_ahead` stay green.

## Parity

Matches stellar-core: `HerderImpl::outOfSyncRecovery` recovers transient out-of-sync via SCP only; `LedgerApplyManagerImpl::startCatchup` rejects `toLedger <= LCL`; core has no archive-probe-at-tip path. The `peer_gap < 12` gate is the henyey analogue of core's "LCL behind the network" condition.

## Plan reference

[Converged Plan comment]()

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-app -- -D warnings (clean)
- [x] cargo test -p henyey-app — 1024+ tests pass, incl. all 43 `hard_reset` tests and the #2789/#1862/#3199/#3205 arc

## Regression test (kind: bug-fix)

- **Tests:** `catchup_impl.rs::test_hard_reset_suppressed_stale_cache_at_tip` and `::test_hard_reset_suppressed_cold_cache_at_tip`
- **Pre-fix:** committed as `626bdf38` — verified FAILED with `counter must not increment ... (#3262)`: `left: 1, right: 0` (main spawns ProbeAhead → counter increments)
- **Post-fix:** verified PASS after `25591efd` (suppression fires: `None`, counter flat, `ConfirmedBehind` retained, cooldown armed, peer-SCP requested)
- The existing `test_hard_reset_not_suppressed_{stale,cold}_cache` were re-pointed to the peers-ahead case (`peer_gap >= 12`) as `..._when_peers_ahead`, so they still validate #1862 (the probe DOES fire when peers are genuinely ahead).

## Deviations from plan

- The widened predicate also changed the behavior of four genuine-hard-reset execution tests (`test_hard_reset_clears_state_and_does_not_spawn_catchup`, `test_hard_reset_proceeds_when_behind`, `test_hard_reset_proceeds_at_tip_zero`, `test_no_previous_reset_routes_to_hard_reset`) that previously relied on Cold-cache-at-`peer_gap=0` proceeding to the probe. They were re-pointed to the peers-ahead fixture (`max_verified_scp_slot` set so `peer_gap >= 12`) — same re-pointing pattern the plan prescribed for the stale/cold tests — so they continue to exercise the genuine hard-reset path. No production-code deviation.

## Follow-up

#3263 is the defense-in-depth follow-up (peer-gap floor on the No-SCP escalation trigger at `consensus.rs:611`) — intentionally NOT in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)