### PR TITLE
Add test-only carve-out to monitor-tick deploy gate

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1591,44 +1591,118 @@ Otherwise enter the deploy path:
    voluntary deploys. Urgent fixes can override by killing the node manually
    before the next tick — the normal startup path will pick up the latest
    origin/main.
-2. **Binary-relevance check**:
+2. **Binary-relevance check** (the path/hunk heuristic only marks a CANDIDATE;
+   the authoritative skip is gated by the binary byte-compare in step 2a):
    ```bash
+   source "$(git rev-parse --show-toplevel)/scripts/lib/monitor-decisions.sh"
+
    if [ "$gate_action" = "proceed-force-rebuild" ]; then
-     # invalid build_sha — skip allowlist, force rebuild
+     # invalid build_sha — skip heuristic, force rebuild
      needs_rebuild="yes"
+   elif changed_paths=$(git diff --name-only "$deployed_sha" origin/main 2>/dev/null); then
+     # ok or missing-fresh: classify every changed path. needs_rebuild stays
+     # "no" only if EVERY path is provably non-binary-affecting; ANY ambiguity
+     # flips to "yes" (fail-safe). skip_kind tracks the strongest skip reason
+     # for the report ("no-binary-impact" vs "test-only").
+     needs_rebuild="no"
+     skip_kind="no-binary-impact"
+     while IFS= read -r p; do
+       [ -z "$p" ] && continue
+       case "$(classify_path_binary_relevance "$p")" in
+         no-impact) ;;                          # allowlisted — never compiled in
+         test-only) skip_kind="test-only" ;;    # crates/*/tests/** integration test
+         needs-hunk-check)
+           # crates/**/src/**.rs: test-only ONLY if every changed line in THIS
+           # file's diff is inside a #[cfg(test)]/mod tests region. Any ambiguity
+           # (zero-context hunk, module deletion, boundary edit) → rebuild.
+           if git diff "$deployed_sha" origin/main -- "$p" | diff_is_test_only; then
+             skip_kind="test-only"
+           else
+             needs_rebuild="yes"; break
+           fi
+           ;;
+         *) needs_rebuild="yes"; break ;;       # rebuild (fail-safe default)
+       esac
+     done <<< "$changed_paths"
    else
-     # ok or missing-fresh: diff from deployed_sha
-     if changed_paths=$(git diff --name-only "$deployed_sha" origin/main 2>/dev/null); then
-       # Evaluate allowlist on $changed_paths (see below).
-       # If every path is allowlisted: needs_rebuild="no"
-       # Else: needs_rebuild="yes"
-       ...
-     else
-       # git diff failed — fail closed, force rebuild.
-       needs_rebuild="yes"
-     fi
+     # git diff failed — fail closed, force rebuild.
+     needs_rebuild="yes"
    fi
    ```
-   If `needs_rebuild="no"` (all paths allowlisted), skip the rebuild + restart:
-   run `git pull --rebase` only, then report
-   `DEPLOY SYNCED (no-binary-impact: allowlisted paths only — pulled <N> commits, no restart)`.
-   Do NOT update `BUILD_SHA_FILE` (the binary hasn't changed).
 
-   The non-binary-impact allowlist is:
-   - `.github/`
-   - `.claude/`
-   - `scripts/`
-   - `docs/`
-   - `metrics/` (dashboards, alerts, observability docs — no runtime impact)
-   - root-level `*.md` files, e.g. `README.md` or `CLAUDE.md`
-   - root-level git metadata dotfiles that never compile into the binary:
-     `.gitignore`, `.gitattributes`, `.gitmodules`
-   - `stellar-specs` / `stellar-specs/` submodule pointer changes only
+   `classify_path_binary_relevance PATH` returns one of `no-impact` |
+   `test-only` | `needs-hunk-check` | `rebuild`:
+   - **`no-impact`** (allowlisted — never compiles into the release binary):
+     `.github/`, `.claude/`, `scripts/`, `docs/`, `metrics/`, root-level `*.md`
+     (e.g. `README.md`, `CLAUDE.md`), root-level git metadata dotfiles
+     (`.gitignore`, `.gitattributes`, `.gitmodules`), and `stellar-specs` /
+     `stellar-specs/` submodule pointer changes.
+   - **`test-only`**: `crates/<crate>/tests/**` — integration tests, a separate
+     compilation target never linked into the `--release` lib/bin.
+   - **`needs-hunk-check`**: `crates/**/src/**.rs` — defer to `diff_is_test_only`
+     on that file's diff (returns 0 only if every changed line is strictly inside
+     a `#[cfg(test)]`/`mod tests` region; ANY ambiguity → rebuild).
+   - **`rebuild`** (FAIL-SAFE default): everything else — `Cargo.toml`,
+     `Cargo.lock`, any `build.rs`, `configs/`, `.rs` outside `src/`/`tests/`,
+     non-`.rs` files under `crates/`, or any unrecognized path. A false
+     "rebuild" costs only a wasted build; a false "skip" could miss a deploy.
 
-   Deny by default: if any path is outside this allowlist, continue to the CI,
-   build, and restart path. In particular, changes to `Cargo.toml`,
-   `Cargo.lock`, any `build.rs`, `crates/`, `configs/`, or mixed docs+code
-   commits require a rebuild + restart.
+2a. **Authoritative binary byte-compare** (only when `needs_rebuild="no"`): the
+    heuristic has marked the changeset a skip CANDIDATE, but shell-based Rust
+    region parsing is brittle, so it does NOT by itself authorize a skip. Build
+    `henyey` at BOTH `deployed_sha` and `origin/main` into the SAME scratch
+    target dir with identical flags, then byte-compare the two produced
+    binaries. Skip the rebuild+restart ONLY if the bytes are identical;
+    otherwise fall through to the normal rebuild+restart path (step 3+).
+    Build BOTH sides freshly in the same path — do NOT compare against the
+    long-running on-disk binary, which may have been built under a different
+    absolute path and so would never match (the carve-out would be inert).
+    ```bash
+    if [ "$needs_rebuild" = "no" ]; then
+      CMP_TARGET="/home/tomer/data/$MONITOR_SESSION_ID/binrel-cmp-target"
+      BIN_OLD="/home/tomer/data/$MONITOR_SESSION_ID/binrel-old"
+      BIN_NEW="/home/tomer/data/$MONITOR_SESSION_ID/binrel-new"
+      rm -rf "$CMP_TARGET"; mkdir -p "$CMP_TARGET"
+      # Build at deployed_sha, then at origin/main, into the SAME target dir.
+      git stash --include-untracked >/dev/null 2>&1 || true
+      git checkout --quiet "$deployed_sha" \
+        && CARGO_TARGET_DIR="$CMP_TARGET" cargo build --release -p henyey \
+        && cp "$CMP_TARGET/release/henyey" "$BIN_OLD"
+      git checkout --quiet origin/main \
+        && CARGO_TARGET_DIR="$CMP_TARGET" cargo build --release -p henyey \
+        && cp "$CMP_TARGET/release/henyey" "$BIN_NEW"
+      if [ -f "$BIN_OLD" ] && [ -f "$BIN_NEW" ] && cmp -s "$BIN_OLD" "$BIN_NEW"; then
+        binary_identical="yes"
+      else
+        binary_identical="no"   # heuristic miss OR non-reproducible build → rebuild
+      fi
+      rm -rf "$CMP_TARGET" "$BIN_OLD" "$BIN_NEW"
+    fi
+    ```
+    On a **confirmed skip** (`needs_rebuild="no"` AND `binary_identical="yes"`):
+    run `git pull --rebase` only, then advance `BUILD_SHA_FILE` to the new sha:
+    ```bash
+    new_sha=$(git rev-parse origin/main)
+    printf '%s\n' "$new_sha" > "${BUILD_SHA_FILE}.tmp"
+    mv "${BUILD_SHA_FILE}.tmp" "$BUILD_SHA_FILE"
+    ```
+    The bytes are confirmed byte-identical, so the running binary IS the
+    origin/main binary — advancing `BUILD_SHA_FILE` is correct and fixes the
+    per-tick re-trip (the gate no longer re-evaluates this same changeset every
+    tick). Report:
+    - `DEPLOY SYNCED (test-only: binary byte-identical — pulled <N> commits, no restart)` when `skip_kind="test-only"`;
+    - `DEPLOY SYNCED (no-binary-impact: allowlisted paths only — pulled <N> commits, no restart)` when `skip_kind="no-binary-impact"`.
+
+    If `binary_identical="no"` (a heuristic false-positive OR a
+    non-reproducible build): set `needs_rebuild="yes"` and fall through to the
+    normal build+restart path. A heuristic miss therefore costs at most one
+    wasted build, NEVER a missed deploy.
+
+    > NOTE on reproducibility: this depends on `cargo build --release` being
+    > bit-identical across two same-path builds. If that does not hold in
+    > practice, `binary_identical` will be `no` and the gate simply always
+    > rebuilds — strictly no worse than the legacy "always rebuild on `crates/`"
+    > behavior, just with a wasted build on test-only changes.
 3. **Quarantine gate** (only reached when `needs_rebuild=yes`):
    ```bash
    # --- Quarantine gate ---

--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -664,3 +664,236 @@ grep_heartbeat_lines() {
     grep -E "$pattern" "$log_file" 2>/dev/null
   fi
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# classify_path_binary_relevance PATH  (issue #3215)
+#
+# Path-level classifier for the monitor-tick §10 deploy-gate binary-relevance
+# check. Given a single repo-relative changed path, prints exactly ONE verdict:
+#
+#   no-impact         — allowlisted: documentation/CI/tooling/specs that never
+#                       compiles into the release binary.
+#   test-only         — crates/<crate>/tests/** integration tests (a separate
+#                       compilation target, never linked into --release lib/bin).
+#   needs-hunk-check  — crates/**/src/**.rs: MAY be test-only at the hunk level;
+#                       the caller must run diff_is_test_only on this file's diff.
+#   rebuild           — FAIL-SAFE default for EVERYTHING else (Cargo.toml,
+#                       Cargo.lock, any build.rs, configs/, .rs outside src/tests,
+#                       non-.rs under crates/, or any unrecognized path).
+#
+# The classifier is deliberately conservative: a false "rebuild" costs only a
+# wasted build, while a false "no-impact"/"test-only" could skip a real deploy —
+# so anything not provably non-binary-affecting falls through to rebuild.
+#
+# Prints the verdict to stdout. Returns 0 always.
+# ─────────────────────────────────────────────────────────────────────────────
+classify_path_binary_relevance() {
+  local path="$1"
+
+  # Empty path → fail-safe.
+  if [[ -z "$path" ]]; then
+    echo "rebuild"
+    return 0
+  fi
+
+  # --- Allowlist: paths that never compile into the release binary. ---
+  case "$path" in
+    .github/*|.claude/*|scripts/*|docs/*|metrics/*)
+      echo "no-impact"; return 0 ;;
+    .gitignore|.gitattributes|.gitmodules)
+      echo "no-impact"; return 0 ;;
+    stellar-specs|stellar-specs/*)
+      echo "no-impact"; return 0 ;;
+  esac
+  # Root-level *.md (e.g. README.md, CLAUDE.md) — no slash, .md suffix.
+  if [[ "$path" != */* && "$path" == *.md ]]; then
+    echo "no-impact"; return 0
+  fi
+
+  # --- crates/<crate>/tests/** : integration tests, never in --release lib/bin.
+  # Matches a `tests/` directory directly under a single crate dir.
+  if [[ "$path" == crates/*/tests/* ]]; then
+    echo "test-only"; return 0
+  fi
+
+  # --- crates/**/src/**.rs : source that MAY be hunk-level test-only.
+  # Must be a .rs file living under a `src/` directory inside crates/.
+  if [[ "$path" == crates/*/src/*.rs && "$path" == *.rs ]]; then
+    echo "needs-hunk-check"; return 0
+  fi
+
+  # --- Everything else: fail-safe rebuild. ---
+  echo "rebuild"
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# diff_is_test_only  (reads ONE file's unified diff on stdin)  (issue #3215)
+#
+# Hunk-level classifier: returns 0 ONLY if EVERY changed (`+`/`-`) line in the
+# diff lies strictly inside a `#[cfg(test)]` / `mod tests` region, tracked by
+# brace-depth from the region opener to its matching close brace. ANY of the
+# following → return 1 (rebuild), because the change may affect the binary:
+#
+#   - a changed line outside any confirmed cfg(test) region;
+#   - a changed line ON the `#[cfg(test)]` attribute or the `mod tests {` opener
+#     itself (the region boundary is being mutated — ambiguous);
+#   - a hunk that cannot be anchored (zero-context hunk, whole-module deletion,
+#     or any parse ambiguity);
+#   - an empty / unreadable diff.
+#
+# Deliberately dumb + fail-safe: its safety comes from defaulting to rebuild on
+# ANY ambiguity, NOT from parsing Rust accurately. It is NOT a Rust parser and
+# must not grow into one. The authoritative skip is gated downstream by a
+# release-binary byte-compare; this function only prunes the candidate set.
+#
+# The diff is re-walked using ONLY the new-file ('+'/' ') lines (the post-change
+# file content the hunk headers describe). We reconstruct the post-change line
+# stream, tag each reconstructed line as "changed" if it is an added line or sits
+# adjacent to a removed line, and verify every changed line is inside a region.
+#
+# Returns: 0 = test-only (safe-to-consider-skip candidate); 1 = rebuild.
+# ─────────────────────────────────────────────────────────────────────────────
+diff_is_test_only() {
+  awk '
+    BEGIN {
+      in_region = 0      # currently inside a confirmed #[cfg(test)] region
+      depth = 0          # brace depth within the region
+      pending_cfg = 0    # saw #[cfg(test)] attribute, awaiting its mod opener
+      saw_hunk = 0       # at least one @@ hunk header seen
+      saw_change = 0     # at least one +/- content line seen
+      bad = 0            # a changed line landed outside a region / on a boundary
+    }
+
+    # Skip diff metadata lines that arent hunk content.
+    /^diff --git / { next }
+    /^index /      { next }
+    /^--- /        { next }
+    /^\+\+\+ /     { next }
+    /^old mode /   { next }
+    /^new mode /   { next }
+    /^similarity / { next }
+    /^rename /     { next }
+    /^new file /   { next }
+    /^deleted file / { next }
+    /^Binary files / { bad = 1; next }
+
+    # Hunk header. Reject zero-context / zero-line headers we cannot anchor:
+    # a hunk whose new-file span is "+N,0" (pure deletion, no post lines) or
+    # "+N" with no count and no context cannot be situated inside a region.
+    /^@@ / {
+      saw_hunk = 1
+      # Parse the "+start,len" field. Forms: @@ -a,b +c,d @@  or  @@ -a +c @@
+      hdr = $0
+      # Extract the +c,d token.
+      if (match(hdr, /\+[0-9]+(,[0-9]+)?/)) {
+        plus = substr(hdr, RSTART, RLENGTH)
+        sub(/^\+/, "", plus)
+        if (index(plus, ",") > 0) {
+          split(plus, pp, ",")
+          newlen = pp[2] + 0
+        } else {
+          newlen = 1
+        }
+        # A hunk that adds no post-change lines (pure deletion) cannot be
+        # anchored as "inside a test region" — fail-safe.
+        if (newlen == 0) { bad = 1 }
+      } else {
+        bad = 1
+      }
+      next
+    }
+
+    # Content lines. Only meaningful after a hunk header.
+    {
+      if (saw_hunk == 0) { next }   # stray line before any hunk → ignore
+
+      sign = substr($0, 1, 1)
+      text = substr($0, 2)
+
+      if (sign == "-") {
+        # A removed line. If it is inside a region, fine; if it touches a region
+        # boundary, flag. We treat removed lines conservatively: a removed line
+        # that is NOT inside a confirmed region → bad. Removed lines do not
+        # advance the post-change brace tracker (they are gone), but they DO
+        # signal a change at the current region state.
+        saw_change = 1
+        # If the removed line is the region opener/attribute, the boundary is
+        # being mutated → ambiguous.
+        if (text ~ /#\[cfg\(test\)\]/ || text ~ /(^|[[:space:]])mod[[:space:]]+tests([[:space:]]|\{|$)/) {
+          bad = 1
+        } else if (in_region == 0) {
+          bad = 1
+        }
+        next
+      }
+
+      # Context (space) or added (plus) line — part of the post-change file.
+      changed = (sign == "+") ? 1 : 0
+      if (sign == "+") saw_change = 1
+
+      # --- Region tracking on the post-change line stream. ---
+      # Detect a #[cfg(test)] attribute: arms the next mod opener.
+      is_cfg_attr = (text ~ /#\[cfg\(test\)\]/)
+      # Detect a `mod tests` opener (allow `pub mod tests`, trailing brace/space).
+      is_mod_open = (text ~ /(^|[[:space:]])mod[[:space:]]+tests([[:space:]]*\{|[[:space:]]*$)/)
+
+      if (changed && (is_cfg_attr || is_mod_open)) {
+        # Editing the region boundary itself → ambiguous → fail-safe.
+        bad = 1
+      }
+
+      if (is_cfg_attr) {
+        pending_cfg = 1
+      }
+
+      # Count braces on this line to maintain depth when inside a region.
+      opens = gsub(/\{/, "{", text)   # gsub returns count of substitutions
+      closes = gsub(/\}/, "}", text)
+
+      if (in_region == 0) {
+        # Entering a region only when a #[cfg(test)]-armed `mod tests {` opens.
+        if (is_mod_open && pending_cfg) {
+          in_region = 1
+          pending_cfg = 0
+          # The opener line itself: a changed opener was already flagged above.
+          # Initialize depth from the braces on the opener line.
+          depth = opens - closes
+          if (depth <= 0) {
+            # `mod tests;` (no body) or one-liner — no region body to be inside.
+            in_region = 0
+            depth = 0
+          }
+        } else {
+          # Not in a region. A changed line here is outside → bad.
+          if (changed) bad = 1
+          # A `mod tests {` without a preceding #[cfg(test)] is not a test region
+          # we trust; pending_cfg only persists to the immediately-following mod.
+          if (is_mod_open) pending_cfg = 0
+        }
+      } else {
+        # Inside a region: this line is in-region BEFORE applying its own braces
+        # for the closing case. A changed in-region line is allowed.
+        depth += opens - closes
+        if (depth <= 0) {
+          # Region closed on/at this line. A changed line that closes the region
+          # is at the boundary → ambiguous → fail-safe.
+          if (changed) bad = 1
+          in_region = 0
+          depth = 0
+        }
+      }
+
+      next
+    }
+
+    END {
+      # Fail-safe on: any boundary/outside violation, an empty diff, a diff with
+      # no hunks, or a diff with no actual changes.
+      if (bad)         { exit 1 }
+      if (saw_hunk == 0) { exit 1 }
+      if (saw_change == 0) { exit 1 }
+      exit 0
+    }
+  '
+}

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=368
+TAP_PLAN=395
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -9590,6 +9590,318 @@ BOARDEOF
     tap_ok "structural: monitor-tick/SKILL.md surfaces henyey_startup_peak_anon_rss_mb"
   else
     tap_not_ok "structural: monitor-tick/SKILL.md surfaces henyey_startup_peak_anon_rss_mb" "not found"
+  fi
+
+  # ── Test-only deploy-gate carve-out (#3215) ─────────────────────────────────
+  # Two pure functions in monitor-decisions.sh power the §10 deploy-gate
+  # binary-relevance check:
+  #   classify_path_binary_relevance PATH → no-impact | test-only |
+  #                                          needs-hunk-check | rebuild (fail-safe)
+  #   diff_is_test_only  (reads one file's unified diff on stdin) → 0 iff every
+  #                       changed line is strictly inside a #[cfg(test)]/mod tests
+  #                       region; ANY ambiguity → non-zero (rebuild).
+  # The functions only mark a CANDIDATE; the authoritative skip is gated on a
+  # release-binary byte-compare in SKILL.md §10 (structural assertions below).
+
+  # --- classify_path_binary_relevance: path-level table test ---
+  if classify_path_binary_relevance ".github/workflows/ci.yml" >/dev/null 2>&1; then
+    _has_classify=yes
+  else
+    _has_classify=no
+  fi
+
+  _cls() { classify_path_binary_relevance "$1" 2>/dev/null; }
+
+  if [[ "$(_cls ".github/workflows/ci.yml")" == "no-impact" ]]; then
+    tap_ok "classify_path: .github/ → no-impact"
+  else
+    tap_not_ok "classify_path: .github/ → no-impact" "got '$(_cls ".github/workflows/ci.yml")'"
+  fi
+  if [[ "$(_cls ".claude/skills/monitor-tick/SKILL.md")" == "no-impact" ]]; then
+    tap_ok "classify_path: .claude/ → no-impact"
+  else
+    tap_not_ok "classify_path: .claude/ → no-impact" "got '$(_cls ".claude/skills/monitor-tick/SKILL.md")'"
+  fi
+  if [[ "$(_cls "scripts/lib/monitor-decisions.sh")" == "no-impact" ]]; then
+    tap_ok "classify_path: scripts/ → no-impact"
+  else
+    tap_not_ok "classify_path: scripts/ → no-impact" "got '$(_cls "scripts/lib/monitor-decisions.sh")'"
+  fi
+  if [[ "$(_cls "README.md")" == "no-impact" ]]; then
+    tap_ok "classify_path: root *.md → no-impact"
+  else
+    tap_not_ok "classify_path: root *.md → no-impact" "got '$(_cls "README.md")'"
+  fi
+  if [[ "$(_cls "stellar-specs")" == "no-impact" ]]; then
+    tap_ok "classify_path: stellar-specs submodule → no-impact"
+  else
+    tap_not_ok "classify_path: stellar-specs submodule → no-impact" "got '$(_cls "stellar-specs")'"
+  fi
+  if [[ "$(_cls "crates/app/tests/publish_tests.rs")" == "test-only" ]]; then
+    tap_ok "classify_path: crates/*/tests/** → test-only"
+  else
+    tap_not_ok "classify_path: crates/*/tests/** → test-only" "got '$(_cls "crates/app/tests/publish_tests.rs")'"
+  fi
+  if [[ "$(_cls "crates/app/src/app/publish.rs")" == "needs-hunk-check" ]]; then
+    tap_ok "classify_path: crates/**/src/**.rs → needs-hunk-check"
+  else
+    tap_not_ok "classify_path: crates/**/src/**.rs → needs-hunk-check" "got '$(_cls "crates/app/src/app/publish.rs")'"
+  fi
+  # Fail-safe: everything else → rebuild.
+  if [[ "$(_cls "Cargo.toml")" == "rebuild" ]]; then
+    tap_ok "classify_path: Cargo.toml → rebuild (fail-safe)"
+  else
+    tap_not_ok "classify_path: Cargo.toml → rebuild (fail-safe)" "got '$(_cls "Cargo.toml")'"
+  fi
+  if [[ "$(_cls "Cargo.lock")" == "rebuild" ]]; then
+    tap_ok "classify_path: Cargo.lock → rebuild (fail-safe)"
+  else
+    tap_not_ok "classify_path: Cargo.lock → rebuild (fail-safe)" "got '$(_cls "Cargo.lock")'"
+  fi
+  if [[ "$(_cls "crates/app/build.rs")" == "rebuild" ]]; then
+    tap_ok "classify_path: crates/*/build.rs → rebuild (fail-safe)"
+  else
+    tap_not_ok "classify_path: crates/*/build.rs → rebuild (fail-safe)" "got '$(_cls "crates/app/build.rs")'"
+  fi
+  if [[ "$(_cls "configs/validator-mainnet.toml")" == "rebuild" ]]; then
+    tap_ok "classify_path: configs/ → rebuild (fail-safe)"
+  else
+    tap_not_ok "classify_path: configs/ → rebuild (fail-safe)" "got '$(_cls "configs/validator-mainnet.toml")'"
+  fi
+  # .rs under crates/ but NOT in src/ or tests/ (e.g. benches, examples) → rebuild.
+  if [[ "$(_cls "crates/app/benches/apply_load.rs")" == "rebuild" ]]; then
+    tap_ok "classify_path: crates/*/benches/*.rs → rebuild (fail-safe)"
+  else
+    tap_not_ok "classify_path: crates/*/benches/*.rs → rebuild (fail-safe)" "got '$(_cls "crates/app/benches/apply_load.rs")'"
+  fi
+  # Non-.rs file under crates/src (e.g. an included .json/.wasm fixture) → rebuild.
+  if [[ "$(_cls "crates/app/src/fixtures/data.json")" == "rebuild" ]]; then
+    tap_ok "classify_path: non-.rs under crates/src → rebuild (fail-safe)"
+  else
+    tap_not_ok "classify_path: non-.rs under crates/src → rebuild (fail-safe)" "got '$(_cls "crates/app/src/fixtures/data.json")'"
+  fi
+
+  # --- diff_is_test_only: hunk-level ---
+  # PASS case: a src/*.rs diff whose every changed line is strictly inside a
+  # #[cfg(test)] mod tests { ... } region.
+  _diff_test_only_pass() {
+    cat <<'CANNED'
+diff --git a/crates/app/src/app/publish.rs b/crates/app/src/app/publish.rs
+index 1111111..2222222 100644
+--- a/crates/app/src/app/publish.rs
++++ b/crates/app/src/app/publish.rs
+@@ -200,6 +200,7 @@ fn produce(x: u32) -> u32 {
+ #[cfg(test)]
+ mod tests {
+     use super::*;
++    // new helper comment inside tests
+     #[test]
+     fn test_produce_doubles() {
+         assert_eq!(produce(2), 4);
+@@ -210,3 +211,4 @@ mod tests {
+     fn test_produce_zero() {
+         assert_eq!(produce(0), 0);
++        assert_ne!(produce(0), 1);
+     }
+ }
+CANNED
+  }
+  if _diff_test_only_pass | diff_is_test_only 2>/dev/null; then
+    tap_ok "diff_is_test_only: all hunks inside #[cfg(test)] mod tests → test-only"
+  else
+    tap_not_ok "diff_is_test_only: all hunks inside #[cfg(test)] mod tests → test-only" "expected rc 0"
+  fi
+
+  # FAIL (a): a hunk OUTSIDE the cfg(test) region → rebuild.
+  _diff_outside() {
+    cat <<'CANNED'
+diff --git a/crates/app/src/app/publish.rs b/crates/app/src/app/publish.rs
+index 1111111..2222222 100644
+--- a/crates/app/src/app/publish.rs
++++ b/crates/app/src/app/publish.rs
+@@ -10,3 +10,4 @@ fn produce(x: u32) -> u32 {
+     let y = x * 2;
++    let y = y + 1;
+     y
+ }
+CANNED
+  }
+  if _diff_outside | diff_is_test_only 2>/dev/null; then
+    tap_not_ok "diff_is_test_only: production hunk → rebuild (fail-safe)" "expected non-zero"
+  else
+    tap_ok "diff_is_test_only: production hunk → rebuild (fail-safe)"
+  fi
+
+  # FAIL (b): a MIXED diff (one test hunk + one production hunk) → rebuild.
+  _diff_mixed() {
+    cat <<'CANNED'
+diff --git a/crates/app/src/app/publish.rs b/crates/app/src/app/publish.rs
+index 1111111..2222222 100644
+--- a/crates/app/src/app/publish.rs
++++ b/crates/app/src/app/publish.rs
+@@ -10,3 +10,4 @@ fn produce(x: u32) -> u32 {
+     let y = x * 2;
++    let y = y + 1;
+     y
+ }
+@@ -200,5 +201,6 @@ mod tests {
+ #[cfg(test)]
+ mod tests {
+     #[test]
++    fn test_new() { assert!(true); }
+     fn test_old() {}
+ }
+CANNED
+  }
+  if _diff_mixed | diff_is_test_only 2>/dev/null; then
+    tap_not_ok "diff_is_test_only: mixed test+production diff → rebuild (fail-safe)" "expected non-zero"
+  else
+    tap_ok "diff_is_test_only: mixed test+production diff → rebuild (fail-safe)"
+  fi
+
+  # FAIL (c): a diff that edits the #[cfg(test)]/mod tests opener line itself →
+  # rebuild (the boundary is ambiguous — can't confirm region membership).
+  _diff_boundary() {
+    cat <<'CANNED'
+diff --git a/crates/app/src/app/publish.rs b/crates/app/src/app/publish.rs
+index 1111111..2222222 100644
+--- a/crates/app/src/app/publish.rs
++++ b/crates/app/src/app/publish.rs
+@@ -198,4 +198,5 @@ fn produce(x: u32) -> u32 {
+ }
++#[cfg(test)]
+ mod tests {
+     use super::*;
+CANNED
+  }
+  if _diff_boundary | diff_is_test_only 2>/dev/null; then
+    tap_not_ok "diff_is_test_only: edits #[cfg(test)] opener → rebuild (fail-safe)" "expected non-zero"
+  else
+    tap_ok "diff_is_test_only: edits #[cfg(test)] opener → rebuild (fail-safe)"
+  fi
+
+  # FAIL (d): a zero-context hunk / whole cfg(test)-module deletion the
+  # brace-tracker cannot anchor inside a confirmed region → rebuild (Critic A).
+  _diff_zerocontext() {
+    cat <<'CANNED'
+diff --git a/crates/app/src/app/publish.rs b/crates/app/src/app/publish.rs
+index 1111111..2222222 100644
+--- a/crates/app/src/app/publish.rs
++++ b/crates/app/src/app/publish.rs
+@@ -50,0 +51,1 @@
++    let unanchored = compute();
+CANNED
+  }
+  if _diff_zerocontext | diff_is_test_only 2>/dev/null; then
+    tap_not_ok "diff_is_test_only: zero-context hunk → rebuild (fail-safe)" "expected non-zero"
+  else
+    tap_ok "diff_is_test_only: zero-context hunk → rebuild (fail-safe)"
+  fi
+  _diff_moddelete() {
+    cat <<'CANNED'
+diff --git a/crates/app/src/app/publish.rs b/crates/app/src/app/publish.rs
+index 1111111..0000000 100644
+--- a/crates/app/src/app/publish.rs
++++ b/crates/app/src/app/publish.rs
+@@ -1,4 +0,0 @@
+-fn produce(x: u32) -> u32 {
+-    x * 2
+-}
+CANNED
+  }
+  if _diff_moddelete | diff_is_test_only 2>/dev/null; then
+    tap_not_ok "diff_is_test_only: whole-module deletion → rebuild (fail-safe)" "expected non-zero"
+  else
+    tap_ok "diff_is_test_only: whole-module deletion → rebuild (fail-safe)"
+  fi
+
+  # --- End-to-end gate decision (canned multi-file `git diff` mock, #3248 style) ---
+  # Walk a changeset path-by-path applying classify_path_binary_relevance, and
+  # for needs-hunk-check paths drive diff_is_test_only on that file's per-file
+  # diff. The aggregate decision: needs_rebuild=no iff EVERY path resolves to
+  # no-impact or test-only (the latter confirmed by diff_is_test_only); else yes.
+  _gate_decide() {
+    # $1 = newline-separated changed paths; reads per-file diffs from a mock
+    # `_gate_filediff <path>` the caller defines.
+    local paths="$1" p verdict needs="no"
+    while IFS= read -r p; do
+      [[ -z "$p" ]] && continue
+      verdict="$(classify_path_binary_relevance "$p" 2>/dev/null)"
+      case "$verdict" in
+        no-impact) ;;
+        test-only) ;;
+        needs-hunk-check)
+          if ! _gate_filediff "$p" | diff_is_test_only 2>/dev/null; then
+            needs="yes"; break
+          fi
+          ;;
+        *) needs="yes"; break ;;
+      esac
+    done <<< "$paths"
+    echo "$needs"
+  }
+
+  # (a) test-only changeset → needs_rebuild=no candidate.
+  _gate_filediff() { _diff_test_only_pass; }
+  local _changeset_a="crates/app/tests/publish_tests.rs
+crates/app/src/app/publish.rs
+README.md"
+  if [[ "$(_gate_decide "$_changeset_a")" == "no" ]]; then
+    tap_ok "gate-decision: test-only changeset → needs_rebuild=no candidate"
+  else
+    tap_not_ok "gate-decision: test-only changeset → needs_rebuild=no candidate" "got '$(_gate_decide "$_changeset_a")'"
+  fi
+
+  # (b) real-src changeset → needs_rebuild=yes (the fail-safe).
+  _gate_filediff() { _diff_outside; }
+  local _changeset_b="crates/app/src/app/publish.rs"
+  if [[ "$(_gate_decide "$_changeset_b")" == "yes" ]]; then
+    tap_ok "gate-decision: real-src changeset → needs_rebuild=yes (fail-safe)"
+  else
+    tap_not_ok "gate-decision: real-src changeset → needs_rebuild=yes (fail-safe)" "got '$(_gate_decide "$_changeset_b")'"
+  fi
+
+  # (c) a Cargo.toml in the changeset forces rebuild regardless of test-only siblings.
+  _gate_filediff() { _diff_test_only_pass; }
+  local _changeset_c="crates/app/tests/publish_tests.rs
+Cargo.toml"
+  if [[ "$(_gate_decide "$_changeset_c")" == "yes" ]]; then
+    tap_ok "gate-decision: Cargo.toml in changeset → needs_rebuild=yes (fail-safe)"
+  else
+    tap_not_ok "gate-decision: Cargo.toml in changeset → needs_rebuild=yes (fail-safe)" "got '$(_gate_decide "$_changeset_c")'"
+  fi
+  unset -f _gate_filediff
+
+  # --- Structural assertions: SKILL.md §10 wires the functions + byte-compare ---
+  local tick_md="$REPO_ROOT/.claude/skills/monitor-tick/SKILL.md"
+  if grep -q 'classify_path_binary_relevance' "$tick_md"; then
+    tap_ok "structural: monitor-tick/SKILL.md calls classify_path_binary_relevance"
+  else
+    tap_not_ok "structural: monitor-tick/SKILL.md calls classify_path_binary_relevance" "not found"
+  fi
+  if grep -q 'diff_is_test_only' "$tick_md"; then
+    tap_ok "structural: monitor-tick/SKILL.md calls diff_is_test_only"
+  else
+    tap_not_ok "structural: monitor-tick/SKILL.md calls diff_is_test_only" "not found"
+  fi
+  # The authoritative skip is gated on a release-binary byte-compare.
+  if grep -qiE 'byte-compare|byte-identical|cmp -s|byte compare' "$tick_md"; then
+    tap_ok "structural: monitor-tick/SKILL.md retains binary byte-compare confirmation"
+  else
+    tap_not_ok "structural: monitor-tick/SKILL.md retains binary byte-compare confirmation" "not found"
+  fi
+  if grep -q 'DEPLOY SYNCED (test-only' "$tick_md"; then
+    tap_ok "structural: monitor-tick/SKILL.md reports DEPLOY SYNCED (test-only…)"
+  else
+    tap_not_ok "structural: monitor-tick/SKILL.md reports DEPLOY SYNCED (test-only…)" "not found"
+  fi
+  # On a confirmed test-only skip, BUILD_SHA_FILE advances (fixes per-tick re-trip).
+  local syncsec
+  syncsec=$(extract_md_section "$tick_md" '^   On a confirmed test-only skip' '^[0-9]\. ' 2>/dev/null || true)
+  if grep -q 'BUILD_SHA_FILE' "$tick_md"; then
+    tap_ok "structural: monitor-tick/SKILL.md advances BUILD_SHA_FILE on confirmed skip"
+  else
+    tap_not_ok "structural: monitor-tick/SKILL.md advances BUILD_SHA_FILE on confirmed skip" "not found"
   fi
 }
 check_skill_structure


### PR DESCRIPTION
Closes #3215

## Summary

Adds a fail-safe **test-only carve-out** to the monitor-tick §10 deploy-gate binary-relevance check. A `deployed_sha..origin/main` diff confined to test-only code (`crates/*/tests/**` plus `#[cfg(test)]`/`mod tests` regions inside `crates/**/src/**.rs`) can skip the rebuild+restart — but only after an authoritative release-binary byte-compare confirms the binary is unchanged. ANY non-test or ambiguous change still forces a rebuild (fail-safe).

Two pure functions are added to `scripts/lib/monitor-decisions.sh` (appended after `eval_memory_guardrail` from #3227 — no collision):
- `classify_path_binary_relevance PATH` → `no-impact` | `test-only` | `needs-hunk-check` | `rebuild` (fail-safe default for `Cargo.toml`, `Cargo.lock`, `build.rs`, `configs/`, non-test `.rs`, etc.).
- `diff_is_test_only` (reads one file's unified diff on stdin) → 0 only if every changed line is strictly inside a `#[cfg(test)]`/`mod tests` region via brace-depth tracking; any ambiguity (zero-context hunk, whole-module deletion, boundary edit) → rebuild.

`monitor-tick/SKILL.md` §10 step 2 is wired to call these, and a new step 2a performs the **authoritative byte-compare**: the heuristic only marks a CANDIDATE; the skip fires only after building `henyey` at both the deployed SHA and origin/main in the same scratch target and confirming the binaries are byte-identical. A heuristic miss costs at most a wasted build, never a missed deploy. On a confirmed skip, `BUILD_SHA_FILE` advances (fixes the per-tick re-trip).

Edits stay strictly in §10 (deploy gate). Check-4/check-7/daily-summary (#3227) and the restart-trigger/remediation ladder (#3219) are untouched.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3215#issuecomment-4721855585)

## Test plan

- [x] `bash scripts/test-monitor-skill-snippets.sh` — 1..395, all pass (27 new TAP cases for #3215)
- [x] `bash scripts/test-shell-lib-cross-shell.sh` — 1..27, all pass (monitor-decisions.sh sourced under zsh)
- [x] `bash -n` clean on both `monitor-decisions.sh` and `test-monitor-skill-snippets.sh`
- [x] `cargo fmt --check` (no Rust changed); clippy green via pre-commit hook

## New coverage (kind: feature)

- **`classify_path_binary_relevance` table:** `.github/`/`.claude/`/`scripts/`/root `*.md`/`stellar-specs`→no-impact; `crates/*/tests/**`→test-only; `crates/**/src/**.rs`→needs-hunk-check; `Cargo.toml`/`Cargo.lock`/`build.rs`/`configs/`/benches/non-.rs→rebuild.
- **`diff_is_test_only` PASS:** all hunks inside `#[cfg(test)] mod tests` → 0.
- **`diff_is_test_only` fail-safe:** production hunk; mixed test+production; `#[cfg(test)]` opener edit; zero-context hunk; whole-module deletion → all rebuild.
- **End-to-end gate decision:** test-only changeset → `needs_rebuild=no` candidate; real-src changeset → `yes`; `Cargo.toml` sibling → `yes`.
- **Structural:** SKILL.md calls both functions, retains the byte-compare confirmation + `DEPLOY SYNCED (test-only…)` report + `BUILD_SHA_FILE` advance.
- **Pre-fix:** committed as `ea65fa4e65c9663a6334117dda1098f2b919b0b6` — 19 of the new cases FAILED on main (functions absent, SKILL unwired); fail-safe cases passed vacuously.
- **Post-fix:** all 395 pass after `a740d2cbbbf31cd21554c3841fb48ef4a1d9e531`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)