### PR TITLE
Wire compat peer-admin handlers to overlay/DB side effects

### DIFF
--- a/crates/app/PARITY_STATUS.md
+++ b/crates/app/PARITY_STATUS.md
@@ -120,12 +120,26 @@ Corresponds to: `CommandHandler.h`
 | `generateLoad()` | native and compat handlers (feature-gated via `loadgen`) | Full |
 | `testAcc()` | compat handler with deterministic key derivation | Full |
 | `manualClose()` | works, but explicit seq/time params are rejected in compat/native handlers | Partial |
-| `connect()` / `dropPeer()` / `unban()` / `bans()` | native handlers work; compat handlers are placeholders or incomplete | Partial |
+| `connect()` / `dropPeer()` / `unban()` / `bans()` | native and compat handlers wired to overlay/DB side effects; two intentional compat divergences (see note below) | Full |
 | `ll()` | native dynamic log control works; compat handler is minimal | Partial |
 | `logRotate()` | placeholder response only | Partial |
 | `banaccounts()` / `unbanaccounts()` | — | None |
 | legacy survey commands (`surveyTopology()`, `stopSurvey()`, `getSurveyResult()`) | — | None |
 | time-sliced survey commands (`startSurveyCollecting()`, `stopSurveyCollecting()`, `surveyTopologyTimeSliced()`) | native handlers implemented; compat endpoints are stubs | Partial |
+
+**Intentional compat divergences for `connect` / `dropPeer` / `unban` / `bans`** (CommandHandler.cpp:478/~543/566/553), both documented and deliberate:
+
+1. **Trailing newline.** stellar-core's `retStr` carries no `\n`; henyey's compat
+   plain-text handlers append a trailing `\n` by the established compat convention
+   (e.g. `maintenance` → `"Done\n"`), so all compat plain-text endpoints are
+   internally consistent. Message text otherwise byte-matches core
+   (`"Connect to: PEER:PORT"`, `"Drop peer: NODE"`, `"Drop and ban peer: NODE"`,
+   `"Peer NODE not found"`, `"Unban peer: NODE"`, and the two "Must specify…"
+   guidance strings).
+2. **Empty `/bans` shape.** stellar-core's `bans()` emits jsoncpp `{"bans": null}`
+   when no bans exist; henyey emits `{"bans": []}` to match its own native
+   `/bans` (`BansResponse`) and because an empty array is unambiguous. SSC /
+   stellar-rpc consumers treat the two equivalently.
 
 ### Query server (`src/http/mod.rs`, `src/http/handlers/query.rs`)
 
@@ -195,7 +209,6 @@ Features not yet implemented. These ARE counted against parity %.
 | stellar-core Component | Priority | Notes |
 |------------------------|----------|-------|
 | `BannedAccountsPersistor` and `FILTERED_G_ADDRESSES` flow | High | No persisted banned-account subsystem or admin endpoints |
-| Compat `connect` / `droppeer` / `unban` / `bans` behavior | Medium | Compat handlers mostly return placeholders instead of mutating state |
 | Compat time-sliced survey admin routes | Medium | Native routes work; compat routes are still stubs |
 | `manualclose` explicit sequence/close-time parameters | Medium | Upstream standalone semantics are not exposed by handlers |
 | Scheduled online self-check parity | Medium | Manual self-check exists, but upstream periodic scheduling test is unmatched |
@@ -231,7 +244,7 @@ Features not yet implemented. These ARE counted against parity %.
 | Area | stellar-core Tests | Rust Tests | Notes |
 |------|-------------------|------------|-------|
 | Config and compat translation | 9 TEST_CASE / 21 SECTION | 64 `#[test]` | Strong coverage for loading, validation, and captive-core translation |
-| Command handler / compat HTTP | 5 TEST_CASE / 27 SECTION | 46 `#[test]` | Includes handler helpers, generateLoad, testacc; some compat behaviors are still stubs |
+| Command handler / compat HTTP | 5 TEST_CASE / 27 SECTION | 55 `#[test]` | Includes handler helpers, generateLoad, testacc, and live-App peer-admin tests (connect/droppeer/unban/bans); survey compat routes remain stubs |
 | Query server | 1 TEST_CASE / 9 SECTION | 7 `#[test]` | Good coverage of lookup ordering and validation |
 | Run/catchup utilities | 4 TEST_CASE / 5 SECTION | 19 `#[test]` | Target parsing and run-mode helpers are well covered |
 | Self-check scheduling | 1 TEST_CASE / 0 SECTION | 0 `#[test]` | No dedicated periodic self-check scheduling tests |
@@ -242,7 +255,7 @@ Features not yet implemented. These ARE counted against parity %.
 
 ### Test Gaps
 
-- Compat admin endpoints lack parity-style integration tests for real side effects (`connect`, `droppeer`, `unban`, survey control).
+- Compat peer-admin endpoints (`connect`, `droppeer`, `unban`, `bans`) now have live-App tests asserting real overlay/DB side effects; survey-control compat routes still lack parity-style side-effect tests.
 - There is no Rust equivalent of upstream's scheduled online self-check test in `SelfCheckTests.cpp`.
 - Account-ban persistence has no Rust tests because the subsystem is not implemented. Upstream has 4 TEST_CASE / 21 SECTION.
 - HTTP threaded server behavior (3 TEST_CASE upstream in `HttpThreadedTests.cpp`) has no direct equivalent.

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -459,6 +459,260 @@ fn is_leap_year(y: u32) -> bool {
 mod tests {
     use super::*;
 
+    // ── Live-App peer-admin handler tests (#3294) ───────────────────────
+    //
+    // These exercise the real wiring of the four compat peer-admin handlers
+    // (`/connect`, `/droppeer`, `/unban`, `/bans`) against a live `App`
+    // backed by a tempdir SQLite database, mirroring stellar-core
+    // `CommandHandler` response shapes.
+
+    use std::sync::Arc;
+
+    use http_body_util::BodyExt;
+
+    use crate::app::App;
+    use crate::compat_http::CompatServerState;
+    use crate::http::types::{ConnectParams, DropPeerParams, UnbanParams};
+
+    /// Build a `CompatServerState` backed by a real (minimal) `App` with a
+    /// tempdir database and no default peers. Returns `(TempDir, state)`; the
+    /// `TempDir` guard is returned first so it outlives the state (which holds
+    /// open DB handles).
+    async fn mk_compat_state() -> (tempfile::TempDir, Arc<CompatServerState>) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("compat-peer-admin.db");
+        let mut config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        // Avoid pulling in default network peers in unit tests.
+        config.overlay.known_peers.clear();
+        config.is_compat_config = true;
+        let app = App::new(config).await.unwrap();
+        let state = Arc::new(CompatServerState {
+            app: Arc::new(app),
+            started_on: "2024-01-01T00:00:00Z".to_string(),
+            #[cfg(feature = "loadgen")]
+            loadgen_state: None,
+        });
+        (dir, state)
+    }
+
+    /// Collect a plain-text response body into a `String`.
+    async fn body_text(response: axum::response::Response) -> String {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    /// Collect a JSON response body and parse it.
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// Generate a fresh peer (PeerId + its G... strkey).
+    fn mk_peer() -> (henyey_overlay::PeerId, String) {
+        let secret = henyey_crypto::SecretKey::generate();
+        let public = secret.public_key();
+        let strkey = public.to_strkey();
+        let peer_id = henyey_overlay::PeerId::from_bytes(*public.as_bytes());
+        (peer_id, strkey)
+    }
+
+    /// `/bans` reflects the real DB `load_bans` result — a banned peer's
+    /// strkey appears in the `bans` array. FAILS on `origin/main` (the stub
+    /// always returns `{"bans": []}` regardless of DB state).
+    #[tokio::test]
+    async fn test_compat_bans_reflects_db_load_bans() {
+        let (_dir, state) = mk_compat_state().await;
+        let (peer_id, strkey) = mk_peer();
+        // Start overlay so ban_peer's overlay side completes; the DB row is the
+        // part /bans reads back.
+        state.app.start_overlay().await.unwrap();
+        state.app.ban_peer(peer_id).await.unwrap();
+
+        let resp = compat_bans_handler(State(Arc::clone(&state)))
+            .await
+            .into_response();
+        let json = body_json(resp).await;
+        let bans = json["bans"].as_array().expect("bans array");
+        assert!(
+            bans.iter().any(|b| b.as_str() == Some(strkey.as_str())),
+            "banned strkey {strkey} not found in {json}"
+        );
+        state.app.shutdown();
+    }
+
+    /// `/bans` with no bans yields the documented `{"bans": []}` shape.
+    #[tokio::test]
+    async fn test_compat_bans_empty() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_bans_handler(State(Arc::clone(&state)))
+            .await
+            .into_response();
+        let json = body_json(resp).await;
+        assert_eq!(json, serde_json::json!({"bans": []}));
+        state.app.shutdown();
+    }
+
+    /// `/unban?node=<strkey>` removes the DB ban row AND returns
+    /// `"Unban peer: <node>\n"`. FAILS on `origin/main` (the stub returns
+    /// `"done\n"` with no side effect, so the ban would persist).
+    #[tokio::test]
+    async fn test_compat_unban_removes_ban() {
+        let (_dir, state) = mk_compat_state().await;
+        let (peer_id, strkey) = mk_peer();
+        state.app.start_overlay().await.unwrap();
+        state.app.ban_peer(peer_id).await.unwrap();
+        // Precondition: the ban is present.
+        let before = state.app.banned_peers().await.unwrap();
+        assert!(
+            before
+                .iter()
+                .any(|p| peer_id_strkey(p) == Some(strkey.clone())),
+            "ban should be present before unban"
+        );
+
+        let params = UnbanParams {
+            peer_id: None,
+            node: Some(strkey.clone()),
+        };
+        let resp = compat_unban_handler(State(Arc::clone(&state)), Query(params))
+            .await
+            .into_response();
+        let text = body_text(resp).await;
+        assert_eq!(text, format!("Unban peer: {strkey}\n"));
+
+        // Real DB side effect: the ban is gone.
+        let after = state.app.banned_peers().await.unwrap();
+        assert!(
+            !after
+                .iter()
+                .any(|p| peer_id_strkey(p) == Some(strkey.clone())),
+            "ban should be removed after unban"
+        );
+        state.app.shutdown();
+    }
+
+    /// `/unban` with no `node` → the stellar-core "must specify" message.
+    #[tokio::test]
+    async fn test_compat_unban_missing_node() {
+        let (_dir, state) = mk_compat_state().await;
+        let params = UnbanParams {
+            peer_id: None,
+            node: None,
+        };
+        let resp = compat_unban_handler(State(Arc::clone(&state)), Query(params))
+            .await
+            .into_response();
+        let text = body_text(resp).await;
+        assert_eq!(text, "Must specify at least peer id: unban?node=NODE_ID\n");
+        state.app.shutdown();
+    }
+
+    /// `/unban?node=garbage` (unresolvable) → "Peer <node> not found".
+    #[tokio::test]
+    async fn test_compat_unban_unresolvable_node() {
+        let (_dir, state) = mk_compat_state().await;
+        let params = UnbanParams {
+            peer_id: None,
+            node: Some("garbage".to_string()),
+        };
+        let resp = compat_unban_handler(State(Arc::clone(&state)), Query(params))
+            .await
+            .into_response();
+        let text = body_text(resp).await;
+        assert_eq!(text, "Peer garbage not found\n");
+        state.app.shutdown();
+    }
+
+    /// `/droppeer` with no `node` → the stellar-core "must specify" message.
+    #[tokio::test]
+    async fn test_compat_droppeer_missing_node() {
+        let (_dir, state) = mk_compat_state().await;
+        let params = DropPeerParams {
+            peer_id: None,
+            node: None,
+            ban: None,
+        };
+        let resp = compat_droppeer_handler(State(Arc::clone(&state)), Query(params))
+            .await
+            .into_response();
+        let text = body_text(resp).await;
+        assert_eq!(
+            text,
+            "Must specify at least peer id: droppeer?node=NODE_ID\n"
+        );
+        state.app.shutdown();
+    }
+
+    /// `/droppeer?node=<strkey>` for a peer that is not connected →
+    /// "Peer <node> not found".
+    #[tokio::test]
+    async fn test_compat_droppeer_not_found() {
+        let (_dir, state) = mk_compat_state().await;
+        state.app.start_overlay().await.unwrap();
+        let (_peer_id, strkey) = mk_peer();
+        let params = DropPeerParams {
+            peer_id: None,
+            node: Some(strkey.clone()),
+            ban: None,
+        };
+        let resp = compat_droppeer_handler(State(Arc::clone(&state)), Query(params))
+            .await
+            .into_response();
+        let text = body_text(resp).await;
+        assert_eq!(text, format!("Peer {strkey} not found\n"));
+        state.app.shutdown();
+    }
+
+    /// `/connect` with no `peer`/`port` → the stellar-core "must specify"
+    /// message.
+    #[tokio::test]
+    async fn test_compat_connect_missing_param() {
+        let (_dir, state) = mk_compat_state().await;
+        let params = ConnectParams {
+            addr: None,
+            peer: None,
+            port: None,
+        };
+        let resp = compat_connect_handler(State(Arc::clone(&state)), Query(params))
+            .await
+            .into_response();
+        let text = body_text(resp).await;
+        assert_eq!(
+            text,
+            "Must specify a peer and port: connect&peer=PEER&port=PORT\n"
+        );
+        state.app.shutdown();
+    }
+
+    /// `/connect?peer=127.0.0.1&port=11625` → the fire-and-forget success
+    /// message (mirrors stellar-core's unconditional retStr). Proves the
+    /// wiring/side-effect path is invoked.
+    #[tokio::test]
+    async fn test_compat_connect_success_shape() {
+        let (_dir, state) = mk_compat_state().await;
+        state.app.start_overlay().await.unwrap();
+        let params = ConnectParams {
+            addr: None,
+            peer: Some("127.0.0.1".to_string()),
+            port: Some(11625),
+        };
+        let resp = compat_connect_handler(State(Arc::clone(&state)), Query(params))
+            .await
+            .into_response();
+        let text = body_text(resp).await;
+        assert_eq!(text, "Connect to: 127.0.0.1:11625\n");
+        state.app.shutdown();
+    }
+
+    /// Helper: PeerId → its G... strkey (used by ban-state assertions).
+    fn peer_id_strkey(peer_id: &henyey_overlay::PeerId) -> Option<String> {
+        henyey_crypto::PublicKey::from_bytes(peer_id.as_bytes())
+            .ok()
+            .map(|pk| pk.to_strkey())
+    }
+
     // ── /upgrades response shape tests ──────────────────────────────────
 
     /// Verify the default `/upgrades` response (no mode param) has `current` and `scheduled`.

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -116,38 +116,118 @@ pub(crate) async fn compat_ll_handler(
 
 // ── Peer management (plain text) ─────────────────────────────────────────
 
+/// GET /connect?peer=PEER&port=PORT
+///
+/// Mirrors stellar-core `CommandHandler::connect` (CommandHandler.cpp:478):
+/// the connect is fire-and-forget, so the success string is returned
+/// unconditionally once a peer+port are supplied (independent of whether the
+/// TCP connection ultimately succeeds). Wires into [`App::connect_peer`].
 pub(crate) async fn compat_connect_handler(
-    State(_state): State<Arc<CompatServerState>>,
+    State(state): State<Arc<CompatServerState>>,
     Query(params): Query<ConnectParams>,
 ) -> impl IntoResponse {
-    match params.peer {
-        Some(_peer) => "done\n".to_string(),
-        None => "Must specify a peer: connect?peer=<ip>&port=<port>\n".to_string(),
-    }
+    // stellar-core keys on both peer and port being present.
+    let (Some(peer), Some(port)) = (params.peer.clone(), params.port) else {
+        return "Must specify a peer and port: connect&peer=PEER&port=PORT\n".to_string();
+    };
+
+    let addr = match crate::http::helpers::parse_connect_params(&params) {
+        Ok(addr) => addr,
+        // A malformed peer/port still yields the "must specify" guidance, as
+        // there is no resolvable target to connect to.
+        Err(_) => {
+            return "Must specify a peer and port: connect&peer=PEER&port=PORT\n".to_string();
+        }
+    };
+
+    // Fire-and-forget: kick off the connect but do not reflect its outcome,
+    // matching stellar-core's unconditional retStr.
+    let _ = state.app.connect_peer(addr).await;
+    format!("Connect to: {}:{}\n", peer, port)
 }
 
+/// GET /droppeer?node=NODE_ID[&ban=1]
+///
+/// Mirrors stellar-core `CommandHandler::dropPeer` (CommandHandler.cpp:~543):
+/// keyed on `node`. Wires into [`App::disconnect_peer`] (+ [`App::ban_peer`]
+/// when `ban=1`). Any disconnect failure variant or an unresolvable node id
+/// collapses to the "not found" string so internal error prose never leaks.
 pub(crate) async fn compat_droppeer_handler(
-    State(_state): State<Arc<CompatServerState>>,
+    State(state): State<Arc<CompatServerState>>,
     Query(params): Query<DropPeerParams>,
 ) -> impl IntoResponse {
-    match params.node {
-        Some(_) => "done\n".to_string(),
-        None => "Must specify a peer: droppeer?node=<node_id>\n".to_string(),
+    let Some(node) = params.node.clone() else {
+        return "Must specify at least peer id: droppeer?node=NODE_ID\n".to_string();
+    };
+
+    let peer_id = match crate::http::helpers::parse_peer_id_params(&None, &params.node) {
+        Ok(peer_id) => peer_id,
+        // resolveNodeID-false in core → "Peer X not found".
+        Err(_) => return format!("Peer {} not found\n", node),
+    };
+
+    // Any DisconnectError (PeerNotFound or OverlayUnavailable) maps to the
+    // core not-found string.
+    if state.app.disconnect_peer(&peer_id).await.is_err() {
+        return format!("Peer {} not found\n", node);
+    }
+
+    let ban_requested = params.ban.unwrap_or(0) == 1;
+    if ban_requested {
+        // The disconnect already happened; a ban failure is non-fatal to the
+        // compat response (the peer is dropped regardless).
+        let _ = state.app.ban_peer(peer_id).await;
+        format!("Drop and ban peer: {}\n", node)
+    } else {
+        format!("Drop peer: {}\n", node)
     }
 }
 
+/// GET /unban?node=NODE_ID
+///
+/// Mirrors stellar-core `CommandHandler::unban` (CommandHandler.cpp:566):
+/// returns the success string whenever the node id resolves. Wires into
+/// [`App::unban_peer`], which removes the DB ban row first; an
+/// overlay-unavailable error after that point is collapsed to success because
+/// the meaningful (DB) side effect has already happened.
 pub(crate) async fn compat_unban_handler(
-    State(_state): State<Arc<CompatServerState>>,
-    Query(_params): Query<UnbanParams>,
+    State(state): State<Arc<CompatServerState>>,
+    Query(params): Query<UnbanParams>,
 ) -> impl IntoResponse {
-    "done\n"
+    let Some(node) = params.node.clone() else {
+        return "Must specify at least peer id: unban?node=NODE_ID\n".to_string();
+    };
+
+    let peer_id = match crate::http::helpers::parse_peer_id_params(&None, &params.node) {
+        Ok(peer_id) => peer_id,
+        Err(_) => return format!("Peer {} not found\n", node),
+    };
+
+    // unban_peer removes the DB row before its overlay check, so even an
+    // overlay-unavailable Err means the meaningful side effect succeeded.
+    // core returns "Unban peer:" whenever the id resolves, regardless.
+    let _ = state.app.unban_peer(&peer_id).await;
+    format!("Unban peer: {}\n", node)
 }
 
 /// GET /bans
+///
+/// Mirrors stellar-core `CommandHandler::bans` (CommandHandler.cpp:553):
+/// returns the banned node strkeys. Wires into [`App::banned_peers`] (pure DB
+/// `load_bans`). The empty case emits `{"bans": []}` (a documented divergence
+/// from core's jsoncpp `{"bans": null}`; see crates/app/PARITY_STATUS.md).
 pub(crate) async fn compat_bans_handler(
-    State(_state): State<Arc<CompatServerState>>,
+    State(state): State<Arc<CompatServerState>>,
 ) -> impl IntoResponse {
-    Json(serde_json::json!({"bans": []}))
+    let bans = state
+        .app
+        .banned_peers()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(crate::http::helpers::peer_id_to_strkey)
+        .collect::<Vec<_>>();
+    Json(serde_json::json!({ "bans": bans }))
 }
 
 // ── JSON endpoints (delegate to native logic) ───────────────────────────

--- a/crates/app/src/http/helpers.rs
+++ b/crates/app/src/http/helpers.rs
@@ -7,7 +7,7 @@ use stellar_xdr::curr::LedgerUpgrade;
 use super::types::{ConnectParams, UpgradeItem};
 
 /// Parse connect endpoint parameters into a PeerAddress.
-pub(super) fn parse_connect_params(params: &ConnectParams) -> Result<PeerAddress, String> {
+pub(crate) fn parse_connect_params(params: &ConnectParams) -> Result<PeerAddress, String> {
     if let Some(addr) = params.addr.as_ref() {
         return crate::config::parse_peer_address(addr);
     }
@@ -23,7 +23,7 @@ pub(super) fn parse_connect_params(params: &ConnectParams) -> Result<PeerAddress
 }
 
 /// Parse a peer_id or node parameter into a PeerId.
-pub(super) fn parse_peer_id_params(
+pub(crate) fn parse_peer_id_params(
     peer_id: &Option<String>,
     node: &Option<String>,
 ) -> Result<PeerId, String> {
@@ -59,7 +59,7 @@ pub(super) fn node_id_to_strkey(node_id: &stellar_xdr::curr::NodeId) -> Option<S
 }
 
 /// Convert a PeerId to its strkey representation.
-pub(super) fn peer_id_to_strkey(peer_id: PeerId) -> Option<String> {
+pub(crate) fn peer_id_to_strkey(peer_id: PeerId) -> Option<String> {
     node_id_to_strkey(&stellar_xdr::curr::NodeId(peer_id.0))
 }
 


### PR DESCRIPTION
Closes #3294

## Summary

Replaces the four stubbed compat peer-admin handlers (`/connect`, `/droppeer`, `/unban`, `/bans`) in `crates/app/src/compat_http/handlers/plaintext.rs` with calls into the already-shipped native `App` methods (`connect_peer`, `disconnect_peer`, `ban_peer`/`unban_peer`, `banned_peers`), formatting responses to byte-match stellar-core `CommandHandler.cpp`. The `parse_connect_params` / `parse_peer_id_params` / `peer_id_to_strkey` helpers in `crates/app/src/http/helpers.rs` are widened from `pub(super)` to `pub(crate)` so the sibling `compat_http` module reuses them instead of duplicating parsing. Overlay/DB logic is untouched.

Behavioral fidelity per the converged plan and critic minor items:
- All `DisconnectError` variants (and unresolvable node ids) collapse to `"Peer <node> not found\n"` — internal error prose never leaks.
- `unban_peer` removes the DB ban row before its overlay-availability check, so an overlay-unavailable `Err` collapses to the success text `"Unban peer: <node>\n"`; the unban test calls `start_overlay()`.
- `/connect` returns `"Connect to: <peer>:<port>\n"` unconditionally (fire-and-forget, mirroring core's retStr).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3294#issuecomment-4723533805)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-app — 1040 lib + integration + doc tests pass (22 in `compat_http::handlers::plaintext::tests`)

## Side-effect regression tests (prove real wiring)

Two new tests genuinely fail on `origin/main` (the stubs have no side effect) and pass after the fix:

- **`test_compat_bans_reflects_db_load_bans`**
  - Pre-fix (`8e469321`): FAILED — `banned strkey G... not found in {"bans":[]}` (stub always returns `{"bans": []}`).
  - Post-fix (`ecb103e3`): PASSES — the banned peer's strkey appears in the `bans` array via real `load_bans`.
- **`test_compat_unban_removes_ban`**
  - Pre-fix (`8e469321`): FAILED — `left: "done\n"`, `right: "Unban peer: G...\n"` (stub returns canned `"done\n"`, ban persists).
  - Post-fix (`ecb103e3`): PASSES — returns `"Unban peer: <node>\n"` AND `banned_peers()` no longer contains the peer (real DB unban).

The remaining 7 new tests cover missing-param / not-found / unresolvable / success-shape across all four endpoints.

## Parity

Message strings byte-match `CommandHandler.cpp` (connect:478, dropPeer:~543, bans:553, unban:566). Two intentional, documented divergences in `crates/app/PARITY_STATUS.md`: trailing `\n` (henyey compat plain-text convention) and empty `/bans` as `{"bans": []}` (core emits jsoncpp `{"bans": null}`; SSC/stellar-rpc treat them equivalently). Overlay PARITY_STATUS.md unchanged — overlay APIs already exist and are consumed, not modified.

## Deviations from plan

- Also widened `peer_id_to_strkey` in `http/helpers.rs` to `pub(crate)` (the plan named only the two parse helpers) so `/bans` reuses the native handler's exact strkey conversion rather than duplicating it. Minor, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)