### PR TITLE
Add SSC history mission: config fixture, URL-extraction hardening, publish/catchup round-trip

### DIFF
--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -1102,23 +1102,43 @@ fn warn_unrecognized_keys(table: &toml::map::Map<String, toml::Value>) -> Result
     Ok(())
 }
 
-/// Extract a base URL from a stellar-core curl command template.
+/// Extract a base URL from a stellar-core / SSC archive command template.
 ///
 /// Input:  `"curl -sf https://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"`
 /// Output: `Some("https://history.stellar.org/prd/core-testnet/core_testnet_001")`
 ///
-/// Also handles simpler forms like `"wget -q {0} -O {1}"` where no URL is present.
+/// Also handles simpler forms like `"wget -q {0} -O {1}"` and `"cp …"` where no
+/// URL is present, returning `None`.
+///
+/// The URL is taken from the first `http(s)://` token in the command. The
+/// `{0}`/`{1}` path-template placeholders mark where the remote/local path is
+/// substituted, so the URL is truncated at the first `{` and then any
+/// query-string and trailing slash is trimmed. This is more robust than
+/// stripping a fixed `/{0}` suffix, because SSC may render the template with a
+/// query string, shell quotes, or a trailing slash before the placeholder
+/// (history feasibility doc §6 flagged the fixed-suffix form as brittle).
 fn extract_url_from_curl_cmd(cmd: &str) -> Option<String> {
-    // Look for an http/https URL in the command string
-    for token in cmd.split_whitespace() {
+    for raw_token in cmd.split_whitespace() {
+        // Strip surrounding shell quotes SSC/stellar-core may wrap the URL in,
+        // e.g. `'https://host/{0}?auth=tok'`.
+        let token = raw_token.trim_matches(|c| c == '\'' || c == '"');
         if token.starts_with("http://") || token.starts_with("https://") {
-            // Strip the /{0} suffix that stellar-core appends for the remote path template
-            let url = token
-                .trim_end_matches("/{0}")
-                .trim_end_matches("/{1}")
-                .trim_end_matches("{0}")
-                .trim_end_matches("{1}");
-            return Some(url.to_string());
+            // The `{0}`/`{1}` placeholder marks where the path is substituted.
+            // Truncate the URL there so anything after (incl. a query string
+            // appended after the placeholder) is dropped.
+            let mut url = match token.find('{') {
+                Some(idx) => &token[..idx],
+                None => token,
+            };
+            // Drop a query string that precedes the placeholder, then a single
+            // trailing slash, so the base URL has no spurious suffix.
+            if let Some(q) = url.find('?') {
+                url = &url[..q];
+            }
+            let url = url.trim_end_matches('/');
+            if url.len() > "https://".len() {
+                return Some(url.to_string());
+            }
         }
     }
     None
@@ -1524,6 +1544,7 @@ mod tests {
 
     #[test]
     fn test_extract_url_from_curl_cmd() {
+        // --- Existing testnet shapes: behavior MUST stay identical ---
         assert_eq!(
             extract_url_from_curl_cmd(
                 "curl -sf https://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
@@ -1538,6 +1559,54 @@ mod tests {
 
         // No URL in command
         assert_eq!(extract_url_from_curl_cmd("cp /local/{0} /dest/{1}"), None);
+
+        // --- AC#2 hardening (#3295): literal SSC `get` template shapes ---
+        // In-cluster localhost archive read-back (own publishing archive).
+        assert_eq!(
+            extract_url_from_curl_cmd("curl -sf http://localhost:1570/{0} -o {1}"),
+            Some("http://localhost:1570".to_string())
+        );
+        // In-cluster peer pod hostname with port.
+        assert_eq!(
+            extract_url_from_curl_cmd("curl -sf http://ssc-core-0.ssc.local:1570/{0} -o {1}"),
+            Some("http://ssc-core-0.ssc.local:1570".to_string())
+        );
+
+        // Trailing slash directly before the placeholder is normalized away.
+        assert_eq!(
+            extract_url_from_curl_cmd("curl -sf https://history.example.org/archive/{0} -o {1}"),
+            Some("https://history.example.org/archive".to_string())
+        );
+        // A double slash before the placeholder normalizes to a single base.
+        assert_eq!(
+            extract_url_from_curl_cmd("curl -sf https://history.example.org/archive//{0} -o {1}"),
+            Some("https://history.example.org/archive".to_string())
+        );
+
+        // Quoted URL with a query string appended after the placeholder — the
+        // fixed-suffix-strip form returned None here (silent empty URL); the
+        // hardened extractor recovers the base.
+        assert_eq!(
+            extract_url_from_curl_cmd("curl -sf 'https://history.example.org/{0}?auth=tok' -o {1}"),
+            Some("https://history.example.org".to_string())
+        );
+
+        // Put-style command where the URL is the last token and {1} is the file.
+        assert_eq!(
+            extract_url_from_curl_cmd("curl -T {1} https://history.example.org/{0}"),
+            Some("https://history.example.org".to_string())
+        );
+
+        // --- Forms with no extractable URL → None ---
+        // wget with the URL supplied via the {0} placeholder (no literal URL).
+        assert_eq!(extract_url_from_curl_cmd("wget -q {0} -O {1}"), None);
+        // A bare scheme with no host must not produce a phantom archive URL.
+        assert_eq!(extract_url_from_curl_cmd("curl -sf http:// -o {1}"), None);
+        // Plain cp upload command (no URL).
+        assert_eq!(
+            extract_url_from_curl_cmd("cp {1} /opt/stellar/history/ssc_local/{0}"),
+            None
+        );
     }
 
     #[test]
@@ -2314,6 +2383,101 @@ mod tests {
         );
 
         // Compat flag set.
+        assert!(config.is_compat_config);
+    }
+
+    /// AC#2 of the SSC history mission (#3295): the mission-shaped
+    /// `stellar-core.cfg` that SSC renders for a **publishing validator** —
+    /// one that both reads from peer archives (`get`) and writes its own
+    /// checkpoints (`put` + `mkdir`) into a cluster-local archive — must be
+    /// accepted by henyey *without manual patching*.
+    ///
+    /// This is distinct from `test_ssc_generated_config_full_parse` (a
+    /// read-only watcher with `get`-only archives) and
+    /// `test_ssc_mission_mixed_config_parse` (a validator with NO history).
+    /// Here we assert the full `[HISTORY.*]` triple round-trips: extracted
+    /// `url`, preserved `put`/`mkdir` strings, and `get_enabled`/`put_enabled`
+    /// flags, plus the inline `[[VALIDATORS]].HISTORY` `get`-only archives.
+    ///
+    /// The test drives the same `is_stellar_core_format` +
+    /// `translate_stellar_core_config` entry the binary's config-load path
+    /// uses, so it exercises real parsing, not a stub. It fails if a future
+    /// SSC template-rendering change breaks URL extraction or drops the
+    /// publish commands.
+    #[test]
+    fn test_ssc_mission_history_config_parse() {
+        let fixture = include_str!("compat_http/test_fixtures/ssc_mission_history.cfg");
+        let raw: toml::Value = toml::from_str(fixture).unwrap();
+
+        assert!(
+            is_stellar_core_format(&raw),
+            "SSC history config must be detected as stellar-core format"
+        );
+
+        let config = translate_stellar_core_config(&raw).unwrap();
+
+        // --- Node is a publishing validator ---
+        assert!(config.node.is_validator);
+
+        // --- History archives: 2 from [HISTORY.*] + 2 inline [[VALIDATORS]].HISTORY ---
+        // The publishing archive `ssc_local` carries the full get/put/mkdir triple.
+        let ssc_local = config
+            .history
+            .archives
+            .iter()
+            .find(|a| a.name == "ssc_local")
+            .expect("must have [HISTORY.ssc_local] archive");
+        assert_eq!(
+            ssc_local.url, "http://localhost:1570",
+            "url must be extracted from the localhost curl `get` template, with the /{{0}} suffix stripped"
+        );
+        assert!(ssc_local.get_enabled, "ssc_local has a `get`");
+        assert!(ssc_local.put_enabled, "ssc_local has a `put`");
+        assert_eq!(
+            ssc_local.put.as_deref(),
+            Some("cp {0} /opt/stellar/history/ssc_local/{1}"),
+            "the `put` command template must be preserved verbatim for the uploader"
+        );
+        assert_eq!(
+            ssc_local.mkdir.as_deref(),
+            Some("mkdir -p /opt/stellar/history/ssc_local/{0}"),
+            "the `mkdir` command template must be preserved verbatim"
+        );
+
+        // The read-only peer mirror `ssc_peer` is get-only (no put/mkdir).
+        let ssc_peer = config
+            .history
+            .archives
+            .iter()
+            .find(|a| a.name == "ssc_peer")
+            .expect("must have [HISTORY.ssc_peer] archive");
+        assert_eq!(ssc_peer.url, "http://ssc-core-1.ssc.local:1570");
+        assert!(ssc_peer.get_enabled);
+        assert!(!ssc_peer.put_enabled, "peer mirror is read-only");
+        assert!(ssc_peer.put.is_none());
+        assert!(ssc_peer.mkdir.is_none());
+
+        // Inline [[VALIDATORS]].HISTORY archives (get-only) are also present.
+        let ssc_core_0 = config
+            .history
+            .archives
+            .iter()
+            .find(|a| a.name == "ssc_core_0")
+            .expect("must have inline VALIDATORS HISTORY archive ssc_core_0");
+        assert_eq!(ssc_core_0.url, "http://ssc-core-0.ssc.local:1570");
+        assert!(ssc_core_0.get_enabled);
+        assert!(!ssc_core_0.put_enabled);
+
+        // Total: 2 from [HISTORY.*] + 2 from [[VALIDATORS]].HISTORY.
+        assert_eq!(
+            config.history.archives.len(),
+            4,
+            "expected 4 archives (2 [HISTORY.*] + 2 inline), got {}",
+            config.history.archives.len()
+        );
+
+        // Compat flag set — proves the binary's load path treats this as a
+        // stellar-core compat config (no manual patching).
         assert!(config.is_compat_config);
     }
 

--- a/crates/app/src/compat_http/test_fixtures/ssc_mission_history.cfg
+++ b/crates/app/src/compat_http/test_fixtures/ssc_mission_history.cfg
@@ -1,0 +1,77 @@
+# Supercluster (SSC) generated configuration fixture — HISTORY publishing validator.
+#
+# This represents the config SSC's Kubernetes mission controller generates for a
+# *publishing* validator in a history mission (issue #3295). Unlike
+# `ssc_generated_config.cfg` (a read-only watcher), this node both READS from
+# peer archives (`get`) and WRITES its own checkpoints (`put` + `mkdir`) into a
+# cluster-local archive directory shared across the mission's pods.
+#
+# SHAPE PROVENANCE / CONFIRMATION STATUS:
+#   - The flat top-level keys and the `[[VALIDATORS]]` inline-HISTORY `get`
+#     curl template are reproduced verbatim from the captured #3292 mission
+#     config + `ssc_generated_config.cfg` (CONFIRMED shape).
+#   - The `[HISTORY.<name>]` `get`/`put`/`mkdir` command triples follow
+#     stellar-core's documented archive-command convention (`{0}` = remote
+#     path, `{1}` = local path; see stellar-core docs/software/commands and
+#     `Config.cpp` HISTORY parsing). SSC renders an in-cluster filesystem
+#     archive shared via a mounted volume, so `put`/`mkdir` use `cp`/`mkdir -p`
+#     against an in-pod mount path rather than a remote uploader.
+#   - >>> NEEDS LIVE CONFIRMATION (AC#5/#6): the exact rendered `put`/`mkdir`
+#     strings, the mount path, and whether SSC prefixes a remote-copy wrapper
+#     must be verified against a real SSC history-mission RUN. Any divergence
+#     becomes an AC#8 follow-up. <<<
+
+NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+HTTP_PORT = 11626
+PEER_PORT = 11625
+DATABASE = "sqlite3:///opt/stellar/stellar-core.db"
+BUCKET_DIR_PATH = "/opt/stellar/buckets"
+NODE_SEED = "SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+NODE_IS_VALIDATOR = true
+NODE_HOME_DOMAIN = "ssc.local"
+
+# A publishing validator: SSC enables both catchup-from-peer and self-publish.
+CATCHUP_COMPLETE = false
+CATCHUP_RECENT = 1024
+UNSAFE_QUORUM = true
+FORCE_SCP = true
+
+AUTOMATIC_MAINTENANCE_PERIOD = 3600
+AUTOMATIC_MAINTENANCE_COUNT = 50000
+
+KNOWN_PEERS = ["ssc-core-0.ssc.local:11625", "ssc-core-1.ssc.local:11625", "ssc-core-2.ssc.local:11625"]
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN = "ssc.local"
+QUALITY = "HIGH"
+
+# Validators — peers expose read-only archives via an in-cluster curl `get`.
+[[VALIDATORS]]
+NAME = "ssc_core_0"
+HOME_DOMAIN = "ssc.local"
+PUBLIC_KEY = "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS = "ssc-core-0.ssc.local"
+HISTORY = "curl -sf http://ssc-core-0.ssc.local:1570/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME = "ssc_core_1"
+HOME_DOMAIN = "ssc.local"
+PUBLIC_KEY = "GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP"
+ADDRESS = "ssc-core-1.ssc.local"
+HISTORY = "curl -sf http://ssc-core-1.ssc.local:1570/{0} -o {1}"
+
+# History archives — this node's OWN publishing archive plus a peer read mirror.
+#
+# `ssc_local` is the writable archive backed by an in-pod mounted volume.
+# stellar-core's command convention: {0} = LOCAL staged file, {1} = REMOTE path:
+#   get   — read back files this node published (used for differential upload)
+#   put   — copy the staged local file ({0}) to the archive's remote path ({1})
+#   mkdir — create the archive's destination directory ({0}) before a put
+[HISTORY.ssc_local]
+get = "curl -sf http://localhost:1570/{0} -o {1}"
+put = "cp {0} /opt/stellar/history/ssc_local/{1}"
+mkdir = "mkdir -p /opt/stellar/history/ssc_local/{0}"
+
+# `ssc_peer` is a read-only mirror of a peer's archive (no put/mkdir).
+[HISTORY.ssc_peer]
+get = "curl -sf http://ssc-core-1.ssc.local:1570/{0} -o {1}"

--- a/crates/history/PARITY_STATUS.md
+++ b/crates/history/PARITY_STATUS.md
@@ -3,7 +3,7 @@
 **Crate**: `henyey-history`
 **Upstream**: `stellar-core/src/history/`
 **Overall Parity**: 79%
-**Last Updated**: 2026-05-20
+**Last Updated**: 2026-06-16
 
 ## Summary
 
@@ -12,7 +12,7 @@
 | Checkpoint math | Full | Matches 64-ledger checkpoint rules |
 | Archive path generation | Full | Standard shard and dirty paths covered |
 | HAS parsing and diffing | Full | Bucket-list hash, parsing, futures, and diffing all covered |
-| Archive HTTP and shell access | Full | Native HTTP reads plus shell-command writes |
+| Archive HTTP and shell access | Full | Native HTTP reads plus shell-command writes; offline publish→catchup round-trip over a `cp`/`mkdir` command-template archive and `file://` is CI-pinned (`tests/publish_catchup_roundtrip.rs`, #3295) |
 | Archive manager | Partial | No random selection or work wrappers |
 | Checkpoint builder | Full | Crash-safe dirty-file recovery implemented |
 | Publish queue persistence | Full | SQLite-backed queue replaces filesystem queue |

--- a/crates/history/tests/publish_catchup_roundtrip.rs
+++ b/crates/history/tests/publish_catchup_roundtrip.rs
@@ -1,0 +1,186 @@
+//! AC#3 of the SSC history mission (#3295): an offline publish -> catchup
+//! round-trip that exercises the *real* publish + command-template upload +
+//! catchup code paths (not a stub), asserting ledger-hash agreement.
+//!
+//! Both tests build a deterministic single-checkpoint archive from the public
+//! `test_utils` `make_*` helpers (NOT the HTTP-server fixture
+//! `build_single_checkpoint_archive`), publish it with
+//! `PublishManager::publish_checkpoint`, then make it readable to catchup:
+//!
+//!   * `test_publish_command_template_then_catchup` uploads the staged
+//!     checkpoint into a destination dir via `UploadPlan::execute` against a
+//!     `RemoteArchive { put: "cp {0} {1}", mkdir: "mkdir -p {0}" }` — the same
+//!     SSC-style command-template upload path the publishing-validator config
+//!     in `ssc_mission_history.cfg` uses — then catches up over `file://<dest>`.
+//!
+//!   * `test_publish_file_local_then_catchup` skips the command-template hop:
+//!     catchup reads directly from the publish staging dir over `file://`.
+//!
+//! Both assert the caught-up ledger sequence and final ledger hash match the
+//! published checkpoint header. No loopback socket is bound, so (unlike the
+//! HTTP-server fixture) there is no `FixtureBindDenied` skip guard.
+
+use henyey_bucket::{Bucket, HotArchiveBucketList};
+use henyey_common::Hash256;
+use henyey_db::Database;
+use henyey_history::{
+    archive::HistoryArchive,
+    catchup::{CatchupManagerBuilder, CatchupOptions},
+    publish::{PublishConfig, PublishManager},
+    test_utils::{
+        combined_bucket_list_hash, make_bucket_list_with_hash, make_test_header,
+        DEFAULT_FIXTURE_PASSPHRASE,
+    },
+    upload::UploadPlan,
+    RemoteArchive, RemoteArchiveConfig,
+};
+use henyey_ledger::{LedgerManager, LedgerManagerConfig};
+use stellar_xdr::curr::{LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt};
+
+/// Build the deterministic single empty-bucket checkpoint and publish it into
+/// `staging_dir`. Returns `(checkpoint_seq, expected_header_hash)`.
+///
+/// This mirrors `test_utils::build_single_checkpoint_archive`'s data — an empty
+/// level-0 bucket, a header whose `bucket_list_hash` is the combined live ||
+/// hot-archive hash — but routes it through the real publish pipeline
+/// (`PublishManager::publish_checkpoint`) instead of an HTTP fixture.
+fn publish_single_checkpoint(checkpoint: u32, staging_dir: &std::path::Path) -> Hash256 {
+    let bucket = Bucket::from_entries(vec![]).expect("empty bucket");
+    let bucket_hash = bucket.hash();
+    let bucket_list = make_bucket_list_with_hash(bucket_hash, bucket);
+    let bucket_list_hash = bucket_list.hash();
+
+    let hot_archive = HotArchiveBucketList::new();
+    let combined = combined_bucket_list_hash(bucket_list_hash, hot_archive.hash());
+
+    let header = make_test_header(checkpoint, combined);
+    let header_hash = henyey_history::verify::compute_header_hash(&header).expect("header hash");
+    let header_entry = LedgerHeaderHistoryEntry {
+        hash: header_hash.into(),
+        header,
+        ext: LedgerHeaderHistoryEntryExt::default(),
+    };
+
+    let manager = PublishManager::new(PublishConfig {
+        local_path: staging_dir.to_path_buf(),
+        network_passphrase: Some(DEFAULT_FIXTURE_PASSPHRASE.to_string()),
+        ..Default::default()
+    });
+
+    // Build the HAS from the bucket list + hot archive so it carries the
+    // version-2 hot-archive levels catchup expects, then publish.
+    let has = henyey_history::build_history_archive_state(
+        checkpoint,
+        &bucket_list,
+        Some(&hot_archive),
+        Some(DEFAULT_FIXTURE_PASSPHRASE.to_string()),
+    )
+    .expect("build HAS");
+
+    let state = manager
+        .publish_checkpoint(
+            checkpoint,
+            std::slice::from_ref(&header_entry),
+            &[],
+            &[],
+            &bucket_list,
+            Some(&has),
+        )
+        .expect("publish checkpoint");
+    assert!(
+        state.files_written > 0,
+        "publish must write at least the headers + HAS + bucket"
+    );
+
+    header_hash
+}
+
+/// Catch up from `file://<archive_dir>/` to `checkpoint` and assert the
+/// resulting ledger seq + hash match the published checkpoint header.
+async fn catchup_and_assert(
+    archive_dir: &std::path::Path,
+    checkpoint: u32,
+    expected_hash: Hash256,
+) {
+    // file:// URL with a trailing slash so relative archive paths resolve.
+    let url = format!("file://{}/", archive_dir.display());
+    let archive = HistoryArchive::new(&url).expect("file:// archive");
+
+    let bucket_dir = tempfile::tempdir().expect("bucket dir");
+    let bucket_manager =
+        henyey_bucket::BucketManager::new(bucket_dir.path().to_path_buf()).expect("bucket manager");
+    let db = Database::open_in_memory().expect("db");
+
+    let ledger_manager = LedgerManager::new(
+        DEFAULT_FIXTURE_PASSPHRASE.to_string(),
+        LedgerManagerConfig {
+            validate_bucket_hash: false,
+            ..Default::default()
+        },
+    );
+
+    let mut manager = CatchupManagerBuilder::new()
+        .add_archive(archive)
+        .bucket_manager(bucket_manager)
+        .database(db)
+        .options(CatchupOptions {
+            verify_buckets: true,
+            verify_headers: true,
+        })
+        .build()
+        .expect("catchup manager");
+
+    let output = manager
+        .catchup_to_ledger(checkpoint, &ledger_manager)
+        .await
+        .expect("catchup");
+
+    assert_eq!(output.ledger_seq, checkpoint, "caught up to wrong ledger");
+    assert_eq!(
+        output.ledger_hash, expected_hash,
+        "caught-up ledger hash must match the published checkpoint header hash"
+    );
+}
+
+/// Publish -> SSC-style `cp`/`mkdir` command-template upload -> catchup over file://.
+#[tokio::test]
+async fn test_publish_command_template_then_catchup() {
+    let checkpoint = 63u32;
+
+    let staging = tempfile::tempdir().expect("staging dir");
+    let dest = tempfile::tempdir().expect("dest dir");
+
+    let expected_hash = publish_single_checkpoint(checkpoint, staging.path());
+
+    // Upload every staged file into the destination archive via the SSC-style
+    // command templates, using stellar-core's substitution convention:
+    // `{0}` = LOCAL staged file (absolute), `{1}` = REMOTE (dest-relative) path.
+    // `cp {0} <dest>/{1}` copies the staged file into place; `mkdir -p
+    // <dest>/{0}` (mkdir uses `{0}` for the directory) creates the parent first.
+    let put_cmd = format!("cp {{0}} {}/{{1}}", dest.path().display());
+    let mkdir_cmd = format!("mkdir -p {}/{{0}}", dest.path().display());
+    let remote = RemoteArchive::new(RemoteArchiveConfig {
+        name: "ssc_local".to_string(),
+        get_cmd: None,
+        put_cmd: Some(put_cmd),
+        mkdir_cmd: Some(mkdir_cmd),
+    });
+
+    let plan = UploadPlan::from_staging_dir(staging.path()).expect("upload plan");
+    plan.execute(&remote)
+        .await
+        .expect("command-template upload");
+
+    catchup_and_assert(dest.path(), checkpoint, expected_hash).await;
+}
+
+/// Publish -> catchup directly from the staging dir over file:// (no upload hop).
+#[tokio::test]
+async fn test_publish_file_local_then_catchup() {
+    let checkpoint = 127u32;
+
+    let staging = tempfile::tempdir().expect("staging dir");
+    let expected_hash = publish_single_checkpoint(checkpoint, staging.path());
+
+    catchup_and_assert(staging.path(), checkpoint, expected_hash).await;
+}

--- a/docs/supercluster-feasibility.md
+++ b/docs/supercluster-feasibility.md
@@ -172,15 +172,30 @@ Impact:
 
 The publish/catchup plumbing exists, but the remaining issue is execution confidence.
 
-Two caveats should be called out explicitly:
+Two caveats were originally called out here; one is now closed offline (#3295):
 
-- mission-level reliability has not been demonstrated through SSC
-- HISTORY config parsing extracts archive URLs heuristically from `get` command strings in `crates/app/src/compat_config.rs:236`, which may be brittle depending on how SSC renders command templates
+- **Closed (offline):** HISTORY config parsing extracts archive URLs from the
+  `get` command template in `extract_url_from_curl_cmd`
+  (`crates/app/src/compat_config.rs`). This was previously a brittle fixed-suffix
+  strip; it is now hardened (quotes, query strings, trailing slashes, and the
+  `{0}`/`{1}` placeholder all handled) and pinned by unit tests plus a captured
+  SSC publishing-validator config fixture
+  (`crates/app/src/compat_http/test_fixtures/ssc_mission_history.cfg`) via
+  `test_ssc_mission_history_config_parse`. The fixture's exact `put`/`mkdir`
+  rendering still needs live confirmation against a real SSC history mission.
+- **Closed (offline):** an end-to-end publish→catchup round-trip — henyey
+  publishes a checkpoint, uploads it through a `cp`/`mkdir` command-template
+  archive, then catches up over `file://` and reaches the published ledger hash
+  — is now CI-pinned (`crates/history/tests/publish_catchup_roundtrip.rs`).
+- **Still open:** mission-level reliability has not been demonstrated through a
+  live SSC RUN (cross-tool archive readability + live catchup-to-hash). See the
+  operator runbook in `docs/supercluster-mission-3295.md` (AC#4/#5/#6 of #3295).
 
 Impact:
 
 - history missions belong after mixed-image bring-up and basic HTTP parity work
-- the risk is lower than metrics/loadgen, but it is real
+- the remaining risk is concentrated in the live RUN, not the henyey-side
+  publish/catchup/config-parse paths, which are now offline-pinned
 
 ### 7. `--minimal-for-in-memory-mode` is accepted but silently ignored
 

--- a/docs/supercluster-mission-3295.md
+++ b/docs/supercluster-mission-3295.md
@@ -1,0 +1,148 @@
+# Supercluster Mission #3295 — History Publish/Catchup Mission
+
+**Issue:** [#3295](https://github.com/stellar-experimental/henyey/issues/3295)
+**Companion docs:** [`supercluster-mission-3292.md`](./supercluster-mission-3292.md) (the first mixed-image mission — pattern + harness source), [`supercluster-nsc-workflow.md`](./supercluster-nsc-workflow.md) (#3304 — the verified `nsc` build/publish/launch surface), [`supercluster-feasibility.md`](./supercluster-feasibility.md) (§6 history reliability).
+
+This runbook drives an **SSC history mission**: a henyey node **publishes** its
+own checkpoints to a history archive and **catches up** from an SSC-managed
+archive, proving henyey's history publish/catchup interops with an SSC-generated
+`[HISTORY.*]` archive configuration.
+
+## What this mission validates (acceptance criteria)
+
+| AC | Criterion | How it is checked | Autonomous / Operator |
+|----|-----------|-------------------|------------------------|
+| AC#1 | a real SSC-generated `stellar-core.cfg` with `[HISTORY.*]` is captured as a fixture | `crates/app/src/compat_http/test_fixtures/ssc_mission_history.cfg` (shape flagged for live confirmation) | **Autonomous** |
+| AC#2 | henyey parses that config **without manual patching** | `test_ssc_mission_history_config_parse` + hardened `extract_url_from_curl_cmd` unit tests in `crates/app/src/compat_config.rs` | **Autonomous** |
+| AC#3 | publish→catchup round-trip with SSC-style archive command templates | `crates/history/tests/publish_catchup_roundtrip.rs` — real publish → `cp`/`mkdir` command-template upload → `file://` catchup, asserting ledger-hash agreement | **Autonomous** |
+| AC#4 | run an SSC history mission (or closest equivalent) | live `nsc` + `stellar/supercluster` dotnet harness | **Operator** |
+| AC#5 | henyey-published archive files are readable by henyey **and, where practical, by stellar-core tools** | cross-tool read against a live mission archive | **Operator** |
+| AC#6 | catchup reaches the **expected ledger hash in the live mission** | live mission observation | **Operator** |
+| AC#7 | logs / config / image digest / exact invocation **captured** | run-dir layout + the artifact checklist below | **Operator** |
+| AC#8 | any failure becomes a **concrete follow-up issue** | operator files a follow-up per the checklist | **Operator** |
+
+## Why most of the henyey-side risk is already closed offline
+
+Per the #3295 triage, henyey's history machinery is production-grade: catchup &
+replay, verification, archive HTTP + shell-command access, the checkpoint
+builder, and publish-queue persistence are all at **Full** parity
+(`crates/history/PARITY_STATUS.md`). henyey performs publishing **natively in the
+`history` crate** rather than via stellar-core's Work-class wrappers, so
+`historywork`'s "Publish pipeline = None" row is a taxonomy gap, **not** a
+functional one.
+
+The one genuine henyey-side compat risk the feasibility doc §6 flagged was the
+**heuristic HISTORY-template URL extraction** (`extract_url_from_curl_cmd`).
+That is now hardened and pinned (AC#2), and the publish→catchup path is now
+CI-pinned offline (AC#3). What remains is **live execution confidence** —
+cross-tool archive readability and live catchup-to-hash — which needs a real
+SSC RUN and is handed to the operator below.
+
+## Archive-layout parity (what AC#5 cross-tool readability depends on)
+
+The offline tests prove **henyey reads what henyey wrote**. True cross-tool
+readability (stellar-core reading henyey's archive and vice versa) is the
+operator's AC#5. The three load-bearing surfaces are at stellar-core v26.0.1
+parity:
+
+- **Root HAS path:** `.well-known/stellar-history.json` (`paths.rs`), matching
+  stellar-core's well-known location.
+- **Checkpoint/bucket path sharding:**
+  `category/ll/ll/ll/<category>-<8hexledger>.<ext>` and
+  `bucket/hh/hh/hh/bucket-<hash>.xdr.gz` (`paths.rs`).
+- **HAS JSON shape:** `version` / `server` / `currentLedger` /
+  `networkPassphrase` / `currentBuckets` / `hotArchiveBuckets`, version 2 for
+  protocol 24+ (with hot archive), matching `HistoryArchive.cpp`.
+- **Upload ordering:** data files → per-checkpoint HAS → root HAS **last**
+  (`upload.rs`), matching stellar-core's "root HAS marks the archive
+  initialized, must be last" rule.
+
+## Autonomous deliverable vs. operator-executed run
+
+This is a **validation mission**: the deliverable is *fixtures + tests + runbook
++ a follow-up-on-failure handoff*, not production code. The live multi-hour k8s
+mission **cannot run inside one autonomous task** — it needs an interactive
+`nsc login` (browser OAuth), a long-lived k8s cluster, and the external
+`stellar/supercluster` dotnet harness (not vendored here).
+
+**Shipped autonomously (in the PR):**
+
+- `crates/app/src/compat_http/test_fixtures/ssc_mission_history.cfg` — the SSC publishing-validator config fixture (AC#1).
+- `crates/app/src/compat_config.rs::test_ssc_mission_history_config_parse` + hardened `extract_url_from_curl_cmd` unit tests (AC#2).
+- `crates/history/tests/publish_catchup_roundtrip.rs` — the offline publish→catchup round-trip (AC#3).
+- doc updates to `crates/history/PARITY_STATUS.md` and `docs/supercluster-feasibility.md` §6 (AC#8 docs).
+- this runbook.
+
+**Operator-executed (NOT done in the PR):** the mission RUN itself (AC#4 / AC#5
+cross-tool / AC#6) — see the checklist below.
+
+## OPERATOR CHECKLIST — the live history mission RUN
+
+> Everything below is **operator-executed** against live infra. The PR does NOT
+> run any of it and does NOT fabricate a mission transcript.
+
+1. **Auth** (one-time per session): `nsc login` (interactive browser OAuth).
+   Review the verified build/publish/launch commands in
+   [`supercluster-nsc-workflow.md`](./supercluster-nsc-workflow.md) (#3304).
+2. **Build + push + provision (nsc side):** build and push the henyey image,
+   capture the **`sha256` digest**, and `nsc create` an ephemeral k8s instance.
+   (Reuse the `scripts/ssc/launch-mission-3292.sh` wrapper if launching a mixed
+   topology; a history mission additionally needs a **publishing** node, i.e.
+   `NODE_IS_VALIDATOR=true` with a writable `[HISTORY.<name>]` archive — see the
+   fixture shape.)
+3. **Drive the SSC dotnet harness** (`stellar/supercluster`, external) pointed at
+   the **digest-pinned** image + the instance kubeconfig (`nsc kubeconfig write`).
+   Configure at least one henyey publishing node and a shared/cluster-local
+   history archive (e.g. a mounted volume the pods `cp` into, or an in-cluster
+   HTTP archive served by a sidecar). Let it externalize past **at least one
+   checkpoint boundary** (every 64 ledgers) so a publish actually occurs.
+4. **AC#2 (live) — confirm the fixture shape:** capture the **SSC-generated
+   `stellar-core.cfg`** and `diff` its `[HISTORY.*]` `get`/`put`/`mkdir`
+   templates against
+   `crates/app/src/compat_http/test_fixtures/ssc_mission_history.cfg`. The
+   fixture's `put`/`mkdir`/mount-path strings are inferred from stellar-core
+   conventions; **a structural skew is a follow-up issue (AC#8), not a silent
+   patch.** Confirm henyey's binary `load_config` accepts the real config
+   unmodified.
+5. **AC#6 (live) — catchup to hash:** point a fresh henyey node at the mission
+   archive and run `henyey catchup` to a published checkpoint. Assert the
+   reported ledger hash matches the network's ledger hash at that seq:
+   ```bash
+   # On the catching-up henyey node (file://, http(s)://, or cmd archive):
+   henyey catchup --archive <archive-url> --to <checkpoint-ledger>
+   # Compare against the network's seq+hash:
+   curl -s http://<publishing-pod>:11626/info | jq '.info.ledger'
+   ```
+6. **AC#5 (cross-tool readability):**
+   - **henyey→henyey** is already proven offline (AC#3). Live, confirm a second
+     henyey node catches up from the **henyey-published** archive (step 5).
+   - **henyey→stellar-core:** point a stellar-core node (or `stellar-core
+     catchup` / its archive reader) at the **henyey-published** archive and
+     confirm it reads the root HAS, the per-checkpoint HAS, the headers, and the
+     buckets without error. Byte-check a henyey-published
+     `.well-known/stellar-history.json` against stellar-core's expectations.
+   - **stellar-core→henyey:** point henyey at a **stellar-core-published**
+     mission archive and catch up (step 5 against that archive).
+   - Any read failure or HAS-shape divergence → **follow-up issue (AC#8)**.
+7. **Capture artifacts** into `runs/<date>-mission-3295/` and onto #3295:
+   - `image-digest.txt` (the immutable `sha256:` reference),
+   - `instance.json` (nsc instance metadata),
+   - the **SSC-generated `stellar-core.cfg`** (and the diff vs. the fixture),
+   - the exact `nsc` + dotnet invocations,
+   - a sample of the **henyey-published archive tree** (root HAS + one
+     checkpoint's HAS/headers/buckets),
+   - the catchup-to-hash output (henyey and, where run, stellar-core),
+   - `nsc kubectl get all -A` + per-pod henyey/stellar-core logs.
+8. **Teardown:** `nsc destroy <instance-id> --force`, then `nsc list -o json` to
+   confirm the ephemeral cluster is gone (see #3304 §5).
+9. **On any failure:** file a **concrete follow-up issue** (AC#8) with the
+   captured artifacts — do NOT silently patch henyey or the fixture to make the
+   run pass.
+
+### Watch-item (#3299)
+
+`--minimal-for-in-memory-mode` is currently accepted-and-ignored by henyey
+(#3299). henyey runs persistent SQLite, which is fine for one bounded mission.
+Watch for subtle state issues across mission restarts; if the SSC default node
+bootstrap relies on ephemeral in-memory semantics, file a follow-up rather than
+blocking the mission.


### PR DESCRIPTION
Closes #3295

## Summary

Ships the **autonomously-doable** half of the SSC history mission (#3295): proves
henyey's history publish/catchup interops with an SSC-generated `[HISTORY.*]`
archive configuration, offline and CI-pinned, and hands the live k8s mission to
the operator as a concrete checklist. Mirrors #3292 / PR #3306.

- **AC#1** — NEW `crates/app/src/compat_http/test_fixtures/ssc_mission_history.cfg`:
  an SSC publishing-validator config with real `[HISTORY.*]` `get`/`put`/`mkdir`
  command templates (seeded from #3292's captured shape + `ssc_generated_config.cfg`;
  header comment flags the `put`/`mkdir`/mount values needing live confirmation).
- **AC#2** — `test_ssc_mission_history_config_parse` (config-acceptance over the
  fixture, no manual patching) AND hardening of the one real henyey-side risk:
  `extract_url_from_curl_cmd` (`compat_config.rs`, used for `[HISTORY.*]` and
  inline `[[VALIDATORS]].HISTORY`). The extractor now takes the URL from the
  first `http(s)://` token, strips shell quotes, truncates at the `{0}`/`{1}`
  placeholder, drops a query string, and trims a trailing slash — pinned by unit
  tests against the literal SSC `get` shapes. Behavior is byte-identical for the
  existing testnet curl shapes.
- **AC#3** — NEW `crates/history/tests/publish_catchup_roundtrip.rs`: a REAL
  offline publish→catchup round-trip using the public `make_*` helpers +
  `PublishManager::publish_checkpoint` → `UploadPlan::execute(RemoteArchive{cp/mkdir})`
  → `HistoryArchive` over `file://` → `catchup_to_ledger`, asserting ledger-hash
  agreement. Uses the `make_*` helpers (NOT the HTTP-server fixture); `file://`
  needs no loopback bind, so there is no skip guard.
- **AC#8 (docs)** — `crates/history/PARITY_STATUS.md`, `docs/supercluster-feasibility.md`
  §6 (brittleness + round-trip closed offline; stale `:236` ref fixed), and a new
  operator runbook `docs/supercluster-mission-3295.md`.

The live SSC mission (AC#4), cross-tool archive readability (AC#5), and live
catchup-to-hash (AC#6) require interactive `nsc login` + a multi-hour k8s cluster
+ the un-vendored `stellar/supercluster` dotnet harness — they are posted as an
operator checklist (runbook + a comment on #3295), NOT executed or faked here.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3295#issuecomment-4723970916)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-app -p henyey-history — all pass (app 1042 lib + integration; history 558 lib + `publish_catchup_roundtrip` 2/2 + existing catchup/replay/serialize)

## Failing-test-first (feature new-coverage)

- The URL-extraction hardening cases in `test_extract_url_from_curl_cmd`
  (double-slash normalization, quoted query-string URL) were verified to FAIL on
  the current-main extractor before the hardening landed.
- The publish→catchup round-trip exercises real publish + command-template upload
  + catchup (not a stub) and asserts the caught-up `ledger_hash` equals the
  published checkpoint header hash.

## Deviations from plan

- The plan's prose used `put = "cp {1} {0}"`; stellar-core's actual substitution
  convention (confirmed against `RemoteArchive::put_file` and the existing
  `test_local_history_archive_with_cp_commands`) is `{0}`=local file, `{1}`=remote
  path, so the fixture and round-trip use `cp {0} <dest>/{1}` / `mkdir -p <dest>/{0}`.
- `historywork/PARITY_STATUS.md` was NOT changed: publishing is native to the
  `history` crate, so the Work-class taxonomy gap does not shift status (plan said
  "+ historywork if status shifts").

🤖 Generated with [Claude Code](https://claude.com/claude-code)