### PR TITLE
Emit real medida rates/percentiles for the 4 SSC-read compat metrics

### DIFF
--- a/crates/app/PARITY_STATUS.md
+++ b/crates/app/PARITY_STATUS.md
@@ -12,6 +12,7 @@
 | Application lifecycle and runtime wiring | Full | Init, run, catchup, shutdown, recovery loops; `lost_sync_count` metric matches stellar-core single-site `mLostSync.Mark()` (#2612) |
 | Configuration loading and compat translation | Partial | Core TOML and captive-core translation work; many stellar-core helpers omitted |
 | HTTP admin and query surfaces | Partial | Core endpoints exist including generateLoad; several compat admin routes are stubbed or absent |
+| Compat `/metrics` medida rates/percentiles | Partial | EWMA meter rates (`scp.value.valid`/`scp.value.invalid`, `ledger.ledger.close` rate fields) are an **exact** port of medida `ewma.cc`/`meter.cc`; timer/histogram percentiles (`ledger.ledger.close`, `ledger.transaction.count`) use an R7-over-256-sample-ring **documented approximation** of medida's CKMS-30s sample (#3296) — see [Compat `/metrics` medida accumulators](#compat-metrics-medida-accumulators-srcmedida_compatrs) |
 | Catchup and restart recovery | Full | Archive catchup, replay, restart restore, publish flow wired |
 | Persistent state integration | Partial | Critical state persisted through `henyey-db`; some SCP helper APIs absent |
 | Transaction flooding | Partial | Pull-mode advert/demand scheduling; classic flood budgets use stellar-core truncate-then-round integer arithmetic with distinct `FLOOD_TX_PERIOD_MS` for broadcast budget; Soroban advert/demand capacity remains a gap; advert flush cadence is consolidated with broadcast (200 ms) rather than separate (100 ms); removed non-parity `base_fee` overlay pre-filter on `GeneralizedTxSet` receive (stellar-core does zero validation at receive layer); overlay receive layer now matches stellar-core (zero structural validation — all validation deferred to herder via `prepare_for_apply`); buffered ledger close validates tx sets via `prepare_for_apply` before application (matching stellar-core `LedgerManagerImpl.cpp:1542`); flood advert stamping uses `tracking_consensus_ledger_index()` matching stellar-core `Peer::recvFloodAdvert()` (`Peer.cpp:2089`) |
@@ -36,6 +37,7 @@
 | `ApplicationImpl.cpp`, `TransactionQueue.cpp`, `TxAdverts.cpp`, `TxDemandsManager.cpp` | `src/app/tx_flooding.rs` | Tx advert/demand scheduling; classic flood budget rounding matches stellar-core integer arithmetic; broadcast period uses `flood_tx_period_ms` (200 ms, matching `FLOOD_TX_PERIOD_MS`) |
 | `Config.h` / `Config.cpp` | `src/config.rs`, `src/compat_config.rs` | Native TOML config plus stellar-core-format translation |
 | `CommandHandler.h` / `CommandHandler.cpp` | `src/http/mod.rs`, `src/http/handlers/`, `src/compat_http/` | Native Axum server plus compat wire-format server |
+| `lib/libmedida/.../stats/ewma.cc`, `meter.cc`, `stats/snapshot.cc` | `src/medida_compat.rs` | EWMA meter rates (exact); R7-reservoir timer/histogram percentiles (documented CKMS approximation) for the compat `/metrics` endpoint (#3296) |
 | `QueryServer.h` / `QueryServer.cpp` | `src/http/mod.rs`, `src/http/handlers/query.rs` | Separate query server with snapshot lookups |
 | `Maintainer.h` / `Maintainer.cpp` | `src/maintainer.rs` | Automatic background maintenance |
 | `PersistentState.h` / `PersistentState.cpp` | `src/app/mod.rs`, `henyey-db` | App owns usage; storage primitives live in `henyey-db` |
@@ -260,6 +262,44 @@ Features not yet implemented. These ARE counted against parity %.
 - Account-ban persistence has no Rust tests because the subsystem is not implemented. Upstream has 4 TEST_CASE / 21 SECTION.
 - HTTP threaded server behavior (3 TEST_CASE upstream in `HttpThreadedTests.cpp`) has no direct equivalent.
 
+### Compat `/metrics` medida accumulators (`src/medida_compat.rs`)
+
+Corresponds to: `lib/libmedida/src/medida/stats/ewma.cc`, `meter.cc`,
+`stats/snapshot.cc`; reported by `src/compat_http/handlers/metrics.rs`.
+
+stellar-core's `/metrics` endpoint emits medida JSON with in-process EWMA rates
+and timer/histogram percentiles. henyey's native metrics layer is Prometheus-based
+and does not maintain these, so the compat handler previously emitted hardcoded
+`0.0`s. `src/medida_compat.rs` adds in-process accumulators for exactly the four
+metrics SSC missions read (#3296):
+
+| medida metric | henyey accumulator | Parity |
+|---------------|--------------------|--------|
+| `ledger.ledger.close` rate fields (`mean_rate`, `1/5/15_min_rate`) | `EwmaMeter` (embedded, `event_type="calls"`) | **Full** — exact port of `ewma.cc`/`meter.cc`: alphas `1-exp(-5/(60·N))`, 5s lazy `TickIfNecessary`, first-sample seeding, `mean_rate = count·1e9/elapsed_ns` |
+| `scp.value.valid` / `scp.value.invalid` meters | `EwmaMeter` (`event_type="value"`, `HerderSCPDriver.cpp:55,57`) | **Full** — same EWMA port; fed app-side by delta-marking the already-exposed `ScpMetricsSnapshot` cumulative totals on the periodic metrics refresh (no herder→app coupling) |
+| `ledger.ledger.close` / `ledger.transaction.count` percentiles + `min/max/mean/stddev/sum` | `ReservoirSample` (256-entry ring + R7 interpolation) | **Partial** — see divergence below |
+
+**Documented percentile divergence (Partial).** stellar-core's default
+`Timer`/`Histogram` sample is a **CKMS** error-bounded streaming sketch over a
+30-second sliding window (`Timer::GetSnapshot()` → `Snapshot::CKMSImpl::getValue`).
+henyey instead keeps the last **256 observations** in a fixed-capacity ring and
+computes percentiles with the **R7 (Hyndman-Fan) interpolation over a sorted
+vector** copied verbatim from medida's `snapshot.cc Snapshot::VectorImpl::getValue`.
+Two precise differences:
+
+1. **Algorithm:** R7 exact-sorted interpolation vs CKMS error-bounded sketch — the
+   percentile *values* differ.
+2. **Window:** a **256-observation capacity window, NOT a time window** vs CKMS's
+   30-second time window. Under accelerated-time missions (e.g. 1s closes) 256
+   closes span ~256s of history, far wider than 30s, so percentiles are
+   smoother/laggier than stellar-core's.
+
+This is sufficient for SSC's presence/ordering/non-zero assertion class (SSC has
+no oracle for the exact CKMS values a henyey node would produce). `min`/`max`/
+`mean`/`sum` are stored/scaled in milliseconds to match stellar-core's timer
+`duration_unit`. If a mission proves sensitive to the window, the ring capacity
+can be tuned or a real CKMS port landed as a follow-up.
+
 ## Verification Results
 
 - **Testnet verification**: Node successfully syncs and tracks consensus on testnet, closing ledgers in parity with stellar-core validators.
@@ -275,7 +315,7 @@ Features not yet implemented. These ARE counted against parity %.
 
 | Category | Count |
 |----------|-------|
-| Implemented (Full) | 90 |
-| Gaps (None + Partial) | 39 |
+| Implemented (Full) | 92 |
+| Gaps (None + Partial) | 40 |
 | Intentional Omissions | 24 |
-| **Parity** | **90 / (90 + 39) = 70%** |
+| **Parity** | **92 / (92 + 40) = 70%** |

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2342,6 +2342,14 @@ impl App {
                 .record(result.stats.close_time_ms as f64 / 1000.0);
         }
 
+        // Feed the medida-compat `ledger.ledger.close` timer (close duration in
+        // ms) + embedded meter, and the `ledger.transaction.count` histogram,
+        // for the stellar-core-compatible /metrics endpoint (#3296).
+        crate::medida_compat::medida_compat().record_ledger_close(
+            result.stats.close_time_ms as f64,
+            result.stats.tx_count as u64,
+        );
+
         // Phase 5: Per-phase close-duration histograms (LedgerClosePerf).
         if let Some(ref perf) = result.perf {
             let us_to_secs = |us: u64| us as f64 / 1_000_000.0;

--- a/crates/app/src/compat_http/handlers/metrics.rs
+++ b/crates/app/src/compat_http/handlers/metrics.rs
@@ -22,8 +22,9 @@ use crate::compat_http::CompatServerState;
 /// - `"timer"`: count + duration percentiles + rate
 /// - `"meter"`: count + event rate
 ///
-/// We emit real values where we have them and zero placeholders for
-/// rate/percentile fields we don't yet track.
+/// The four medida metrics SSC missions read emit REAL in-process
+/// rate/percentile values from the [`crate::medida_compat`] accumulators. Other
+/// rate/percentile fields we don't track remain `0.0` placeholders.
 pub(crate) async fn compat_metrics_handler(
     State(state): State<Arc<CompatServerState>>,
 ) -> impl IntoResponse {
@@ -32,88 +33,133 @@ pub(crate) async fn compat_metrics_handler(
     let (pending_count, authenticated_count) = app.peer_counts().await;
     let ledger_tx_count = app.ledger_tx_count();
 
-    Json(serde_json::json!({
+    // Read real medida-compat snapshots. The scp meters are fed (delta-marked)
+    // from the periodic metrics refresh path; the close timer/histogram are fed
+    // from the ledger-close path.
+    let compat = crate::medida_compat::medida_compat();
+
+    let scalars = MetricsScalars {
+        protocol_version: info.protocol_version,
+        peer_count: authenticated_count + pending_count,
+        authenticated_count,
+        pending_count,
+        pending_transactions: app.pending_transaction_count(),
+        ledger_tx_count,
+    };
+
+    Json(build_metrics_json(&scalars, compat))
+}
+
+/// Non-metrics-registry scalar values (counters/gauges) the handler reports.
+struct MetricsScalars {
+    protocol_version: u32,
+    peer_count: usize,
+    authenticated_count: usize,
+    pending_count: usize,
+    pending_transactions: usize,
+    ledger_tx_count: u64,
+}
+
+/// Build the medida-compatible `/metrics` JSON, reading real rate/percentile
+/// values from the [`crate::medida_compat::MedidaCompat`] accumulators. Factored
+/// out of the async handler so it can be unit-tested without a live `App`.
+///
+/// Field names/types/order mirror stellar-core's `json_reporter.cc`
+/// `Process(Timer/Meter/Histogram)`. scp meters use `event_type = "value"`
+/// (`HerderSCPDriver.cpp:55,57`); the close timer's embedded meter uses
+/// `event_type = "calls"` (`LedgerManagerImpl.cpp:204`).
+fn build_metrics_json(
+    s: &MetricsScalars,
+    compat: &crate::medida_compat::MedidaCompat,
+) -> serde_json::Value {
+    let close_timer = compat.close_timer.snapshot();
+    let close_meter = compat.close_meter.snapshot();
+    let tx_hist = compat.tx_count_histogram.snapshot();
+    let scp_valid = compat.scp_value_valid.snapshot();
+    let scp_invalid = compat.scp_value_invalid.snapshot();
+
+    serde_json::json!({
         "metrics": {
             "ledger.ledger.close": {
                 "type": "timer",
-                "count": info.ledger_seq,
+                "count": close_timer.count,
                 "event_type": "calls",
                 "rate_unit": "second",
-                "mean_rate": 0.0,
-                "1_min_rate": 0.0,
-                "5_min_rate": 0.0,
-                "15_min_rate": 0.0,
+                "mean_rate": close_meter.mean_rate,
+                "1_min_rate": close_meter.one_minute_rate,
+                "5_min_rate": close_meter.five_minute_rate,
+                "15_min_rate": close_meter.fifteen_minute_rate,
                 "duration_unit": "millisecond",
-                "min": 0.0,
-                "max": 0.0,
-                "mean": 0.0,
-                "stddev": 0.0,
-                "sum": 0.0,
-                "median": 0.0,
-                "75%": 0.0,
-                "95%": 0.0,
-                "98%": 0.0,
-                "99%": 0.0,
-                "99.9%": 0.0,
-                "100%": 0.0
+                "min": close_timer.min,
+                "max": close_timer.max,
+                "mean": close_timer.mean,
+                "stddev": close_timer.stddev,
+                "sum": close_timer.sum,
+                "median": close_timer.median,
+                "75%": close_timer.p75,
+                "95%": close_timer.p95,
+                "98%": close_timer.p98,
+                "99%": close_timer.p99,
+                "99.9%": close_timer.p999,
+                "100%": close_timer.max
             },
             "ledger.transaction.count": {
                 "type": "histogram",
-                "count": ledger_tx_count,
-                "min": 0.0,
-                "max": 0.0,
-                "mean": 0.0,
-                "stddev": 0.0,
-                "median": 0.0,
-                "75%": 0.0,
-                "95%": 0.0,
-                "98%": 0.0,
-                "99%": 0.0,
-                "99.9%": 0.0,
-                "100%": 0.0
+                "count": s.ledger_tx_count,
+                "min": tx_hist.min,
+                "max": tx_hist.max,
+                "mean": tx_hist.mean,
+                "stddev": tx_hist.stddev,
+                "median": tx_hist.median,
+                "75%": tx_hist.p75,
+                "95%": tx_hist.p95,
+                "98%": tx_hist.p98,
+                "99%": tx_hist.p99,
+                "99.9%": tx_hist.p999,
+                "100%": tx_hist.max
             },
             "peer.peer.count": {
                 "type": "counter",
-                "count": authenticated_count + pending_count
+                "count": s.peer_count
             },
             "peer.peer.authenticated-count": {
                 "type": "counter",
-                "count": authenticated_count
+                "count": s.authenticated_count
             },
             "peer.peer.pending-count": {
                 "type": "counter",
-                "count": pending_count
+                "count": s.pending_count
             },
             "herder.pending.transactions": {
                 "type": "counter",
-                "count": app.pending_transaction_count()
+                "count": s.pending_transactions
             },
             "ledger.ledger.version": {
                 "type": "counter",
-                "count": info.protocol_version
+                "count": s.protocol_version
             },
             "scp.value.valid": {
                 "type": "meter",
-                "count": info.ledger_seq,
-                "event_type": "events",
+                "count": scp_valid.count,
+                "event_type": "value",
                 "rate_unit": "second",
-                "mean_rate": 0.0,
-                "1_min_rate": 0.0,
-                "5_min_rate": 0.0,
-                "15_min_rate": 0.0
+                "mean_rate": scp_valid.mean_rate,
+                "1_min_rate": scp_valid.one_minute_rate,
+                "5_min_rate": scp_valid.five_minute_rate,
+                "15_min_rate": scp_valid.fifteen_minute_rate
             },
             "scp.value.invalid": {
                 "type": "meter",
-                "count": 0,
-                "event_type": "events",
+                "count": scp_invalid.count,
+                "event_type": "value",
                 "rate_unit": "second",
-                "mean_rate": 0.0,
-                "1_min_rate": 0.0,
-                "5_min_rate": 0.0,
-                "15_min_rate": 0.0
+                "mean_rate": scp_invalid.mean_rate,
+                "1_min_rate": scp_invalid.one_minute_rate,
+                "5_min_rate": scp_invalid.five_minute_rate,
+                "15_min_rate": scp_invalid.fifteen_minute_rate
             }
         }
-    }))
+    })
 }
 
 #[cfg(test)]
@@ -229,6 +275,161 @@ mod tests {
         let rate_fields = ["mean_rate", "1_min_rate", "5_min_rate", "15_min_rate"];
         for field in &rate_fields {
             assert!(meter.get(*field).is_some(), "meter must have '{field}'");
+        }
+    }
+
+    use super::{build_metrics_json, MetricsScalars};
+    use crate::medida_compat::MedidaCompat;
+
+    fn test_scalars() -> MetricsScalars {
+        MetricsScalars {
+            protocol_version: 23,
+            peer_count: 5,
+            authenticated_count: 4,
+            pending_count: 1,
+            pending_transactions: 3,
+            ledger_tx_count: 42,
+        }
+    }
+
+    /// The four SSC-read metrics emit REAL non-zero rate/percentile values after
+    /// synthetic observations (the pre-fix handler hardcoded these to 0.0). Also
+    /// asserts the scp meters use `event_type="value"`, the counts are real, and
+    /// the medida JSON shape is unchanged.
+    #[test]
+    fn test_metrics_real_values_after_observations() {
+        use std::time::{Duration, Instant};
+        // Anchor the meters 6s in the past and mark there, so that when the
+        // handler reads the meters at the current wall clock the EWMA lazy-tick
+        // (5s interval) has fired at least once and the rate fields are non-zero
+        // — faithful medida behaviour (rates seed on the first tick, not on the
+        // mark).
+        let past = Instant::now() - Duration::from_secs(6);
+        let compat = MedidaCompat::new_for_test_at(past);
+        // Synthetic ledger closes: durations (ms) + tx counts.
+        for (ms, txs) in [(100.0, 50), (200.0, 80), (150.0, 60), (90.0, 40)] {
+            compat.record_ledger_close_at(ms, txs, past);
+        }
+        // Feed scp meters from cumulative snapshots (delta-marked) in the past.
+        compat.feed_scp_at(120, 7, past);
+
+        let v = build_metrics_json(&test_scalars(), &compat);
+        let m = v["metrics"].as_object().unwrap();
+
+        // --- Close timer: real percentiles + rate ---
+        let close = &m["ledger.ledger.close"];
+        assert_eq!(close["type"], "timer");
+        assert_eq!(close["count"], 4, "timer count is real observation count");
+        assert_eq!(close["event_type"], "calls");
+        assert!(
+            close["median"].as_f64().unwrap() > 0.0,
+            "median must be non-zero, got {}",
+            close["median"]
+        );
+        assert!(
+            close["99%"].as_f64().unwrap() > 0.0,
+            "99% must be non-zero, got {}",
+            close["99%"]
+        );
+        assert!(
+            close["1_min_rate"].as_f64().unwrap() > 0.0,
+            "1_min_rate must be non-zero, got {}",
+            close["1_min_rate"]
+        );
+        assert!(close["min"].as_f64().unwrap() > 0.0);
+        assert!(close["max"].as_f64().unwrap() > 0.0);
+        assert!(close["sum"].as_f64().unwrap() > 0.0);
+        // Percentile ordering.
+        let med = close["median"].as_f64().unwrap();
+        let p99 = close["99%"].as_f64().unwrap();
+        assert!(med <= p99, "median {med} <= p99 {p99}");
+
+        // --- tx-count histogram: real percentiles ---
+        let hist = &m["ledger.transaction.count"];
+        assert_eq!(hist["type"], "histogram");
+        assert_eq!(hist["count"], 42, "histogram count from ledger_tx_count");
+        assert!(
+            hist["median"].as_f64().unwrap() > 0.0,
+            "hist median non-zero"
+        );
+        assert!(hist["max"].as_f64().unwrap() >= hist["median"].as_f64().unwrap());
+
+        // --- scp meters: event_type "value", real count + rate ---
+        let valid = &m["scp.value.valid"];
+        assert_eq!(valid["type"], "meter");
+        assert_eq!(
+            valid["event_type"], "value",
+            "scp meter event_type is 'value'"
+        );
+        assert_eq!(valid["count"], 120, "scp.value.valid count is real total");
+        assert!(
+            valid["1_min_rate"].as_f64().unwrap() > 0.0,
+            "scp.value.valid 1_min_rate must be non-zero"
+        );
+        let invalid = &m["scp.value.invalid"];
+        assert_eq!(invalid["event_type"], "value");
+        assert_eq!(invalid["count"], 7, "scp.value.invalid count is real total");
+
+        // --- Shape preserved: all 9 metrics with type+count ---
+        assert_eq!(m.len(), 9, "should still emit 9 metrics");
+        for (name, metric) in m {
+            assert!(metric.get("type").is_some(), "{name} has type");
+            assert!(metric.get("count").is_some(), "{name} has count");
+        }
+        // Timer/histogram percentile field names unchanged.
+        for field in ["median", "75%", "95%", "98%", "99%", "99.9%", "100%"] {
+            assert!(close.get(field).is_some(), "timer has {field}");
+            assert!(hist.get(field).is_some(), "histogram has {field}");
+        }
+    }
+
+    /// With no observations, the four metrics report 0.0 rate/percentile fields
+    /// and the shape matches the existing shape contract.
+    #[test]
+    fn test_metrics_zero_at_startup() {
+        let compat = MedidaCompat::new_for_test();
+        let v = build_metrics_json(&test_scalars(), &compat);
+        let m = v["metrics"].as_object().unwrap();
+
+        let close = &m["ledger.ledger.close"];
+        assert_eq!(close["count"], 0);
+        for field in [
+            "mean_rate",
+            "1_min_rate",
+            "5_min_rate",
+            "15_min_rate",
+            "min",
+            "max",
+            "mean",
+            "stddev",
+            "sum",
+            "median",
+            "75%",
+            "95%",
+            "98%",
+            "99%",
+            "99.9%",
+            "100%",
+        ] {
+            assert_eq!(close[field].as_f64().unwrap(), 0.0, "close {field} is 0.0");
+        }
+
+        let valid = &m["scp.value.valid"];
+        assert_eq!(valid["count"], 0);
+        assert_eq!(valid["event_type"], "value");
+        for field in ["mean_rate", "1_min_rate", "5_min_rate", "15_min_rate"] {
+            assert_eq!(
+                valid[field].as_f64().unwrap(),
+                0.0,
+                "scp valid {field} is 0.0"
+            );
+        }
+
+        // Shape contract: 9 metrics, all with type+count.
+        assert_eq!(m.len(), 9);
+        for (name, metric) in m {
+            assert!(metric.get("type").is_some(), "{name} has type");
+            assert!(metric.get("count").is_some(), "{name} has count");
         }
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -61,6 +61,7 @@ pub mod config;
 pub mod http;
 pub mod logging;
 pub mod maintainer;
+pub mod medida_compat;
 pub mod meta_stream;
 pub mod meta_writer;
 pub mod metrics;

--- a/crates/app/src/medida_compat.rs
+++ b/crates/app/src/medida_compat.rs
@@ -475,11 +475,43 @@ impl MedidaCompat {
         }
     }
 
+    /// Construct a fresh, isolated registry for unit tests (the process-global
+    /// [`medida_compat`] singleton is shared and not suitable for assertions on
+    /// exact values).
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Self {
+        Self::new()
+    }
+
+    /// Like [`new_for_test`], but anchors the meters' start/last-tick instants at
+    /// `now`. Marking at `now` and reading the snapshot at a wall clock ≥5s later
+    /// then exercises the lazy-tick rate path deterministically.
+    #[cfg(test)]
+    pub(crate) fn new_for_test_at(now: Instant) -> Self {
+        MedidaCompat {
+            close_timer: ReservoirSample::new(),
+            close_meter: EwmaMeter::new_at(now),
+            tx_count_histogram: ReservoirSample::new(),
+            scp_value_valid: EwmaMeter::new_at(now),
+            scp_value_invalid: EwmaMeter::new_at(now),
+            scp_last_seen: Mutex::new(ScpLastSeen::default()),
+        }
+    }
+
     /// Record a ledger close: `close_ms` into the close timer + meter, `tx_count`
     /// into the tx-count histogram. Called from the ledger-close path.
     pub fn record_ledger_close(&self, close_ms: f64, tx_count: u64) {
         self.close_timer.update(close_ms);
         self.close_meter.mark(1);
+        self.tx_count_histogram.update(tx_count as f64);
+    }
+
+    /// Like [`record_ledger_close`], but marks the close meter at an injected
+    /// instant so the EWMA lazy-tick behaviour is deterministically testable.
+    #[cfg(test)]
+    pub(crate) fn record_ledger_close_at(&self, close_ms: f64, tx_count: u64, now: Instant) {
+        self.close_timer.update(close_ms);
+        self.close_meter.mark_at(1, now);
         self.tx_count_histogram.update(tx_count as f64);
     }
 
@@ -499,6 +531,29 @@ impl MedidaCompat {
         }
         if invalid_delta > 0 {
             self.scp_value_invalid.mark(invalid_delta);
+        }
+    }
+
+    /// Like [`feed_scp`], but marks at an injected instant for deterministic
+    /// rate tests.
+    #[cfg(test)]
+    pub(crate) fn feed_scp_at(
+        &self,
+        value_valid_total: u64,
+        value_invalid_total: u64,
+        now: Instant,
+    ) {
+        let mut last = self.scp_last_seen.lock().unwrap();
+        let valid_delta = value_valid_total.saturating_sub(last.value_valid_total);
+        let invalid_delta = value_invalid_total.saturating_sub(last.value_invalid_total);
+        last.value_valid_total = value_valid_total;
+        last.value_invalid_total = value_invalid_total;
+        drop(last);
+        if valid_delta > 0 {
+            self.scp_value_valid.mark_at(valid_delta, now);
+        }
+        if invalid_delta > 0 {
+            self.scp_value_invalid.mark_at(invalid_delta, now);
         }
     }
 }

--- a/crates/app/src/medida_compat.rs
+++ b/crates/app/src/medida_compat.rs
@@ -1,0 +1,777 @@
+//! In-process medida-compatible rate (EWMA meter) and percentile (R7 reservoir)
+//! accumulators for the stellar-core compatibility `/metrics` endpoint.
+//!
+//! stellar-core's `/metrics` endpoint reports medida-format JSON in which
+//! `meter` and `timer` metrics carry exponentially-weighted moving-average
+//! (EWMA) rates (`1_min_rate`/`5_min_rate`/`15_min_rate`/`mean_rate`) and
+//! `timer`/`histogram` metrics carry duration percentiles
+//! (`median`/`75%`/`95%`/`98%`/`99%`/`99.9%`/`100%`) plus
+//! `min`/`max`/`mean`/`stddev`/`sum`. henyey's native metrics layer is built on
+//! Prometheus primitives and does NOT maintain these in-process, so the compat
+//! handler previously emitted hardcoded `0.0`s for every rate/percentile field.
+//!
+//! This module fills that gap for exactly the four metrics SSC missions read:
+//! `ledger.ledger.close` (timer), `ledger.transaction.count` (histogram),
+//! `scp.value.valid` and `scp.value.invalid` (meters). No other metric is
+//! instrumented here.
+//!
+//! ## Parity
+//!
+//! - [`EwmaMeter`] is a faithful port of stellar-core's
+//!   `lib/libmedida/src/medida/stats/ewma.cc` + `meter.cc`: the alpha constants
+//!   `1 - exp(-5 / (60 * N))` for N ∈ {1, 5, 15} minutes, the 5-second LAZY
+//!   `TickIfNecessary` model (ticks are applied on read/mark, NOT via an
+//!   event-loop timer), first-sample seeding, and `mean_rate = count * 1e9 /
+//!   elapsed_ns`. The clock is injectable so the decay behaviour is
+//!   deterministically testable. This is a high-fidelity port.
+//!
+//! - [`ReservoirSample`] is a **documented approximation** of stellar-core's
+//!   timer/histogram percentiles. stellar-core's default `Timer`/`Histogram`
+//!   sample is a **CKMS** error-bounded streaming sketch over a 30-second
+//!   sliding window (`Timer::GetSnapshot()` → `CKMSImpl::getValue`). This module
+//!   instead keeps the last 256 observations in a fixed-capacity ring and
+//!   computes percentiles with the **R7 (Hyndman-Fan) interpolation over a
+//!   sorted vector** copied verbatim from medida's `snapshot.cc
+//!   Snapshot::VectorImpl::getValue`. The divergences are (a) algorithm — R7
+//!   exact-sorted interpolation vs CKMS error-bounded sketch — and (b) window —
+//!   a 256-observation capacity window vs CKMS's 30-second time window. This is
+//!   sufficient for SSC's presence/ordering/non-zero assertion class (SSC has no
+//!   oracle for the exact CKMS values a henyey node would produce). See
+//!   `crates/app/PARITY_STATUS.md`.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Tick interval: stellar-core ticks the EWMAs every 5 seconds.
+const TICK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Fixed reservoir capacity (capacity-windowed, NOT time-windowed — see module docs).
+const RESERVOIR_CAPACITY: usize = 256;
+
+// EWMA alpha constants — `alpha = 1 - exp(-INTERVAL / SECONDS_PER_MINUTE / N)`,
+// matching `medida/stats/ewma.cc`'s kM1/kM5/kM15_ALPHA. INTERVAL = 5s.
+fn m1_alpha() -> f64 {
+    1.0 - (-5.0_f64 / 60.0 / 1.0).exp()
+}
+fn m5_alpha() -> f64 {
+    1.0 - (-5.0_f64 / 60.0 / 5.0).exp()
+}
+fn m15_alpha() -> f64 {
+    1.0 - (-5.0_f64 / 60.0 / 15.0).exp()
+}
+
+/// A single exponentially-weighted moving average — port of medida's
+/// `stats::EWMA::Impl`.
+///
+/// `rate_` is stored in events-per-nanosecond (medida uses `count /
+/// interval_nanos`); [`Ewma::rate`] scales it to events-per-second.
+#[derive(Debug, Clone)]
+struct Ewma {
+    initialized: bool,
+    /// Rate in events per nanosecond.
+    rate: f64,
+    /// Accumulated count not yet folded into `rate` by a tick.
+    uncounted: i64,
+    alpha: f64,
+    interval_nanos: f64,
+}
+
+impl Ewma {
+    fn new(alpha: f64) -> Self {
+        Ewma {
+            initialized: false,
+            rate: 0.0,
+            uncounted: 0,
+            alpha,
+            interval_nanos: TICK_INTERVAL.as_nanos() as f64,
+        }
+    }
+
+    /// `medida EWMA::Impl::update` — accumulate uncounted events.
+    fn update(&mut self, n: i64) {
+        self.uncounted += n;
+    }
+
+    /// `medida EWMA::Impl::tick` — fold the uncounted events into the rate.
+    fn tick(&mut self) {
+        let count = self.uncounted as f64;
+        self.uncounted = 0;
+        let instant_rate = count / self.interval_nanos;
+        if self.initialized {
+            self.rate += self.alpha * (instant_rate - self.rate);
+        } else {
+            self.rate = instant_rate;
+            self.initialized = true;
+        }
+    }
+
+    /// `medida EWMA::Impl::getRate` — scale to events per `duration`. Default
+    /// duration is one second, matching medida's `getRate()`.
+    fn rate(&self, duration: Duration) -> f64 {
+        self.rate * duration.as_nanos() as f64
+    }
+}
+
+/// A medida-compatible meter — port of `medida::Meter::Impl`.
+///
+/// Holds three EWMAs (1/5/15-minute), a cumulative count, and a start instant.
+/// Ticks are applied lazily on `mark`/read based on the injectable clock, so no
+/// event-loop timer is required.
+#[derive(Debug)]
+struct MeterInner {
+    count: u64,
+    start: Instant,
+    last_tick: Instant,
+    m1: Ewma,
+    m5: Ewma,
+    m15: Ewma,
+}
+
+impl MeterInner {
+    fn new(now: Instant) -> Self {
+        MeterInner {
+            count: 0,
+            start: now,
+            last_tick: now,
+            m1: Ewma::new(m1_alpha()),
+            m5: Ewma::new(m5_alpha()),
+            m15: Ewma::new(m15_alpha()),
+        }
+    }
+
+    /// `medida Meter::Impl::TickIfNecessary` — apply `age / 5s` ticks.
+    fn tick_if_necessary(&mut self, now: Instant) {
+        // `now` may be earlier than `last_tick` only under clock skew; saturate.
+        let age = now.saturating_duration_since(self.last_tick);
+        if age > TICK_INTERVAL {
+            let required_ticks = (age.as_nanos() / TICK_INTERVAL.as_nanos()) as u64;
+            // Advance last_tick by exactly the number of whole intervals consumed,
+            // mirroring stellar-core which sets last_tick = now (it recomputes age
+            // from the same `now`); we advance by whole intervals so a fractional
+            // remainder is carried to the next call (equivalent for whole counts).
+            self.last_tick += TICK_INTERVAL * (required_ticks as u32);
+            for _ in 0..required_ticks {
+                self.m1.tick();
+                self.m5.tick();
+                self.m15.tick();
+            }
+        }
+    }
+
+    /// `medida Meter::Impl::Mark` — tick-if-necessary THEN add.
+    fn mark(&mut self, n: u64, now: Instant) {
+        self.tick_if_necessary(now);
+        self.count += n;
+        self.m1.update(n as i64);
+        self.m5.update(n as i64);
+        self.m15.update(n as i64);
+    }
+
+    fn one_minute_rate(&mut self, now: Instant) -> f64 {
+        self.tick_if_necessary(now);
+        self.m1.rate(Duration::from_secs(1))
+    }
+    fn five_minute_rate(&mut self, now: Instant) -> f64 {
+        self.tick_if_necessary(now);
+        self.m5.rate(Duration::from_secs(1))
+    }
+    fn fifteen_minute_rate(&mut self, now: Instant) -> f64 {
+        self.tick_if_necessary(now);
+        self.m15.rate(Duration::from_secs(1))
+    }
+
+    /// `medida Meter::Impl::mean_rate` — `count * rate_unit_ns / elapsed_ns`.
+    fn mean_rate(&self, now: Instant) -> f64 {
+        if self.count > 0 {
+            let elapsed = now.saturating_duration_since(self.start).as_nanos();
+            if elapsed == 0 {
+                return 0.0;
+            }
+            (self.count as f64) * 1e9 / (elapsed as f64)
+        } else {
+            0.0
+        }
+    }
+}
+
+/// A snapshot of a meter's rate fields, in events per second.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeterSnapshot {
+    pub count: u64,
+    pub mean_rate: f64,
+    pub one_minute_rate: f64,
+    pub five_minute_rate: f64,
+    pub fifteen_minute_rate: f64,
+}
+
+/// A medida-compatible meter with an injectable clock.
+///
+/// `mark` is called from the producing thread (e.g. the metrics refresh path);
+/// reads happen from the async `/metrics` handler. All access is guarded by a
+/// `Mutex` exactly as medida guards its `Meter::Impl`. Contention is negligible
+/// — a few marks every ~5 seconds.
+#[derive(Debug)]
+pub struct EwmaMeter {
+    inner: Mutex<MeterInner>,
+}
+
+impl EwmaMeter {
+    /// Construct a meter whose start/last-tick instants are `now`.
+    pub fn new_at(now: Instant) -> Self {
+        EwmaMeter {
+            inner: Mutex::new(MeterInner::new(now)),
+        }
+    }
+
+    /// Construct a meter anchored at the current wall clock.
+    pub fn new() -> Self {
+        Self::new_at(Instant::now())
+    }
+
+    /// Mark `n` events at instant `now`.
+    pub fn mark_at(&self, n: u64, now: Instant) {
+        if n == 0 {
+            return;
+        }
+        let mut inner = self.inner.lock().unwrap();
+        inner.mark(n, now);
+    }
+
+    /// Mark `n` events at the current wall clock.
+    pub fn mark(&self, n: u64) {
+        self.mark_at(n, Instant::now());
+    }
+
+    /// Snapshot all rate fields at instant `now`.
+    pub fn snapshot_at(&self, now: Instant) -> MeterSnapshot {
+        let mut inner = self.inner.lock().unwrap();
+        MeterSnapshot {
+            count: inner.count,
+            mean_rate: inner.mean_rate(now),
+            one_minute_rate: inner.one_minute_rate(now),
+            five_minute_rate: inner.five_minute_rate(now),
+            fifteen_minute_rate: inner.fifteen_minute_rate(now),
+        }
+    }
+
+    /// Snapshot all rate fields at the current wall clock.
+    pub fn snapshot(&self) -> MeterSnapshot {
+        self.snapshot_at(Instant::now())
+    }
+}
+
+impl Default for EwmaMeter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// R7 percentile interpolation over a sorted slice — verbatim port of medida's
+/// `Snapshot::VectorImpl::getValue` (`snapshot.cc`).
+///
+/// `values` MUST be sorted ascending. `quantile` is in `[0.0, 1.0]`. Returns
+/// `0.0` for an empty slice (matching medida).
+fn r7_quantile(values: &[f64], quantile: f64) -> f64 {
+    debug_assert!((0.0..=1.0).contains(&quantile));
+    if values.is_empty() {
+        return 0.0;
+    }
+    // Step 1: range of allowed indexes [0, max_idx].
+    let max_idx = values.len() - 1;
+    // Step 2: ideal fractional index (1.0 => max_idx).
+    let ideal_index = quantile * (max_idx as f64);
+    // Step 3: floor and integral lo/hi indexes.
+    let floor_ideal = ideal_index.floor();
+    let lo_idx = floor_ideal as usize;
+    let hi_idx = lo_idx + 1;
+    // Step 4: no upper sample to interpolate with => return the highest.
+    if hi_idx > max_idx {
+        return values[max_idx];
+    }
+    // Step 5: linear interpolation between lo and hi.
+    let delta = ideal_index - floor_ideal;
+    let lower = values[lo_idx];
+    let upper = values[hi_idx];
+    lower + delta * (upper - lower)
+}
+
+/// A snapshot of a reservoir's distribution statistics, in the reservoir's
+/// stored unit (milliseconds, for the close timer / tx-count histogram).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReservoirSnapshot {
+    pub count: u64,
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    pub stddev: f64,
+    pub sum: f64,
+    pub median: f64,
+    pub p75: f64,
+    pub p95: f64,
+    pub p98: f64,
+    pub p99: f64,
+    pub p999: f64,
+}
+
+impl ReservoirSnapshot {
+    /// The all-zero snapshot returned for an empty reservoir.
+    pub const ZERO: ReservoirSnapshot = ReservoirSnapshot {
+        count: 0,
+        min: 0.0,
+        max: 0.0,
+        mean: 0.0,
+        stddev: 0.0,
+        sum: 0.0,
+        median: 0.0,
+        p75: 0.0,
+        p95: 0.0,
+        p98: 0.0,
+        p99: 0.0,
+        p999: 0.0,
+    };
+}
+
+/// A fixed-capacity ring of the last [`RESERVOIR_CAPACITY`] observations, with
+/// R7 percentile interpolation — a documented approximation of medida's
+/// CKMS-backed timer/histogram (see module docs).
+#[derive(Debug)]
+struct ReservoirInner {
+    /// Ring buffer of observations (in the stored unit, ms).
+    ring: Vec<f64>,
+    /// Next write position.
+    pos: usize,
+    /// Total observations ever recorded (NOT the ring length).
+    count: u64,
+}
+
+impl ReservoirInner {
+    fn new() -> Self {
+        ReservoirInner {
+            ring: Vec::with_capacity(RESERVOIR_CAPACITY),
+            pos: 0,
+            count: 0,
+        }
+    }
+
+    fn update(&mut self, value: f64) {
+        if self.ring.len() < RESERVOIR_CAPACITY {
+            self.ring.push(value);
+        } else {
+            self.ring[self.pos] = value;
+            self.pos = (self.pos + 1) % RESERVOIR_CAPACITY;
+        }
+        self.count += 1;
+    }
+
+    fn snapshot(&self) -> ReservoirSnapshot {
+        if self.ring.is_empty() {
+            return ReservoirSnapshot::ZERO;
+        }
+        let n = self.ring.len();
+        let mut sorted = self.ring.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+        let sum: f64 = sorted.iter().sum();
+        let mean = sum / n as f64;
+        // Sample stddev (n-1 denominator) matches medida's UniformSample/Histogram
+        // stddev which divides by (count - 1); for n == 1 medida returns 0.0.
+        let stddev = if n > 1 {
+            let var = sorted.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (n as f64 - 1.0);
+            var.sqrt()
+        } else {
+            0.0
+        };
+
+        ReservoirSnapshot {
+            count: self.count,
+            min: sorted[0],
+            max: sorted[n - 1],
+            mean,
+            stddev,
+            sum,
+            median: r7_quantile(&sorted, 0.5),
+            p75: r7_quantile(&sorted, 0.75),
+            p95: r7_quantile(&sorted, 0.95),
+            p98: r7_quantile(&sorted, 0.98),
+            p99: r7_quantile(&sorted, 0.99),
+            p999: r7_quantile(&sorted, 0.999),
+        }
+    }
+}
+
+/// A bounded-reservoir sample feeding R7 percentiles plus min/max/mean/stddev/sum,
+/// used for the close timer and tx-count histogram. Thread-safe via a `Mutex`;
+/// observations come from the ledger-close path (a few per ~5s), reads from the
+/// async `/metrics` handler. See module docs for the CKMS divergence.
+#[derive(Debug)]
+pub struct ReservoirSample {
+    inner: Mutex<ReservoirInner>,
+}
+
+impl ReservoirSample {
+    pub fn new() -> Self {
+        ReservoirSample {
+            inner: Mutex::new(ReservoirInner::new()),
+        }
+    }
+
+    /// Record an observation (in the stored unit, ms for our timers/histograms).
+    pub fn update(&self, value: f64) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.update(value);
+    }
+
+    /// Snapshot the current distribution statistics.
+    pub fn snapshot(&self) -> ReservoirSnapshot {
+        self.inner.lock().unwrap().snapshot()
+    }
+}
+
+impl Default for ReservoirSample {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The fixed, scoped set of medida-compat accumulators.
+///
+/// Exactly the four metrics SSC missions read. The close timer additionally
+/// carries an embedded meter (for its rate fields, `event_type = "calls"`); the
+/// scp meters use `event_type = "value"`.
+#[derive(Debug)]
+pub struct MedidaCompat {
+    /// `ledger.ledger.close` percentiles/min/max/etc. (ms reservoir).
+    pub close_timer: ReservoirSample,
+    /// `ledger.ledger.close` rate fields (embedded meter, event_type "calls").
+    pub close_meter: EwmaMeter,
+    /// `ledger.transaction.count` percentiles/min/max/etc.
+    pub tx_count_histogram: ReservoirSample,
+    /// `scp.value.valid` meter (event_type "value").
+    pub scp_value_valid: EwmaMeter,
+    /// `scp.value.invalid` meter (event_type "value").
+    pub scp_value_invalid: EwmaMeter,
+    /// Last-seen cumulative scp counters, for delta-feeding the meters from the
+    /// already-exposed `ScpMetricsSnapshot` without double-counting (the marks
+    /// must be persisted across refresh ticks).
+    pub scp_last_seen: Mutex<ScpLastSeen>,
+}
+
+/// Last-seen cumulative scp value counters used to compute per-tick deltas.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ScpLastSeen {
+    pub value_valid_total: u64,
+    pub value_invalid_total: u64,
+}
+
+impl MedidaCompat {
+    fn new() -> Self {
+        MedidaCompat {
+            close_timer: ReservoirSample::new(),
+            close_meter: EwmaMeter::new(),
+            tx_count_histogram: ReservoirSample::new(),
+            scp_value_valid: EwmaMeter::new(),
+            scp_value_invalid: EwmaMeter::new(),
+            scp_last_seen: Mutex::new(ScpLastSeen::default()),
+        }
+    }
+
+    /// Record a ledger close: `close_ms` into the close timer + meter, `tx_count`
+    /// into the tx-count histogram. Called from the ledger-close path.
+    pub fn record_ledger_close(&self, close_ms: f64, tx_count: u64) {
+        self.close_timer.update(close_ms);
+        self.close_meter.mark(1);
+        self.tx_count_histogram.update(tx_count as f64);
+    }
+
+    /// Feed the scp meters from a cumulative `ScpMetricsSnapshot` by marking the
+    /// delta since the last call. Called from the periodic metrics refresh so
+    /// the marks are spread over time (truer EWMA shape than dumping the whole
+    /// backlog at scrape). The cumulative totals are the meters' `count`.
+    pub fn feed_scp(&self, value_valid_total: u64, value_invalid_total: u64) {
+        let mut last = self.scp_last_seen.lock().unwrap();
+        let valid_delta = value_valid_total.saturating_sub(last.value_valid_total);
+        let invalid_delta = value_invalid_total.saturating_sub(last.value_invalid_total);
+        last.value_valid_total = value_valid_total;
+        last.value_invalid_total = value_invalid_total;
+        drop(last);
+        if valid_delta > 0 {
+            self.scp_value_valid.mark(valid_delta);
+        }
+        if invalid_delta > 0 {
+            self.scp_value_invalid.mark(invalid_delta);
+        }
+    }
+}
+
+static MEDIDA_COMPAT: OnceLock<MedidaCompat> = OnceLock::new();
+
+/// The process-global medida-compat registry.
+pub fn medida_compat() -> &'static MedidaCompat {
+    MEDIDA_COMPAT.get_or_init(MedidaCompat::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Advance the EWMA by one simulated minute: 12 ticks of 5s each, with no
+    /// new marks — mirrors medida's `elapseMinute` test helper.
+    fn elapse_minute(meter: &EwmaMeter, base: Instant, minute_index: u64) -> Instant {
+        // Advance the injected clock by 12 * 5s = 60s in 5s steps, reading the
+        // rate each step so tick_if_necessary applies exactly one tick per read.
+        let mut now = base;
+        for step in 1..=12u64 {
+            now = base + TICK_INTERVAL * ((minute_index * 12 + step) as u32);
+            // A zero-mark snapshot applies the pending ticks without adding events.
+            meter.snapshot_at(now);
+        }
+        now
+    }
+
+    /// The three EWMA alpha constants match medida's kM1/kM5/kM15_ALPHA.
+    #[test]
+    fn test_ewma_matches_medida_constants() {
+        // medida: kM1_ALPHA = 1 - exp(-5/60/1), etc.
+        assert!((m1_alpha() - 0.07995558_f64).abs() < 1e-7, "m1 alpha");
+        assert!((m5_alpha() - 0.01652854_f64).abs() < 1e-7, "m5 alpha");
+        assert!((m15_alpha() - 0.00554014_f64).abs() < 1e-7, "m15 alpha");
+    }
+
+    /// Port of medida `test_ewma.cc aOneMinuteEWMAWithAValueOfThree`: after one
+    /// update(3)+tick the rate is 0.6/s, decaying over successive minutes.
+    /// Drives a raw `Ewma` exactly as medida's EWMA unit test does.
+    #[test]
+    fn test_ewma_one_minute_decay_vector() {
+        let mut ewma = Ewma::new(m1_alpha());
+        ewma.update(3);
+        ewma.tick();
+        let r = ewma.rate(Duration::from_secs(1));
+        assert!((r - 0.6).abs() < 1e-6, "initial rate {r}");
+        // Expected values from medida test_ewma.cc after each elapsed minute.
+        let expected = [
+            0.22072766, 0.08120117, 0.02987224, 0.01098938, 0.00404277, 0.00148725, 0.00054713,
+            0.00020128, 0.00007405, 0.00002724, 0.00001002, 0.00000369, 0.00000136, 0.00000050,
+            0.00000018,
+        ];
+        for e in expected {
+            for _ in 0..12 {
+                ewma.tick();
+            }
+            let r = ewma.rate(Duration::from_secs(1));
+            assert!((r - e).abs() < 1e-6, "expected {e}, got {r}");
+        }
+    }
+
+    /// Port of medida `test_ewma.cc aFifteenMinuteEWMAWithAValueOfThree` first
+    /// few steps, validating the 15-minute alpha decay.
+    #[test]
+    fn test_ewma_fifteen_minute_decay_vector() {
+        let mut ewma = Ewma::new(m15_alpha());
+        ewma.update(3);
+        ewma.tick();
+        assert!((ewma.rate(Duration::from_secs(1)) - 0.6).abs() < 1e-6);
+        let expected = [0.56130419, 0.52510399, 0.49123845, 0.45955700];
+        for e in expected {
+            for _ in 0..12 {
+                ewma.tick();
+            }
+            assert!((ewma.rate(Duration::from_secs(1)) - e).abs() < 1e-6);
+        }
+    }
+
+    /// The lazy tick advances the rate on elapsed wall-clock WITHOUT new marks:
+    /// mark once, then advance the injected clock and assert the 1-min rate
+    /// decays toward zero. Validates the injectable-clock decay path.
+    #[test]
+    fn test_ewma_decays_with_injected_clock() {
+        let base = Instant::now();
+        let meter = EwmaMeter::new_at(base);
+        // Mark 3 events, then apply the first tick by reading 5s later.
+        meter.mark_at(3, base);
+        let after_first_tick = base + TICK_INTERVAL + Duration::from_millis(1);
+        let snap0 = meter.snapshot_at(after_first_tick);
+        // After one tick: instant rate = 3 / 5s = 0.6/s.
+        assert!(
+            (snap0.one_minute_rate - 0.6).abs() < 1e-6,
+            "first-tick rate {}",
+            snap0.one_minute_rate
+        );
+        // Advance one minute with no new marks — rate must decay.
+        let now = elapse_minute(&meter, after_first_tick, 0);
+        let snap1 = meter.snapshot_at(now);
+        assert!(
+            snap1.one_minute_rate < snap0.one_minute_rate,
+            "rate should decay: {} !< {}",
+            snap1.one_minute_rate,
+            snap0.one_minute_rate
+        );
+        assert!(snap1.one_minute_rate > 0.0, "rate still positive");
+        // After many minutes it approaches zero.
+        let mut t = now;
+        for m in 1..=10 {
+            t = elapse_minute(&meter, after_first_tick, m);
+        }
+        let snap_final = meter.snapshot_at(t);
+        assert!(
+            snap_final.one_minute_rate < 0.01,
+            "rate decayed near zero: {}",
+            snap_final.one_minute_rate
+        );
+    }
+
+    /// A fresh meter with no marks reports 0.0 for all rates and mean_rate.
+    #[test]
+    fn test_ewma_zero_at_startup() {
+        let base = Instant::now();
+        let meter = EwmaMeter::new_at(base);
+        let snap = meter.snapshot_at(base + Duration::from_secs(30));
+        assert_eq!(snap.count, 0);
+        assert_eq!(snap.mean_rate, 0.0);
+        assert_eq!(snap.one_minute_rate, 0.0);
+        assert_eq!(snap.five_minute_rate, 0.0);
+        assert_eq!(snap.fifteen_minute_rate, 0.0);
+    }
+
+    /// mean_rate = count * 1e9 / elapsed_ns. Two marks over 10s ⇒ 0.2/s.
+    #[test]
+    fn test_ewma_mean_rate() {
+        let base = Instant::now();
+        let meter = EwmaMeter::new_at(base);
+        meter.mark_at(1, base);
+        meter.mark_at(1, base);
+        let snap = meter.snapshot_at(base + Duration::from_secs(10));
+        assert_eq!(snap.count, 2);
+        assert!(
+            (snap.mean_rate - 0.2).abs() < 1e-9,
+            "mean_rate {}",
+            snap.mean_rate
+        );
+    }
+
+    /// R7 percentiles over a known sample match the medida VectorImpl formula,
+    /// and are monotonically ordered.
+    #[test]
+    fn test_reservoir_r7_percentiles() {
+        let res = ReservoirSample::new();
+        // 1..=100 inclusive.
+        for i in 1..=100u64 {
+            res.update(i as f64);
+        }
+        let snap = res.snapshot();
+        assert_eq!(snap.count, 100);
+        assert_eq!(snap.min, 1.0);
+        assert_eq!(snap.max, 100.0);
+        assert!((snap.mean - 50.5).abs() < 1e-9, "mean {}", snap.mean);
+        // R7 over sorted [1..100], max_idx=99:
+        //   median: ideal=0.5*99=49.5 => 50 + 0.5*(51-50)=50.5
+        //   p75:    ideal=0.75*99=74.25 => 75 + 0.25*(76-75)=75.25
+        //   p95:    ideal=0.95*99=94.05 => 95 + 0.05*(96-95)=95.05
+        //   p99:    ideal=0.99*99=98.01 => 99 + 0.01*(100-99)=99.01
+        assert!((snap.median - 50.5).abs() < 1e-9, "median {}", snap.median);
+        assert!((snap.p75 - 75.25).abs() < 1e-9, "p75 {}", snap.p75);
+        assert!((snap.p95 - 95.05).abs() < 1e-9, "p95 {}", snap.p95);
+        assert!((snap.p99 - 99.01).abs() < 1e-9, "p99 {}", snap.p99);
+        // Ordering.
+        assert!(snap.median <= snap.p75);
+        assert!(snap.p75 <= snap.p95);
+        assert!(snap.p95 <= snap.p99);
+        assert!(snap.p99 <= snap.p999);
+        assert!(snap.p999 <= snap.max);
+    }
+
+    /// Direct R7 unit check against medida's getValue on a tiny vector.
+    #[test]
+    fn test_r7_quantile_interpolation() {
+        // sorted [10, 20, 30, 40], max_idx=3.
+        let v = [10.0, 20.0, 30.0, 40.0];
+        // median: ideal=0.5*3=1.5 => 20 + 0.5*(30-20)=25.
+        assert!((r7_quantile(&v, 0.5) - 25.0).abs() < 1e-9);
+        // p75: ideal=0.75*3=2.25 => 30 + 0.25*(40-30)=32.5.
+        assert!((r7_quantile(&v, 0.75) - 32.5).abs() < 1e-9);
+        // q=1.0 => max.
+        assert!((r7_quantile(&v, 1.0) - 40.0).abs() < 1e-9);
+        // q=0.0 => min.
+        assert!((r7_quantile(&v, 0.0) - 10.0).abs() < 1e-9);
+    }
+
+    /// An empty reservoir reports all-zero percentiles/min/max/mean/stddev.
+    #[test]
+    fn test_reservoir_empty_is_zero() {
+        let res = ReservoirSample::new();
+        let snap = res.snapshot();
+        assert_eq!(snap, ReservoirSnapshot::ZERO);
+        assert_eq!(snap.count, 0);
+        assert_eq!(snap.median, 0.0);
+        assert_eq!(snap.p99, 0.0);
+        assert_eq!(snap.min, 0.0);
+        assert_eq!(snap.max, 0.0);
+    }
+
+    /// The ring keeps only the last RESERVOIR_CAPACITY observations.
+    #[test]
+    fn test_reservoir_ring_evicts() {
+        let res = ReservoirSample::new();
+        // Insert 256 small values, then 256 large values — the large ones evict
+        // the small ones, so min/max reflect only the large window.
+        for _ in 0..RESERVOIR_CAPACITY {
+            res.update(1.0);
+        }
+        for _ in 0..RESERVOIR_CAPACITY {
+            res.update(1000.0);
+        }
+        let snap = res.snapshot();
+        assert_eq!(snap.count, (RESERVOIR_CAPACITY * 2) as u64);
+        assert_eq!(snap.min, 1000.0, "small values should be evicted");
+        assert_eq!(snap.max, 1000.0);
+        assert!((snap.mean - 1000.0).abs() < 1e-9);
+    }
+
+    /// stddev uses the (n-1) sample denominator and is 0.0 for a single sample.
+    #[test]
+    fn test_reservoir_stddev() {
+        let res = ReservoirSample::new();
+        res.update(5.0);
+        assert_eq!(res.snapshot().stddev, 0.0, "single sample stddev is 0");
+        let res2 = ReservoirSample::new();
+        for v in [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0] {
+            res2.update(v);
+        }
+        // Sample stddev of this classic dataset (n-1 denom) is ~2.13809.
+        let s = res2.snapshot().stddev;
+        assert!((s - 2.1380899).abs() < 1e-6, "stddev {s}");
+    }
+
+    /// Delta-feeding the scp meters from cumulative snapshots marks only the
+    /// delta and tracks the cumulative count.
+    #[test]
+    fn test_feed_scp_delta() {
+        let compat = MedidaCompat::new();
+        compat.feed_scp(10, 2);
+        assert_eq!(compat.scp_value_valid.snapshot().count, 10);
+        assert_eq!(compat.scp_value_invalid.snapshot().count, 2);
+        // Second feed marks only the delta (15-10=5, 3-2=1).
+        compat.feed_scp(15, 3);
+        assert_eq!(compat.scp_value_valid.snapshot().count, 15);
+        assert_eq!(compat.scp_value_invalid.snapshot().count, 3);
+        // Non-increasing totals (restart) mark nothing.
+        compat.feed_scp(15, 3);
+        assert_eq!(compat.scp_value_valid.snapshot().count, 15);
+    }
+
+    /// record_ledger_close feeds both the close timer/meter and tx histogram.
+    #[test]
+    fn test_record_ledger_close() {
+        let compat = MedidaCompat::new();
+        compat.record_ledger_close(120.0, 50);
+        compat.record_ledger_close(80.0, 30);
+        let timer = compat.close_timer.snapshot();
+        assert_eq!(timer.count, 2);
+        assert_eq!(timer.min, 80.0);
+        assert_eq!(timer.max, 120.0);
+        assert_eq!(compat.close_meter.snapshot().count, 2);
+        let hist = compat.tx_count_histogram.snapshot();
+        assert_eq!(hist.count, 2);
+        assert_eq!(hist.min, 30.0);
+        assert_eq!(hist.max, 50.0);
+    }
+}

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -1314,6 +1314,13 @@ pub(crate) async fn refresh_gauges(state: &ServerState) {
     SCP_VALUE_VALID_TOTAL.absolute(snap.scp.value_valid_total);
     SCP_VALUE_INVALID_TOTAL.absolute(snap.scp.value_invalid_total);
     SCP_NOMINATION_COMBINECANDIDATES_TOTAL.absolute(snap.scp.combine_candidates_total);
+
+    // Feed the medida-compat scp meters (`scp.value.valid`/`scp.value.invalid`)
+    // for the stellar-core-compatible /metrics endpoint by delta-marking the
+    // cumulative totals on this periodic refresh, so marks are spread over time
+    // for a truer EWMA shape than dumping the whole backlog at scrape (#3296).
+    crate::medida_compat::medida_compat()
+        .feed_scp(snap.scp.value_valid_total, snap.scp.value_invalid_total);
 }
 
 // ── Process health helpers ──────────────────────────────────────────────

--- a/docs/supercluster-feasibility.md
+++ b/docs/supercluster-feasibility.md
@@ -120,18 +120,28 @@ The handler now returns 8 metrics in proper medida JSON format with `type` field
 
 | Metric | Type | Value Source |
 |--------|------|-------------|
-| `ledger.ledger.close` | timer | ledger sequence (count), zero placeholders for rate/percentile |
+| `ledger.ledger.close` | timer | real observation count + EWMA rates (exact) + R7-reservoir percentiles/min/max/mean/stddev/sum (ms, documented approximation) (#3296) |
 | `peer.peer.count` | counter | real authenticated + pending count |
 | `peer.peer.authenticated-count` | counter | real authenticated count |
 | `peer.peer.pending-count` | counter | real pending count |
 | `herder.pending.transactions` | counter | real pending tx count |
 | `ledger.ledger.version` | counter | real protocol version |
-| `scp.value.valid` | meter | ledger sequence (count), zero rate placeholders |
-| `scp.value.invalid` | meter | zero (count + rate) |
+| `ledger.transaction.count` | histogram | real `ledger_tx_count` + R7-reservoir percentiles (#3296) |
+| `scp.value.valid` | meter | real cumulative count + EWMA rates, `event_type="value"` (#3296) |
+| `scp.value.invalid` | meter | real cumulative count + EWMA rates, `event_type="value"` (#3296) |
 
-3 unit tests validate the response shape, type fields, and rate fields.
+Unit tests validate the response shape, type fields, rate fields, and (post-#3296)
+non-zero real rate/percentile values after synthetic observations plus zero-at-startup.
 
-**Remaining gap**: Rate and percentile values are zero placeholders. This is fine for SSC missions that only check metric names and structure, but would need real tracking if SSC makes assertions about rate values.
+**Real metrics tracking (#3296)**: The four SSC-read metrics now emit REAL
+rate/percentile values from in-process accumulators in `crates/app/src/medida_compat.rs`:
+EWMA meter rates are an exact port of medida `ewma.cc`/`meter.cc`; timer/histogram
+percentiles use an R7-over-256-sample-ring **documented approximation** of medida's
+CKMS-30s sample (the algorithm differs — R7 exact-sorted vs CKMS sketch — and the
+window is capacity-based not time-based). Sufficient for SSC presence/ordering/
+non-zero assertions; SSC has no oracle for exact CKMS values. See
+`crates/app/PARITY_STATUS.md`. The other compat metrics' rate/percentile fields
+remain `0.0` placeholders (not SSC-read).
 
 Commit: `fc12e03`
 
@@ -322,7 +332,7 @@ Remaining work:
 
 | Item | Status | Priority |
 |------|--------|----------|
-| Real metrics tracking (rates/percentiles are zero placeholders) | NOT DONE | Low — only needed if SSC checks rate values |
+| Real metrics tracking for the 4 SSC-read metrics (EWMA rates + R7-reservoir percentiles) | DONE (#3296) | — percentiles are a documented CKMS approximation (`crates/app/src/medida_compat.rs`) |
 | Missing loadgen modes (`upgrade_setup`, `create_upgrade`, `pay_pregenerated`, `soroban_invoke_apply_load`) | NOT DONE | Low — deferred until SSC needs them |
 | End-to-end SSC mission validation | NOT DONE | Medium — requires SSC infrastructure |
 | `loadgen` feature verification in SSC deployment path | NOT DONE | Low — feature is enabled by default |
@@ -388,7 +398,7 @@ Candidate work:
 - [x] SSC config fixture parse test
 - [x] response-shape regression tests exist for every new or modified endpoint (36+ tests)
 - [ ] all-Henyey payment mission attempted and results recorded
-- [ ] real metrics tracking (rate/percentile values)
+- [x] real metrics tracking (rate/percentile values) for the 4 SSC-read metrics (#3296; percentiles are a documented CKMS approximation)
 
 ### Phase 3 handoff checklist
 


### PR DESCRIPTION
Closes #3296

## Summary

The compat `/metrics` endpoint previously hardcoded every medida rate (`mean_rate`, `1/5/15_min_rate`) and timer/histogram percentile to `0.0`, so SSC metric-asserting missions had no trustworthy data. This adds in-process medida-compatible accumulators in `crate:app` and wires the handler to emit REAL values for exactly the four metrics SSC reads: `ledger.ledger.close` (timer), `ledger.transaction.count` (histogram), and `scp.value.valid`/`scp.value.invalid` (meters). No other metric is instrumented, and there is no `crate:herder` edit (the scp meters are fed app-side by diffing the already-exposed `ScpMetricsSnapshot`).

New module `crates/app/src/medida_compat.rs`:
- **`EwmaMeter`** — verbatim port of medida `stats/ewma.cc` + `meter.cc`: alphas `1-exp(-5/(60·N))` for N∈{1,5,15}, 5s LAZY `TickIfNecessary` (tick-on-read/mark, no event-loop timer), first-sample seeding, `mean_rate = count·1e9/elapsed_ns`, injectable clock.
- **`ReservoirSample`** — fixed 256-entry ring + R7 percentile interpolation copied from medida `snapshot.cc VectorImpl::getValue`; min/max/mean/stddev/sum over the ring in ms.
- **`MedidaCompat`** registry (OnceLock) holding the scoped set + a persisted last-seen counter for delta-feeding the scp meters.

Feed points (all in `crate:app`): `ledger_close.rs` feeds the close timer/meter (`close_time_ms`) and tx-count histogram (`tx_count`); `metrics.rs::refresh_gauges` delta-marks the two scp meters from `ScpMetricsSnapshot` cumulative totals on the periodic tick (spread over time for truer EWMA, last-seen persisted in the registry). The scp meters' `event_type` is fixed to `"value"` (`HerderSCPDriver.cpp:55,57`); the close timer's embedded meter keeps `"calls"`. All `count` fields come from real observation/cumulative counts, not `ledger_seq`.

Thread-safety: each accumulator is `Mutex`-guarded exactly as medida; marks happen a few times per ~5s close (no hot-path contention). Lazy tick means zero new event-loop wiring.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3296#issuecomment-4723935508)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-app — 1056 lib + integration tests pass

New coverage (feature):
- `medida_compat::tests::{test_ewma_matches_medida_constants, test_ewma_one_minute_decay_vector, test_ewma_fifteen_minute_decay_vector, test_ewma_decays_with_injected_clock, test_ewma_zero_at_startup, test_ewma_mean_rate, test_reservoir_r7_percentiles, test_r7_quantile_interpolation, test_reservoir_empty_is_zero, test_reservoir_ring_evicts, test_reservoir_stddev, test_feed_scp_delta, test_record_ledger_close}` — validate against medida's own EWMA decay vectors and the R7 formula.
- `compat_http/handlers/metrics.rs::tests::{test_metrics_real_values_after_observations, test_metrics_zero_at_startup}`.

**Fail-before / pass-after:** `test_metrics_real_values_after_observations` asserts non-zero `median`/`99%`/`1_min_rate`, `event_type=="value"`, and real counts (`scp.value.valid` count == 120). Against the pre-fix handler every one of these was hardcoded (`0.0`, `"events"`, `ledger_seq`), so the test fails-before and passes-after. Existing shape tests (`test_metrics_response_shape`, `test_all_metrics_have_type_field`, `test_meter_metrics_have_rate_fields`) are preserved.

## Deviations from plan

None. The PR was NOT split — the R7 reservoir stayed a thin VectorImpl port (no CKMS port attempted), so EWMA rates and percentiles ship together as one reviewable PR, as the plan permitted.

## Parity

EWMA meter rates: exact port. Percentiles: documented **Partial** approximation — R7-over-256-sample-ring (capacity-windowed) vs stellar-core's CKMS-30s (time-windowed) sample; sufficient for SSC's presence/ordering/non-zero assertion class. Recorded in `crates/app/PARITY_STATUS.md` and `docs/supercluster-feasibility.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)