### PR TITLE
Document new-db --minimal-for-in-memory-mode as a parity-correct no-op

### DIFF
--- a/crates/app/PARITY_STATUS.md
+++ b/crates/app/PARITY_STATUS.md
@@ -198,7 +198,7 @@ Features excluded by design. These are NOT counted against parity %.
 | `TmpDirManager`, `ProcessManager`, raw `LedgerTxnRoot` exposure | Different runtime architecture; not part of `henyey-app`'s public API |
 | Protocol-23 corruption verifier/reconciler | Repository targets protocol 24+ only |
 | `CommandLine.h`, `SettingsUpgradeUtils.h`, and `dumpxdr.h` utilities | Owned by the `henyey` binary crate, not `henyey-app` |
-| `minimalDBForInMemoryMode()` / `canRebuildInMemoryLedgerFromBuckets()` | Test-only upstream helpers not mirrored in this crate |
+| `minimalDBForInMemoryMode()` / `canRebuildInMemoryLedgerFromBuckets()` | Test-only upstream helpers not mirrored in this crate. The corresponding `new-db --minimal-for-in-memory-mode` CLI flag (in the `henyey` binary crate) is an intentional accepted-no-op — parity-correct, since v26 stellar-core removed the flag and always builds a full persistent DB (#3299). |
 | `BUILD_TESTS`-only overlay toggle (`getRunInOverlayOnlyMode` / `setRunInOverlayOnlyMode`) | Rust test strategy uses different hooks and feature gates |
 | `testTx()` | Test-only wire-format endpoint; no production use |
 

--- a/crates/henyey/PARITY_STATUS.md
+++ b/crates/henyey/PARITY_STATUS.md
@@ -54,7 +54,7 @@ Corresponds to: `CommandLine.cpp`, `ApplicationUtils.h`
 |--------------|------|--------|
 | `run()` / `setupApp()` / `runApp()` | `cmd_run()` | Full |
 | `runCatchup()` / `catchup()` | `cmd_catchup()` | Full |
-| `runNewDB()` / `initializeDatabase()` | `cmd_new_db()` | Full |
+| `runNewDB()` / `initializeDatabase()` | `cmd_new_db()` | Full — the legacy `--minimal-for-in-memory-mode` flag is accepted as an intentional parity-correct no-op (v26 upstream removed it; `new-db` always builds a full persistent DB). See #3299. |
 | `runUpgradeDB()` | `cmd_upgrade_db()` | Full |
 | `runPublish()` / `publish()` | `cmd_publish_history()` | Full |
 | `runWriteVerifiedCheckpointHashes()` | `cmd_verify_checkpoints()` | Full |
@@ -114,7 +114,7 @@ Features excluded by design. These are NOT counted against parity %.
 | `checkStellarCoreMajorVersionProtocolIdentity()` | Cargo versioning and protocol gating replace upstream release-tag validation |
 | `loadXdr()` / `rebuildLedgerFromBuckets()` | `BUILD_TESTS`-only utilities; workspace uses regular Rust tests instead |
 | `runFuzz()` / `runGenFuzz()` / `runTest()` | Fuzzing and test execution are handled by Cargo tooling, not the binary |
-| `minimalDBForInMemoryMode()` / `canRebuildInMemoryLedgerFromBuckets()` | In-memory mode is deprecated and intentionally unsupported |
+| `minimalDBForInMemoryMode()` / `canRebuildInMemoryLedgerFromBuckets()` | In-memory mode is deprecated and intentionally unsupported. The corresponding `new-db --minimal-for-in-memory-mode` CLI flag is accepted as an intentional no-op for invocation compatibility — parity-correct, since v26 stellar-core removed the flag and always builds a full persistent DB (#3299). |
 | `setAuthenticatedLedgerHashPair()` | `--start-at-ledger` and `--start-at-hash` are accepted only as no-op compat flags |
 | `applyBucketsForLCL()` | Ledger rebuild internals live in lower crates rather than the CLI binary |
 | `getStellarCoreMajorReleaseVersion()` | Helper is unnecessary because `cmd_version()` emits Rust-owned version strings directly |

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -909,7 +909,15 @@ enum Commands {
         #[arg(long)]
         force: bool,
 
-        /// Deprecated: accepted for stellar-core compatibility, ignored.
+        /// Accepted for stellar-core compatibility; intentional parity-correct
+        /// no-op. stellar-core v26 removed both this flag and the deprecated
+        /// in-memory run mode it served (`runNewDB` → `initializeDatabase(cfg)`
+        /// always builds a full persistent DB). henyey likewise always builds a
+        /// full persistent DB, so accepting and ignoring the flag is
+        /// behaviorally identical to upstream — not an unfinished feature.
+        /// Accepting (rather than erroring) keeps legacy SSC/captive-core
+        /// invocations that still pass the flag working. Do NOT wire this up to
+        /// resurrect an in-memory/minimal-schema mode.
         #[arg(long = "minimal-for-in-memory-mode", hide = true)]
         minimal_for_in_memory_mode: bool,
     },
@@ -1370,6 +1378,10 @@ async fn main() -> anyhow::Result<()> {
         Commands::NewDb {
             path,
             force,
+            // Intentionally dropped: parity-correct no-op (see the field doc on
+            // `NewDb.minimal_for_in_memory_mode`). stellar-core v26 removed this
+            // flag and `new-db` always builds a full persistent DB, exactly as
+            // `cmd_new_db` does. Do not wire this into `cmd_new_db`.
             minimal_for_in_memory_mode: _,
         } => cmd_new_db(config, path, force).await,
 
@@ -3644,6 +3656,54 @@ mod tests {
         // Test basic parsing
         let cli = Cli::parse_from(["rs-stellar-core", "info"]);
         assert!(matches!(cli.command, Commands::Info));
+    }
+
+    /// Pins the `new-db --minimal-for-in-memory-mode` flag as an accepted
+    /// parity-correct no-op. stellar-core v26 removed both the flag and the
+    /// in-memory run mode it served; henyey always builds a full persistent DB,
+    /// so the flag is accepted (legacy SSC/captive-core invocations keep
+    /// working) but carries no behavioral signal into `cmd_new_db`. This test
+    /// locks that contract so a future refactor cannot silently change it. See
+    /// #3299.
+    #[test]
+    fn test_cli_new_db_minimal_flag_accepted_noop() {
+        // The flag parses successfully (accepted, not rejected) and yields the
+        // default `path`/`force` while the flag itself reads `true`.
+        let cli = Cli::parse_from(["rs-stellar-core", "new-db", "--minimal-for-in-memory-mode"]);
+        match cli.command {
+            Commands::NewDb {
+                path,
+                force,
+                minimal_for_in_memory_mode,
+            } => {
+                assert!(
+                    minimal_for_in_memory_mode,
+                    "--minimal-for-in-memory-mode should parse to true"
+                );
+                assert_eq!(path, None, "flag must not affect `path`");
+                assert!(!force, "flag must not affect `force`");
+            }
+            _ => panic!("Expected NewDb command"),
+        }
+
+        // Omitting the flag defaults it to false and leaves `path`/`force`
+        // identical — the flag is purely additive and inert.
+        let cli = Cli::parse_from(["rs-stellar-core", "new-db"]);
+        match cli.command {
+            Commands::NewDb {
+                path,
+                force,
+                minimal_for_in_memory_mode,
+            } => {
+                assert!(
+                    !minimal_for_in_memory_mode,
+                    "flag must default to false when omitted"
+                );
+                assert_eq!(path, None, "default `path` should be None");
+                assert!(!force, "default `force` should be false");
+            }
+            _ => panic!("Expected NewDb command"),
+        }
     }
 
     /// Pins the compiled-in jemalloc `malloc_conf` so a future edit cannot

--- a/docs/supercluster-feasibility.md
+++ b/docs/supercluster-feasibility.md
@@ -182,16 +182,19 @@ Impact:
 - history missions belong after mixed-image bring-up and basic HTTP parity work
 - the risk is lower than metrics/loadgen, but it is real
 
-### 7. `--minimal-for-in-memory-mode` is accepted but silently ignored
+### 7. `--minimal-for-in-memory-mode` is an intentional parity-correct no-op
 
-The `new-db` command accepts the `--minimal-for-in-memory-mode` flag for stellar-core compatibility (`crates/henyey/src/main.rs:422`), but the flag is a no-op. Henyey always creates a persistent SQLite database.
+The `new-db` command accepts the `--minimal-for-in-memory-mode` flag for stellar-core compatibility (`crates/henyey/src/main.rs:872`) and silently ignores it. This is **not** a gap: it is the parity-correct behavior.
 
-If SSC passes this flag expecting in-memory node behavior (faster startup, no disk state), the resulting node will behave differently than expected -- persistent state, slower teardown, possible stale-state issues across mission restarts.
+stellar-core v26 removed both this flag and the deprecated `--in-memory` run mode it served. Upstream `runNewDB` (`stellar-core/src/main/CommandLine.cpp:1191`) now calls only `initializeDatabase(cfg)` and always builds a full persistent database — there is no minimal/reduced-schema path anywhere in `CommandLine.cpp`. Henyey likewise always creates a full persistent SQLite database, so accepting and ignoring the flag produces a node that is behaviorally identical to upstream v26.
+
+Accepting (rather than erroring on) the legacy flag is a deliberate superset for invocation compatibility: SSC/captive-core invocations that still pass `--minimal-for-in-memory-mode` keep working, and the resulting full-DB node matches what upstream produces for the same command. No warning is emitted, matching upstream's silent behavior on this path (a warning would be henyey-only mission-log noise).
+
+The contract is pinned by `test_cli_new_db_minimal_flag_accepted_noop` in `crates/henyey/src/main.rs`, which asserts the flag is accepted and carries no behavioral signal into `cmd_new_db`.
 
 Impact:
 
-- may cause subtle mission failures that look like state corruption rather than a compatibility gap
-- should be an explicit known-limitation callout, not a silent no-op
+- none — resolved as a documented intentional no-op (see #3299)
 
 ### 8. SSC may expect additional CLI surface beyond the currently documented path
 
@@ -419,7 +422,7 @@ The project should not claim Henyey-only SSC readiness until all of the followin
 - [ ] at least one Henyey-only payment/topology mission passes end to end
 - [x] every SSC-facing compat endpoint has unit tests that validate its response shape against a stellar-core reference fixture
 - [x] the `create` mode behavioral deviation is fixed (returns deprecation message, not silent alias)
-- [ ] the `--minimal-for-in-memory-mode` behavioral deviation is either fixed or explicitly documented with its mission impact
+- [x] the `--minimal-for-in-memory-mode` flag is resolved as an intentional parity-correct no-op (stellar-core v26 removed the flag and in-memory mode; henyey always builds a full persistent DB — see section 7 and #3299)
 
 ## Implementation Commits
 


### PR DESCRIPTION
Closes #3299

## Summary

Locks in the legacy `new-db --minimal-for-in-memory-mode` flag as an intentional, parity-correct accepted-no-op. stellar-core v26 removed both the flag and the deprecated in-memory run mode it served — `runNewDB` (`stellar-core/src/main/CommandLine.cpp:1191`) now calls only `initializeDatabase(cfg)` and always builds a full persistent DB. henyey likewise always builds a full persistent DB, so accepting and ignoring the flag is behaviorally identical to upstream. Policy: keep accepting silently (no deprecation warning, no resurrected in-memory mode), so legacy SSC/captive-core invocations passing the flag keep working. This is a docs + contract-pinning-test change with no behavior change.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3299#issuecomment-4723957808)

## Changes

- `crates/henyey/src/main.rs` — expanded the `NewDb.minimal_for_in_memory_mode` field doc comment and added a destructure-site comment explaining the deliberate parity-correct no-op; added `test_cli_new_db_minimal_flag_accepted_noop`.
- `docs/supercluster-feasibility.md` — rewrote section 7 from "silently ignored / known-limitation" to "intentional parity-correct no-op", fixed the stale `main.rs:422` ref to `:872`, and marked the checklist item resolved.
- `crates/henyey/PARITY_STATUS.md` and `crates/app/PARITY_STATUS.md` — added flag-no-op clarification notes.

## Test plan

- [x] cargo fmt --check (henyey)
- [x] cargo clippy --all -- -D warnings (CI scope — passes; the `--all-targets` lint that fails locally is a pre-existing rust-1.95 artifact in untouched test code, not run by CI)
- [x] `cargo test -p henyey --bins test_cli_new_db_minimal_flag_accepted_noop` passes
- [x] `cargo build -p henyey`

## Regression test

n/a — kind is feature/docs; behavior is unchanged. The new test is contract-pinning new coverage, not a main-failing regression.

## Deviations from plan

None. (Line numbers drifted from the plan's `:871-873` / `:1332` to `:912` / `:1373` because main advanced; the edits target the named field/site, unchanged in substance.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)