### PR TITLE
Add first mixed-image Supercluster mission deliverable (#3292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,3 +171,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run project-loop skill snippet harness
         run: bash scripts/test-project-loop-skill-snippets.sh
+
+  ssc-mission-3292-scripts:
+    name: SSC Mission 3292 Scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run SSC mission #3292 script harness (dry-run + self-check)
+        run: bash scripts/ssc/test-mission-3292-scripts.sh

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -2224,45 +2224,66 @@ mod tests {
             Some("SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2")
         );
 
-        // --- Quorum set: exactly 4 DISTINCT keys (henyey + 3 stellar-core) ---
-        // henyey's own key is derived from NODE_SEED, and it is ALSO listed in
-        // [[VALIDATORS]] by PUBLIC_KEY. Assert no `$self`-resolution error and
-        // no double-counting: the set is exactly 4 distinct keys (the inverse
-        // of `test_quorum_set_self_without_node_seed_fails`).
+        // --- Quorum: the listed [[VALIDATORS]] are exactly the 3 stellar-core
+        // peers; henyey's own key is added automatically (NOT listed in its own
+        // [[VALIDATORS]], mirroring stellar-core's addSelfToValidators which
+        // never dedups, Config.cpp:869-898). So the auto-generated quorum-set
+        // key list holds the 3 distinct core keys...
         let henyey_self_key = henyey_crypto::SecretKey::from_strkey(
             "SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2",
         )
         .unwrap()
         .public_key()
         .to_strkey();
-        let validators = &config.node.quorum_set.validators;
-        assert_eq!(
-            validators.len(),
-            4,
-            "expected exactly 4 quorum validators (henyey + 3 core), got {}: {:?}",
-            validators.len(),
-            validators
-        );
-        let distinct: std::collections::HashSet<&String> = validators.iter().collect();
-        assert_eq!(
-            distinct.len(),
-            4,
-            "quorum validators must be 4 DISTINCT keys (no double-counting of self)"
-        );
-        // henyey's own derived key is present in the quorum.
-        assert!(
-            validators.contains(&henyey_self_key),
-            "quorum must contain henyey's own derived key {henyey_self_key}"
-        );
-        // The 3 stellar-core validator keys are present.
-        for core_key in [
+        let core_keys = [
             "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y",
             "GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP",
             "GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z",
-        ] {
+        ];
+        let validators = &config.node.quorum_set.validators;
+        assert_eq!(
+            validators.len(),
+            3,
+            "expected the 3 listed stellar-core validators, got {}: {:?}",
+            validators.len(),
+            validators
+        );
+        for core_key in core_keys {
             assert!(
                 validators.contains(&core_key.to_string()),
                 "quorum must contain stellar-core key {core_key}"
+            );
+        }
+        // henyey does NOT list itself in [[VALIDATORS]] (no duplicate self).
+        assert!(
+            !validators.contains(&henyey_self_key),
+            "henyey must not list its own key in [[VALIDATORS]] (self is auto-added)"
+        );
+
+        // ...and the FULL 4-node quorum (3 core + auto-added self) materializes
+        // in the ValidatorWeightConfig, with exactly 4 DISTINCT node ids and no
+        // self double-counting (the inverse of
+        // `test_quorum_set_self_without_node_seed_fails`).
+        let vwc = config
+            .validator_weight_config
+            .as_ref()
+            .expect("mission validator config must build a ValidatorWeightConfig");
+        assert_eq!(
+            vwc.validator_entries.len(),
+            4,
+            "weight config must hold 4 distinct validators (3 core + self), got {}",
+            vwc.validator_entries.len()
+        );
+        let self_node_id = parse_node_id(&henyey_self_key).unwrap();
+        assert!(
+            vwc.validator_entries.contains_key(&self_node_id),
+            "weight config must contain henyey's auto-added self entry"
+        );
+        for core_key in core_keys {
+            let nid = parse_node_id(core_key).unwrap();
+            assert!(
+                vwc.validator_entries.contains_key(&nid),
+                "weight config must contain stellar-core key {core_key}"
             );
         }
 

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -2183,6 +2183,119 @@ mod tests {
         assert!(config.is_compat_config);
     }
 
+    /// AC#2 of the first mixed-image Supercluster (SSC) mission (#3292): the
+    /// mission-shaped, mixed-cluster `stellar-core.cfg` that SSC renders for a
+    /// **henyey validator** node in a 4-node (1 henyey + 3 stellar-core)
+    /// cluster must be accepted by henyey *without manual patching*.
+    ///
+    /// This is distinct from `test_ssc_generated_config_full_parse`, which
+    /// covers a testnet *watcher* shape (`NODE_IS_VALIDATOR=false`, real
+    /// testnet peers, history archives). Here the node is a VALIDATOR
+    /// participating as a minority in a stellar-core-majority quorum, with
+    /// in-cluster pod hostnames, accelerated close time, and NO history.
+    ///
+    /// The test drives the exact `is_stellar_core_format` +
+    /// `translate_stellar_core_config` entry the binary's `load_config` path
+    /// uses (main.rs), so it exercises real parsing, not a stub. It fails if
+    /// the mission fixture is not parseable (the durable, CI-enforced
+    /// regression artifact the triage report required).
+    #[test]
+    fn test_ssc_mission_mixed_config_parse() {
+        let fixture = include_str!("compat_http/test_fixtures/ssc_mission_mixed.cfg");
+        let raw: toml::Value = toml::from_str(fixture).unwrap();
+
+        // Detected as stellar-core format (the binary's branch in load_config).
+        assert!(
+            is_stellar_core_format(&raw),
+            "mission mixed-cluster config must be detected as stellar-core format"
+        );
+
+        // Translates without error — i.e. accepted WITHOUT manual patching (AC#2).
+        let config = translate_stellar_core_config(&raw).unwrap();
+
+        // --- Node is a VALIDATOR (the henyey node participates in consensus) ---
+        assert!(
+            config.node.is_validator,
+            "mission node must be a validator (NODE_IS_VALIDATOR=true)"
+        );
+        // NODE_SEED is the henyey node's own seed (the strkey before " self").
+        assert_eq!(
+            config.node.node_seed.as_deref(),
+            Some("SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2")
+        );
+
+        // --- Quorum set: exactly 4 DISTINCT keys (henyey + 3 stellar-core) ---
+        // henyey's own key is derived from NODE_SEED, and it is ALSO listed in
+        // [[VALIDATORS]] by PUBLIC_KEY. Assert no `$self`-resolution error and
+        // no double-counting: the set is exactly 4 distinct keys (the inverse
+        // of `test_quorum_set_self_without_node_seed_fails`).
+        let henyey_self_key = henyey_crypto::SecretKey::from_strkey(
+            "SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2",
+        )
+        .unwrap()
+        .public_key()
+        .to_strkey();
+        let validators = &config.node.quorum_set.validators;
+        assert_eq!(
+            validators.len(),
+            4,
+            "expected exactly 4 quorum validators (henyey + 3 core), got {}: {:?}",
+            validators.len(),
+            validators
+        );
+        let distinct: std::collections::HashSet<&String> = validators.iter().collect();
+        assert_eq!(
+            distinct.len(),
+            4,
+            "quorum validators must be 4 DISTINCT keys (no double-counting of self)"
+        );
+        // henyey's own derived key is present in the quorum.
+        assert!(
+            validators.contains(&henyey_self_key),
+            "quorum must contain henyey's own derived key {henyey_self_key}"
+        );
+        // The 3 stellar-core validator keys are present.
+        for core_key in [
+            "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y",
+            "GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP",
+            "GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z",
+        ] {
+            assert!(
+                validators.contains(&core_key.to_string()),
+                "quorum must contain stellar-core key {core_key}"
+            );
+        }
+
+        // --- Accelerated close time on (SSC integration missions) ---
+        assert!(
+            config.testing.accelerate_time,
+            "ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING must be true"
+        );
+
+        // --- In-cluster known peers (pod hostnames, NOT real testnet peers) ---
+        // The henyey ADDRESS and the 3 core ADDRESSes are in-cluster pod DNS.
+        assert!(
+            !config.overlay.known_peers.is_empty(),
+            "mission config must yield in-cluster known peers"
+        );
+        for peer in &config.overlay.known_peers {
+            assert!(
+                peer.host.contains("ssc-mission-3292") || peer.host.ends_with(".svc.cluster.local"),
+                "known peer must be an in-cluster pod hostname, got {peer:?}"
+            );
+        }
+
+        // --- NO history archives (first mission excludes history) ---
+        assert!(
+            config.history.archives.is_empty(),
+            "first mission has no history archives, got {}",
+            config.history.archives.len()
+        );
+
+        // Compat flag set.
+        assert!(config.is_compat_config);
+    }
+
     /// Verify that the existing captive-core-testnet.cfg also parses correctly.
     #[test]
     fn test_captive_core_testnet_cfg_parse() {

--- a/crates/app/src/compat_http/test_fixtures/ssc_mission_mixed.cfg
+++ b/crates/app/src/compat_http/test_fixtures/ssc_mission_mixed.cfg
@@ -1,0 +1,89 @@
+# Supercluster (SSC) mission-shaped MIXED-CLUSTER configuration fixture.
+#
+# This is the config SSC's Kubernetes mission controller renders for the
+# HENYEY VALIDATOR node in the first mixed-image interop mission (#3292):
+#   - 3 stellar-core validators + 1 henyey validator
+#   - stellar-core-majority quorum (henyey is a minority validator)
+#   - in-cluster pod hostnames (NOT real testnet peers)
+#   - accelerated close time, NO history / loadgen / survey
+#
+# It is DISTINCT from `ssc_generated_config.cfg`, which is a testnet *watcher*
+# shape (NODE_IS_VALIDATOR=false, real testnet peers, history archives).
+#
+# Field shapes are derived from stellar-core/src/main/Config.cpp so this is a
+# config a real stellar-core node in the SAME cluster would also accept:
+#   - [[HOME_DOMAINS]] uses QUALITY = "MEDIUM" so validators do NOT require a
+#     HISTORY archive (Config.cpp rejects HIGH/CRITICAL quality validators
+#     without an archive; MEDIUM/LOW do not). This keeps the first mission
+#     history-free while remaining stellar-core-valid.
+#   - UNSAFE_QUORUM = true is REQUIRED: Config.cpp:918-923 rejects a small
+#     quorum (4 nodes / threshold below the safety floor) unless this is set.
+#   - NODE_HOME_DOMAIN must be set and must match a [[HOME_DOMAINS]] entry for
+#     a validator node (Config.cpp:875-896).
+#
+# NOTE (AC#2 residual): this fixture is hand-authored from the documented
+# stellar-core/SSC config conventions. The offline parse test proves henyey's
+# translator accepts it; only the live mission RUN fully closes AC#2 by feeding
+# henyey the FIRST real SSC-emitted config. Validate this fixture against that
+# real config during the run — a structural skew should spawn a follow-up.
+
+NETWORK_PASSPHRASE = "Standalone Network ; February 2017"
+HTTP_PORT = 11626
+PEER_PORT = 11625
+PUBLIC_HTTP_PORT = true
+DATABASE = "sqlite3:///opt/stellar/stellar-core.db"
+BUCKET_DIR_PATH = "/opt/stellar/buckets"
+
+# This node (henyey) is a VALIDATOR. NODE_SEED ends in " self" per the
+# stellar-core convention; the strkey before " self" is the node's own seed,
+# from which henyey derives its own public key for the quorum set.
+NODE_SEED = "SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+NODE_IS_VALIDATOR = true
+NODE_HOME_DOMAIN = "ssc-mission-3292.local"
+
+# Small-quorum safety override (required by Config.cpp for a 4-node cluster).
+UNSAFE_QUORUM = true
+FAILURE_SAFETY = 1
+
+# Accelerated close time for the bounded integration mission.
+ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true
+
+# First mission excludes loadgen / survey.
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false
+
+# Keys SSC may emit that henyey silently ignores.
+RUN_STANDALONE = false
+DISABLE_XDR_FSYNC = true
+
+# Home domains. MEDIUM quality => no HISTORY archive required (history-free
+# mission). All four nodes share the one in-cluster home domain.
+[[HOME_DOMAINS]]
+HOME_DOMAIN = "ssc-mission-3292.local"
+QUALITY = "MEDIUM"
+
+# Validators: the 3 stellar-core peers. The local henyey node is NOT listed
+# here — stellar-core's addSelfToValidators (Config.cpp:869-898) appends the
+# local node's own key automatically from NODE_SEED + NODE_HOME_DOMAIN, so a
+# node never lists itself in its own [[VALIDATORS]] (doing so would be a
+# duplicate). henyey mirrors this exactly. The full 4-validator quorum is thus
+# the 3 entries below + the auto-added self.
+#
+# ADDRESS fields are in-cluster pod hostnames (SSC StatefulSet pod DNS), NOT
+# real testnet peers. No HISTORY (MEDIUM quality => archive not required).
+[[VALIDATORS]]
+NAME = "core-0"
+HOME_DOMAIN = "ssc-mission-3292.local"
+PUBLIC_KEY = "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS = "ssc-mission-3292-core-0.ssc-mission-3292.svc.cluster.local:11625"
+
+[[VALIDATORS]]
+NAME = "core-1"
+HOME_DOMAIN = "ssc-mission-3292.local"
+PUBLIC_KEY = "GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP"
+ADDRESS = "ssc-mission-3292-core-1.ssc-mission-3292.svc.cluster.local:11625"
+
+[[VALIDATORS]]
+NAME = "core-2"
+HOME_DOMAIN = "ssc-mission-3292.local"
+PUBLIC_KEY = "GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z"
+ADDRESS = "ssc-mission-3292-core-2.ssc-mission-3292.svc.cluster.local:11625"

--- a/docs/supercluster-mission-3292.md
+++ b/docs/supercluster-mission-3292.md
@@ -1,0 +1,122 @@
+# Supercluster Mission #3292 — First Mixed-Image Network
+
+**Issue:** [#3292](https://github.com/stellar-experimental/henyey/issues/3292)
+**Companion docs:** [`supercluster-nsc-workflow.md`](./supercluster-nsc-workflow.md) (#3304 — the verified `nsc` build/publish/launch surface), [`supercluster-feasibility.md`](./supercluster-feasibility.md).
+
+This runbook drives the **first mixed-image Supercluster (SSC) mission**: a small
+network of **3 stellar-core validators + 1 henyey validator**, with a
+**stellar-core-majority quorum**, that exercises the henyey↔stellar-core interop
+boundary end-to-end.
+
+## What this mission validates (acceptance criteria)
+
+| AC | Criterion | How it is checked |
+|----|-----------|-------------------|
+| AC#1 | henyey image launches under the `stellar-core` entrypoint | Dockerfile `henyey`→`stellar-core` symlink (already merged); the mission pods come up |
+| AC#2 | SSC-generated `stellar-core.cfg` accepted by henyey **without manual patching** | Offline regression test `test_ssc_mission_mixed_config_parse` over `crates/app/src/compat_http/test_fixtures/ssc_mission_mixed.cfg`; closed fully only by the live run (see residual below) |
+| AC#3 | henyey establishes **authenticated overlay** connections with stellar-core peers | `assert-mission-3292.sh` — `peer.peer.authenticated-count > 0` |
+| AC#4 | the mixed network **externalizes ledgers** over a window | `assert-mission-3292.sh` — henyey ledger seq advances |
+| AC#5 | henyey **agrees with stellar-core on latest ledger seq+hash** | `assert-mission-3292.sh` — `(ledger num, ledger hash)` match at a common seq |
+| AC#6 | henyey stays **`Synced!`** | `assert-mission-3292.sh` — `/info.state == "Synced!"` |
+| AC#7 | logs / config / image digest / exact invocation **captured** | run-dir layout + this runbook's artifact checklist |
+| AC#8 | any failure becomes a **concrete follow-up issue** | operator files a follow-up per the checklist |
+
+**Scope (first mission, deliberately minimal):** EXCLUDES history (#3295),
+survey (#3298), loadgen/MaxTPS (#3297), protocol upgrades (#3300), and topology
+admin (#3294). It needs none of the richer compat endpoints (#3296 real metric
+rate/percentile values) — AC#5/#6 read ledger seq/hash + the real
+`peer.peer.authenticated-count` counter, not rate/percentile values.
+
+## Topology / mixed-cluster config
+
+The henyey node runs as a **minority validator** in a stellar-core-majority
+quorum, so it predominantly *follows* externalized values — the EXTERNALIZE
+receipt path, which is at **Full** parity (`crates/herder/PARITY_STATUS.md`).
+Overlay auth/handshake is also **Full** (`crates/overlay/PARITY_STATUS.md`).
+
+The mission-shaped config is fixtured at
+`crates/app/src/compat_http/test_fixtures/ssc_mission_mixed.cfg`:
+
+- `NODE_IS_VALIDATOR = true`, `NODE_SEED = "… self"` — henyey is its own validator.
+- One shared `[[HOME_DOMAINS]]` at `QUALITY = "MEDIUM"` — MEDIUM/LOW quality
+  validators do **not** require a HISTORY archive (stellar-core
+  `Config.cpp:744–752`), so the mission is genuinely history-free *and*
+  stellar-core-acceptable.
+- `[[VALIDATORS]]` lists the **3 stellar-core peers only**. henyey does **not**
+  list itself — stellar-core's `addSelfToValidators` (`Config.cpp:869–898`)
+  appends the local node's key automatically (and never dedups), and henyey
+  mirrors this. The full 4-node quorum = 3 listed + auto-added self.
+- `UNSAFE_QUORUM = true` — **required**: `Config.cpp:918–923` rejects a small
+  4-node quorum otherwise.
+- `ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true` for a bounded run.
+- in-cluster pod DNS hostnames (`*.svc.cluster.local`), NOT real testnet peers.
+
+> **AC#2 residual (operator step):** the offline test proves henyey's *translator*
+> accepts a faithfully-authored mission config. It does **not** prove the binary's
+> full `load_config` path accepts the **first real SSC-emitted** config. During
+> the live run, diff the SSC-generated `stellar-core.cfg` against this fixture; a
+> structural skew (e.g. SSC renders a flat `KNOWN_PEERS` of pod IPs rather than
+> `[[VALIDATORS]].ADDRESS`) should spawn a **follow-up issue**, not a silent patch.
+
+## Autonomous deliverable vs. operator-executed run
+
+This is a **validation mission**: the deliverable is *fixtures + tooling +
+runbook + a follow-up-on-failure handoff*, not production code. The live
+multi-hour k8s mission **cannot run inside one autonomous task** — it needs an
+interactive `nsc login` (browser OAuth), a long-lived k8s cluster, and the
+external `stellar/supercluster` dotnet harness (not vendored here).
+
+**Shipped autonomously (in the PR):**
+
+- `crates/app/src/compat_http/test_fixtures/ssc_mission_mixed.cfg` — the durable, CI-enforced mission config fixture.
+- `crates/app/src/compat_config.rs::test_ssc_mission_mixed_config_parse` — the config-acceptance regression test (AC#2).
+- `scripts/ssc/launch-mission-3292.sh` — thin wrapper over #3304's verified `nsc` commands; `--dry-run` for CI.
+- `scripts/ssc/assert-mission-3292.sh` — encodes AC#3–#6 as a runnable check; `--self-check` for CI.
+- this runbook.
+
+**Operator-executed (NOT done in the PR):** the mission RUN itself — see the
+checklist below.
+
+## OPERATOR CHECKLIST — the live mission RUN
+
+> Everything below is **operator-executed** against live infra. The PR does NOT
+> run any of it and does NOT fabricate a mission transcript.
+
+1. **Auth** (one-time per session): `nsc login` (interactive browser OAuth), then
+   `scripts/ssc/launch-mission-3292.sh --dry-run` to review the commands.
+2. **Build + push + provision (nsc side):** run `scripts/ssc/launch-mission-3292.sh`
+   (no `--dry-run`). It runs the smoke check, builds+pushes the henyey image,
+   captures the **`sha256` digest**, `nsc create`s an ephemeral k8s instance,
+   writes `runs/<date>-mission-3292/`, and prints the exact SSC dotnet invocation.
+3. **Drive the SSC dotnet harness** (`stellar/supercluster`, external) pointed at
+   the **digest-pinned** image + the instance kubeconfig (`nsc kubeconfig write`).
+   Configure the mixed topology (3 stellar-core + 1 henyey, core-majority quorum).
+4. **Validate** with `scripts/ssc/assert-mission-3292.sh`:
+   ```bash
+   scripts/ssc/assert-mission-3292.sh \
+     --henyey-info    http://<henyey-pod>:11626/info \
+     --core-info      http://<core-pod>:11626/info \
+     --henyey-metrics http://<henyey-pod>:11626/metrics \
+     --window-secs 60
+   ```
+   This checks AC#3 (authenticated peers), AC#4 (ledger advances), AC#5 (seq+hash
+   agreement), AC#6 (Synced!).
+5. **Capture artifacts** into `runs/<date>-mission-3292/` and onto #3292:
+   - `image-digest.txt` (the immutable `sha256:` reference),
+   - `instance.json` (nsc instance metadata),
+   - the **SSC-generated `stellar-core.cfg`** (and diff vs. the fixture — see AC#2 residual),
+   - the exact `nsc` + dotnet invocations,
+   - `nsc kubectl get all -A` + per-pod henyey/stellar-core logs,
+   - the `assert-mission-3292.sh` output.
+6. **Teardown:** `nsc destroy <instance-id> --force`, then `nsc list -o json` to
+   confirm the ephemeral cluster is gone (see #3304 §5).
+7. **On any failure:** file a **concrete follow-up issue** (AC#8) with the captured
+   artifacts — do NOT silently patch henyey or the fixture to make the run pass.
+
+### Watch-item (#3299)
+
+`--minimal-for-in-memory-mode` is currently accepted-and-ignored by henyey
+(#3299). henyey runs persistent SQLite, which is fine for one bounded mission.
+Watch for subtle state issues across mission restarts; if the SSC default node
+bootstrap relies on ephemeral in-memory semantics, file a follow-up rather than
+blocking the mission.

--- a/scripts/ssc/assert-mission-3292.sh
+++ b/scripts/ssc/assert-mission-3292.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# assert-mission-3292.sh — operator-run acceptance checks for the first
+# mixed-image Supercluster (SSC) mission (#3292). Run this against a LIVE
+# mission (the nsc-side instance is up and the SSC dotnet harness has the
+# mixed network running). It encodes mission acceptance criteria AC#3–AC#6 as
+# a runnable, exit-coded check.
+#
+#   AC#3 overlay authenticated peering : henyey peer.peer.authenticated-count > 0
+#   AC#4 ledger externalize over window: henyey ledger seq advances across the window
+#   AC#5 seq + hash agreement          : henyey and a stellar-core peer agree on
+#                                        (ledger num, ledger hash) at a common seq
+#   AC#6 henyey stays Synced           : henyey /info state == "Synced!"
+#
+# Field paths (verified against the henyey compat handlers, which mirror
+# stellar-core's /info and /metrics shapes):
+#   /info    -> .info.state, .info.ledger.num, .info.ledger.hash
+#   /metrics -> .metrics["peer.peer.authenticated-count"].count
+#
+# Usage:
+#   scripts/ssc/assert-mission-3292.sh \
+#       --henyey-info    http://<henyey-pod>:11626/info \
+#       --core-info      http://<core-pod>:11626/info \
+#       --henyey-metrics http://<henyey-pod>:11626/metrics \
+#       [--window-secs 60] [--poll-secs 5] [--self-check]
+#
+#   --self-check   Run an offline self-test of the JSON-extraction + agreement
+#                  logic against built-in fixtures (no live infra, no curl).
+#                  CI / the harness runs this to exercise the assert logic.
+#
+set -euo pipefail
+
+HENYEY_INFO=""
+CORE_INFO=""
+HENYEY_METRICS=""
+WINDOW_SECS=60
+POLL_SECS=5
+SELF_CHECK=0
+
+usage() { sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --henyey-info) HENYEY_INFO="$2"; shift 2 ;;
+    --core-info) CORE_INFO="$2"; shift 2 ;;
+    --henyey-metrics) HENYEY_METRICS="$2"; shift 2 ;;
+    --window-secs) WINDOW_SECS="$2"; shift 2 ;;
+    --poll-secs) POLL_SECS="$2"; shift 2 ;;
+    --self-check) SELF_CHECK=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' is required" >&2; exit 2; }; }
+need jq
+
+# --- JSON extractors (apples-to-apples with stellar-core /info shape) --------
+info_state()  { jq -r '.info.state'        <<<"$1"; }
+info_seq()    { jq -r '.info.ledger.num'   <<<"$1"; }
+info_hash()   { jq -r '.info.ledger.hash'  <<<"$1"; }
+metric_auth() { jq -r '.metrics["peer.peer.authenticated-count"].count' <<<"$1"; }
+
+# --- Self-check: exercise the logic offline against fixtures -----------------
+if [ "$SELF_CHECK" -eq 1 ]; then
+  echo "=== assert-mission-3292 self-check (offline) ==="
+  HENYEY_FIX='{"info":{"state":"Synced!","ledger":{"num":12345,"hash":"deadbeef"}}}'
+  CORE_FIX='{"info":{"state":"Synced!","ledger":{"num":12345,"hash":"deadbeef"}}}'
+  METRICS_FIX='{"metrics":{"peer.peer.authenticated-count":{"type":"counter","count":3}}}'
+  fail=0
+  [ "$(info_state  "$HENYEY_FIX")" = "Synced!" ] || { echo "FAIL: state extract"; fail=1; }
+  [ "$(info_seq    "$HENYEY_FIX")" = "12345" ]   || { echo "FAIL: seq extract"; fail=1; }
+  [ "$(info_hash   "$HENYEY_FIX")" = "deadbeef" ]|| { echo "FAIL: hash extract"; fail=1; }
+  [ "$(metric_auth "$METRICS_FIX")" = "3" ]      || { echo "FAIL: auth-count extract"; fail=1; }
+  # agreement at a common seq
+  if [ "$(info_seq "$HENYEY_FIX")" = "$(info_seq "$CORE_FIX")" ] \
+     && [ "$(info_hash "$HENYEY_FIX")" = "$(info_hash "$CORE_FIX")" ]; then
+    echo "OK: seq+hash agreement logic"
+  else
+    echo "FAIL: agreement logic"; fail=1
+  fi
+  # mismatch must be detected
+  CORE_BAD='{"info":{"state":"Synced!","ledger":{"num":12345,"hash":"feedface"}}}'
+  if [ "$(info_hash "$HENYEY_FIX")" != "$(info_hash "$CORE_BAD")" ]; then
+    echo "OK: hash-mismatch detection"
+  else
+    echo "FAIL: hash-mismatch not detected"; fail=1
+  fi
+  if [ "$fail" -eq 0 ]; then echo "=== self-check PASSED ==="; exit 0; else echo "=== self-check FAILED ==="; exit 1; fi
+fi
+
+# --- Live mode requires the three endpoints ----------------------------------
+need curl
+[ -n "$HENYEY_INFO" ] && [ -n "$CORE_INFO" ] && [ -n "$HENYEY_METRICS" ] || {
+  echo "ERROR: live mode needs --henyey-info, --core-info, and --henyey-metrics" >&2
+  usage 1
+}
+
+fetch() { curl -sf "$1" || { echo "ERROR: failed to fetch $1" >&2; exit 3; }; }
+
+fails=0
+
+# AC#6: henyey stays Synced
+echo "--- AC#6: henyey Synced state ---"
+H_INFO="$(fetch "$HENYEY_INFO")"
+H_STATE="$(info_state "$H_INFO")"
+echo "henyey state: $H_STATE"
+[ "$H_STATE" = "Synced!" ] || { echo "FAIL AC#6: henyey not Synced! (got '$H_STATE')"; fails=1; }
+
+# AC#3: authenticated overlay peering
+echo "--- AC#3: overlay authenticated peering ---"
+H_METRICS="$(fetch "$HENYEY_METRICS")"
+H_AUTH="$(metric_auth "$H_METRICS")"
+echo "henyey peer.peer.authenticated-count: $H_AUTH"
+{ [ -n "$H_AUTH" ] && [ "$H_AUTH" != "null" ] && [ "$H_AUTH" -gt 0 ]; } \
+  || { echo "FAIL AC#3: no authenticated peers"; fails=1; }
+
+# AC#4: ledger externalize over a fixed window (seq advances)
+echo "--- AC#4: ledger externalize over ${WINDOW_SECS}s window ---"
+START_SEQ="$(info_seq "$H_INFO")"
+echo "start seq: $START_SEQ"
+elapsed=0
+END_SEQ="$START_SEQ"
+while [ "$elapsed" -lt "$WINDOW_SECS" ]; do
+  sleep "$POLL_SECS"
+  elapsed=$((elapsed + POLL_SECS))
+  END_SEQ="$(info_seq "$(fetch "$HENYEY_INFO")")"
+  echo "  t+${elapsed}s seq: $END_SEQ"
+done
+if [ "$END_SEQ" -gt "$START_SEQ" ]; then
+  echo "OK AC#4: ledger advanced $START_SEQ -> $END_SEQ"
+else
+  echo "FAIL AC#4: ledger did not advance over window ($START_SEQ -> $END_SEQ)"; fails=1
+fi
+
+# AC#5: seq + hash agreement with a stellar-core peer
+echo "--- AC#5: seq + hash agreement with stellar-core peer ---"
+# Re-read both close together so they are likely at the same seq.
+H_INFO="$(fetch "$HENYEY_INFO")"
+C_INFO="$(fetch "$CORE_INFO")"
+H_SEQ="$(info_seq "$H_INFO")"; H_HASH="$(info_hash "$H_INFO")"
+C_SEQ="$(info_seq "$C_INFO")"; C_HASH="$(info_hash "$C_INFO")"
+echo "henyey: seq=$H_SEQ hash=$H_HASH"
+echo "core:   seq=$C_SEQ hash=$C_HASH"
+if [ "$H_SEQ" = "$C_SEQ" ]; then
+  if [ "$H_HASH" = "$C_HASH" ]; then
+    echo "OK AC#5: agree on seq+hash at $H_SEQ"
+  else
+    echo "FAIL AC#5: HASH MISMATCH at seq $H_SEQ (henyey=$H_HASH core=$C_HASH)"; fails=1
+  fi
+else
+  # Different seq is not necessarily a failure (clock skew between reads); warn
+  # and direct the operator to re-run once both are at a common seq.
+  echo "WARN AC#5: seq skew between reads (henyey=$H_SEQ core=$C_SEQ); re-run to compare at a common seq"
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "=== MISSION ASSERTIONS PASSED (AC#3,#4,#6 green; AC#5 see above) ==="
+  exit 0
+else
+  echo "=== MISSION ASSERTIONS FAILED — file a follow-up issue per the runbook ==="
+  exit 1
+fi

--- a/scripts/ssc/launch-mission-3292.sh
+++ b/scripts/ssc/launch-mission-3292.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# launch-mission-3292.sh — stand up the nsc-side launch surface for the first
+# mixed-image Supercluster (SSC) mission (#3292): 3 stellar-core validators +
+# 1 henyey validator, stellar-core-majority quorum.
+#
+# This is a THIN WRAPPER over the verified `nsc` commands documented in
+# docs/supercluster-nsc-workflow.md (#3304): auth smoke check -> build+push
+# the henyey image -> capture the image digest -> `nsc create` an ephemeral
+# k8s instance -> write the run-dir layout -> print the exact SSC dotnet
+# invocation to hand off.
+#
+# IMPORTANT — this script does NOT run the mission. The actual mission RUN is
+# performed by the external `stellar/supercluster` dotnet harness (NOT vendored
+# here) against the published image + the instance kubeconfig, and is tracked
+# in #3292 as operator-executed work. This script gets you up to the hand-off
+# point and prints the exact SSC invocation.
+#
+# Modes:
+#   --dry-run   Assemble and print every command + the run-dir layout WITHOUT
+#               invoking `nsc` or touching live infra. CI / the harness runs
+#               this to exercise the command-assembly logic with no auth.
+#   (default)   Execute the nsc-side steps for real (requires `nsc login`).
+#
+# Usage:
+#   scripts/ssc/launch-mission-3292.sh [--dry-run] [--registry REG]
+#                                      [--image-tag TAG] [--duration DUR]
+#                                      [--runs-dir DIR]
+#
+set -euo pipefail
+
+# --- Defaults (verified values from docs/supercluster-nsc-workflow.md) -------
+REGISTRY="nscr.io/k4jkul01t5rr0"      # SDF workspace registry (substitute your tenant)
+IMAGE_NAME="henyey"
+IMAGE_TAG="ssc"
+DURATION="2h"                          # ephemeral instance lifetime
+K8S_VERSION="1.33"
+RUNS_DIR=""                            # default derived below from date
+DRY_RUN=0
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --registry) REGISTRY="$2"; shift 2 ;;
+    --image-tag) IMAGE_TAG="$2"; shift 2 ;;
+    --duration) DURATION="$2"; shift 2 ;;
+    --runs-dir) RUNS_DIR="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+IMAGE_REF="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+DATE_TAG="$(date +%Y%m%d)"
+[ -n "$RUNS_DIR" ] || RUNS_DIR="runs/${DATE_TAG}-mission-3292"
+
+# `run` echoes the command; in --dry-run it does NOT execute it.
+run() {
+  echo "+ $*"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    "$@"
+  fi
+}
+
+echo "=== SSC mission #3292 launch (nsc side) ==="
+echo "registry:   $REGISTRY"
+echo "image ref:  $IMAGE_REF"
+echo "duration:   $DURATION"
+echo "k8s:        $K8S_VERSION"
+echo "run dir:    $RUNS_DIR"
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "MODE:       DRY RUN (no nsc calls, no live infra)"
+else
+  echo "MODE:       LIVE (requires prior 'nsc login')"
+fi
+echo
+
+# --- Run-dir layout (docs/supercluster-nsc-workflow.md §4) -------------------
+# In dry-run we still create the layout so CI can assert it; the directory is
+# harmless and lives wherever the operator/CI invokes the script.
+echo "--- 0. Run directory layout ---"
+run mkdir -p "$RUNS_DIR/logs" "$RUNS_DIR/ssc"
+echo
+
+# --- 1. Auth smoke check (#3304 §1) ------------------------------------------
+echo "--- 1. Auth smoke check ---"
+run nsc auth check-login
+run nsc workspace describe
+echo
+
+# --- 2. Build + publish + capture digest (#3304 §2) --------------------------
+echo "--- 2. Build & publish the henyey image ---"
+run nsc build -f Dockerfile --platform linux/amd64 --push -n "$IMAGE_REF" .
+echo "--- 2b. Capture immutable image digest ---"
+DIGEST_FILE="$RUNS_DIR/image-digest.txt"
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "+ nsc registry describe $IMAGE_REF -o json > $DIGEST_FILE"
+  IMAGE_DIGEST="sha256:<captured-at-runtime>"
+else
+  nsc registry describe "$IMAGE_REF" -o json > "$DIGEST_FILE"
+  IMAGE_DIGEST="$(grep -o '"digest":[^,]*' "$DIGEST_FILE" | head -1 | sed 's/.*"\(sha256:[a-f0-9]*\)".*/\1/')"
+fi
+IMAGE_PINNED="${REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}"
+echo "image (pinned by digest): $IMAGE_PINNED"
+echo
+
+# --- 3. Provision the ephemeral k8s instance (#3304 §3a) ---------------------
+echo "--- 3. Provision ephemeral k8s instance (nsc side) ---"
+INSTANCE_JSON="$RUNS_DIR/instance.json"
+run nsc create --ephemeral \
+  --enable="kubernetes:${K8S_VERSION}" \
+  --duration="$DURATION" \
+  --output_json_to="$INSTANCE_JSON" \
+  --purpose="SSC mission #3292 (henyey mixed validator)"
+echo
+
+# --- 4. Hand off to the SSC dotnet harness (owned by #3292, NOT run here) -----
+echo "--- 4. Hand off to SSC dotnet harness (operator-executed, NOT run here) ---"
+cat <<HANDOFF
+The mission RUN is performed by the external stellar/supercluster dotnet
+harness (not vendored in this repo). Point it at the published image (pin by
+DIGEST for reproducibility) and the instance kubeconfig:
+
+  nsc kubeconfig write            # write a kubeconfig for the instance
+  # then, from the stellar/supercluster checkout:
+  dotnet run --project src/App -- \\
+      --image=${IMAGE_PINNED} \\
+      --kubeconfig=<path-from-nsc-kubeconfig-write> \\
+      MissionMixedImageNetworkSurvey   # or the agreed first mixed-image mission name
+
+Topology for the first mission (see docs/supercluster-mission-3292.md):
+  - 3 stellar-core validators + 1 henyey validator
+  - stellar-core-majority quorum (henyey is a minority validator)
+  - accelerated close time, no history / loadgen / survey
+
+Once the network is up, validate it with:
+  scripts/ssc/assert-mission-3292.sh \\
+      --henyey-info http://<henyey-pod>:11626/info \\
+      --core-info   http://<core-pod>:11626/info \\
+      --henyey-metrics http://<henyey-pod>:11626/metrics
+
+Then capture artifacts into ${RUNS_DIR}/ and onto #3292 (see the runbook §"Artifacts").
+HANDOFF
+echo
+
+echo "=== nsc-side launch surface ready (mission RUN handed to operator/#3292) ==="

--- a/scripts/ssc/test-mission-3292-scripts.sh
+++ b/scripts/ssc/test-mission-3292-scripts.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# test-mission-3292-scripts.sh — CI smoke test for the SSC mission #3292 helper
+# scripts. Exercises their command-assembly and assertion logic WITHOUT any live
+# infra (`nsc`, k8s, curl), so the launch/assert paths are covered in CI.
+#
+# Covers:
+#   - bash -n syntax of both helper scripts
+#   - launch-mission-3292.sh --dry-run assembles the verified nsc commands and
+#     the run-dir layout without invoking nsc
+#   - assert-mission-3292.sh --self-check validates its JSON-extraction and
+#     seq+hash agreement / mismatch logic against built-in fixtures
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCH="$SCRIPT_DIR/launch-mission-3292.sh"
+ASSERT="$SCRIPT_DIR/assert-mission-3292.sh"
+
+fail=0
+check() {
+  local desc="$1"; shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"; fail=1
+  fi
+}
+
+echo "=== SSC mission #3292 script harness ==="
+
+# 1. Syntax.
+check "launch script bash -n" bash -n "$LAUNCH"
+check "assert script bash -n" bash -n "$ASSERT"
+
+# 2. Launch dry-run assembles commands without invoking nsc.
+TMP_RUNS="$(mktemp -d)"
+trap 'rm -rf "$TMP_RUNS"' EXIT
+DRY_OUT="$(bash "$LAUNCH" --dry-run --runs-dir "$TMP_RUNS/run")"
+echo "$DRY_OUT" | grep -q "MODE:       DRY RUN" \
+  && echo "PASS: launch dry-run mode banner" || { echo "FAIL: dry-run banner"; fail=1; }
+echo "$DRY_OUT" | grep -q "nsc build -f Dockerfile --platform linux/amd64 --push -n" \
+  && echo "PASS: launch assembles build+push command" || { echo "FAIL: build command"; fail=1; }
+echo "$DRY_OUT" | grep -q "nsc create --ephemeral" \
+  && echo "PASS: launch assembles nsc create" || { echo "FAIL: nsc create"; fail=1; }
+echo "$DRY_OUT" | grep -q "operator" \
+  && echo "PASS: launch flags operator-owned mission RUN" || { echo "FAIL: operator handoff"; fail=1; }
+# run-dir layout command assembled (dry-run prints but does not execute it)
+echo "$DRY_OUT" | grep -q "mkdir -p $TMP_RUNS/run/logs $TMP_RUNS/run/ssc" \
+  && echo "PASS: launch assembles run-dir layout" || { echo "FAIL: run-dir layout command"; fail=1; }
+# dry-run must NOT touch live infra: nothing created on disk
+[ ! -e "$TMP_RUNS/run" ] \
+  && echo "PASS: dry-run created nothing on disk (no live nsc/fs writes)" || { echo "FAIL: dry-run touched the filesystem"; fail=1; }
+
+# 3. Assert self-check.
+check "assert self-check (offline logic)" bash "$ASSERT" --self-check
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "=== ALL SSC mission #3292 script checks PASSED ==="
+  exit 0
+else
+  echo "=== SSC mission #3292 script checks FAILED ==="
+  exit 1
+fi


### PR DESCRIPTION
Closes #3292

## Summary

Ships the autonomously-doable deliverable for the **first mixed-image Supercluster (SSC) mission** — a small network of 3 stellar-core validators + 1 henyey validator with a stellar-core-majority quorum. The long-lived k8s mission RUN itself (interactive `nsc login`, multi-hour cluster, external `stellar/supercluster` dotnet harness) is explicitly handed to the operator via a runbook checklist — no mission transcript is fabricated.

Delivered:
- **`crates/app/src/compat_http/test_fixtures/ssc_mission_mixed.cfg`** — mission-shaped mixed-cluster `stellar-core.cfg` (henyey VALIDATOR via `NODE_SEED … self`, shared `MEDIUM`-quality `[[HOME_DOMAINS]]` so no history archive is required, `UNSAFE_QUORUM=true` for the 4-node quorum, accelerated close time, in-cluster pod hostnames, no history/loadgen/survey). Field shapes derived from stellar-core `Config.cpp`; the local node is NOT listed in its own `[[VALIDATORS]]`, mirroring `addSelfToValidators`. Distinct from the existing `ssc_generated_config.cfg` (a `NODE_IS_VALIDATOR=false` testnet-watcher shape).
- **`test_ssc_mission_mixed_config_parse`** (in `compat_config.rs`) — config-acceptance regression test (AC#2): drives the same `is_stellar_core_format` + `translate_stellar_core_config` entry the binary's `load_config` uses; asserts validator mode, 3 listed core keys + auto-added self = 4 distinct entries in the `ValidatorWeightConfig` (no `$self` double-count), accelerated time, in-cluster known peers, no history archives.
- **`scripts/ssc/launch-mission-3292.sh`** — thin wrapper over the verified #3304 `nsc` commands (auth smoke → build+push → capture digest → `nsc create --ephemeral` → print exact SSC dotnet invocation), with `--dry-run` for CI.
- **`scripts/ssc/assert-mission-3292.sh`** — encodes AC#3–6 (authenticated peering via the real `peer.peer.authenticated-count` counter, ledger externalize over a window, seq+hash agreement, `Synced!`) against a running mission, with `--self-check` offline mode.
- **`scripts/ssc/test-mission-3292-scripts.sh`** + a new `ci.yml` job — CI smoke (bash -n + launch `--dry-run` + assert `--self-check`), no live infra.
- **`docs/supercluster-mission-3292.md`** — runbook + OPERATOR CHECKLIST for the live run.

An operator checklist for the live RUN is also posted as a comment on #3292.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3292#issuecomment-4722994322)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (the exact CI command) — clean
- [x] `cargo test -p henyey-app compat_config` — 132 pass (incl. the new test + all named existing tests)
- [x] `bash scripts/ssc/test-mission-3292-scripts.sh` — launch `--dry-run` + assert `--self-check` green

## Regression / TDD trail

- **Test:** `crates/app/src/compat_config.rs::test_ssc_mission_mixed_config_parse`
- **Pre-fixture:** committed as `c3ecacf9` — verified FAILED (compile: `couldn't read … ssc_mission_mixed.cfg`, i.e. the test genuinely requires real fixture parsing, not a stub).
- **Post-fixture:** verified PASSES after `c7dec32e`.

## Honored plan MINOR items

- (A) Asserts the 4 distinct quorum entries and confirms no `$self`-resolution / double-count error (via `ValidatorWeightConfig`).
- (A) Runbook notes the offline test proves only the translator; the live launch fully closes AC#2.
- (B) HOME_DOMAINS/QUALITY/VALIDATORS/UNSAFE_QUORUM shapes cross-checked against `Config.cpp` (MEDIUM quality ⇒ no history archive required); "validate vs first real SSC config" flagged as an operator step that may spawn a follow-up.
- (B) Assert helper uses the verified `/info` (`.info.state`, `.info.ledger.num/.hash`) and `/metrics` (`peer.peer.authenticated-count`) shapes — apples-to-apples with stellar-core.
- (C) Scripts kept thin; the concrete operator RUN checklist (exact invocation, window, artifacts) is in the runbook and the #3292 comment.

## Deviations from plan

- The plan listed `quorum_set.validators` as containing 4 keys including henyey self. In henyey (matching stellar-core's `addSelfToValidators`), self is auto-added to the `ValidatorWeightConfig`, NOT to the listed `quorum_set.validators`; listing self in `[[VALIDATORS]]` is a parity error (duplicate). The test therefore asserts 3 listed core keys + the 4-distinct-validator weight config (including auto-added self). Same 4-node quorum, parity-faithful mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)