### PR TITLE
Classify History Publish (Testnet) sync-timeout vs publish regression

### DIFF
--- a/.github/workflows/history-publish.yml
+++ b/.github/workflows/history-publish.yml
@@ -46,12 +46,34 @@ jobs:
         run: cargo build --release -p henyey
 
       - name: Run history publish integration test
+        # --soft-on-sync-timeout (#3280): the phase-1 wait can hit its deadline
+        # for two very different reasons. (1) The node SYNCED testnet but
+        # published no checkpoint — a REAL publish regression — stays a hard red
+        # (PUBLISH-REGRESSION). (2) The node NEVER reached sync in time — an
+        # environmental testnet-liveness timeout (the chronic flake this job
+        # hits: the same commit passes/fails on different days purely on testnet
+        # health) — is soft-skipped to a neutral exit 0 with a grep-able
+        # SOFT-SKIP marker. The phase-2 byte-compare against SDF's testnet
+        # archive is NEVER soft-skipped (a mismatch is always a hard red).
+        #
+        # De-gating the sync-timeout is safe because the publish CODE PATH is
+        # also covered deterministically on every PR by ci.yml's
+        # `cargo test --workspace` suite: enqueue-at-boundary trigger
+        # (crates/app/src/app/ledger_close.rs), publish-queue drain
+        # (crates/history/src/publish_queue.rs, crates/app/src/app/publish.rs),
+        # checkpoint build (crates/history/src/checkpoint_builder.rs), HAS
+        # (crates/history/src/archive_state.rs), upload
+        # (crates/history/src/upload.rs), and compare logic
+        # (crates/history/src/compare.rs). What this job uniquely adds — the
+        # live byte-match against SDF's testnet archive (phase 2) — is preserved.
+        # The flag is scoped to this testnet job only; the script defaults OFF.
         run: |
           TIMEOUT="${{ inputs.timeout }}"
           TIMEOUT="${TIMEOUT:-1500}"
 
           ./scripts/test-history-publish.sh \
             --no-build \
+            --soft-on-sync-timeout \
             --timeout "$TIMEOUT" \
             --data-dir "${{ runner.temp }}/publish-test"
 
@@ -74,11 +96,29 @@ jobs:
           echo "## History Publish (Testnet)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
+          LOG_FILE="$DATA_DIR/validator.log"
+
           if [[ -f "$HAS_FILE" ]]; then
             CHECKPOINT=$(jq -r '.currentLedger' "$HAS_FILE" 2>/dev/null || echo "unknown")
             echo "- **Checkpoint:** $CHECKPOINT" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- **Checkpoint:** none published" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+          # Surface the phase-1 deadline disposition (#3280) so a soft-skipped
+          # environmental SYNC-TIMEOUT stays visible on this daily job rather
+          # than silently passing. Derive it from the same on-disk signals the
+          # script's classifier uses: a published HAS, and the run-loop sync
+          # marker "Node is synced" in validator.log.
+          if [[ -f "$HAS_FILE" ]]; then
+            DISPOSITION="PUBLISHED"
+          elif [[ -f "$LOG_FILE" ]] && grep -qF "Node is synced" "$LOG_FILE"; then
+            DISPOSITION="PUBLISH-REGRESSION (synced but no checkpoint)"
+          elif [[ -f "$LOG_FILE" ]]; then
+            DISPOSITION="SYNC-TIMEOUT (environmental; soft-skipped)"
+          else
+            DISPOSITION="unknown (no validator log)"
+          fi
+          echo "- **Disposition:** $DISPOSITION" >> "$GITHUB_STEP_SUMMARY"
 
           echo "- **Status:** ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/test-history-publish-harness.sh
+++ b/scripts/test-history-publish-harness.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# scripts/test-history-publish-harness.sh — TAP regression/coverage tests for the
+# History Publish (Testnet) sync-vs-publish disposition classifier introduced in
+# #3280.
+#
+# Background (#3280): the "History Publish (Testnet)" daily workflow runs
+# scripts/test-history-publish.sh, which (phase 1) waits up to --timeout seconds
+# for the node to sync testnet and publish its first checkpoint, then (phase 2)
+# byte-compares that checkpoint against SDF's live testnet archive. The phase-1
+# deadline used to be a single blanket `exit 1`, which conflated TWO very
+# different outcomes:
+#   * the node SYNCED but never published a checkpoint — a real publish
+#     regression that must stay a hard red, AND
+#   * the node NEVER reached sync in time — an environmental testnet-liveness
+#     timeout (the chronic flake the issue tracks; same SHA passed/failed on
+#     different days), which should be soft-skippable.
+#
+# The classifier (test-history-publish.sh --classify-only <data-dir>) decides the
+# phase-1 deadline disposition from concrete signals already present on disk:
+#   * a published HAS (history/.well-known/stellar-history.json, currentLedger>0)
+#   * the node's sync marker in validator.log — the EXACT string the run loop
+#     logs once it reaches Synced/Validating: "Node is synced"
+#     (crates/app/src/run_cmd.rs::wait_for_sync). Pinned by a harness assertion
+#     below so a log-wording drift breaks this harness loudly instead of silently
+#     inverting the synced-vs-never-synced dispositions.
+#
+# Dispositions and exit codes (classify-only):
+#   PUBLISHED         exit 0  — HAS present (caller proceeds to phase-2 compare)
+#   PUBLISH-REGRESSION exit 1 — synced but no HAS by deadline (real regression)
+#   SYNC-TIMEOUT      exit 1  — never synced, flag OFF (byte-identical default)
+#   SYNC-TIMEOUT      exit 0  — never synced, --soft-on-sync-timeout (SOFT-SKIP)
+#
+# Run: bash scripts/test-history-publish-harness.sh
+# Requires: bash 4+, jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/test-history-publish.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/history-publish.yml"
+RUN_CMD="$REPO_ROOT/crates/app/src/run_cmd.rs"
+
+# The exact sync marker the run loop emits when the node reaches sync. This is
+# the single source of truth shared between the classifier and the assertion
+# pinning it (test_sync_marker_matches_run_loop_log below).
+SYNC_MARKER="Node is synced"
+
+# TAP output
+TEST_COUNT=0
+PASS_COUNT=0
+FAIL_COUNT=0
+
+tap_ok() {
+    TEST_COUNT=$((TEST_COUNT + 1))
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "ok $TEST_COUNT - $1"
+}
+
+tap_not_ok() {
+    TEST_COUNT=$((TEST_COUNT + 1))
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "not ok $TEST_COUNT - $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  # $2"
+    fi
+}
+
+tap_plan() {
+    echo "1..$1"
+}
+
+# --- Setup ---
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+# Build a synthetic data-dir fixture mirroring what test-history-publish.sh
+# creates at runtime: a validator.log (optionally containing the sync marker)
+# and an optional published HAS file.
+#
+# Args: <name> <synced: yes|no> <has_ledger: int|none>
+make_fixture() {
+    local name="$1"
+    local synced="$2"
+    local has_ledger="$3"
+    local data_dir="$TMPDIR_BASE/fixture-$name"
+    local log="$data_dir/validator.log"
+    local has_dir="$data_dir/history/.well-known"
+
+    mkdir -p "$data_dir/history/.well-known" "$data_dir/buckets"
+
+    {
+        echo "starting validator..."
+        echo "closing ledger 1"
+        echo "closing ledger 2"
+        if [[ "$synced" == "yes" ]]; then
+            echo "  INFO state=Synced $SYNC_MARKER"
+        fi
+        echo "closing ledger 3"
+    } > "$log"
+
+    if [[ "$has_ledger" != "none" ]]; then
+        printf '{"currentLedger": %s}\n' "$has_ledger" > "$has_dir/stellar-history.json"
+    fi
+
+    echo "$data_dir"
+}
+
+# ============================================================
+# Test 1: never synced + --soft-on-sync-timeout → neutral soft-skip
+#
+# The environmental testnet-liveness case (#3280): validator.log lacks the sync
+# marker and no HAS was published. Under the opt-in flag this is a neutral
+# exit 0 with a grep-able SOFT-SKIP marker. FAILS on origin/main: the flag does
+# not exist and the deadline path is an unconditional `exit 1`.
+# ============================================================
+test_never_synced_soft_skip() {
+    local data_dir
+    data_dir=$(make_fixture "soft" no none)
+
+    local out="$TMPDIR_BASE/out-soft.txt"
+    local exit_code=0
+    "$SCRIPT" --soft-on-sync-timeout --classify-only "$data_dir" >"$out" 2>&1 || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        tap_ok "never_synced_with_flag_exits_zero"
+    else
+        tap_not_ok "never_synced_with_flag_exits_zero" "exit=$exit_code (expected 0 soft-skip)"
+    fi
+
+    if grep -q 'SOFT-SKIP' "$out"; then
+        tap_ok "never_synced_with_flag_emits_soft_skip"
+    else
+        tap_not_ok "never_synced_with_flag_emits_soft_skip" "no SOFT-SKIP marker in output"
+    fi
+
+    # A soft-skip must NOT be mislabelled a publish regression.
+    if ! grep -q 'PUBLISH-REGRESSION' "$out"; then
+        tap_ok "never_synced_soft_skip_not_publish_regression"
+    else
+        tap_not_ok "never_synced_soft_skip_not_publish_regression" \
+            "PUBLISH-REGRESSION emitted for an environmental sync timeout"
+    fi
+}
+
+# ============================================================
+# Test 2: synced but no checkpoint → hard red with PUBLISH-REGRESSION
+#
+# The correctness keystone (#3280): the node reached sync (marker present) but
+# published no HAS by the deadline — a real publish regression. This must stay a
+# hard red EVEN WITH --soft-on-sync-timeout, and emit the PUBLISH-REGRESSION
+# marker (not SOFT-SKIP).
+# ============================================================
+test_synced_no_publish_hard_red() {
+    local data_dir
+    data_dir=$(make_fixture "regress" yes none)
+
+    local out="$TMPDIR_BASE/out-regress.txt"
+    local exit_code=0
+    "$SCRIPT" --soft-on-sync-timeout --classify-only "$data_dir" >"$out" 2>&1 || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        tap_ok "synced_no_publish_exits_nonzero"
+    else
+        tap_not_ok "synced_no_publish_exits_nonzero" "exit=$exit_code (expected hard red)"
+    fi
+
+    if grep -q 'PUBLISH-REGRESSION' "$out"; then
+        tap_ok "synced_no_publish_emits_publish_regression"
+    else
+        tap_not_ok "synced_no_publish_emits_publish_regression" "no PUBLISH-REGRESSION marker"
+    fi
+
+    # Must NOT soft-skip a real regression even with the flag on.
+    if ! grep -q 'SOFT-SKIP' "$out"; then
+        tap_ok "synced_no_publish_not_soft_skipped"
+    else
+        tap_not_ok "synced_no_publish_not_soft_skipped" \
+            "SOFT-SKIP emitted for a synced-but-no-publish regression (masks a real break)"
+    fi
+}
+
+# ============================================================
+# Test 3: never synced WITHOUT the flag → still hard red (byte-identical default)
+#
+# Scope guard: with the flag OFF (local/dev default and any non-testnet caller),
+# the deadline path stays a hard red exactly as before — proving the soft-skip is
+# strictly opt-in.
+# ============================================================
+test_never_synced_default_red() {
+    local data_dir
+    data_dir=$(make_fixture "default" no none)
+
+    local out="$TMPDIR_BASE/out-default.txt"
+    local exit_code=0
+    "$SCRIPT" --classify-only "$data_dir" >"$out" 2>&1 || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        tap_ok "never_synced_without_flag_stays_red"
+    else
+        tap_not_ok "never_synced_without_flag_stays_red" "exit=$exit_code (expected non-zero default)"
+    fi
+
+    if ! grep -q 'SOFT-SKIP' "$out"; then
+        tap_ok "never_synced_without_flag_no_soft_skip"
+    else
+        tap_not_ok "never_synced_without_flag_no_soft_skip" "SOFT-SKIP emitted without the flag"
+    fi
+}
+
+# ============================================================
+# Test 4: published checkpoint → PUBLISHED disposition (proceed to compare)
+#
+# When a HAS with currentLedger>0 exists, the classifier reports PUBLISHED and
+# exits 0 — the caller then proceeds to the (unchanged) phase-2 compare. This
+# disposition is independent of the sync marker / soft flag.
+# ============================================================
+test_published_proceeds() {
+    local data_dir
+    data_dir=$(make_fixture "published" yes 63)
+
+    local out="$TMPDIR_BASE/out-published.txt"
+    local exit_code=0
+    "$SCRIPT" --classify-only "$data_dir" >"$out" 2>&1 || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]] && grep -q 'PUBLISHED' "$out"; then
+        tap_ok "published_checkpoint_reports_published"
+    else
+        tap_not_ok "published_checkpoint_reports_published" \
+            "exit=$exit_code, PUBLISHED present=$(grep -q 'PUBLISHED' "$out" && echo yes || echo no)"
+    fi
+
+    # A published checkpoint is neither a soft-skip nor a regression.
+    if ! grep -q 'SOFT-SKIP' "$out" && ! grep -q 'PUBLISH-REGRESSION' "$out"; then
+        tap_ok "published_checkpoint_no_other_markers"
+    else
+        tap_not_ok "published_checkpoint_no_other_markers" \
+            "unexpected SOFT-SKIP/PUBLISH-REGRESSION marker on a published checkpoint"
+    fi
+}
+
+# ============================================================
+# Test 5: the sync marker is pinned to the real run-loop log string
+#
+# Critic-A mandate (#3280): the classifier's "node reached sync" detection must
+# be tied to a CONCRETE signal that cannot silently rot. The run loop logs the
+# sync transition exactly once via tracing::info!(..., "Node is synced") in
+# crates/app/src/run_cmd.rs::wait_for_sync. This asserts (a) that exact string is
+# still present in run_cmd.rs (so a future log-wording change breaks here loudly,
+# forcing the classifier's grep to be updated in lockstep), and (b) that the
+# classifier in test-history-publish.sh greps for that same marker string.
+# ============================================================
+test_sync_marker_matches_run_loop_log() {
+    if [[ ! -f "$RUN_CMD" ]]; then
+        tap_not_ok "sync_marker_present_in_run_loop" "run_cmd.rs not found at $RUN_CMD"
+        tap_not_ok "classifier_greps_for_sync_marker" "run_cmd.rs not found"
+        return
+    fi
+
+    # (a) The exact marker is still emitted by wait_for_sync.
+    if grep -qF "\"$SYNC_MARKER\"" "$RUN_CMD"; then
+        tap_ok "sync_marker_present_in_run_loop"
+    else
+        tap_not_ok "sync_marker_present_in_run_loop" \
+            "run_cmd.rs no longer logs \"$SYNC_MARKER\" — update SYNC_MARKER and the classifier grep in lockstep"
+    fi
+
+    # (b) The classifier script greps for the same marker string.
+    if grep -qF "$SYNC_MARKER" "$SCRIPT"; then
+        tap_ok "classifier_greps_for_sync_marker"
+    else
+        tap_not_ok "classifier_greps_for_sync_marker" \
+            "test-history-publish.sh does not grep for the pinned sync marker \"$SYNC_MARKER\""
+    fi
+}
+
+# ============================================================
+# Test 6: workflow wires --soft-on-sync-timeout on the testnet job only
+#
+# The daily testnet job must opt into the soft-skip (the whole point of #3280),
+# and the run step must invoke the script with the flag. Text/structure
+# assertion (the harness cannot run the GitHub Actions runner).
+# ============================================================
+test_workflow_wires_soft_flag() {
+    if [[ ! -f "$WORKFLOW" ]]; then
+        tap_not_ok "workflow_passes_soft_on_sync_timeout" "workflow not found"
+        tap_not_ok "workflow_runs_history_publish_script" "workflow not found"
+        return
+    fi
+
+    if grep -q -- '--soft-on-sync-timeout' "$WORKFLOW"; then
+        tap_ok "workflow_passes_soft_on_sync_timeout"
+    else
+        tap_not_ok "workflow_passes_soft_on_sync_timeout" \
+            "history-publish.yml must pass --soft-on-sync-timeout on the run step"
+    fi
+
+    if grep -q 'test-history-publish.sh' "$WORKFLOW"; then
+        tap_ok "workflow_runs_history_publish_script"
+    else
+        tap_not_ok "workflow_runs_history_publish_script" \
+            "workflow no longer runs scripts/test-history-publish.sh"
+    fi
+}
+
+# --- Run all tests ---
+tap_plan 14
+
+test_never_synced_soft_skip
+test_synced_no_publish_hard_red
+test_never_synced_default_red
+test_published_proceeds
+test_sync_marker_matches_run_loop_log
+test_workflow_wires_soft_flag
+
+echo ""
+echo "# Results: $PASS_COUNT/$TEST_COUNT passed, $FAIL_COUNT failed"
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/test-history-publish.sh
+++ b/scripts/test-history-publish.sh
@@ -9,10 +9,46 @@
 #   ./scripts/test-history-publish.sh --timeout 1200    # wait up to 20 min
 #   ./scripts/test-history-publish.sh --checkpoint 63   # compare specific checkpoint
 #   ./scripts/test-history-publish.sh --data-dir /tmp/x # use specific data directory
+#   ./scripts/test-history-publish.sh --soft-on-sync-timeout  # neutral skip if testnet never synced
+#   ./scripts/test-history-publish.sh --classify-only /path/to/data-dir  # offline classifier (tests)
 #
 # Exit codes:
-#   0 = checkpoint matches SDF archive
-#   1 = mismatch or error
+#   0 = checkpoint matches SDF archive (or an environmental sync-timeout was
+#       soft-skipped under --soft-on-sync-timeout)
+#   1 = mismatch, real error, or a genuine publish regression (synced but no
+#       checkpoint published; see the disposition taxonomy below)
+#
+# --- Phase-1 deadline disposition taxonomy (#3280) ---
+# The test has two phases: phase 1 waits up to --timeout for the node to sync
+# testnet and publish its first checkpoint (HAS); phase 2 byte-compares that
+# checkpoint against SDF's live testnet archive (a parity cross-check no in-repo
+# unit test replicates — it is ALWAYS a hard red on mismatch, never soft-skipped).
+#
+# The phase-1 deadline used to be a single blanket `exit 1`, which conflated two
+# very different outcomes. It is now classified into three dispositions, decided
+# from concrete on-disk signals (a published HAS, and the node's sync marker in
+# validator.log):
+#   1. PUBLISHED          — a checkpoint was published in time. Proceed to the
+#                           (unchanged) phase-2 compare. Mismatch => hard red.
+#   2. PUBLISH-REGRESSION — the node SYNCED (validator.log contains the run-loop
+#                           sync marker "Node is synced", emitted by
+#                           crates/app/src/run_cmd.rs::wait_for_sync) but published
+#                           NO checkpoint by the deadline. This is a REAL publish
+#                           regression — the issue's literal symptom — and stays a
+#                           HARD RED (exit 1) even under --soft-on-sync-timeout.
+#   3. SYNC-TIMEOUT       — the node NEVER reached sync by the deadline. This is
+#                           an environmental testnet-liveness timeout (the chronic
+#                           flake #3280 tracks: the same commit passes/fails on
+#                           different days purely on testnet health). With
+#                           --soft-on-sync-timeout it is a neutral exit 0 with a
+#                           grep-able SOFT-SKIP marker (reusing the #3272/#3273
+#                           SOFT-SKIP convention); WITHOUT the flag (the default,
+#                           so local/dev behavior is byte-identical) it stays a
+#                           hard red exit 1.
+#
+# The sync marker grep is pinned by scripts/test-history-publish-harness.sh so a
+# future change to the run-loop log wording breaks the harness loudly instead of
+# silently inverting dispositions 2 and 3.
 #
 set -euo pipefail
 
@@ -26,6 +62,22 @@ TIMEOUT=1200        # 20 minutes max wait for first checkpoint
 CHECKPOINT=""      # auto-detect from published HAS
 KEEP_DATA=false
 DATA_DIR_OVERRIDE=""  # if set, use this instead of auto-generated path
+# Opt-in (#3280, default OFF): convert a phase-1 SYNC-TIMEOUT disposition (node
+# never reached sync by the deadline) into a neutral exit 0 + SOFT-SKIP marker.
+# Default OFF => byte-identical local/dev behavior; a synced-but-no-publish
+# PUBLISH-REGRESSION and a phase-2 compare mismatch ALWAYS stay hard red.
+SOFT_ON_SYNC_TIMEOUT=false
+# Offline test seam: when set, run only the deadline classifier against an
+# existing data-dir (a validator.log + optional published HAS) and exit with the
+# classified disposition — no validator/build/testnet required. Used by
+# scripts/test-history-publish-harness.sh.
+CLASSIFY_ONLY_DIR=""
+
+# The exact run-loop sync marker (crates/app/src/run_cmd.rs::wait_for_sync logs
+# tracing::info!(..., "Node is synced") once on reaching Synced/Validating). This
+# is the single source of truth for "the node reached sync"; pinned by the
+# harness so a log-wording drift is caught loudly. See the taxonomy header.
+SYNC_MARKER="Node is synced"
 
 # SDF testnet reference archive
 SDF_ARCHIVE="https://history.stellar.org/prd/core-testnet/core_testnet_001"
@@ -33,17 +85,75 @@ SDF_ARCHIVE="https://history.stellar.org/prd/core-testnet/core_testnet_001"
 # Parse args
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --no-build)     DO_BUILD=false; shift ;;
-    --timeout)      TIMEOUT="$2"; shift 2 ;;
-    --checkpoint)   CHECKPOINT="$2"; shift 2 ;;
-    --keep-data)    KEEP_DATA=true; shift ;;
-    --data-dir)     DATA_DIR_OVERRIDE="$2"; KEEP_DATA=true; shift 2 ;;
+    --no-build)             DO_BUILD=false; shift ;;
+    --timeout)              TIMEOUT="$2"; shift 2 ;;
+    --checkpoint)           CHECKPOINT="$2"; shift 2 ;;
+    --keep-data)            KEEP_DATA=true; shift ;;
+    --data-dir)             DATA_DIR_OVERRIDE="$2"; KEEP_DATA=true; shift 2 ;;
+    --soft-on-sync-timeout) SOFT_ON_SYNC_TIMEOUT=true; shift ;;
+    --classify-only)        CLASSIFY_ONLY_DIR="$2"; shift 2 ;;
     -h|--help)
       sed -n '3,14p' "$0" | sed 's/^# \?//'
       exit 0 ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
   esac
 done
+
+# --- Phase-1 deadline classifier (the disposition seam, #3280) ---
+# Decide the phase-1 deadline disposition for <data-dir> from concrete on-disk
+# signals, honoring $SOFT_ON_SYNC_TIMEOUT. Emits a single grep-able disposition
+# line and returns:
+#   PUBLISHED          -> return 0 (caller proceeds to phase-2 compare)
+#   PUBLISH-REGRESSION -> return 1 (synced but no checkpoint: a real regression)
+#   SYNC-TIMEOUT       -> return 0 if --soft-on-sync-timeout (emits SOFT-SKIP),
+#                         else return 1 (byte-identical default hard red)
+# Kept as a standalone function with no side effects beyond stdout so the harness
+# can drive it offline via --classify-only.
+classify_deadline() {
+  local data_dir="$1"
+  local log_file="$data_dir/validator.log"
+  local has_file="$data_dir/history/.well-known/stellar-history.json"
+
+  # Disposition 1: a checkpoint was published (HAS present, currentLedger > 0).
+  if [[ -f "$has_file" ]]; then
+    local current_ledger
+    current_ledger=$(jq -r '.currentLedger' "$has_file" 2>/dev/null || echo "0")
+    if [[ "$current_ledger" =~ ^[0-9]+$ ]] && [[ "$current_ledger" -gt 0 ]]; then
+      echo "DISPOSITION: PUBLISHED (currentLedger=$current_ledger) — proceeding to phase-2 compare"
+      return 0
+    fi
+  fi
+
+  # Did the node reach sync? Grep the run-loop sync marker in validator.log.
+  local synced=false
+  if [[ -f "$log_file" ]] && grep -qF "$SYNC_MARKER" "$log_file"; then
+    synced=true
+  fi
+
+  if [[ "$synced" == true ]]; then
+    # Disposition 2: synced but no checkpoint published — a REAL publish
+    # regression. Always a hard red, even under --soft-on-sync-timeout.
+    echo "DISPOSITION: PUBLISH-REGRESSION — node reached sync ('$SYNC_MARKER') but published no checkpoint by the deadline (hard red, #3280)"
+    return 1
+  fi
+
+  # Disposition 3: never reached sync — environmental testnet-liveness timeout.
+  if [[ "$SOFT_ON_SYNC_TIMEOUT" == true ]]; then
+    echo "=== SOFT-SKIP: testnet never reached sync by the deadline (environmental, not a henyey publish failure) ===" >&2
+    echo "=== SOFT-SKIP: DISPOSITION SYNC-TIMEOUT treated as neutral (#3280); validator.log/HAS artifacts preserved ===" >&2
+    echo "DISPOSITION: SYNC-TIMEOUT (soft-skipped) — node never reached sync; neutral exit 0 under --soft-on-sync-timeout"
+    return 0
+  fi
+  echo "DISPOSITION: SYNC-TIMEOUT — node never reached sync by the deadline (hard red; pass --soft-on-sync-timeout to neutralize, #3280)"
+  return 1
+}
+
+# Offline test seam: classify an existing data-dir and exit. No build/validator.
+if [[ -n "$CLASSIFY_ONLY_DIR" ]]; then
+  CLASSIFY_EXIT=0
+  classify_deadline "$CLASSIFY_ONLY_DIR" || CLASSIFY_EXIT=$?
+  exit $CLASSIFY_EXIT
+fi
 
 # --- Data dirs ---
 if [[ -n "$DATA_DIR_OVERRIDE" ]]; then
@@ -176,7 +286,15 @@ while true; do
     echo "ERROR: Timed out after ${TIMEOUT}s waiting for checkpoint"
     echo "Last 50 lines of validator log:"
     tail -50 "$LOG_FILE"
-    exit 1
+    echo
+    # Classify the deadline outcome (#3280): a synced-but-no-publish is a real
+    # PUBLISH-REGRESSION (hard red); a never-synced is an environmental
+    # SYNC-TIMEOUT (soft-skippable under --soft-on-sync-timeout). At the deadline
+    # no HAS exists, so classify_deadline returns either PUBLISH-REGRESSION
+    # (exit 1) or SYNC-TIMEOUT (exit 0 if the flag is set, else exit 1).
+    DEADLINE_EXIT=0
+    classify_deadline "$DATA_DIR" || DEADLINE_EXIT=$?
+    exit $DEADLINE_EXIT
   fi
 
   # Check if the process is still alive


### PR DESCRIPTION
Closes #3280

## Summary

The "History Publish (Testnet)" daily workflow waits up to 1500s for the node to sync testnet and publish its first checkpoint. The phase-1 deadline used to be a single blanket `exit 1`, conflating a real publish regression with an environmental testnet-liveness timeout (the chronic flake #3280 tracks: the same commit `bd1ca63` passed/failed on different days purely on testnet health).

This replaces that single disposition with three, decided inside `scripts/test-history-publish.sh` from concrete on-disk signals (option b1, in-script flag):

1. **PUBLISHED** — checkpoint published in time → proceed to the unchanged phase-2 `compare-checkpoint` against SDF's archive (mismatch = hard red, untouched).
2. **PUBLISH-REGRESSION** — node SYNCED but published no checkpoint by the deadline → hard red, even under the new flag. This is the issue's literal symptom and the correctness keystone.
3. **SYNC-TIMEOUT** — node never reached sync → environmental. Under the new opt-in `--soft-on-sync-timeout` flag (default OFF, so behavior is byte-identical unless passed) → neutral `exit 0` + grep-able `SOFT-SKIP` marker (reusing the #3272/#3273 convention). Without the flag it stays a hard red.

Sync detection is pinned to the run loop's `"Node is synced"` marker (`crates/app/src/run_cmd.rs::wait_for_sync`), with a harness assertion tying the classifier's grep to that exact string so a log-wording drift breaks the harness loudly. No boundary-counting (per critics A/C — conservative "synced-but-no-HAS ⇒ red"). The flag is wired ON for the testnet job only; the disposition is surfaced in the run Summary.

This is CI/test-harness infra only — no henyey crate source changed, no runtime behavior changes (flag defaults OFF). The publish code path remains covered per-PR by `cargo test --workspace`, and the phase-2 parity cross-check against SDF is preserved as a hard red.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3280#issuecomment-4711672544)

## Test plan

- [x] New harness `scripts/test-history-publish-harness.sh` (14 assertions) — failing-first on `f0d22fc3` (6/14 fail on current main), passing on `6b698e78` (14/14).
- [x] Existing `scripts/test-quickstart-harness.sh` — 85/85 pass (unaffected).
- [x] `bash -n` syntax check on both scripts; `--help` unchanged; `history-publish.yml` valid YAML.
- [x] Pre-commit hooks (fmt + clippy) pass.

Harness coverage maps to the plan's test list: (a) synced-but-no-publish → PUBLISH-REGRESSION hard red; (b) never-synced + `--soft-on-sync-timeout` → exit 0 + SOFT-SKIP; (c) never-synced WITHOUT the flag → byte-identical hard red; (d) sync-marker pin assertion; plus PUBLISHED disposition and workflow wiring.

## Deviations from plan

None. Kind: test-only (no Rust regression test — the bisect proved there is no code regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)