### PR TITLE
Add (3e) stuck-but-alive SYNC FAILURE auto-restart to monitor ladder

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -811,6 +811,73 @@ Board-route to Backlog: `bash .github/skills/shared/scripts/move-issue-status.sh
 Recurrence-after-fix → NEW issue, not a comment on a closed one. Known prior
 incidents: #1904, #1873, #1921, #1949.
 
+**(3e) Stuck-but-alive SYNC FAILURE auto-restart** — a node can be alive AND
+responsive (admin `/info` answers) yet make no ledger progress: a frozen local
+`lcl`, climbing RPC `age`, RPC `unhealthy`, and RSS under the OOM floor. This is
+the residual mode left after (3c) (owns the fatal-state-wipe case) and (3b)
+(owns the UNRESPONSIVE / frozen-event-loop case). (3e) is the **mirror of (3b)**:
+(3b) fires when the admin port is dead/timed-out; (3e) requires a *live,
+answering* port — mutually exclusive by construction. It is a band-aid for root
+cause #3218 (overlay SCP broadcast backpressure); the escalate-on-streak guard
+surfaces a restart loop as `urgent` rather than silently masking the defect.
+
+Evaluate (3e) **strictly last** in the alive-process path — order is
+(3c) soft-fail-wipe → (3b) wedge → **(3e) stuck-alive-sync** — so it only catches
+the residual responsive-but-frozen state. The decision is made by the pure
+function `classify_stuck_alive_sync` (`scripts/lib/monitor-decisions.sh`, already
+sourced), which is the **sole reader/writer** of the per-session streak state
+file; the caller passes only the live `lcl` and the file path.
+
+```bash
+# Skip unless the process is alive AND this is NOT the wedge case (3b owns
+# unresponsive). PROC_RESPONSIVE: admin /info answered non-empty within timeout.
+[ -z "$PID" ] && : # skip — dead-process path (3a/3d) handles this
+INFO_BODY=$(curl -s -m 3 "http://localhost:$MONITOR_ADMIN_PORT/info" 2>/dev/null)
+PROC_RESPONSIVE=$([ -n "$INFO_BODY" ] && echo yes || echo no)
+# NODE_STATE: the /info `state` field — "Synced!" (healthy/validating),
+# "Catching up", "Booting", "Stopping" (crates/app/.../handlers/info.rs).
+NODE_STATE=$(printf '%s' "$INFO_BODY" | grep -oP '"state"\s*:\s*"\K[^"]+' | head -1)
+# CURRENT_LCL: local last-closed-ledger number (from /info `ledger.num`).
+CURRENT_LCL=$(printf '%s' "$INFO_BODY" | grep -oP '"num"\s*:\s*\K[0-9]+' | head -1)
+# AGE_SEC: RPC getHealth wall-clock `age` (the check-(2) staleness signal).
+# RPC_STATUS: "healthy" | "unhealthy" from validator-mode getHealth.
+# RSS_MB: the RSS measured in check (4) (reused; OOM gate owns RSS-over-floor).
+STUCK_STATE_FILE="/home/tomer/data/$MONITOR_SESSION_ID/metrics/stuck_restart_state"
+mkdir -p "$(dirname "$STUCK_STATE_FILE")"
+classify_stuck_alive_sync "$NODE_STATE" "$CURRENT_LCL" "$AGE_SEC" "$RPC_STATUS" \
+  "$RSS_MB" "$PROC_RESPONSIVE" "$STUCK_STATE_FILE"
+```
+
+`classify_stuck_alive_sync` sets `STUCK_ALIVE_SYNC`. It is `yes` only when ALL
+six hold: state matches `valid|synced|track` (case-insensitive substring; never
+`Catching up`/`Booting`); `PROC_RESPONSIVE=yes`; `RPC_STATUS=unhealthy`;
+`AGE_SEC > 600`; frozen-lcl wall-clock dwell `>= 600s` (cadence-independent,
+mirroring check (2)'s `<ledger>|<ts>` STUCK idiom — fires at ~10 min of freeze
+regardless of tick spacing); and `RSS_MB < 16384`. Thresholds are named
+constants at the top of the function for operator retuning. Guards: a **900s
+cooldown** (`NOW - last_restart < 900` → `cooldown`, no restart this tick) and a
+**max-3-restarts / 2h** guard (`>= 3` restarts in a 7200s rolling window →
+`escalate`, no restart).
+
+- On `STUCK_ALIVE_SYNC=yes`: **Stop-PID**, **Rotate-log** with suffix `stuck`,
+  then **Relaunch** (verbatim reuse of the Common-procedures machinery). The
+  `stuck` suffix is already a recognized rotation type (Crash-recovery signal 1
+  and check (5) retention), so the next tick sees `CRASH_RECOVERY=yes` and
+  extends the sync deadline to 60m — it will not false-fire SYNC FAILURE during
+  the legitimate replay that follows the restart.
+- On `STUCK_ALIVE_SYNC=escalate`: do **NOT** restart. File a single
+  `urgent`-labeled issue (reusing the (3b)-wedge filing idiom) noting the
+  restart streak and pointing at the unfixed root cause #3218 (overlay SCP
+  broadcast backpressure / near-tip-stall recovery); if #3218 is closed,
+  escalate to the operator. A restart loop is itself the signal that the root
+  cause is unaddressed.
+- On `STUCK_ALIVE_SYNC=cooldown` or `no`: report-only, no action this tick.
+
+This trigger fires ONLY on the genuine stuck-but-alive signature and never
+during legitimate transient sync/catch-up — a false restart on a consensus
+validator is harmful. The 600s frozen-lcl dwell + six-way AND-gate + 900s
+cooldown + max-3/2h guard enforce that conservatism.
+
 **(4) Memory** — `ps -o rss= -p $(_find_session_process "$HOME/data" "/proc" "$MONITOR_SESSION_ID")`, convert to MB.
 
 The guardrail is **host-RAM-relative** (not absolute GB) so the same skill gives

--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -897,3 +897,170 @@ diff_is_test_only() {
     }
   '
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# classify_stuck_alive_sync NODE_STATE CURRENT_LCL AGE_SEC RPC_STATUS RSS_MB \
+#                           PROC_RESPONSIVE STATE_FILE [NOW_EPOCH]
+#
+# Pure decision function for the monitor-tick remediation rung (3e):
+# "stuck-but-alive SYNC FAILURE" auto-restart (issue #3219).
+#
+# Detects a node that is ALIVE and RESPONSIVE (admin /info answers) but is NOT
+# making ledger progress: a frozen local `lcl`, climbing RPC `age`, RPC
+# `unhealthy`, and RSS UNDER the OOM floor. This is the residual failure mode
+# left over after (3c) soft-fail-wipe (owns the fatal-state-wipe case) and (3b)
+# wedge (owns the UNRESPONSIVE / frozen-event-loop case). (3e) is the MIRROR of
+# (3b): (3b) fires when the admin port is dead/timed-out; (3e) requires a live,
+# answering port (PROC_RESPONSIVE=yes). The two are mutually exclusive by
+# construction, so (3e) can never poach the wedge path.
+#
+# Band-aid for root cause #3218 (overlay SCP broadcast backpressure). The
+# max-restarts→escalate guard ensures a restart loop surfaces as `urgent`
+# rather than silently masking the unfixed defect.
+#
+# Mirrors detect_soft_fail_blocked's injectable-time design: NOW_EPOCH is the
+# optional last positional arg (defaults to wall clock) so all dwell/cooldown/
+# window arithmetic is deterministically testable.
+#
+# SOLE READER/WRITER of STATE_FILE — the caller supplies only the live
+# CURRENT_LCL value and the file path; this function owns all reads/writes of
+# `frozen_lcl`, `frozen_since_epoch`, `last_restart_epoch`, and `restart_epochs`.
+# On each call: if CURRENT_LCL != frozen_lcl, the lcl advanced (NOT stuck) → reset
+# frozen_lcl=CURRENT_LCL and frozen_since_epoch=NOW; else frozen_since_epoch
+# accumulates. frozen_lcl_seconds = NOW - frozen_since_epoch.
+#
+# Thresholds (named constants — operators may retune):
+#   STUCK_AGE_SEC=600       RPC wall-clock `age` floor (check (2)'s 30s is a
+#                           report-only flag; a restart must be far more
+#                           conservative). AGE + frozen-lcl are an intentionally
+#                           conservative AND (correlation only reduces false-fire).
+#   STUCK_DWELL_SEC=600     frozen-lcl wall-clock dwell (cadence-independent;
+#                           mirrors check (2)'s "<ledger>|<ts>" STUCK idiom).
+#   OOM_FLOOR_MB=16384      RSS ceiling; the OOM gate (check (4)) owns over-floor.
+#   STUCK_COOLDOWN_SEC=900  min seconds between stuck-restarts.
+#   STUCK_WINDOW_SEC=7200   rolling window (2h) for the max-restarts guard.
+#   MAX_STUCK_RESTARTS=3    max stuck-restarts within the window before escalate.
+#
+# State-set match: case-insensitive substring `valid` | `synced` | `track`.
+# Verified against the real /info `state` enum
+# (crates/app/src/compat_http/handlers/info.rs): healthy/validating →
+# "Synced!" (matches `synced`), catch-up → "Catching up" (no match → never
+# fires), boot → "Booting", stop → "Stopping". The extra `valid`/`track`
+# substrings are defensive against future enum drift.
+#
+# Sets global STUCK_ALIVE_SYNC ∈ "yes" | "no" | "cooldown" | "escalate":
+#   yes       — all six AND-gate conditions hold and neither guard tripped;
+#               appends NOW to restart_epochs and sets last_restart_epoch=NOW.
+#   cooldown  — conditions hold but NOW - last_restart_epoch < STUCK_COOLDOWN_SEC.
+#   escalate  — conditions hold but >= MAX_STUCK_RESTARTS within STUCK_WINDOW_SEC.
+#   no        — any AND-gate condition fails.
+# Returns: 0 always. Does NO process I/O (no kill/relaunch) — the (3e) rung does that.
+# ─────────────────────────────────────────────────────────────────────────────
+classify_stuck_alive_sync() {
+  local node_state="$1"
+  local current_lcl="$2"
+  local age_sec="$3"
+  local rpc_status="$4"
+  local rss_mb="$5"
+  local proc_responsive="$6"
+  local state_file="$7"
+  local now_epoch="${8:-$(date +%s)}"
+
+  # Named thresholds (operator-retunable).
+  local STUCK_AGE_SEC=600
+  local STUCK_DWELL_SEC=600
+  local OOM_FLOOR_MB=16384
+  local STUCK_COOLDOWN_SEC=900
+  local STUCK_WINDOW_SEC=7200
+  local MAX_STUCK_RESTARTS=3
+
+  STUCK_ALIVE_SYNC="no"
+
+  # ── Read prior state (this function is the sole reader/writer). ─────────────
+  local frozen_lcl="" frozen_since_epoch="" last_restart_epoch="0" restart_epochs=""
+  if [[ -f "$state_file" ]]; then
+    local line key val
+    while IFS='=' read -r key val; do
+      case "$key" in
+        frozen_lcl)          frozen_lcl="$val" ;;
+        frozen_since_epoch)  frozen_since_epoch="$val" ;;
+        last_restart_epoch)  last_restart_epoch="$val" ;;
+        restart_epochs)      restart_epochs="$val" ;;
+      esac
+    done < "$state_file"
+  fi
+  [[ -z "$last_restart_epoch" ]] && last_restart_epoch="0"
+
+  # ── Frozen-lcl bookkeeping: reset on advance, else accumulate. ──────────────
+  if [[ "$current_lcl" != "$frozen_lcl" ]]; then
+    frozen_lcl="$current_lcl"
+    frozen_since_epoch="$now_epoch"
+  fi
+  # Defensive: if the state file was missing/corrupt, anchor frozen_since to now.
+  [[ -z "$frozen_since_epoch" ]] && frozen_since_epoch="$now_epoch"
+
+  local frozen_lcl_seconds=$(( now_epoch - frozen_since_epoch ))
+  [[ "$frozen_lcl_seconds" -lt 0 ]] && frozen_lcl_seconds=0
+
+  # Prune restart_epochs to the rolling window (drop entries older than the window).
+  local pruned="" e
+  for e in $restart_epochs; do
+    [[ "$e" =~ ^[0-9]+$ ]] || continue
+    if [[ $(( now_epoch - e )) -lt "$STUCK_WINDOW_SEC" ]]; then
+      pruned="${pruned:+$pruned }$e"
+    fi
+  done
+  restart_epochs="$pruned"
+
+  # ── Persist the (possibly reset/pruned) state before any early return. ──────
+  _write_stuck_state() {
+    printf 'frozen_lcl=%s\nfrozen_since_epoch=%s\nlast_restart_epoch=%s\nrestart_epochs=%s\n' \
+      "$frozen_lcl" "$frozen_since_epoch" "$last_restart_epoch" "$restart_epochs" \
+      > "$state_file" 2>/dev/null || true
+  }
+
+  # ── Six-way AND-gate. Any miss → "no" (state persisted, no restart). ────────
+  # 1. Healthy/validating state (case-insensitive substring valid|synced|track).
+  local lc_state
+  lc_state=$(printf '%s' "$node_state" | tr '[:upper:]' '[:lower:]')
+  case "$lc_state" in
+    *valid*|*synced*|*track*) : ;;   # match — continue
+    *) _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0 ;;
+  esac
+  # 2. Process responsive (mirror of (3b) wedge).
+  [[ "$proc_responsive" == "yes" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
+  # 3. RPC unhealthy.
+  [[ "$rpc_status" == "unhealthy" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
+  # 4. age over threshold.
+  [[ "$age_sec" -gt "$STUCK_AGE_SEC" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
+  # 5. frozen-lcl dwell met.
+  [[ "$frozen_lcl_seconds" -ge "$STUCK_DWELL_SEC" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
+  # 6. RSS under OOM floor.
+  [[ "$rss_mb" -lt "$OOM_FLOOR_MB" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
+
+  # ── Guards (conditions 1–6 hold). ───────────────────────────────────────────
+  # Cooldown: too soon after the last stuck-restart.
+  if [[ "$last_restart_epoch" -gt 0 ]] \
+     && [[ $(( now_epoch - last_restart_epoch )) -lt "$STUCK_COOLDOWN_SEC" ]]; then
+    _write_stuck_state
+    STUCK_ALIVE_SYNC="cooldown"
+    return 0
+  fi
+  # Max-restarts: a restart loop signals #3218 is unfixed → escalate, no restart.
+  local restart_count=0
+  for e in $restart_epochs; do
+    restart_count=$(( restart_count + 1 ))
+  done
+  if [[ "$restart_count" -ge "$MAX_STUCK_RESTARTS" ]]; then
+    _write_stuck_state
+    STUCK_ALIVE_SYNC="escalate"
+    return 0
+  fi
+
+  # ── Fire: record this restart and return yes. ──────────────────────────────
+  restart_epochs="${restart_epochs:+$restart_epochs }$now_epoch"
+  last_restart_epoch="$now_epoch"
+  _write_stuck_state
+  STUCK_ALIVE_SYNC="yes"
+  return 0
+}

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=395
+TAP_PLAN=406
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -1874,6 +1874,159 @@ PYEOF
   else
     tap_not_ok "consistency: SKILL.md references detect_soft_fail_blocked and has_fatal_wipe_evidence" \
       "One or both functions not referenced in monitor-tick/SKILL.md"
+  fi
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # classify_stuck_alive_sync tests (T63a–T63k)
+  # Source: scripts/lib/monitor-decisions.sh — (3e) stuck-but-alive SYNC FAILURE
+  # auto-restart trigger (issue #3219).
+  #
+  # Contract: classify_stuck_alive_sync NODE_STATE CURRENT_LCL AGE_SEC RPC_STATUS \
+  #             RSS_MB PROC_RESPONSIVE STATE_FILE [NOW_EPOCH]
+  # Sets STUCK_ALIVE_SYNC ∈ yes|no|cooldown|escalate. The function is the sole
+  # reader/writer of STATE_FILE. NOW_EPOCH is injectable for deterministic tests.
+  # ════════════════════════════════════════════════════════════════════════════
+
+  local NOW_SA=1700000000             # fixed reference for stuck-alive tests
+  local sa_dir="$TEST_ROOT/stuck-alive"
+  mkdir -p "$sa_dir"
+
+  # Helper: seed a state file with a frozen lcl that has been frozen for N seconds
+  # (so frozen_lcl_seconds = N at NOW_SA). Optional last_restart_epoch / restart_epochs.
+  _sa_seed() {
+    # $1=file $2=frozen_lcl $3=frozen_for_sec $4=last_restart_epoch $5=restart_epochs(space-sep)
+    local f="$1" lcl="$2" frozen_for="$3" last_restart="${4:-0}" epochs="${5:-}"
+    printf 'frozen_lcl=%s\nfrozen_since_epoch=%s\nlast_restart_epoch=%s\nrestart_epochs=%s\n' \
+      "$lcl" "$((NOW_SA - frozen_for))" "$last_restart" "$epochs" > "$f"
+  }
+
+  # ── Test 63a: full reproduced signature → yes ──────────────────────────────
+  # Synced! + lcl frozen 700s + age 700 + unhealthy + RSS 10240 + responsive.
+  local sa_a="$sa_dir/a.state"
+  _sa_seed "$sa_a" 55000000 700
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "yes" "$sa_a" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "yes" ]]; then
+    tap_ok "stuck-alive: full signature (frozen 700s + age 700 + unhealthy + RSS 10240 + responsive) → yes"
+  else
+    tap_not_ok "stuck-alive: full signature → yes" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63b: transient sync (Catching up) → no ────────────────────────────
+  local sa_b="$sa_dir/b.state"
+  _sa_seed "$sa_b" 55000000 700
+  classify_stuck_alive_sync "Catching up" 55000000 700 "unhealthy" 10240 "yes" "$sa_b" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: transient sync (Catching up) → no"
+  else
+    tap_not_ok "stuck-alive: transient sync (Catching up) → no" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63c: 3b wedge (PROC_RESPONSIVE=no) → no ───────────────────────────
+  # The wedge path (3b) owns the unresponsive case; (3e) must NOT poach it.
+  local sa_c="$sa_dir/c.state"
+  _sa_seed "$sa_c" 55000000 700
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "no" "$sa_c" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: 3b wedge (PROC_RESPONSIVE=no) → no (mirror of wedge path)"
+  else
+    tap_not_ok "stuck-alive: 3b wedge (PROC_RESPONSIVE=no) → no" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63d: healthy validating (RPC healthy, age 4s) → no ────────────────
+  local sa_d="$sa_dir/d.state"
+  _sa_seed "$sa_d" 55000000 4
+  classify_stuck_alive_sync "Synced!" 55000000 4 "healthy" 10240 "yes" "$sa_d" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: healthy validating (RPC healthy, age 4s) → no"
+  else
+    tap_not_ok "stuck-alive: healthy validating → no" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63e: RSS over OOM floor (17000 > 16384) → no ──────────────────────
+  # The OOM gate (check 4) owns RSS-over-floor restarts.
+  local sa_e="$sa_dir/e.state"
+  _sa_seed "$sa_e" 55000000 700
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 17000 "yes" "$sa_e" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: RSS over OOM floor (17000) → no (OOM gate owns this)"
+  else
+    tap_not_ok "stuck-alive: RSS over OOM floor → no" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63f: dwell not met (frozen_lcl_seconds=300 < 600) → no ────────────
+  local sa_f="$sa_dir/f.state"
+  _sa_seed "$sa_f" 55000000 300
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "yes" "$sa_f" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: dwell not met (frozen_lcl_seconds=300 < 600) → no"
+  else
+    tap_not_ok "stuck-alive: dwell not met → no" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63g: frozen counter resets when lcl advances → no (state hygiene) ──
+  # State file says frozen at 55000000 for 700s, but CURRENT_LCL is 55000010
+  # (advanced) → the function must reset frozen_since to NOW and NOT fire.
+  local sa_g="$sa_dir/g.state"
+  _sa_seed "$sa_g" 55000000 700
+  classify_stuck_alive_sync "Synced!" 55000010 700 "unhealthy" 10240 "yes" "$sa_g" "$NOW_SA"
+  local g_result="$STUCK_ALIVE_SYNC"
+  # Verify the state file was rewritten with the new lcl and a fresh frozen_since.
+  local g_frozen_lcl g_frozen_since
+  g_frozen_lcl=$(grep '^frozen_lcl=' "$sa_g" | cut -d= -f2)
+  g_frozen_since=$(grep '^frozen_since_epoch=' "$sa_g" | cut -d= -f2)
+  if [[ "$g_result" == "no" && "$g_frozen_lcl" == "55000010" && "$g_frozen_since" == "$NOW_SA" ]]; then
+    tap_ok "stuck-alive: frozen counter resets when lcl advances → no (state hygiene)"
+  else
+    tap_not_ok "stuck-alive: frozen counter resets when lcl advances → no" \
+      "result=$g_result frozen_lcl=$g_frozen_lcl frozen_since=$g_frozen_since (want no/55000010/$NOW_SA)"
+  fi
+
+  # ── Test 63h: cooldown active (last_restart 300s ago < 900s) → cooldown ─────
+  local sa_h="$sa_dir/h.state"
+  _sa_seed "$sa_h" 55000000 700 "$((NOW_SA - 300))"
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "yes" "$sa_h" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "cooldown" ]]; then
+    tap_ok "stuck-alive: cooldown active (last_restart 300s ago) → cooldown (no restart)"
+  else
+    tap_not_ok "stuck-alive: cooldown active → cooldown" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63i: max-restarts exceeded (3 in 2h window) → escalate ────────────
+  # 3 restart epochs within the 7200s window, last one > cooldown ago.
+  local sa_i="$sa_dir/i.state"
+  local r1=$((NOW_SA - 6000)) r2=$((NOW_SA - 4000)) r3=$((NOW_SA - 2000))
+  _sa_seed "$sa_i" 55000000 700 "$r3" "$r1 $r2 $r3"
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "yes" "$sa_i" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "escalate" ]]; then
+    tap_ok "stuck-alive: max-restarts exceeded (3 in 2h window) → escalate (no restart, urgent)"
+  else
+    tap_not_ok "stuck-alive: max-restarts exceeded → escalate" "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63j: case-insensitive state match (Validating!/Tracking) → yes ────
+  # Enum-drift robustness: if the /info enum ever emits these, the substring
+  # gate (valid|synced|track) still fires when all other signals hold.
+  local sa_j="$sa_dir/j.state"
+  _sa_seed "$sa_j" 55000000 700
+  classify_stuck_alive_sync "Validating!" 55000000 700 "unhealthy" 10240 "yes" "$sa_j" "$NOW_SA"
+  local j1="$STUCK_ALIVE_SYNC"
+  local sa_j2="$sa_dir/j2.state"
+  _sa_seed "$sa_j2" 55000000 700
+  classify_stuck_alive_sync "Tracking" 55000000 700 "unhealthy" 10240 "yes" "$sa_j2" "$NOW_SA"
+  local j2="$STUCK_ALIVE_SYNC"
+  if [[ "$j1" == "yes" && "$j2" == "yes" ]]; then
+    tap_ok "stuck-alive: case-insensitive state match (Validating!/Tracking) → yes (enum-drift robust)"
+  else
+    tap_not_ok "stuck-alive: case-insensitive state match → yes" "Validating!=$j1 Tracking=$j2"
+  fi
+
+  # ── Test 63k: consistency — SKILL.md references classify_stuck_alive_sync ───
+  local tick_file_sa="$REPO_ROOT/.claude/skills/monitor-tick/SKILL.md"
+  if grep -q 'classify_stuck_alive_sync' "$tick_file_sa"; then
+    tap_ok "consistency: monitor-tick/SKILL.md references classify_stuck_alive_sync"
+  else
+    tap_not_ok "consistency: monitor-tick/SKILL.md references classify_stuck_alive_sync" \
+      "(3e) rung not wired in monitor-tick/SKILL.md"
   fi
 
   # ── Test 64: Tick history capture uses quoted heredoc + datetime.now ────────


### PR DESCRIPTION
Closes #3219

## Summary

Adds a new remediation rung **(3e) stuck-but-alive SYNC FAILURE auto-restart** to the monitor-tick ladder, driven by a pure, unit-tested `classify_stuck_alive_sync` appended to `scripts/lib/monitor-decisions.sh`. It auto-restarts a node that is alive and *responsive* (admin `/info` answers) but stuck — frozen local `lcl`, climbing RPC `age`, RPC `unhealthy`, and RSS under the OOM floor — the residual failure mode left after (3c) soft-fail-wipe and (3b) wedge. It is a band-aid for root cause #3218 (overlay SCP broadcast backpressure); the escalate-on-streak guard surfaces a restart loop as `urgent` rather than masking the unfixed defect.

`STUCK_ALIVE_SYNC=yes` fires only when ALL six hold: state matches `valid|synced|track` (case-insensitive substring — verified against the real `/info` enum in `crates/app/src/compat_http/handlers/info.rs` where both healthy states serialize to `"Synced!"`, and `"Catching up"`/`"Booting"` never match); `PROC_RESPONSIVE=yes` (the mirror of the (3b) wedge — mutually exclusive); RPC `unhealthy`; `age > 600s`; **frozen-lcl wall-clock dwell `>= 600s`** (cadence-independent, mirrors check (2)'s `<ledger>|<ts>` STUCK idiom); and `RSS < 16384 MB`. Plus a **900s cooldown** (→`cooldown`) and a **max-3-restarts/2h** guard (→`escalate`, file an urgent issue pointing at #3218). The function is the sole reader/writer of the per-session streak state file; `NOW_EPOCH` is injectable for deterministic tests. On `yes`, the rung reuses the existing Stop-PID / Rotate-log(`stuck`) / Relaunch machinery.

Strictly localized to the remediation-ladder region — **no edits to §10, check (4), or check (7)** — and append-only to the two shared files.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3219#issuecomment-4722481345)

## Test plan

- [x] `bash -n scripts/lib/monitor-decisions.sh` — clean
- [x] `bash -n scripts/test-monitor-skill-snippets.sh` — clean
- [x] `bash scripts/test-monitor-skill-snippets.sh` — all 406 pass (was 395; +11 new cases)

## New coverage (kind: feature)

11 new TAP cases in `scripts/test-monitor-skill-snippets.sh` (T63a–T63k):
- **Pre-implementation:** committed as `01d92fcc` — verified FAILED (harness aborted at `classify_stuck_alive_sync: command not found`, exit 127, function absent).
- **Post-implementation:** verified PASS after `ea0d138c` — all 406 cases green.
- Covers: full reproduced signature → `yes`; transient sync (`Catching up`) → `no`; (3b) wedge (`PROC_RESPONSIVE=no`) → `no`; healthy validating → `no`; RSS over OOM floor → `no`; dwell not met → `no`; frozen counter resets on lcl advance → `no` (state hygiene); cooldown → `cooldown`; max-restarts → `escalate`; case-insensitive state match (`Validating!`/`Tracking`) → `yes`; and the SKILL.md consistency assertion.

## Deviations from plan

None. `/info` `state` enum verified per the plan's explicit requirement: healthy/validating serialize to `"Synced!"` (matched by the `synced` substring), `"Catching up"`/`"Booting"`/`"Stopping"` never match — the gate is correct against the live enum. #3218 is referenced as the escalate target per the converged plan (the original issue noted it may be closed; the rung text also falls back to escalating to the operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)