### PR TITLE
Gate MAX_SEQ_NUM_TO_APPLY construction and consumption on protocol V19

### DIFF
--- a/crates/ledger/src/execution/tx_set.rs
+++ b/crates/ledger/src/execution/tx_set.rs
@@ -345,6 +345,14 @@ fn prefetch_classic_keys(
 
 /// Compute max sequence number per source account for AccountMerge protection.
 fn compute_max_seq_num_to_apply(executor: &mut TransactionExecutor, transactions: &[TxWithFee]) {
+    // stellar-core gates the entire MAX_SEQ_NUM_TO_APPLY accumulation (the
+    // per-tx `accToMaxSeq` map and the `mergeSeen` flag) on protocol >= V19.
+    // See LedgerManagerImpl.cpp:2183. Henyey is protocol 24+ only, so V19 is
+    // always satisfied on supported ledgers and this guard is a provable no-op;
+    // it is retained for exact source-fidelity with stellar-core.
+    if !protocol_version_starts_from(executor.protocol_version, ProtocolVersion::V19) {
+        return;
+    }
     let mut merge_seen = false;
     let mut acc_to_max_seq: HashMap<AccountId, i64> = HashMap::new();
     for (tx, _) in transactions.iter() {

--- a/crates/ledger/tests/transaction_execution/regression.rs
+++ b/crates/ledger/tests/transaction_execution/regression.rs
@@ -3878,6 +3878,115 @@ fn test_audit_577_max_seq_num_to_apply_with_pre_charged() {
     );
 }
 
+/// Parity test for #3109: the MAX_SEQ_NUM_TO_APPLY path is now gated on protocol
+/// >= V19, mirroring stellar-core (LedgerManagerImpl.cpp:2183 construction,
+/// MergeOpFrame.cpp:44 consumption). Henyey is protocol 24+ only, so the gate is
+/// always satisfied and is a provable no-op. This test exercises the full
+/// construction + consumption path on a protocol-24 ledger and asserts the
+/// always-true gate does NOT suppress the check — an AccountMerge whose source
+/// max seq would trigger SeqnumTooFar is still blocked.
+#[test]
+fn test_max_seq_num_to_apply_built_for_merge_protocol24() {
+    use henyey_ledger::execution::{run_transactions_on_executor, FeeStrategy};
+    use henyey_ledger::LedgerDelta;
+    use stellar_xdr::curr::AccountMergeResult;
+
+    let ledger_seq: u32 = 2;
+    let starting_seq: i64 = (ledger_seq as i64) << 32;
+    let protocol_version: u32 = 24; // minimum henyey-supported; gate (>= V19) always true
+
+    let secret = SecretKey::from_seed(&[123u8; 32]);
+    let source_id: AccountId = (&secret.public_key()).into();
+    // Source seq_num == starting_seq so the TX seq_num (starting_seq + 1) passes
+    // the per-tx sequence check; the built MAX_SEQ_NUM_TO_APPLY entry then blocks
+    // the merge with SeqnumTooFar.
+    let (source_key, source_entry) =
+        create_account_entry(source_id.clone(), starting_seq, 100_000_000);
+
+    let dest_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([124u8; 32])));
+    let (dest_key, dest_entry) = create_account_entry(dest_id.clone(), 1, 50_000_000);
+
+    let snapshot = SnapshotBuilder::new(1)
+        .add_entry(source_key, source_entry)
+        .add_entry(dest_key, dest_entry)
+        .build_with_default_header();
+    let snapshot = SnapshotHandle::new(snapshot);
+
+    let network_id = NetworkId::testnet();
+    let base_fee: u32 = 100;
+    let base_reserve: u32 = 5_000_000;
+
+    let op = Operation {
+        source_account: None,
+        body: OperationBody::AccountMerge(MuxedAccount::Ed25519(Uint256([124u8; 32]))),
+    };
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
+        fee: base_fee,
+        seq_num: SequenceNumber(starting_seq + 1),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![op].try_into().unwrap(),
+        ext: TransactionExt::V0,
+    };
+    let mut envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: VecM::default(),
+    });
+    let sig = sign_envelope(&envelope, &secret, &network_id);
+    if let TransactionEnvelope::Tx(ref mut env) = envelope {
+        env.signatures = vec![sig].try_into().unwrap();
+    }
+
+    let context = henyey_tx::LedgerContext::new(
+        ledger_seq,
+        1_000,
+        base_fee,
+        base_reserve,
+        protocol_version,
+        network_id,
+    );
+    let mut executor = TransactionExecutor::new(
+        &context,
+        0,
+        SorobanConfig::default(),
+        ClassicEventConfig::default(),
+    );
+    executor
+        .load_orderbook_offers(&snapshot)
+        .expect("load offers");
+
+    let transactions = vec![(std::sync::Arc::new(envelope), None)];
+    let mut delta = LedgerDelta::new(ledger_seq);
+
+    let result = run_transactions_on_executor(henyey_ledger::execution::RunTransactionsParams {
+        executor: &mut executor,
+        snapshot: &snapshot,
+        transactions: &transactions,
+        base_fee,
+        soroban_base_prng_seed: [0u8; 32],
+        fee_strategy: FeeStrategy::PreChargeInternally,
+        delta: &mut delta,
+    })
+    .expect("run_transactions_on_executor");
+
+    assert!(
+        !result.results[0].success,
+        "AccountMerge must be blocked at protocol 24 (V19 gate always satisfied)"
+    );
+    let op_result = &result.results[0].operation_results[0];
+    match op_result {
+        OperationResult::OpInner(OperationResultTr::AccountMerge(
+            AccountMergeResult::SeqnumTooFar,
+        )) => {}
+        other => panic!("Expected AccountMerge::SeqnumTooFar, got {:?}", other),
+    }
+    assert!(
+        executor.state().get_account(&source_id).is_some(),
+        "source account must still exist when merge is blocked by MAX_SEQ_NUM_TO_APPLY"
+    );
+}
+
 /// Regression test for the single-op savepoint skip optimization.
 ///
 /// When a transaction has exactly one operation, the per-operation savepoint is

--- a/crates/tx/src/operations/execute/account_merge.rs
+++ b/crates/tx/src/operations/execute/account_merge.rs
@@ -1,5 +1,6 @@
 //! AccountMerge operation execution.
 
+use henyey_common::protocol::{protocol_version_starts_from, ProtocolVersion};
 use stellar_xdr::curr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, AccountFlags, AccountId,
     AccountMergeResult, AccountMergeResultCode, MuxedAccount, OperationResult, OperationResultTr,
@@ -17,7 +18,7 @@ pub(crate) fn execute_account_merge(
     dest: &MuxedAccount,
     source: &AccountId,
     state: &mut LedgerStateManager,
-    _context: &LedgerContext,
+    context: &LedgerContext,
 ) -> Result<OperationResult> {
     let dest_account_id = muxed_to_account_id(dest);
 
@@ -43,11 +44,19 @@ pub(crate) fn execute_account_merge(
     }
 
     let starting_seq = state.starting_sequence_number()?;
-    if let Some(&max_seq) = state.get_max_seq_num_to_apply(source) {
-        if max_seq >= starting_seq {
-            return Ok(make_result(AccountMergeResultCode::SeqnumTooFar));
+    // stellar-core only consults the MAX_SEQ_NUM_TO_APPLY map at protocol >= V19
+    // (MergeOpFrame.cpp:44). Henyey is protocol 24+ only, so V19 is always
+    // satisfied on supported ledgers and this guard is a provable no-op; it is
+    // retained for exact source-fidelity with stellar-core.
+    if protocol_version_starts_from(context.protocol_version, ProtocolVersion::V19) {
+        if let Some(&max_seq) = state.get_max_seq_num_to_apply(source) {
+            if max_seq >= starting_seq {
+                return Ok(make_result(AccountMergeResultCode::SeqnumTooFar));
+            }
         }
     }
+    // The raw `seqNum >= maxSeqToApply` check is UNCONDITIONAL in stellar-core
+    // (MergeOpFrame.cpp:55) — only the map lookup above is V19-gated.
     if source_account.seq_num.0 >= starting_seq {
         return Ok(make_result(AccountMergeResultCode::SeqnumTooFar));
     }


### PR DESCRIPTION
Closes #3109

## Summary

Mirror stellar-core's `protocolVersionStartsFrom(ledgerVersion, V_19)` gate on the MAX_SEQ_NUM_TO_APPLY path, which henyey was missing. The map construction (`crates/ledger/src/execution/tx_set.rs::compute_max_seq_num_to_apply`) now early-returns below V19 (matches `LedgerManagerImpl.cpp:2183`), and the map consult in AccountMerge (`crates/tx/src/operations/execute/account_merge.rs`) is wrapped in the same V19 gate (matches `MergeOpFrame.cpp:44`). The unconditional `seq_num >= starting_seq` check is left UNGATED, matching `MergeOpFrame.cpp:55`.

**This is a provable no-op on protocol 24+.** Henyey is protocol 24+ only and V19 (=19) < V24, so `protocol_version_starts_from(pv, V19)` is always true on every supported ledger. No tx set reachable in henyey changes result. This is source-fidelity parity hardening, not an observable-divergence fix — the issue's literal "never built" premise was a false positive (construction already existed at `tx_set.rs:347`); the only real gap vs stellar-core was the missing version gate.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3109#issuecomment-4721859920)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy (pre-commit hook; no new warnings — pre-existing repo lints in untouched files only)
- [x] `cargo test -p henyey-tx` passes (1371 + 12)
- [x] `cargo test -p henyey-ledger --tests` passes (483 + transaction_execution suite incl. new test)
- [x] New parity test `test_max_seq_num_to_apply_built_for_merge_protocol24` passes
- [x] Existing `test_audit_577_max_seq_num_to_apply_with_pre_charged` still passes
- [x] Existing `test_account_merge_blocked_by_max_seq_num_to_apply` still passes

## New coverage

Added `crates/ledger/tests/transaction_execution/regression.rs::test_max_seq_num_to_apply_built_for_merge_protocol24` — exercises full construction + consumption on a protocol-24 ledger and asserts the always-true V19 gate does NOT suppress the check (AccountMerge with source max seq >= starting_seq is still blocked with SeqnumTooFar). Per the plan, no failing-on-main behavioral test is possible (the gate is a no-op at 24+); this is a positive parity/coverage test.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)