### PR TITLE
Sync SCP post-verify label set to canonical 15 labels (add drift_manual_close)

### DIFF
--- a/.claude/skills/monitor-loop/SKILL.md
+++ b/.claude/skills/monitor-loop/SKILL.md
@@ -261,7 +261,7 @@ traffic-proportional and self-calibrating.
 
 | Check | Numerator | Denominator | Threshold | Min denom delta | Severity | Rationale |
 |-------|-----------|-------------|-----------|-----------------|----------|-----------|
-| SCP post-verify acceptance rate | `delta(henyey_scp_post_verify_total{reason="accepted"})` + `delta(henyey_scp_post_verify_total{reason="processed_directly"})` | `sum delta(henyey_scp_post_verify_total{reason="..."})` across all 14 labels | < 0.05 (less than 5% accepted) for 3 ticks | 500 | WARN (→ Bug Filing) | Baseline acceptance ~10-20%; <5% sustained means almost nothing reaches SCP |
+| SCP post-verify acceptance rate | `delta(henyey_scp_post_verify_total{reason="accepted"})` + `delta(henyey_scp_post_verify_total{reason="processed_directly"})` | `sum delta(henyey_scp_post_verify_total{reason="..."})` across all 15 labels | < 0.05 (less than 5% accepted) for 3 ticks | 500 | WARN (→ Bug Filing) | Baseline acceptance ~10-20%; <5% sustained means almost nothing reaches SCP |
 | Transaction apply failure rate | `delta(stellar_ledger_apply_failure_total)` | `delta(stellar_ledger_apply_failure_total)` + `delta(stellar_ledger_apply_success_total)` | > 0.50 (over 50% fail) for 3 ticks | 200 | WARN (investigate) | Normal bad-tx traffic is <50%; sustained >50% suggests apply-engine bug |
 | Pending too-old rate | `delta(stellar_herder_pending_too_old_total)` | `delta(stellar_herder_pending_received_total)` | > 0.50 (over 50% too old) for 3 ticks | 100 | WARN | Overlay lag or stale-envelope flood; sustained >50% means most incoming envelopes reference already-closed slots |
 
@@ -273,7 +273,7 @@ traffic-proportional and self-calibrating.
 - `/metrics` fetch fails
 - `/metrics` returns "recorder not installed"
 - Any required counter missing or invalid
-- Post-verify label set ≠ expected 14 labels (`invalid_sig`, `panic`, `drift_range`, `drift_close_time`, `drift_cannot_receive`, `self_message`, `non_quorum`, `buffered`, `duplicate`, `too_far`, `buffer_full`, `processed_directly`, `per_slot_full`, `accepted`)
+- Post-verify label set ≠ expected 15 labels (`invalid_sig`, `panic`, `drift_range`, `drift_close_time`, `drift_cannot_receive`, `self_message`, `non_quorum`, `buffered`, `duplicate`, `too_far`, `buffer_full`, `processed_directly`, `per_slot_full`, `accepted`, `drift_manual_close`)
 
 On any skip: empty the ratio snapshot, reset all breach streak counters to 0.
 
@@ -302,7 +302,7 @@ path canonicalized in [`shared/metric-alarms.toml`](../shared/metric-alarms.toml
 Separate from ratio snapshot — runs independently of ratio skip conditions (see
 Check 12b in monitor-tick for full state machine). Validator mode only.
 
-**SCP denominator rationale:** Includes all 14 post-verify outcomes (not just errors). Normal
+**SCP denominator rationale:** Includes all 15 post-verify outcomes (not just errors). Normal
 outcomes (`duplicate`, `buffered`, `non_quorum`, `self_message`) appear at healthy-state
 proportions. The ratio measures "of everything that went through post-verify, what fraction
 reached SCP?" The 5% threshold is well below the healthy ~10-20% baseline. The older

--- a/.claude/skills/shared/metric-alarms.toml
+++ b/.claude/skills/shared/metric-alarms.toml
@@ -618,7 +618,7 @@ expected_labels = [
     "invalid_sig", "panic", "drift_range", "drift_close_time",
     "drift_cannot_receive", "self_message", "non_quorum", "buffered",
     "duplicate", "too_far", "buffer_full", "processed_directly",
-    "per_slot_full", "accepted",
+    "per_slot_full", "accepted", "drift_manual_close",
 ]
 ratio_op = "<"
 ratio_threshold = 0.05

--- a/scripts/fixtures/eval-alarms/healthy-current.prom
+++ b/scripts/fixtures/eval-alarms/healthy-current.prom
@@ -40,6 +40,7 @@ henyey_scp_post_verify_total{reason="duplicate"} 300
 henyey_scp_post_verify_total{reason="too_far"} 20
 henyey_scp_post_verify_total{reason="buffer_full"} 5
 henyey_scp_post_verify_total{reason="per_slot_full"} 10
+henyey_scp_post_verify_total{reason="drift_manual_close"} 0
 stellar_herder_pending_too_old_total 50
 stellar_herder_pending_received_total 2000
 # Counter-streak

--- a/scripts/fixtures/eval-alarms/healthy-prev.prom
+++ b/scripts/fixtures/eval-alarms/healthy-prev.prom
@@ -41,6 +41,7 @@ henyey_scp_post_verify_total{reason="duplicate"} 280
 henyey_scp_post_verify_total{reason="too_far"} 18
 henyey_scp_post_verify_total{reason="buffer_full"} 4
 henyey_scp_post_verify_total{reason="per_slot_full"} 9
+henyey_scp_post_verify_total{reason="drift_manual_close"} 0
 stellar_herder_pending_too_old_total 45
 stellar_herder_pending_received_total 1900
 # Counter-streak

--- a/scripts/lib/test_eval_alarms_converged_loop.py
+++ b/scripts/lib/test_eval_alarms_converged_loop.py
@@ -444,6 +444,86 @@ def test_gate_skip_stderr_unified_format():
     assert "state=skipped" in line, f"Missing 'state=skipped' in telemetry: {line}"
 
 
+# ── Test: scp-accept-rate-low not skipped on the real 15-label fixtures (#3281) ─
+
+def test_scp_accept_rate_low_not_label_set_mismatch_on_real_fixtures():
+    """#3281/#3278: scp-accept-rate-low must NOT skip with "label set mismatch".
+
+    Runs the REAL alarm catalog (.claude/skills/shared/metric-alarms.toml) against
+    the REAL healthy eval-alarms fixtures. Before the label-set sync, the catalog
+    `expected_labels` was 14 while the live binary (and the fixtures) emit 15
+    post-verify series including `drift_manual_close`; the evaluator's exact
+    set-equality check then skipped the alarm every tick with skip_reason
+    "label set mismatch", silently disabling SCP accept-rate monitoring.
+
+    This is the observable-impact guard for #3281: once the catalog and both
+    fixtures carry all 15 labels, the alarm must EVALUATE — accepted states are
+    `collecting_baseline` (single-invocation baseline) or `ok`, and skip_reason
+    must not be a label-set mismatch. We deliberately accept `collecting_baseline`
+    in addition to `ok`: a single eval against the two fixtures resets the
+    counter-snapshot identity, so the evaluator legitimately reports
+    `collecting_baseline` rather than a converged ratio.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    catalog_path = repo_root / ".claude" / "skills" / "shared" / "metric-alarms.toml"
+    fixture_dir = repo_root / "scripts" / "fixtures" / "eval-alarms"
+    current_path = fixture_dir / "healthy-current.prom"
+    prev_path = fixture_dir / "healthy-prev.prom"
+
+    assert catalog_path.is_file(), f"missing catalog: {catalog_path}"
+    assert current_path.is_file(), f"missing fixture: {current_path}"
+    assert prev_path.is_file(), f"missing fixture: {prev_path}"
+
+    with tempfile.TemporaryDirectory() as d:
+        state_dir = Path(d) / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+
+        argv = [
+            "eval-alarms",
+            "--catalog", str(catalog_path),
+            "--current", str(current_path),
+            "--prev", str(prev_path),
+            "--state-dir", str(state_dir),
+        ]
+        env = {
+            "PREV_PROM_INVALID": "false",
+            "WARMUP_TICKS_REMAINING": "0",
+            "FRESH_START": "no",
+            "CRASH_RECOVERY": "no",
+            "UPTIME_SECONDS": "9999",
+            "MONITOR_MODE": "validator",
+            "PID": "123",
+            "START_TICKS": "456",
+        }
+
+        stdout_buf = io.StringIO()
+        stderr_buf = io.StringIO()
+        with patch.object(sys, "argv", argv), \
+             patch.object(sys, "stdout", stdout_buf), \
+             patch.object(sys, "stderr", stderr_buf), \
+             patch.dict(os.environ, env, clear=False):
+            rc = main()
+
+        assert rc == 0, f"main() returned {rc}, stderr: {stderr_buf.getvalue()}"
+        output = json.loads(stdout_buf.getvalue())
+
+    results = [a for a in output.get("alarms", []) if a.get("name") == "scp-accept-rate-low"]
+    assert len(results) == 1, f"expected exactly one scp-accept-rate-low result, got {results}"
+    result = results[0]
+
+    skip_reason = result.get("skip_reason")
+    assert skip_reason != "label set mismatch", (
+        f"scp-accept-rate-low skipped with label-set mismatch — the catalog "
+        f"expected_labels and the fixtures disagree on the post-verify label set: "
+        f"{result}"
+    )
+    assert result.get("state") in ("collecting_baseline", "ok"), (
+        f"scp-accept-rate-low did not evaluate (state should be collecting_baseline "
+        f"or ok, skip_reason should be falsy): state={result.get('state')!r} "
+        f"skip_reason={skip_reason!r}"
+    )
+
+
 # ── Run tests ─────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3278
Closes #3281

## Summary

The canonical `PostVerifyReason` source (`crates/herder/src/scp_verify.rs:374`, `GateDriftManualClose => "drift_manual_close"`) defines 15 post-verify labels, compile-time-asserted against `ALL`. Several duplicated copies of the label set were stale at 14, missing `drift_manual_close`. Because the eval-alarms label check does exact set-equality, the `scp-accept-rate-low` alarm skipped every tick with skip_reason `"label set mismatch"` — silently disabling SCP accept-rate monitoring (#3281) — and the pv-label-sync tests failed (#3278). Both issues share this single root cause.

Pure config/doc/test/fixture sync — no Rust change. Synced all duplicated copies to 15 labels:
- `.claude/skills/shared/metric-alarms.toml` — added `drift_manual_close` to `scp-accept-rate-low` `expected_labels` (numerator unchanged).
- `.claude/skills/monitor-loop/SKILL.md` — added `drift_manual_close` to the inline label list and updated the label-count tokens 14→15.
- `scripts/fixtures/eval-alarms/healthy-current.prom` and `healthy-prev.prom` — added `henyey_scp_post_verify_total{reason="drift_manual_close"} 0`.

The fixture series are mandatory: bumping the TOML to 15 without adding the fixture series would invert the bug (the alarm would skip on its own fixture). Value 0 matches the live "all drift reasons = 0" state and leaves the accept-ratio numerically unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3278#issuecomment-4711682698)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — full suite green (1..355, exit 0)
- [x] pv-label-sync group (TAP 169-174) all `ok` — was `not ok` 170-173 on main
- [x] eval-alarms pytest suites: `test_eval_alarms_converged_loop.py` (9 passed), `test_eval_alarms_counter_reset.py` (19 passed), `test_eval_alarms_histogram_rebucket.py` (10 passed)
- [x] `eval-alarms.py --validate-only` valid
- [x] py_compile + bash -n clean

## Regression test

- **#3278 (pre-existing, now passing):** `scripts/test-monitor-skill-snippets.sh` pv-label-sync TAP 170-173 — verified `not ok` on `origin/main`, `ok` after the sync. No edit to those tests.
- **#3281 (new):** `scripts/lib/test_eval_alarms_converged_loop.py::test_scp_accept_rate_low_not_label_set_mismatch_on_real_fixtures` — runs the real catalog against the real 15-label fixtures and asserts `scp-accept-rate-low` does NOT skip with `"label set mismatch"` (accepted states: `collecting_baseline` or `ok`). Verified FAILS when the catalog is reverted to 14 labels against the 15-label fixtures (the live mismatch), PASSES after the sync. Distinctly named to avoid collision with #3279/PR #3283, which also touches the eval-alarms pytest suite.

## Deviations from plan

- The plan enumerated two `14`→`15` count tokens in `monitor-loop/SKILL.md` (lines ~264, ~276). The pv-label-sync count-refs test extracts ALL count tokens in the "D. Ratio checks" section, which also includes a third token at line ~305 ("Includes all 14 post-verify outcomes"). Updated it too (same class of test-validated doc literal); leaving it stale would have kept the count-refs test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)