### PR TITLE
Self-heal near-tip knit divergence via archive rebuild instead of wipe

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -187,11 +187,26 @@ impl App {
         // replaying from the (possibly corrupt/diverged) local state.
         let force_full = self.catchup_needs_full_reset.load(Ordering::SeqCst);
         if force_full {
-            tracing::warn!("Previous catchup failed — forcing full bucket-apply catchup");
+            tracing::warn!(
+                "Previous catchup failed — forcing full bucket-apply catchup \
+                 (archive-authoritative, local state ignored)"
+            );
         }
+
+        // #3282: track whether this catchup is seeded from CLONED LOCAL state.
+        // Only the near-tip fast path below (initialized ledger manager, no
+        // force_full) clones the live LCL header and sets `override_lcl`,
+        // making the *local* LCL the knit subject. A local-vs-archive
+        // divergence on such a catchup is self-healable from the archive (a
+        // one-shot `force_full` rebuild) rather than a terminal wipe; the
+        // force_full / HAS-rebuild / no-existing-state paths are
+        // archive-authoritative and stay terminal on divergence. Default to
+        // `false`; set `true` only on the cloned-local fast path.
+        let mut seeded_from_local_clone = false;
 
         let (existing_state, override_lcl) = if current >= GENESIS_LEDGER_SEQ && !force_full {
             if self.ledger_manager.is_initialized() {
+                seeded_from_local_clone = true;
                 // Fast path: clone from live ledger manager.
                 // Must resolve async merges first — structure-based restart_merges
                 // creates PendingMerge::Async handles, and BucketLevel::clone()
@@ -245,6 +260,14 @@ impl App {
         } else {
             (None, None)
         };
+
+        // Publish the seeding mode so the spawned catchup task can forward it
+        // to `handle_catchup_result` (the single in-flight catchup is
+        // serialized by `catchup_in_progress`, so this read-after-return is
+        // race-free). See `last_catchup_seeded_from_local_clone` (#3282).
+        self.last_catchup_seeded_from_local_clone
+            .store(seeded_from_local_clone, Ordering::SeqCst);
+
         // Run catchup work
         let output = self
             .run_catchup_work(
@@ -2510,11 +2533,27 @@ impl App {
     /// Returns `true` if a fatal state failure was detected and shutdown
     /// has been triggered. The caller must skip all post-catchup work
     /// when this returns `true`.
+    /// Process the outcome of a catchup attempt.
+    ///
+    /// `seeded_from_local_clone` indicates the failed catchup replayed from
+    /// CLONED LOCAL state (the near-tip fast path, `catchup_with_run_mode`
+    /// :193-225, `override_lcl = Some(current)`). When `true`, a
+    /// local-vs-archive divergence error
+    /// ([`HistoryError::is_local_vs_archive_divergence`]) is **self-healable**:
+    /// instead of a terminal wipe, route to a one-shot archive-authoritative
+    /// full bucket-apply rebuild (`catchup_needs_full_reset = true`). When
+    /// `false` (the catchup was already an archive re-derivation, or never
+    /// touched local state), the same divergence stays terminal/fatal — the
+    /// archive disagrees with the consensus chain and the one-shot rebuild
+    /// must not loop (#3282).
+    ///
+    /// Returns `true` iff a fatal shutdown was triggered.
     pub(super) async fn handle_catchup_result(
         &self,
         catchup_result: anyhow::Result<CatchupResult>,
         reset_stuck_state: bool,
         label: &str,
+        seeded_from_local_clone: bool,
     ) -> bool {
         match catchup_result {
             Ok(result) => {
@@ -2665,6 +2704,66 @@ impl App {
                 *self.last_catchup_completed_at.write().await = Some(self.clock.now());
             }
             Err(err) => {
+                // #3282 self-heal: a local-vs-archive state divergence
+                // (KnitLclHashMismatch et al.) on a catchup SEEDED FROM CLONED
+                // LOCAL state is NOT terminal — the cloned local LCL is the
+                // knit subject, and the canonical state can be re-derived from
+                // the archive. Route to a one-shot archive-authoritative full
+                // bucket-apply (`catchup_needs_full_reset = true` ⇒ next
+                // catchup runs with `force_full`, which sets
+                // `existing_state=None`/`override_lcl=None` and ignores the
+                // cloned local state) INSTEAD of a destructive wipe.
+                //
+                // This mirrors stellar-core's near-tip recovery posture: a
+                // knit disagreement is a retryable Work failure surfaced via
+                // the `CatchupWork::fatalFailure()` *boolean*
+                // (stellar-core/src/catchup/CatchupWork.h:80, consumed at
+                // src/catchup/LedgerApplyManagerImpl.cpp:124) — NOT a state
+                // wipe — and recovery applies buckets from the archive HAS
+                // (`CatchupWork::downloadApplyBuckets`,
+                // src/catchup/CatchupWork.cpp:198). The disagreement itself is
+                // `ApplyCheckpointWork::getNextLedgerCloseData` throwing
+                // "replay of <h> at LCL <h> disagreed on hash"
+                // (src/catchup/ApplyCheckpointWork.cpp:236).
+                //
+                // The one-shot latch terminates the loop: the re-spawned
+                // catchup runs archive-authoritative (force_full ⇒
+                // seeded_from_local_clone == false), so if IT also diverges at
+                // knit, the `false` branch below treats it as fatal — the
+                // archive disagrees with the consensus chain and a wipe is
+                // correct. `catchup_needs_full_reset` is cleared on the next
+                // catchup entry (catchup_impl.rs:620), so it cannot re-latch.
+                let is_local_vs_archive_divergence = err
+                    .downcast_ref::<henyey_history::HistoryError>()
+                    .is_some_and(|e| e.is_local_vs_archive_divergence())
+                    || err
+                        .downcast_ref::<henyey_ledger::LedgerError>()
+                        .is_some_and(|e| {
+                            matches!(e, henyey_ledger::LedgerError::HashMismatch { .. })
+                        });
+                if seeded_from_local_clone && is_local_vs_archive_divergence {
+                    tracing::warn!(
+                        error = %err,
+                        "{label} catchup diverged from the archive while replaying \
+                         cloned local state — re-deriving canonical state via a \
+                         one-shot full bucket-apply from the archive (self-heal, \
+                         no wipe). A repeat divergence on the archive rebuild will \
+                         be terminal."
+                    );
+                    self.catchup_needs_full_reset.store(true, Ordering::SeqCst);
+                    // Continue to the shared restore/cooldown tail below (do NOT
+                    // wipe). The next catchup will be archive-authoritative.
+                    self.restore_operational_state().await;
+                    *self.last_catchup_completed_at.write().await = Some(self.clock.now());
+                    if reset_stuck_state {
+                        if let Some(state) = self.consensus_stuck_state.write().await.as_mut() {
+                            state.recovery_attempts = 0;
+                            state.last_recovery_attempt = self.clock.now();
+                        }
+                    }
+                    return false;
+                }
+
                 // Check if this is a fatal catchup failure (verification/integrity
                 // error indicating local state corruption).  Once detected, further
                 // catchup attempts are blocked and the node shuts down.
@@ -5897,7 +5996,9 @@ mod tests {
             henyey_history::HistoryError::VerificationFailed("bucket list hash mismatch".into())
                 .into();
 
-        let fatal = app.handle_catchup_result(Err(err), false, "test").await;
+        let fatal = app
+            .handle_catchup_result(Err(err), false, "test", false)
+            .await;
 
         assert!(
             fatal,
@@ -5933,7 +6034,9 @@ mod tests {
         let err: anyhow::Error =
             henyey_history::HistoryError::ArchiveUnreachable("timeout".into()).into();
 
-        let fatal = app.handle_catchup_result(Err(err), false, "test").await;
+        let fatal = app
+            .handle_catchup_result(Err(err), false, "test", false)
+            .await;
 
         assert!(
             !fatal,
@@ -5971,7 +6074,9 @@ mod tests {
             actual: "def".into(),
         });
 
-        let fatal = app.handle_catchup_result(Err(err), false, "test").await;
+        let fatal = app
+            .handle_catchup_result(Err(err), false, "test", false)
+            .await;
 
         assert!(
             !fatal,
@@ -6009,7 +6114,9 @@ mod tests {
             })
             .into();
 
-        let fatal = app.handle_catchup_result(Err(err), false, "test").await;
+        let fatal = app
+            .handle_catchup_result(Err(err), false, "test", false)
+            .await;
 
         assert!(
             fatal,
@@ -6022,6 +6129,98 @@ mod tests {
         assert!(
             !app.catchup_needs_full_reset.load(Ordering::SeqCst),
             "catchup_needs_full_reset must NOT be set — fatal path skips the else branch"
+        );
+    }
+
+    /// #3282 regression: a `KnitLclHashMismatch` (local-vs-archive divergence)
+    /// on a catchup SEEDED FROM CLONED LOCAL STATE must NOT wipe. Instead it
+    /// must route to a one-shot archive-authoritative full bucket-apply
+    /// rebuild (`catchup_needs_full_reset = true`), self-healing without an
+    /// operator wipe.
+    ///
+    /// FAILS on `origin/main`: today `KnitLclHashMismatch` is
+    /// `is_fatal_catchup_failure()`, so the Err branch unconditionally calls
+    /// `trigger_fatal_shutdown` and returns `true` BEFORE reaching the
+    /// `catchup_needs_full_reset` self-heal in the `else` block — the node
+    /// wipes instead of rebuilding from the archive.
+    #[tokio::test]
+    async fn test_near_tip_knit_mismatch_triggers_full_reset_not_wipe() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        // The exact #3282 observable: a §11.2 case-3 knit-to-LCL mismatch.
+        let err: anyhow::Error = henyey_history::HistoryError::KnitLclHashMismatch {
+            expected: "aa".into(),
+            actual: "bb".into(),
+        }
+        .into();
+
+        // seeded_from_local_clone = true → the failure is against the cloned
+        // local LCL, which the archive can re-derive. Must self-heal.
+        let fatal = app
+            .handle_catchup_result(Err(err), false, "test", true)
+            .await;
+
+        assert!(
+            !fatal,
+            "cloned-local near-tip knit mismatch must NOT be fatal — it self-heals"
+        );
+        assert!(
+            !app.fatal_state_failure.load(Ordering::SeqCst),
+            "fatal_state_failure must NOT be set — the node rebuilds from the archive"
+        );
+        assert!(
+            app.catchup_needs_full_reset.load(Ordering::SeqCst),
+            "catchup_needs_full_reset must be set so the next catchup is an \
+             archive-authoritative full bucket-apply (force_full)"
+        );
+    }
+
+    /// #3282 regression (safety backstop): a `KnitLclHashMismatch` on a
+    /// catchup that was ALREADY an archive re-derivation
+    /// (`seeded_from_local_clone = false`) must STILL go fatal/wipe. If the
+    /// archive rebuild itself diverges at knit, the archive disagrees with the
+    /// consensus chain and a terminal wipe is the correct action — the
+    /// self-heal is one-shot and must not loop. This pins that the fix does
+    /// NOT over-broaden into "never wipe".
+    #[tokio::test]
+    async fn test_full_bucket_apply_knit_mismatch_still_wipes() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+
+        let mut shutdown_rx = app.subscribe_shutdown();
+
+        let err: anyhow::Error = henyey_history::HistoryError::KnitLclHashMismatch {
+            expected: "aa".into(),
+            actual: "bb".into(),
+        }
+        .into();
+
+        // seeded_from_local_clone = false → already an archive rebuild; a knit
+        // mismatch here is genuine unrecoverable corruption.
+        let fatal = app
+            .handle_catchup_result(Err(err), false, "test", false)
+            .await;
+
+        assert!(
+            fatal,
+            "non-cloned-local knit mismatch must be fatal (archive rebuild also diverged)"
+        );
+        assert!(
+            app.fatal_state_failure.load(Ordering::SeqCst),
+            "fatal_state_failure must be set — terminal archive-vs-chain divergence"
+        );
+        assert!(
+            shutdown_rx.try_recv().is_ok(),
+            "shutdown signal must be sent on the terminal divergence"
         );
     }
 

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -2116,7 +2116,20 @@ impl App {
                 Err(_) => None,
             };
 
-            let _ = result_tx.send(PendingCatchupResult::new(catchup_result, persist_ready));
+            // #3282: forward whether this catchup was seeded from cloned local
+            // state, so the event loop's `handle_catchup_result` can route a
+            // local-vs-archive divergence to an archive rebuild (self-heal)
+            // instead of a terminal wipe. Read after the catchup returns —
+            // race-free because `catchup_in_progress` serializes catchups.
+            let seeded_from_local_clone = app
+                .last_catchup_seeded_from_local_clone
+                .load(Ordering::SeqCst);
+
+            let _ = result_tx.send(PendingCatchupResult::new(
+                catchup_result,
+                persist_ready,
+                seeded_from_local_clone,
+            ));
         });
 
         tracing::info!(label, "Catchup task spawned");

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -669,11 +669,13 @@ impl App {
                             // Take persist_ready before moving result.result
                             let persist_ready = result.take_persist_ready();
                             let made_progress = result.made_progress;
+                            let seeded_from_local_clone = result.seeded_from_local_clone;
 
                             let fatal = self.handle_catchup_result(
                                 result.result,
                                 pending.reset_stuck_state,
                                 &pending.label,
+                                seeded_from_local_clone,
                             )
                             .await;
 

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -603,6 +603,18 @@ pub struct App {
     /// replay-only. This is triggered when a previous catchup fails with a
     /// hash mismatch (state divergence, e.g., protocol upgrade missed).
     catchup_needs_full_reset: AtomicBool,
+    /// Records whether the most-recently-started catchup was seeded from
+    /// CLONED LOCAL state (the near-tip replay-only fast path in
+    /// `catchup_with_run_mode`, where `override_lcl = Some(current)` makes the
+    /// *local* LCL the knit subject). Set on every catchup entry — `true` only
+    /// on the cloned-local fast path, `false` on `force_full` archive
+    /// bucket-apply, the HAS-rebuild slow path, or no-existing-state catchup.
+    ///
+    /// The single in-flight catchup is serialized by `catchup_in_progress`, so
+    /// the spawned catchup task reads this immediately after the catchup
+    /// returns to populate [`super::types::PendingCatchupResult`], which feeds
+    /// `handle_catchup_result`'s self-heal-vs-wipe decision (#3282).
+    last_catchup_seeded_from_local_clone: AtomicBool,
     /// Prevent concurrent history publish operations.
     /// When set, a background task is publishing a checkpoint.
     publish_in_progress: AtomicBool,
@@ -1429,6 +1441,7 @@ impl App {
             deferred_catchup: tokio::sync::Mutex::new(None),
             fatal_state_failure: AtomicBool::new(false),
             catchup_needs_full_reset: AtomicBool::new(force_full_catchup),
+            last_catchup_seeded_from_local_clone: AtomicBool::new(false),
             publish_in_progress: AtomicBool::new(false),
             publish_ready_since: std::sync::Mutex::new(None),
             #[cfg(test)]

--- a/crates/app/src/app/persist.rs
+++ b/crates/app/src/app/persist.rs
@@ -615,7 +615,8 @@ mod tests {
             buckets_applied: 1,
             ledgers_replayed: 0,
         });
-        let mut result = crate::app::types::PendingCatchupResult::new(result_ok, Some(ready));
+        let mut result =
+            crate::app::types::PendingCatchupResult::new(result_ok, Some(ready), false);
         assert!(result.made_progress, "buckets_applied > 0 → made_progress");
         assert!(
             result.take_persist_ready().is_some(),
@@ -631,8 +632,11 @@ mod tests {
     #[test]
     fn pending_catchup_result_derives_made_progress() {
         // Error → no progress
-        let err_result =
-            crate::app::types::PendingCatchupResult::new(Err(anyhow::anyhow!("test error")), None);
+        let err_result = crate::app::types::PendingCatchupResult::new(
+            Err(anyhow::anyhow!("test error")),
+            None,
+            false,
+        );
         assert!(!err_result.made_progress);
 
         // Success with no work → no progress
@@ -644,6 +648,7 @@ mod tests {
                 ledgers_replayed: 0,
             }),
             None,
+            false,
         );
         assert!(!no_work.made_progress);
 
@@ -656,6 +661,7 @@ mod tests {
                 ledgers_replayed: 5,
             }),
             None,
+            false,
         );
         assert!(with_progress.made_progress);
     }

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -587,6 +587,11 @@ pub(super) struct PendingCatchupResult {
     pub result: anyhow::Result<CatchupResult>,
     /// Whether catchup actually advanced the ledger.
     pub made_progress: bool,
+    /// Whether the catchup replayed from CLONED LOCAL state (the near-tip
+    /// fast path, `catchup_with_run_mode` :193-225). When `true`, a
+    /// local-vs-archive divergence failure is self-healable via an
+    /// archive-authoritative rebuild instead of a terminal wipe (#3282).
+    pub seeded_from_local_clone: bool,
     /// Ready-to-spawn persist job. Private to force callers through
     /// [`Self::take_persist_ready`], which returns a `#[must_use]` value.
     persist_ready: Option<super::persist::CatchupPersistReady>,
@@ -597,6 +602,7 @@ impl PendingCatchupResult {
     pub(super) fn new(
         result: anyhow::Result<CatchupResult>,
         persist_ready: Option<super::persist::CatchupPersistReady>,
+        seeded_from_local_clone: bool,
     ) -> Self {
         let made_progress = result
             .as_ref()
@@ -604,6 +610,7 @@ impl PendingCatchupResult {
         Self {
             result,
             made_progress,
+            seeded_from_local_clone,
             persist_ready,
         }
     }

--- a/crates/history/src/catchup/buckets.rs
+++ b/crates/history/src/catchup/buckets.rs
@@ -1031,6 +1031,79 @@ mod tests {
         }
     }
 
+    /// #3282 fan-out rule-in/out DIAGNOSTIC: the FULL ledger-header hash
+    /// (not just the `bucketListHash`) must be identical across fan-out values
+    /// `{None, 1, 2, 6}`.
+    ///
+    /// **Why this is here:** build `384b4f6e` (the #3282 incident build) is the
+    /// #3269 fan-out-wiring commit, and `set_restore_apply_fan_out` is wired
+    /// into the catchup manager. #3269 only proved **bucketListHash** equality
+    /// across fan-out; the *full* ledger-header hash also folds in the
+    /// `bucket_list_hash` field (and, downstream, tx-result / upgrades / idpool
+    /// — all archive-sourced and therefore fan-out-independent). This test
+    /// rules fan-out IN or OUT as a contributor to the #3282 divergence by
+    /// hashing a representative `LedgerHeader` whose only fan-out-dependent
+    /// field — `bucket_list_hash` — is set from the restored live bucket list.
+    ///
+    /// **Diagnostic, not a blocker:** if this is GREEN, fan-out is exonerated
+    /// for #3282 (consistent with the timeline evidence that #2886/#2931
+    /// predate ALL fan-out work). If it ever goes RED, that is a SECOND,
+    /// separately-tracked parallel-restore-determinism bug (#3234 lineage) —
+    /// file a follow-up, do NOT widen the #3282 PR into a restore-determinism
+    /// fix.
+    #[tokio::test]
+    async fn test_apply_buckets_full_header_hash_identical_across_fan_out() {
+        use stellar_xdr::curr::{Hash, LedgerHeader};
+
+        // Six distinct non-empty live levels so unbounded fan-out overlaps
+        // multiple concurrent restore workers (maximizes any ordering
+        // sensitivity the diagnostic would surface).
+        let (has, preloaded) = build_live_has_fixture(6);
+
+        let mut header_hashes = Vec::new();
+        let mut hot_hashes = Vec::new();
+        for fan_out in [None, Some(1usize), Some(2), Some(6)] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let mut mgr = catchup_manager_for(dir.path());
+            mgr.set_restore_apply_fan_out(fan_out);
+            let (live_bl, hot_bl, _, _) = mgr
+                .apply_buckets(&has, &preloaded)
+                .await
+                .expect("apply_buckets succeeds");
+
+            // Build a representative ledger header whose only
+            // fan-out-dependent field is the restored live bucketListHash, and
+            // hash the WHOLE header (canonical XDR hash), not just the BL hash.
+            // The remaining header fields are archive-sourced constants, so any
+            // fan-out-induced divergence can ONLY enter via bucket_list_hash.
+            let header = LedgerHeader {
+                ledger_seq: has.current_ledger,
+                bucket_list_hash: Hash(live_bl.hash().0),
+                ..LedgerHeader::default()
+            };
+            header_hashes.push((fan_out, Hash256::hash_xdr(&header)));
+            hot_hashes.push((fan_out, hot_bl.hash()));
+        }
+
+        let (_, header0) = header_hashes[0];
+        for (fan_out, hh) in &header_hashes {
+            assert_eq!(
+                *hh, header0,
+                "FULL ledger-header hash differs for fan_out={fan_out:?} — \
+                 parallel restore concurrency must not change the derived \
+                 ledger header (if RED: file a separate #3234-lineage \
+                 follow-up; do NOT block #3282 on it)"
+            );
+        }
+        let (_, hot0) = hot_hashes[0];
+        for (fan_out, hot) in &hot_hashes {
+            assert_eq!(
+                *hot, hot0,
+                "hot-archive bucketListHash differs for fan_out={fan_out:?}"
+            );
+        }
+    }
+
     /// Default cap (`None`) reproduces the un-capped restore exactly: the
     /// restored `bucketListHash` equals a direct sequential `restore_from_has`
     /// over the same HAS (the pre-#3268 behavior). No-op-at-default guarantee.

--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -1669,6 +1669,79 @@ mod tests {
         );
     }
 
+    /// #3282 (offline reproduction of the production FATAL): a forced
+    /// near-tip `ReplayOnly` recovery catchup is seeded from CLONED LOCAL
+    /// state, so the §11.2 case-3 knit compares the *local* LCL hash against
+    /// the archive's canonical header at the same seq. When the covering
+    /// checkpoint IS published (so the #2937 `checkpoint_publication_gate`
+    /// passes) but the local LCL hash diverges from the canonical archive
+    /// header, the knit raises `KnitLclHashMismatch` — the exact error string
+    /// observed in the production FATAL (`knit-to-LCL failed at LCL: expected
+    /// <A>, got <B>`).
+    ///
+    /// This is the mandated CLAUDE.md "recreate the hash mismatch offline"
+    /// reproduction of the *condition*. It must demonstrate (1) the gate
+    /// passes (published checkpoint) AND (2) the knit still diverges fatally
+    /// — proving the publication gate cannot catch a wrong *local* LCL vs a
+    /// *canonical published* archive header (the divergence class that #2937
+    /// did not cover, hence the #2886/#2931/#3282 recurrence). The *response*
+    /// to this condition (archive-authoritative self-heal instead of wipe) is
+    /// asserted by the app-layer tests `test_near_tip_knit_mismatch_*`.
+    #[test]
+    fn test_offline_near_tip_replay_knit_to_lcl_repro() {
+        // Production incident shape: a forced near-tip catchup whose target's
+        // covering checkpoint is already published on the archive.
+        let target = 63041928; // #3282 forced-catchup target ledger
+        let target_ckpt = crate::checkpoint::checkpoint_containing(target);
+
+        // (1) The covering checkpoint IS published — the archive's frontier
+        // covers it — so the #2937 publication gate PASSES (it would only
+        // divert to a transient CheckpointNotYetPublished if the frontier were
+        // behind the covering checkpoint). This is exactly why #2937 did not
+        // prevent #3282: its gate is keyed on publication, not local-LCL
+        // correctness.
+        assert!(
+            checkpoint_publication_gate(target_ckpt, target).is_ok(),
+            "gate must pass: #3282's covering checkpoint was published"
+        );
+
+        // (2) The near-tip fast path cloned the LIVE local LCL header, making
+        // the *local* LCL the knit subject (catchup_impl.rs:193-225,
+        // override_lcl=Some(current)). Model a local LCL whose own hash
+        // (0x11) disagrees with the archive's canonical header at the same
+        // seq (0xAA). The case-3 (entry.seq == lcl.seq) knit compares
+        // entry.hash (archive, canonical) against lcl.hash (local, divergent).
+        let lcl_seq = target - 1; // LCL is just behind the target (near-tip)
+        let local_lcl = make_test_lcl(lcl_seq, h(0x11), h(0x09));
+        let archive_entry = make_test_entry(lcl_seq, h(0xAA), h(0x09));
+
+        let err = knit_to_lcl_decision(&archive_entry, &local_lcl)
+            .expect_err("divergent local LCL vs canonical archive header must fail the knit");
+
+        // The exact production observable: KnitLclHashMismatch, fatal at the
+        // error layer (detection unchanged — only the app-layer RESPONSE
+        // changes from wipe to archive-rebuild).
+        match &err {
+            HistoryError::KnitLclHashMismatch { expected, actual } => {
+                // `expected` is the LOCAL LCL hash; `actual` is the ARCHIVE's
+                // canonical header hash — matching the production message
+                // "expected <local>, got <archive>".
+                assert_eq!(*expected, h(0x11).to_hex());
+                assert_eq!(*actual, h(0xAA).to_hex());
+            }
+            other => panic!("expected KnitLclHashMismatch, got {other:?}"),
+        }
+        assert!(
+            err.is_fatal_catchup_failure(),
+            "the condition stays fatal at the error layer (§11.2 detection unchanged)"
+        );
+        assert!(
+            err.is_local_vs_archive_divergence(),
+            "KnitLclHashMismatch is a local-vs-archive divergence the node can \
+             self-heal from the archive (the new app-layer response)"
+        );
+    }
+
     // ================================================================
     // #2901: per-checkpoint streaming replay (bounded catchup memory).
     //

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -684,6 +684,53 @@ impl HistoryError {
         )
     }
 
+    /// Returns `true` if this error represents a **local-vs-archive state
+    /// divergence** — the local ledger state (LCL header, replayed header, or
+    /// applied bucket-list) disagrees with the canonical history archive.
+    ///
+    /// This is the divergence class that a forced near-tip recovery catchup
+    /// SEEDED FROM CLONED LOCAL STATE can hit when the local LCL is wrong
+    /// relative to a *published, canonical* archive header (#3282). Such a
+    /// divergence is **self-healable**: re-deriving canonical state from the
+    /// archive (a `force_full` bucket-apply that ignores the local clone)
+    /// rebuilds the correct state without any operator wipe — mirroring
+    /// stellar-core's near-tip recovery via `CatchupWork::downloadApplyBuckets`
+    /// (`stellar-core/src/catchup/CatchupWork.cpp:198`). It is distinct from a
+    /// genuine bucket/verification corruption: detection is unchanged (all of
+    /// these stay `is_fatal_catchup_failure()`); only the app-layer *response*
+    /// branches on this classifier to attempt an archive rebuild BEFORE any
+    /// terminal wipe.
+    ///
+    /// Recognized variants (the four knit/replay header-chain disagreements
+    /// plus the apply-path ledger hash mismatch):
+    /// - [`KnitLclHashMismatch`](HistoryError::KnitLclHashMismatch) — §11.2
+    ///   case 3 (the #3282 observable).
+    /// - [`KnitLclPredecessorHashMismatch`](HistoryError::KnitLclPredecessorHashMismatch)
+    ///   — §11.2 case 2.
+    /// - [`KnitCurrentLedgerPrevHashMismatch`](HistoryError::KnitCurrentLedgerPrevHashMismatch)
+    ///   — §11.2 case 4.
+    /// - [`ReplayHashMismatch`](HistoryError::ReplayHashMismatch) — replay
+    ///   produced a header hash that disagrees with the archive.
+    /// - [`Ledger(LedgerError::HashMismatch)`](HistoryError::Ledger) —
+    ///   apply-path ledger-header hash mismatch.
+    ///
+    /// Deliberately EXCLUDED: bucket/bucket-list verification failures
+    /// (`VerificationFailed`, `VerificationHashMismatch`) and chain-structure
+    /// failures (`InvalidPreviousHash`, `InvalidSequence`, `CorruptHeader`,
+    /// `KnitOvershot`, `FatalChainDisagreement`, `UnsupportedLedgerVersion`,
+    /// `InvalidTxSetHash`) — those indicate problems an archive re-derivation
+    /// would not (or could not) repair, so they remain terminal.
+    pub fn is_local_vs_archive_divergence(&self) -> bool {
+        matches!(
+            self,
+            HistoryError::KnitLclHashMismatch { .. }
+                | HistoryError::KnitLclPredecessorHashMismatch { .. }
+                | HistoryError::KnitCurrentLedgerPrevHashMismatch { .. }
+                | HistoryError::ReplayHashMismatch { .. }
+                | HistoryError::Ledger(henyey_ledger::LedgerError::HashMismatch { .. })
+        )
+    }
+
     /// Classify this error onto the ledger-chain verification taxonomy
     /// ([`LedgerVerifyStatus`], CATCHUP §3.9-1), or `None` if it is not a
     /// verification failure.


### PR DESCRIPTION
Closes #3282

## Summary

A forced near-tip `ReplayOnly` recovery catchup clones the live bucket list + current header and sets `override_lcl = Some(current)`, making the **local** LCL the knit subject. When the local LCL hash diverges from the canonical **published** archive header (so the #2937 publication gate passes — a different divergence class than the unpublished-checkpoint case #2931/#2886 were closed for), the §11.2 case-3 knit raises `KnitLclHashMismatch`. In `handle_catchup_result`'s `Err` branch this was treated as fatal → `trigger_fatal_shutdown` + `fatal_wipe_required`, returning **before** the `else` block where the existing `catchup_needs_full_reset` self-heal lives. So the node wiped instead of rebuilding from the archive — the common defect behind all three recurrences (#2886, #2931, #3282).

The fix tags cloned-local near-tip catchups (`seeded_from_local_clone`, threaded from `catchup_with_run_mode` through the spawned task's `PendingCatchupResult` into `handle_catchup_result`). On a local-vs-archive divergence for such a catchup, it sets `catchup_needs_full_reset` and returns **non-fatal** — the next catchup runs `force_full` (`existing_state=None`, `override_lcl=None`), an archive-authoritative bucket-apply that ignores the cloned local state (mirroring stellar-core `CatchupWork::downloadApplyBuckets`). The latch is **one-shot**: the rebuild runs `seeded_from_local_clone=false`, so a repeat divergence goes terminal/fatal; `catchup_needs_full_reset` is cleared on the next catchup entry so it cannot re-latch.

**Detection is unchanged** — the §11.2 knit matrix, the publication gate, and `is_fatal_catchup_failure` all stay strict. Only the app-layer **response** to this divergence class changes, from wipe to rebuild. Recovery-routing trigger conditions are out of scope (#3266 track).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3282#issuecomment-4712937037)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-app -p henyey-history -- -D warnings` (clean)
- [x] `cargo test -p henyey-history -p henyey-app` passes
- [x] `cargo test --all` passes

## Regression test (bug-fix)

- **Offline repro (condition):** `crates/history/.../replay.rs::test_offline_near_tip_replay_knit_to_lcl_repro` — published gate passes + divergent local LCL ⇒ `KnitLclHashMismatch` (the exact #3282 observable).
- **Fixed response (test 1):** `crates/app/.../catchup_impl.rs::test_near_tip_knit_mismatch_triggers_full_reset_not_wipe` — committed as `b8a5cc2b0e10f06605b12907ebcfe947ae71d5c5` (test) → with the interception disabled this **FAILS** with "must NOT be fatal — it self-heals"; **PASSES** after the fix `cabe805f858760af203390f21959d3366ee4525e` (sets `catchup_needs_full_reset`, no wipe).
- **Safety backstop (test 2):** `test_full_bucket_apply_knit_mismatch_still_wipes` — same error, `seeded_from_local_clone=false` ⇒ still fatal/wipe (no over-broadening).

## Fan-out diagnostic (rule-in/out, #3269)

`crates/history/.../buckets.rs::test_apply_buckets_full_header_hash_identical_across_fan_out` — asserts the **full ledger-header hash** (not just bucketListHash) is identical across `restore_apply_fan_out ∈ {None,1,2,6}`. **GREEN** → fan-out is exonerated as the #3282 recurrence cause (consistent with #2886/#2931 predating all fan-out work). No follow-up issue filed.

## Parity

A knit disagreement is a retryable Work failure upstream (`CatchupWork::fatalFailure()` boolean, `stellar-core/src/catchup/CatchupWork.h:80`, consumed at `LedgerApplyManagerImpl.cpp:124`), surfaced from `ApplyCheckpointWork::getNextLedgerCloseData` (`ApplyCheckpointWork.cpp:236`), recovered via `CatchupWork::downloadApplyBuckets` (`CatchupWork.cpp:198`) — **not** a destructive wipe. The retained terminal wipe is a henyey-stricter policy reached only after the parity-aligned archive re-derivation also fails.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)