### PR TITLE
Add peer_gap floor to No-SCP hard-reset escalation trigger

### DIFF
--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -798,10 +798,23 @@ impl App {
                 // time AND the archive is confirmed behind, escalate to
                 // hard reset. Uses a higher threshold than the fast-track
                 // path because absence of SCP traffic is weaker evidence.
+                //
+                // #3263: gate the escalation behind a peer_gap floor, matching
+                // the sibling peer-ahead site below (consensus.rs:1876). At the
+                // live tip the archive is normally behind, so without a verified
+                // peer ahead this site would otherwise escalate-at-tip. The
+                // `peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD` floor is the
+                // henyey proxy for "genuinely behind the network" and aligns
+                // with stellar-core's SCP-only `HerderImpl::outOfSyncRecovery`,
+                // which never archive-escalates at tip. #1862 far-behind
+                // (peer_gap >= 12 >= 3) is unaffected; a genuinely-stuck node at
+                // peer_gap < 3 is still caught by the independent #2789 120s
+                // wall-clock backstop, so the floor cannot create a new wedge.
                 let archive_is_confirmed_behind =
                     self.archive_recovery_snapshot().await.is_confirmed_behind();
                 let peer_gap = self.effective_peer_gap(current_ledger);
                 if archive_is_confirmed_behind
+                    && peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD
                     && attempts >= RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NO_SCP
                     && !self.is_hard_reset_on_cooldown(peer_gap)
                 {

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -12040,6 +12040,99 @@ mod tests {
         );
     }
 
+    /// #3263 floor: No-SCP escalation must NOT fire when peer_gap is below
+    /// PEER_AHEAD_ESCALATION_THRESHOLD (3) — no verified peer ahead means the
+    /// node is not "genuinely behind the network", matching the sibling
+    /// peer-ahead site and stellar-core's SCP-only outOfSyncRecovery.
+    ///
+    /// Clone of the fires-test but with `max_verified_scp_slot = 2` →
+    /// peer_gap = 2 (< floor). We assert on the per-app `last_hard_reset_offset`
+    /// side-effect, NOT on `is_confirmed_behind`: with current_ledger=0 the
+    /// harness's `ArchiveCheckpointCache` is never primed → Cold → the #3264
+    /// suppression (peer_gap < 12 && cache_not_known_ahead) catches the
+    /// escalation INSIDE `force_post_catchup_hard_reset` and leaves
+    /// confirmed-behind intact even on main, so `is_confirmed_behind` is not a
+    /// pre/post differentiator at peer_gap < 12. The clean differentiator is
+    /// whether `force_post_catchup_hard_reset` was REACHED, observed via its
+    /// cooldown side-effect: 0 = gated out (post-floor); > 0 = reached +
+    /// suppression armed the cooldown (pre-floor, fails on origin/main).
+    #[tokio::test]
+    async fn test_out_of_sync_at_tip_no_scp_low_peer_gap_no_escalation() {
+        let (_dir, app) = make_app_for_peer_ahead_test().await;
+        let current_ledger = 0u32;
+
+        {
+            *app.archive_recovery_status.write().await = ArchiveRecoveryStatus::ConfirmedBehind {
+                backoff_until: None,
+            };
+        }
+        // peer_gap = 2 (below PEER_AHEAD_ESCALATION_THRESHOLD = 3).
+        app.max_verified_scp_slot.store(2, Ordering::Relaxed);
+        app.recovery_attempts_without_progress.store(
+            RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NO_SCP,
+            Ordering::SeqCst,
+        );
+        app.recovery_baseline_ledger
+            .store(current_ledger as u64, Ordering::SeqCst);
+        app.scp_messages_received.store(0, Ordering::Relaxed);
+        app.recovery_baseline_scp_received
+            .store(0, Ordering::SeqCst);
+
+        let result = app.out_of_sync_recovery(current_ledger).await;
+
+        // Escalation gated out by the floor: force_post_catchup_hard_reset is
+        // never reached, so the cooldown is never armed.
+        assert_eq!(
+            app.last_hard_reset_offset.load(Ordering::Relaxed),
+            0,
+            "peer_gap=2 < floor: No-SCP escalation must be gated out \
+             (last_hard_reset_offset stays 0)"
+        );
+        assert!(result.is_none());
+    }
+
+    /// #3263 floor boundary: at peer_gap == PEER_AHEAD_ESCALATION_THRESHOLD (3)
+    /// the No-SCP escalation STILL fires (guards `>=` vs `>` off-by-one).
+    ///
+    /// Same setup as the low-gap test with `max_verified_scp_slot = 3` →
+    /// peer_gap = 3 (exactly at the floor). peer_gap=3 < 12, so the #3264
+    /// Cold-cache suppression catches the escalation inside
+    /// `force_post_catchup_hard_reset` — we therefore assert via the same
+    /// `last_hard_reset_offset > 0` signal (escalation reached the chokepoint,
+    /// suppression armed the cooldown). Passes pre and post.
+    #[tokio::test]
+    async fn test_out_of_sync_at_tip_no_scp_peer_gap_at_floor_fires_hard_reset() {
+        let (_dir, app) = make_app_for_peer_ahead_test().await;
+        let current_ledger = 0u32;
+
+        {
+            *app.archive_recovery_status.write().await = ArchiveRecoveryStatus::ConfirmedBehind {
+                backoff_until: None,
+            };
+        }
+        // peer_gap = 3 (exactly at PEER_AHEAD_ESCALATION_THRESHOLD).
+        app.max_verified_scp_slot.store(3, Ordering::Relaxed);
+        app.recovery_attempts_without_progress.store(
+            RECOVERY_HARD_RESET_ESCALATION_ATTEMPTS_NO_SCP,
+            Ordering::SeqCst,
+        );
+        app.recovery_baseline_ledger
+            .store(current_ledger as u64, Ordering::SeqCst);
+        app.scp_messages_received.store(0, Ordering::Relaxed);
+        app.recovery_baseline_scp_received
+            .store(0, Ordering::SeqCst);
+
+        let _result = app.out_of_sync_recovery(current_ledger).await;
+
+        // Escalation reached force_post_catchup_hard_reset; Cold cache +
+        // peer_gap<12 → #3264 suppression armed the cooldown.
+        assert!(
+            app.last_hard_reset_offset.load(Ordering::Relaxed) > 0,
+            "peer_gap=3 == floor: No-SCP escalation must fire \
+             (reach force_post_catchup_hard_reset, arming cooldown)"
+        );
+    }
+
     /// Step 4 no-SCP path: attempts one below threshold should NOT fire.
     /// Uses current_ledger=0 for AtTip relation.
     #[tokio::test]


### PR DESCRIPTION
Closes #3263

## Summary

Adds a `peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD` (3) floor to the No-SCP hard-reset escalation condition in `out_of_sync_recovery` (`crates/app/src/app/consensus.rs`). This was the **only escalation site lacking the peer-gap floor** — the sibling peer-ahead far-behind site (consensus.rs:1876) already has it. At the live tip the archive is normally behind, so without a verified peer ahead the No-SCP *decision* fired at tip every ~180s (counter/log/cooldown churn) before #3262/#3264's downstream suppression neutralized it. The floor stops the wasted escalation decision at the source and complements #3262/#3264's execution-layer suppression (defense-in-depth).

The change is purely additive — `peer_gap` is already in scope (consensus.rs:803); AND-ing a stronger predicate can only *reduce* firing.

## The arc preserved

- **#1862** far-behind (`peer_gap >= 12`) still escalates (`12 >= 3`) — unchanged.
- **#2789** anti-wedge: a genuinely-stuck node at `peer_gap < 3` is STILL caught by the **independent** 120s wall-clock backstop (`maybe_start_buffered_catchup` → `decide_consensus_stuck_action`, `catchup_impl.rs`), which fires `HardReset(ArchiveBehindStallWallClock)` on `stuck_duration >= 120s` with NO `peer_gap` term. That path is untouched, so the floor cannot create a new wedge.
- **#3199/#3205** near-tip peer-SCP recovery — unaffected.
- **#3262/#3264** execution-layer suppression (`catchup_impl.rs`) — untouched outer defense.

## Parity

stellar-core `HerderImpl::outOfSyncRecovery` (HerderImpl.cpp:521-561) is SCP-only — purge old slots, re-broadcast latest SCP, `getMoreSCPState()`; no archive catchup, no escalation-at-tip absent genuine network-behindness. The `peer_gap >= 3` floor is the henyey proxy for "genuinely behind the network." Moves henyey toward core.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3263#issuecomment-4667498236)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-app -- -D warnings (clean)
- [x] cargo test -p henyey-app (1026 lib + integration, 0 failed) — incl. the new tests and the #1862/#2789-backstop/#3199/#3205/#3264 arc tests

## Regression test (kind: bug-fix)

- **Test:** `crates/app/src/app/mod.rs::test_out_of_sync_at_tip_no_scp_low_peer_gap_no_escalation`
- **Pre-fix:** committed as `1079ae46` — verified FAILED: with no floor, `peer_gap=2` + `attempts>=17` + ConfirmedBehind reaches `force_post_catchup_hard_reset`; the Cold harness cache + `peer_gap<12` triggers the #3264 suppression which arms the cooldown → `last_hard_reset_offset == 1`, so the `== 0` assertion fails.
- **Post-fix:** verified PASSES after `4a84b9c3` — the floor gates the escalation out, `force_post_catchup_hard_reset` is never reached, `last_hard_reset_offset` stays 0.
- **Boundary:** `test_out_of_sync_at_tip_no_scp_peer_gap_at_floor_fires_hard_reset` (`peer_gap=3`) asserts the escalation still fires (reaches the chokepoint → cooldown armed), guarding `>=` vs `>`. Passes pre and post.
- **Unaffected:** `test_out_of_sync_at_tip_no_scp_archive_behind_fires_hard_reset` (`peer_gap=20 >= 12`, bypasses #3264 suppression, asserts on `is_confirmed_behind`) still fires.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)