### PR TITLE
Validate /upgrades protocol-upgrade path end-to-end for SSC mission

### DIFF
--- a/crates/app/PARITY_STATUS.md
+++ b/crates/app/PARITY_STATUS.md
@@ -118,6 +118,7 @@ Corresponds to: `CommandHandler.h`
 | stellar-core | Rust | Status |
 |--------------|------|--------|
 | `info()` / `metrics()` / `peers()` / `quorum()` / `scpInfo()` / `tx()` / `upgrades()` / `dumpProposedSettings()` / `sorobanInfo()` | native and compat handlers | Full |
+| `upgrades()` `mode=set` parameter set | compat handler parses the full SSC param set 1:1 with `CommandHandler.cpp:613-671`; validated offline (#3300) by `test_upgrades_set_parses_full_ssc_param_set`; two read/validation divergences documented below | Full (set path) |
 | `maintenance()` / `clearMetrics()` / `selfCheck()` | native and compat handlers | Full |
 | `generateLoad()` | native and compat handlers (feature-gated via `loadgen`) | Full |
 | `testAcc()` | compat handler with deterministic key derivation | Full |
@@ -142,6 +143,30 @@ Corresponds to: `CommandHandler.h`
    when no bans exist; henyey emits `{"bans": []}` to match its own native
    `/bans` (`BansResponse`) and because an empty array is unambiguous. SSC /
    stellar-rpc consumers treat the two equivalently.
+
+**Documented `/upgrades` read/validation divergences (#3300).** The
+parity-load-bearing path for an SSC protocol-upgrade mission is `mode=set`
+(the harness drives upgrades by setting them); that path parses the exact
+stellar-core parameter set (`upgradetime`, `protocolversion`, `basefee`,
+`basereserve`, `maxtxsetsize`, `flags`, base64 `configupgradesetkey`,
+`maxsorobantxsetsize`, `nominationtimeoutlimit`, `expirationminutes`) and is
+pinned 1:1 by `test_upgrades_set_parses_full_ssc_param_set`. Two divergences are
+on read/validation-feedback paths the mission's SET→observe-externalize flow
+does not require — recorded here as **candidate follow-ups**, not fixed in the
+validation PR:
+
+1. **Empty-mode read shape.** stellar-core returns `"mode required"` on empty
+   mode and serializes `getUpgradesJson()` (`{time,version,fee,maxtxsize,reserve}`,
+   `Upgrades.cpp:58-62`) only under `mode=get`. Henyey returns a bespoke
+   `{current,scheduled}` body on the empty/default mode. Follow-up only if the
+   live mission reads upgrade state via `/upgrades?mode=get`.
+2. **SET-time `configupgradesetkey` validation.** stellar-core validates the key
+   via `ConfigUpgradeSetFrame::makeFromKey` + `isValidForApply` at SET time and
+   rejects an invalid key with `"Error setting configUpgradeSet"`
+   (`CommandHandler.cpp:648-655`). Henyey decodes the key but **defers** validity
+   to nomination/apply (an invalid key simply never nominates). Likely benign,
+   but loud-vs-silent rejection differs. Follow-up only if the live mission
+   relies on SET-time rejection feedback.
 
 ### Query server (`src/http/mod.rs`, `src/http/handlers/query.rs`)
 

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -853,6 +853,208 @@ mod tests {
         assert!(value.get("error").is_some());
     }
 
+    // ── #3300: /upgrades?mode=set exact SSC parameter-set pinning ───────
+    //
+    // Drives the REAL `compat_upgrades_handler` against a live `App` and reads
+    // back the parsed `UpgradeParameters` via `runtime_upgrade_parameters()`,
+    // pinning the parse 1:1 against stellar-core `CommandHandler::upgrades`
+    // (CommandHandler.cpp:613-671). stellar-core's `mode=set` branch accepts
+    // exactly these query params, which must each map to the matching
+    // `UpgradeParameters` field:
+    //   upgradetime, basefee, basereserve, maxtxsetsize, protocolversion,
+    //   flags, configupgradesetkey (base64 XDR), maxsorobantxsetsize,
+    //   nominationtimeoutlimit, expirationminutes.
+    // This is the parity-load-bearing path for an SSC protocol-upgrade
+    // mission (the harness drives upgrades via mode=set).
+
+    /// Build the base64-encoded `configupgradesetkey` XDR that SSC sends, and
+    /// return both the wire string and the decoded key for round-trip checks.
+    fn ssc_config_upgrade_set_key() -> (String, stellar_xdr::curr::ConfigUpgradeSetKey) {
+        use base64::{engine::general_purpose::STANDARD, Engine};
+        use stellar_xdr::curr::{ConfigUpgradeSetKey, ContractId, Hash, Limits, WriteXdr};
+        let key = ConfigUpgradeSetKey {
+            contract_id: ContractId(Hash([0xAB; 32])),
+            content_hash: Hash([0xCD; 32]),
+        };
+        let bytes = key.to_xdr(Limits::none()).expect("encode key");
+        (STANDARD.encode(bytes), key)
+    }
+
+    /// Build the `mode=set` query param map with the full SSC parameter set.
+    fn full_ssc_set_params(config_key_b64: &str) -> std::collections::HashMap<String, String> {
+        let mut m = std::collections::HashMap::new();
+        m.insert("mode".into(), "set".into());
+        // Unix-timestamp form (stellar-core also accepts ISO 8601; both paths
+        // are parsed by the handler — see `parse_iso8601_to_unix`).
+        m.insert("upgradetime".into(), "1700000000".into());
+        m.insert("basefee".into(), "250".into());
+        m.insert("basereserve".into(), "6000000".into());
+        m.insert("maxtxsetsize".into(), "2000".into());
+        m.insert("protocolversion".into(), "25".into());
+        m.insert("flags".into(), "1".into());
+        m.insert("configupgradesetkey".into(), config_key_b64.into());
+        m.insert("maxsorobantxsetsize".into(), "50".into());
+        m.insert("nominationtimeoutlimit".into(), "3".into());
+        m.insert("expirationminutes".into(), "120".into());
+        m
+    }
+
+    /// `/upgrades?mode=set` with the full SSC parameter set parses every
+    /// param into the correct `UpgradeParameters` field. Drives the real
+    /// handler + `App::set_upgrade_parameters`, reads back via
+    /// `runtime_upgrade_parameters()`.
+    #[tokio::test]
+    async fn test_upgrades_set_parses_full_ssc_param_set() {
+        let (_dir, state) = mk_compat_state().await;
+        let (config_key_b64, expected_key) = ssc_config_upgrade_set_key();
+
+        let resp = compat_upgrades_handler(
+            State(Arc::clone(&state)),
+            Query(full_ssc_set_params(&config_key_b64)),
+        )
+        .await
+        .into_response();
+        let json = body_json(resp).await;
+        assert_eq!(json["status"], "ok", "mode=set should succeed: {json}");
+
+        let params = state.app.runtime_upgrade_parameters();
+        assert_eq!(params.upgrade_time, 1_700_000_000, "upgradetime");
+        assert_eq!(params.base_fee, Some(250), "basefee");
+        assert_eq!(params.base_reserve, Some(6_000_000), "basereserve");
+        assert_eq!(params.max_tx_set_size, Some(2000), "maxtxsetsize");
+        assert_eq!(params.protocol_version, Some(25), "protocolversion");
+        assert_eq!(params.flags, Some(1), "flags");
+        assert_eq!(
+            params.max_soroban_tx_set_size,
+            Some(50),
+            "maxsorobantxsetsize"
+        );
+        assert_eq!(
+            params.nomination_timeout_limit,
+            Some(3),
+            "nominationtimeoutlimit"
+        );
+        assert_eq!(params.expiration_minutes, Some(120), "expirationminutes");
+
+        // configupgradesetkey: base64 XDR decoded back to the exact key.
+        let parsed_key = params
+            .config_upgrade_set_key
+            .as_ref()
+            .expect("configupgradesetkey must be parsed")
+            .to_xdr()
+            .expect("key round-trips to XDR");
+        assert_eq!(
+            parsed_key, expected_key,
+            "configupgradesetkey must decode to the exact ConfigUpgradeSetKey"
+        );
+
+        state.app.shutdown();
+    }
+
+    /// `/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z` — the ISO 8601
+    /// "apply immediately" form stellar-core's `isoStringToTm` accepts — parses
+    /// to epoch 0.
+    #[tokio::test]
+    async fn test_upgrades_set_parses_iso8601_upgradetime() {
+        let (_dir, state) = mk_compat_state().await;
+        let mut m = std::collections::HashMap::new();
+        m.insert("mode".into(), "set".into());
+        m.insert("upgradetime".into(), "1970-01-01T00:00:00Z".into());
+        m.insert("protocolversion".into(), "25".into());
+
+        let resp = compat_upgrades_handler(State(Arc::clone(&state)), Query(m))
+            .await
+            .into_response();
+        let json = body_json(resp).await;
+        assert_eq!(json["status"], "ok");
+
+        let params = state.app.runtime_upgrade_parameters();
+        assert_eq!(params.upgrade_time, 0, "epoch ISO 8601 → 0");
+        assert_eq!(params.protocol_version, Some(25));
+        state.app.shutdown();
+    }
+
+    /// `/upgrades?mode=clear` resets the scheduled parameters back to the
+    /// default (no upgrades scheduled), mirroring stellar-core's `clear`
+    /// branch (CommandHandler.cpp:672 — sets an empty `UpgradeParameters`).
+    #[tokio::test]
+    async fn test_upgrades_clear_resets_to_default() {
+        let (_dir, state) = mk_compat_state().await;
+        let (config_key_b64, _key) = ssc_config_upgrade_set_key();
+
+        // First set a full param set.
+        let resp = compat_upgrades_handler(
+            State(Arc::clone(&state)),
+            Query(full_ssc_set_params(&config_key_b64)),
+        )
+        .await
+        .into_response();
+        assert_eq!(body_json(resp).await["status"], "ok");
+        assert!(state
+            .app
+            .runtime_upgrade_parameters()
+            .protocol_version
+            .is_some());
+
+        // Now clear.
+        let mut clear = std::collections::HashMap::new();
+        clear.insert("mode".into(), "clear".into());
+        let resp = compat_upgrades_handler(State(Arc::clone(&state)), Query(clear))
+            .await
+            .into_response();
+        assert_eq!(body_json(resp).await["status"], "ok");
+
+        let params = state.app.runtime_upgrade_parameters();
+        let default = henyey_herder::upgrades::UpgradeParameters::default();
+        assert_eq!(params.protocol_version, default.protocol_version);
+        assert_eq!(params.base_fee, default.base_fee);
+        assert_eq!(params.base_reserve, default.base_reserve);
+        assert_eq!(params.max_tx_set_size, default.max_tx_set_size);
+        assert_eq!(params.flags, default.flags);
+        assert_eq!(
+            params.max_soroban_tx_set_size,
+            default.max_soroban_tx_set_size
+        );
+        assert!(params.config_upgrade_set_key.is_none());
+        assert!(
+            !params.has_any_upgrade(),
+            "clear must remove all scheduled upgrades"
+        );
+        state.app.shutdown();
+    }
+
+    /// Default GET (`/upgrades` with no/empty mode) returns the bespoke
+    /// `{current, scheduled}` shape. NOTE: this is a DOCUMENTED divergence
+    /// from stellar-core, which returns `"mode required"` for empty mode and
+    /// only emits `getUpgradesJson()` under `mode=get` (see PARITY_STATUS).
+    #[tokio::test]
+    async fn test_upgrades_default_get_shape() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_upgrades_handler(
+            State(Arc::clone(&state)),
+            Query(std::collections::HashMap::new()),
+        )
+        .await
+        .into_response();
+        let json = body_json(resp).await;
+        let obj = json.as_object().expect("object body");
+        assert!(obj.contains_key("current"), "default GET has 'current'");
+        assert!(obj.contains_key("scheduled"), "default GET has 'scheduled'");
+        for key in ["ledgerVersion", "baseFee", "baseReserve", "maxTxSetSize"] {
+            assert!(json["current"].get(key).is_some(), "current.{key}");
+        }
+        for key in [
+            "upgradetime",
+            "protocolversion",
+            "basefee",
+            "basereserve",
+            "maxtxsetsize",
+        ] {
+            assert!(json["scheduled"].get(key).is_some(), "scheduled.{key}");
+        }
+        state.app.shutdown();
+    }
+
     // ── /quorum response shape test ─────────────────────────────────────
 
     /// Verify `/quorum` response has `{"quorum": "<hash>"}` shape.

--- a/crates/herder/PARITY_STATUS.md
+++ b/crates/herder/PARITY_STATUS.md
@@ -458,6 +458,17 @@ Corresponds to: `Upgrades.h`
 | `ConfigUpgradeSetFrame::encodeAsString()` | _(not implemented)_ | None |
 | `ConfigUpgradeSetFrame::toJson()` | _(not implemented)_ | None |
 
+**Schedule→nomination validation (#3300).** The schedule→nominate half of the
+SSC protocol-upgrade path is covered offline for every `LedgerUpgrade` variant
+(Version, BaseFee, BaseReserve, MaxTxSetSize, Flags, MaxSorobanTxSetSize, Config)
+by `test_scheduled_params_nominate_each_variant` and
+`test_scheduled_config_variant_nominate`: `create_upgrades_for` emits the
+matching upgrade when the current ledger value differs, suppresses the no-op when
+equal, and `is_valid_for_nomination` accepts at/after `upgrade_time` (rejects
+before). Header/state application is covered in `henyey-ledger`
+(`upgrade_sequence_integration.rs`); the live multi-node externalize run is an
+operator hand-off (`docs/supercluster-mission-3300.md`).
+
 ### ParallelTxSetBuilder (`parallel_tx_set_builder.rs`)
 
 Corresponds to: `ParallelTxSetBuilder.h`

--- a/crates/herder/src/upgrades.rs
+++ b/crates/herder/src/upgrades.rs
@@ -1624,4 +1624,244 @@ mod tests {
             err_msg
         );
     }
+
+    // ── #3300: per-variant scheduling → nomination validation ───────────
+    //
+    // Validates the real `create_upgrades_for` (nomination emitter) and
+    // `is_valid_for_nomination` (nomination acceptance gate) for EVERY
+    // `LedgerUpgrade` variant the SSC protocol-upgrade mission can drive via
+    // `/upgrades?mode=set`. For each variant we assert three things:
+    //   1. `create_upgrades_for` EMITS the matching `LedgerUpgrade` when the
+    //      current ledger value differs from the scheduled value.
+    //   2. `create_upgrades_for` SUPPRESSES the no-op when current == target.
+    //   3. `is_valid_for_nomination` ACCEPTS the produced upgrade at and after
+    //      `upgrade_time`, and REJECTS it before `upgrade_time`.
+    //
+    // Header/state application of the produced upgrades is covered offline by
+    // `crates/ledger/tests/upgrade_sequence_integration.rs`. Together the two
+    // suites cover schedule → nominate → apply for every variant without a
+    // live SCP network (externalize itself is the operator mission).
+
+    /// Current-ledger snapshot fixture with Soroban enabled, used as the
+    /// "before" state every variant upgrades away from.
+    fn baseline_state(close_time: u64) -> CurrentLedgerState {
+        CurrentLedgerState {
+            close_time,
+            protocol_version: 24,
+            base_fee: 100,
+            max_tx_set_size: 1000,
+            base_reserve: 5_000_000,
+            flags: 0,
+            max_soroban_tx_set_size: Some(100),
+        }
+    }
+
+    /// Assert the schedule → nominate behavior for one non-config variant:
+    /// emitted when current differs, suppressed when equal, and accepted by
+    /// `is_valid_for_nomination` at/after `upgrade_time` (rejected before).
+    fn assert_variant_emit_suppress_nominate(
+        params: UpgradeParameters,
+        differing_state: CurrentLedgerState,
+        matching_state: CurrentLedgerState,
+        expected: &LedgerUpgrade,
+    ) {
+        let upgrade_time = params.upgrade_time;
+        let upgrades = Upgrades::new(params);
+
+        // 1. Emitted when the current ledger value differs from the target.
+        let emitted = upgrades
+            .create_upgrades_for(&differing_state, None)
+            .unwrap();
+        assert!(
+            emitted.iter().any(|u| u == expected),
+            "expected {expected:?} to be emitted, got {emitted:?}"
+        );
+
+        // 2. Suppressed (no-op) when the current value already equals the target.
+        let suppressed = upgrades.create_upgrades_for(&matching_state, None).unwrap();
+        assert!(
+            !suppressed.iter().any(|u| u == expected),
+            "expected {expected:?} to be suppressed as a no-op, got {suppressed:?}"
+        );
+
+        // 3a. Accepted for nomination at the exact upgrade_time.
+        assert!(
+            upgrades.is_valid_for_nomination(expected, upgrade_time),
+            "{expected:?} should be valid for nomination at upgrade_time {upgrade_time}"
+        );
+        // 3b. Accepted strictly after upgrade_time.
+        assert!(
+            upgrades.is_valid_for_nomination(expected, upgrade_time + 1),
+            "{expected:?} should be valid for nomination after upgrade_time"
+        );
+        // 3c. Rejected before upgrade_time (timing gate).
+        if upgrade_time > 0 {
+            assert!(
+                !upgrades.is_valid_for_nomination(expected, upgrade_time - 1),
+                "{expected:?} should be rejected before upgrade_time"
+            );
+        }
+    }
+
+    #[test]
+    fn test_scheduled_params_nominate_each_variant() {
+        let t = 1000u64;
+
+        // ── Version ──────────────────────────────────────────────────────
+        let mut p = UpgradeParameters::new(t);
+        p.protocol_version = Some(25);
+        let mut matching = baseline_state(t);
+        matching.protocol_version = 25;
+        assert_variant_emit_suppress_nominate(
+            p,
+            baseline_state(t),
+            matching,
+            &LedgerUpgrade::Version(25),
+        );
+
+        // ── BaseFee ──────────────────────────────────────────────────────
+        let mut p = UpgradeParameters::new(t);
+        p.base_fee = Some(200);
+        let mut matching = baseline_state(t);
+        matching.base_fee = 200;
+        assert_variant_emit_suppress_nominate(
+            p,
+            baseline_state(t),
+            matching,
+            &LedgerUpgrade::BaseFee(200),
+        );
+
+        // ── BaseReserve ──────────────────────────────────────────────────
+        let mut p = UpgradeParameters::new(t);
+        p.base_reserve = Some(6_000_000);
+        let mut matching = baseline_state(t);
+        matching.base_reserve = 6_000_000;
+        assert_variant_emit_suppress_nominate(
+            p,
+            baseline_state(t),
+            matching,
+            &LedgerUpgrade::BaseReserve(6_000_000),
+        );
+
+        // ── MaxTxSetSize ─────────────────────────────────────────────────
+        let mut p = UpgradeParameters::new(t);
+        p.max_tx_set_size = Some(2000);
+        let mut matching = baseline_state(t);
+        matching.max_tx_set_size = 2000;
+        assert_variant_emit_suppress_nominate(
+            p,
+            baseline_state(t),
+            matching,
+            &LedgerUpgrade::MaxTxSetSize(2000),
+        );
+
+        // ── Flags ────────────────────────────────────────────────────────
+        let mut p = UpgradeParameters::new(t);
+        p.flags = Some(1);
+        let mut matching = baseline_state(t);
+        matching.flags = 1;
+        assert_variant_emit_suppress_nominate(
+            p,
+            baseline_state(t),
+            matching,
+            &LedgerUpgrade::Flags(1),
+        );
+
+        // ── MaxSorobanTxSetSize ──────────────────────────────────────────
+        let mut p = UpgradeParameters::new(t);
+        p.max_soroban_tx_set_size = Some(200);
+        let mut matching = baseline_state(t);
+        matching.max_soroban_tx_set_size = Some(200);
+        assert_variant_emit_suppress_nominate(
+            p,
+            baseline_state(t),
+            matching,
+            &LedgerUpgrade::MaxSorobanTxSetSize(200),
+        );
+    }
+
+    /// The Config variant requires a ledger-backed `ConfigUpgradeContext`, so
+    /// it is exercised separately from the scalar variants. Asserts emit (when
+    /// the proposed setting differs), suppress (when it matches), and
+    /// `is_valid_for_nomination` acceptance at/after `upgrade_time`.
+    #[test]
+    fn test_scheduled_config_variant_nominate() {
+        use base64::{engine::general_purpose::STANDARD, Engine};
+        use stellar_xdr::curr::*;
+
+        let proposed = ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
+            ledger_max_instructions: 200_000_000, // differs from current
+            tx_max_instructions: 10_000_000,
+            fee_rate_per_instructions_increment: 100,
+            tx_memory_limit: 50_000_000,
+        });
+        let current = ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
+            ledger_max_instructions: 100_000_000,
+            tx_max_instructions: 10_000_000,
+            fee_rate_per_instructions_increment: 100,
+            tx_memory_limit: 50_000_000,
+        });
+        let upgrade_set = ConfigUpgradeSet {
+            updated_entry: vec![proposed].try_into().unwrap(),
+        };
+
+        // Context where the proposed setting DIFFERS from current → emit.
+        let (ctx_needed, key) =
+            build_config_upgrade_context(&upgrade_set, std::slice::from_ref(&current), 25, 100);
+        // Context where current already equals the proposed setting → suppress.
+        let proposed_for_match =
+            ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
+                ledger_max_instructions: 200_000_000,
+                tx_max_instructions: 10_000_000,
+                fee_rate_per_instructions_increment: 100,
+                tx_memory_limit: 50_000_000,
+            });
+        let (ctx_noop, _key2) =
+            build_config_upgrade_context(&upgrade_set, &[proposed_for_match], 25, 100);
+
+        let upgrade_time = 1000u64;
+        let mut params = UpgradeParameters::new(upgrade_time);
+        params.config_upgrade_set_key = Some(ConfigUpgradeSetKeyJson {
+            contract_id: STANDARD.encode(key.contract_id.0 .0),
+            content_hash: STANDARD.encode(key.content_hash.0),
+        });
+        let upgrades = Upgrades::new(params);
+
+        let state = CurrentLedgerState {
+            close_time: upgrade_time,
+            protocol_version: 25,
+            base_fee: 100,
+            max_tx_set_size: 1000,
+            base_reserve: 5_000_000,
+            flags: 0,
+            max_soroban_tx_set_size: None,
+        };
+
+        // Emit: proposed differs from current.
+        let emitted = upgrades
+            .create_upgrades_for(&state, Some(&ctx_needed))
+            .unwrap();
+        let config_upgrade = emitted
+            .iter()
+            .find(|u| matches!(u, LedgerUpgrade::Config(_)))
+            .cloned()
+            .expect("Config upgrade should be emitted when setting differs");
+        assert_eq!(config_upgrade, LedgerUpgrade::Config(key.clone()));
+
+        // Suppress: proposed already matches current.
+        let suppressed = upgrades
+            .create_upgrades_for(&state, Some(&ctx_noop))
+            .unwrap();
+        assert!(
+            !suppressed
+                .iter()
+                .any(|u| matches!(u, LedgerUpgrade::Config(_))),
+            "Config upgrade should be suppressed when setting already matches, got {suppressed:?}"
+        );
+
+        // Nomination acceptance at/after upgrade_time, rejection before.
+        assert!(upgrades.is_valid_for_nomination(&config_upgrade, upgrade_time));
+        assert!(upgrades.is_valid_for_nomination(&config_upgrade, upgrade_time + 1));
+        assert!(!upgrades.is_valid_for_nomination(&config_upgrade, upgrade_time - 1));
+    }
 }

--- a/crates/ledger/PARITY_STATUS.md
+++ b/crates/ledger/PARITY_STATUS.md
@@ -159,6 +159,19 @@ Corresponds to: `LedgerCloseData` (in upstream `herder/` but used by `LedgerMana
 | `LedgerCloseStats` | `LedgerCloseStats` | Full |
 | `UpgradeContext` | `UpgradeContext` | Full |
 
+**Per-variant upgrade application validation (#3300).** Every `LedgerUpgrade`
+variant the SSC protocol-upgrade mission can schedule is exercised end-to-end
+through the REAL close-loop dispatcher (`close_ledger` → `apply_upgrades_to_delta`
+→ `apply_to_header` / `apply_config_upgrades` / `apply_max_soroban_tx_set_size`)
+by `crates/ledger/tests/upgrade_sequence_integration.rs`:
+`test_apply_each_ledger_upgrade_variant_mutates_header_and_state` (Version,
+BaseFee, BaseReserve, MaxTxSetSize, Flags → header fields / ext V1),
+`test_apply_max_soroban_tx_set_size_variant_mutates_state`
+(`ContractExecutionLanes.ledger_max_tx_count`), and
+`test_apply_config_upgrade_variant_mutates_state` (config-setting state). Driving
+through `close_ledger` (not the leaf functions) deliberately covers the
+dispatcher seam, not just the leaves.
+
 ### snapshot.rs (`snapshot.rs`)
 
 Corresponds to: `LedgerStateSnapshot.h`

--- a/crates/ledger/tests/upgrade_sequence_integration.rs
+++ b/crates/ledger/tests/upgrade_sequence_integration.rs
@@ -1490,3 +1490,205 @@ fn test_base_reserve_upgrade_prepare_liabilities_meta() {
         "Trustline should NOT appear in upgrade changes when all buying offers are erased"
     );
 }
+
+// ===========================================================================
+// #3300 — per-variant upgrade application through the REAL close-loop seam
+//
+// Validation mission (SSC protocol-upgrade): drive EACH `LedgerUpgrade`
+// variant the `/upgrades?mode=set` endpoint can schedule through the REAL
+// close-loop dispatcher (`LedgerManager::close_ledger` →
+// `apply_upgrades_to_delta` → `UpgradeContext::apply_to_header` /
+// `apply_config_upgrades` / `apply_max_soroban_tx_set_size`) over a genesis
+// snapshot, and assert the post-close header/state field mutates to the
+// scheduled value.
+//
+// Going through `close_ledger` (not the leaf functions directly) is
+// deliberate: it exercises the dispatcher SEAM that routes each variant to
+// the correct leaf — the gap Critic A flagged — not just the leaves in
+// isolation. The handler→`UpgradeParameters` parse is covered in
+// `crates/app/.../plaintext.rs`; the schedule→nominate emission is covered in
+// `crates/herder/src/upgrades.rs`. Together: schedule → nominate → apply for
+// every variant, offline.
+// ===========================================================================
+
+/// Version, BaseFee, BaseReserve, MaxTxSetSize, Flags — the header-field
+/// variants — each mutate the post-close header to the scheduled value via
+/// the real dispatcher → `apply_to_header` seam. Flags additionally promotes
+/// `LedgerHeaderExt` from V0 to V1.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_apply_each_ledger_upgrade_variant_mutates_header_and_state() {
+    let handle = tokio::runtime::Handle::current();
+
+    // ── Version: 24 → 25 mutates header.ledger_version ────────────────────
+    {
+        let ledger = init_ledger_manager(24);
+        let close = empty_close_data(&ledger, 1, 100).with_upgrade(LedgerUpgrade::Version(25));
+        let r = ledger
+            .close_ledger(close, Some(handle.clone()))
+            .expect("close Version");
+        assert_eq!(
+            r.header.ledger_version, 25,
+            "Version upgrade must set header.ledger_version"
+        );
+    }
+
+    // ── BaseFee: 100 → 250 mutates header.base_fee ────────────────────────
+    {
+        let ledger = init_ledger_manager(25);
+        let close = empty_close_data(&ledger, 1, 100).with_upgrade(LedgerUpgrade::BaseFee(250));
+        let r = ledger
+            .close_ledger(close, Some(handle.clone()))
+            .expect("close BaseFee");
+        assert_eq!(
+            r.header.base_fee, 250,
+            "BaseFee upgrade must set header.base_fee"
+        );
+    }
+
+    // ── BaseReserve: 100 → 7_000_000 mutates header.base_reserve ──────────
+    {
+        let ledger = init_ledger_manager(25);
+        let close =
+            empty_close_data(&ledger, 1, 100).with_upgrade(LedgerUpgrade::BaseReserve(7_000_000));
+        let r = ledger
+            .close_ledger(close, Some(handle.clone()))
+            .expect("close BaseReserve");
+        assert_eq!(
+            r.header.base_reserve, 7_000_000,
+            "BaseReserve upgrade must set header.base_reserve"
+        );
+    }
+
+    // ── MaxTxSetSize: 100 → 750 mutates header.max_tx_set_size ────────────
+    {
+        let ledger = init_ledger_manager(25);
+        let close =
+            empty_close_data(&ledger, 1, 100).with_upgrade(LedgerUpgrade::MaxTxSetSize(750));
+        let r = ledger
+            .close_ledger(close, Some(handle.clone()))
+            .expect("close MaxTxSetSize");
+        assert_eq!(
+            r.header.max_tx_set_size, 750,
+            "MaxTxSetSize upgrade must set header.max_tx_set_size"
+        );
+    }
+
+    // ── Flags: 0 → 1 promotes ext V0 → V1 and sets ext.flags ──────────────
+    {
+        let ledger = init_ledger_manager(25);
+        let close = empty_close_data(&ledger, 1, 100).with_upgrade(LedgerUpgrade::Flags(1));
+        let r = ledger
+            .close_ledger(close, Some(handle.clone()))
+            .expect("close Flags");
+        match &r.header.ext {
+            LedgerHeaderExt::V1(ext) => {
+                assert_eq!(ext.flags, 1, "Flags upgrade must set header ext V1 flags")
+            }
+            LedgerHeaderExt::V0 => panic!("Flags upgrade must promote ext V0 → V1"),
+        }
+    }
+}
+
+/// MaxSorobanTxSetSize is NOT a header field — it routes through the delta to
+/// the `CONFIG_SETTING_CONTRACT_EXECUTION_LANES` entry's `ledger_max_tx_count`
+/// (matching upstream `upgradeMaxSorobanTxSetSize`). Assert via the upgrade
+/// meta's `Updated` change that the new lane count lands in state.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_apply_max_soroban_tx_set_size_variant_mutates_state() {
+    let ledger = init_ledger_manager(25);
+
+    // Genesis seeds ledger_max_tx_count = 1; upgrade it to 50.
+    let close =
+        empty_close_data(&ledger, 1, 100).with_upgrade(LedgerUpgrade::MaxSorobanTxSetSize(50));
+    let handle = tokio::runtime::Handle::current();
+    let r = ledger
+        .close_ledger(close, Some(handle))
+        .expect("close MaxSorobanTxSetSize");
+
+    let meta = r.meta.expect("close meta");
+    let v2 = match meta {
+        LedgerCloseMeta::V2(v2) => v2,
+        other => panic!("expected V2 meta, got {other:?}"),
+    };
+    let soroban_meta = v2
+        .upgrades_processing
+        .iter()
+        .find(|m| matches!(m.upgrade, LedgerUpgrade::MaxSorobanTxSetSize(_)))
+        .expect("MaxSorobanTxSetSize upgrade must produce UpgradeEntryMeta");
+
+    let updated_lane_count = soroban_meta.changes.iter().find_map(|change| match change {
+        LedgerEntryChange::Updated(entry) => match &entry.data {
+            LedgerEntryData::ConfigSetting(ConfigSettingEntry::ContractExecutionLanes(lanes)) => {
+                Some(lanes.ledger_max_tx_count)
+            }
+            _ => None,
+        },
+        _ => None,
+    });
+    assert_eq!(
+        updated_lane_count,
+        Some(50),
+        "MaxSorobanTxSetSize upgrade must set ContractExecutionLanes.ledger_max_tx_count to 50"
+    );
+}
+
+/// The Config variant routes through the delta to `apply_config_upgrades`,
+/// which writes the proposed `ConfigSettingEntry` into state. Drive a valid
+/// config upgrade (whose key hash matches the stored set) through the real
+/// close loop and assert the targeted setting is updated in the upgrade meta.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_apply_config_upgrade_variant_mutates_state() {
+    let ledger = init_ledger_manager(25);
+
+    // Build a valid ConfigUpgradeSet that changes ContractComputeV0.
+    let proposed =
+        ConfigSettingEntry::ContractComputeV0(stellar_xdr::curr::ConfigSettingContractComputeV0 {
+            ledger_max_instructions: 222_000_000,
+            tx_max_instructions: 10_000_000,
+            fee_rate_per_instructions_increment: 100,
+            tx_memory_limit: 50_000_000,
+        });
+    let upgrade_set = ConfigUpgradeSet {
+        updated_entry: vec![proposed].try_into().expect("one entry"),
+    };
+    let key = make_config_upgrade_key_for_set(&[0xDE; 32], &upgrade_set);
+
+    // Store the upgrade set as CONTRACT_DATA + TTL in soroban state.
+    let data_entry = make_config_upgrade_entry(&key, &upgrade_set, 1);
+    ledger
+        .inject_synthetic_contract_data(data_entry, 1000)
+        .expect("inject config upgrade data");
+
+    let close = empty_close_data(&ledger, 1, 100).with_upgrade(LedgerUpgrade::Config(key.clone()));
+    let handle = tokio::runtime::Handle::current();
+    let r = ledger
+        .close_ledger(close, Some(handle))
+        .expect("close Config");
+
+    let meta = r.meta.expect("close meta");
+    let v2 = match meta {
+        LedgerCloseMeta::V2(v2) => v2,
+        other => panic!("expected V2 meta, got {other:?}"),
+    };
+    let config_meta = v2
+        .upgrades_processing
+        .iter()
+        .find(|m| matches!(m.upgrade, LedgerUpgrade::Config(_)))
+        .expect("Config upgrade must produce UpgradeEntryMeta");
+
+    // The ContractComputeV0 setting must be updated to the proposed value.
+    let updated_max_instructions = config_meta.changes.iter().find_map(|change| match change {
+        LedgerEntryChange::Updated(entry) => match &entry.data {
+            LedgerEntryData::ConfigSetting(ConfigSettingEntry::ContractComputeV0(c)) => {
+                Some(c.ledger_max_instructions)
+            }
+            _ => None,
+        },
+        _ => None,
+    });
+    assert_eq!(
+        updated_max_instructions,
+        Some(222_000_000),
+        "Config upgrade must write the proposed ContractComputeV0 setting into state"
+    );
+}

--- a/docs/supercluster-feasibility.md
+++ b/docs/supercluster-feasibility.md
@@ -241,7 +241,7 @@ The compat HTTP handler test suite was built from scratch during this work. Curr
 | `/metrics` | 3 | Response shape, type fields, rate fields |
 | `/testacc` | 10 | Response/error/not-found shapes, key derivation, seed padding |
 | `/generateload` | 4 | Request construction, debug, clone, stop mode |
-| Plaintext endpoints | 10 | Bans, quorum, scp, upgrades shapes, ISO8601 parsing |
+| Plaintext endpoints | 14 | Bans, quorum, scp, upgrades shapes, ISO8601 parsing, full `/upgrades?mode=set` SSC param-set pinning + `mode=clear` reset (#3300) |
 | Panic handler | 1 | `{"exception": "generic"}` shape |
 | **Total** | **36+** | |
 
@@ -272,7 +272,7 @@ The config parsing layer (`crates/app/src/compat_config.rs`) has 27 unit tests c
 | ComplexTopology with all Henyey nodes | **HIGH** | Same as SimplePayment |
 | Sustained load generation missions | MEDIUM | Rate/percentile metrics are zero placeholders; may need real tracking |
 | History catchup / publish missions | MEDIUM | Core machinery exists, but SSC mission validation and HISTORY-template compatibility remain open |
-| ProtocolUpgrade missions | MEDIUM | `/upgrades` exists, but mission-level execution is still unverified |
+| ProtocolUpgrade missions | LOW (pending live run) | `/upgrades` `mode=set` param set pinned 1:1 to stellar-core and the full schedule→nominate→apply path is covered by offline regression tests for every `LedgerUpgrade` variant (#3300); only the live multi-node SSC run remains (operator hand-off) |
 | VersionMix / mixed images | HIGH | Best near-term path to value |
 | EmitMeta-style missions | HIGH | Existing metadata support is already strong |
 | NetworkSurvey missions | LOW | Compat endpoints are stubs today |
@@ -365,13 +365,13 @@ Required work:
 
 1. Validate history publish from Henyey through SSC-generated archive config.
 2. Validate catchup from those archives.
-3. Exercise `/upgrades` end to end in mission form.
+3. Exercise `/upgrades` end to end in mission form. **Offline half done (#3300):** the `mode=set` param set is pinned 1:1 to stellar-core and the full schedule→nominate→apply path is covered by per-variant regression tests; the live multi-node SSC protocol-upgrade run is an operator hand-off — see [`docs/supercluster-mission-3300.md`](./supercluster-mission-3300.md).
 4. Verify cross-version or mixed-image history behavior if that is part of the target rollout.
 
 Exit criteria:
 
 - Henyey can publish history in SSC-managed runs and catch up from it reliably
-- upgrade missions complete without compatibility-specific failures
+- upgrade missions complete without compatibility-specific failures (offline regression complete #3300; live run pending)
 
 ### Phase 4 -- Optional parity work for lower-priority missions
 
@@ -423,8 +423,8 @@ Candidate work:
 - [ ] HISTORY parsing tested against SSC-style templates (fixtures from real SSC configs)
 - [ ] publish/catchup round-trip integration test passes outside SSC
 - [ ] publish/catchup scenario exercised under SSC
-- [ ] upgrade mission exercised under SSC
-- [ ] `/upgrades` response shape tested against stellar-core reference
+- [ ] upgrade mission exercised under SSC (operator hand-off — see [`docs/supercluster-mission-3300.md`](./supercluster-mission-3300.md))
+- [x] `/upgrades` `mode=set` parameter set tested 1:1 against stellar-core `CommandHandler.cpp:613-671`; per-variant schedule→nominate→apply regression covered offline (#3300)
 - [ ] remaining history/upgrade blockers documented precisely
 
 ### Phase 4 handoff checklist

--- a/docs/supercluster-mission-3300.md
+++ b/docs/supercluster-mission-3300.md
@@ -1,0 +1,148 @@
+# Supercluster Mission #3300 — Protocol-Upgrade Mission
+
+**Issue:** [#3300](https://github.com/stellar-experimental/henyey/issues/3300)
+**Companion docs:** [`supercluster-nsc-workflow.md`](./supercluster-nsc-workflow.md) (the verified `nsc` build/publish/launch surface), [`supercluster-mission-3292.md`](./supercluster-mission-3292.md) (first mixed-image mission this builds on), [`supercluster-feasibility.md`](./supercluster-feasibility.md).
+
+This runbook drives a **live multi-node SSC protocol-upgrade mission**: a mixed
+network (stellar-core validators + at least one henyey node) where an operator
+drives the stellar-core-compatible `/upgrades?mode=set` admin endpoint and
+observes the full **schedule → nominate → externalize → apply** path land an
+upgrade at the upgrade ledger, in agreement across the mixed cluster.
+
+It is the protocol-upgrade counterpart to the history mission and the next-to-last
+issue in the SSC epic drain order (#3292–#3300). Like #3292, the upgrade
+machinery is already **Full** parity end-to-end; the deliverable is
+*mission-definition + offline regression artifacts + parity-doc updates + an
+operator runbook*, not new production code.
+
+## What this mission validates (acceptance criteria)
+
+| AC | Criterion | How it is checked |
+|----|-----------|-------------------|
+| AC#1 | henyey accepts `/upgrades?mode=set` with the exact SSC parameter set | Offline regression test `test_upgrades_set_parses_full_ssc_param_set` (param set pinned 1:1 to stellar-core `CommandHandler.cpp:613-671`); live: the SSC harness `mode=set` request returns `status: ok` |
+| AC#2 | each scheduled `LedgerUpgrade` variant is **nominated** when its value differs and **suppressed** as a no-op when equal | Offline `test_scheduled_params_nominate_each_variant` + `test_scheduled_config_variant_nominate`; live: the upgrade appears in `scp`/nomination and externalizes |
+| AC#3 | the upgrade is **applied at the upgrade ledger** and reflected in the header/state | Offline `test_apply_each_ledger_upgrade_variant_mutates_header_and_state` + the soroban/config variant tests; live: `/info` / ledger header before vs. after the upgrade ledger |
+| AC#4 | henyey and stellar-core **agree on the post-upgrade ledger** (seq+hash, and the upgraded field) | live: compare `/info` ledger num/hash and the upgraded field (e.g. `protocol_version`, `base_fee`) across the mixed cluster at a common seq |
+| AC#5 | henyey stays **`Synced!`** across the upgrade | live: `/info.state == "Synced!"` before, during, and after |
+| AC#6 | logs / config / image digest / exact `/upgrades?mode=set` invocation + before/after headers **captured** | run-dir layout + this runbook's artifact checklist |
+| AC#7 | any param/parity gap the live run surfaces becomes a **concrete follow-up issue** | operator files a follow-up per the checklist; never a silent patch |
+
+**Scope:** a protocol-upgrade mission over the mixed network from #3292. It does
+NOT add new upgrade machinery — all three layers (admin endpoint parse, herder
+nominate, ledger apply) are already implemented for every `LedgerUpgrade`
+variant.
+
+## The upgrade path being exercised (already Full)
+
+| Layer | Location | Status |
+|-------|----------|--------|
+| Admin endpoint parse (`/upgrades?mode=set`) | `crates/app/src/compat_http/handlers/plaintext.rs` (`compat_upgrades_handler`) | Full — param set matches `CommandHandler.cpp:613-671` |
+| Herder schedule → nominate | `crates/herder/src/upgrades.rs` (`create_upgrades_for`, `is_valid_for_nomination`) | Full |
+| Ledger apply | `crates/ledger/src/close.rs` (`apply_to_header`, `apply_config_upgrades`, `apply_max_soroban_tx_set_size`) dispatched from `crates/ledger/src/manager.rs` (`apply_upgrades_to_delta`) | Full |
+| Externalize (SCP) | `crates/herder` EXTERNALIZE receipt path | Full (#3292) |
+
+The `mode=set` parameters the SSC harness can drive, each mapped to a
+`LedgerUpgrade` variant at apply time:
+
+| `/upgrades?mode=set` param | `UpgradeParameters` field | `LedgerUpgrade` variant | Applied to |
+|---|---|---|---|
+| `upgradetime` | `upgrade_time` | (timing gate, all variants) | — |
+| `protocolversion` | `protocol_version` | `Version` | `header.ledger_version` |
+| `basefee` | `base_fee` | `BaseFee` | `header.base_fee` |
+| `basereserve` | `base_reserve` | `BaseReserve` | `header.base_reserve` |
+| `maxtxsetsize` | `max_tx_set_size` | `MaxTxSetSize` | `header.max_tx_set_size` |
+| `flags` | `flags` | `Flags` | `header.ext` V1 `flags` |
+| `configupgradesetkey` (base64 XDR) | `config_upgrade_set_key` | `Config` | config-setting state (delta) |
+| `maxsorobantxsetsize` | `max_soroban_tx_set_size` | `MaxSorobanTxSetSize` | `ContractExecutionLanes.ledger_max_tx_count` (delta) |
+| `nominationtimeoutlimit` | `nomination_timeout_limit` | (nomination timeout tuning) | — |
+| `expirationminutes` | `expiration_minutes` | (proposal expiry) | — |
+
+## Known read/validation divergences (documented, NOT blocking)
+
+Both are on read/validation-feedback paths the mission's `mode=set` →
+observe-externalize flow does NOT require. They are recorded in the relevant
+`PARITY_STATUS.md` files and are **candidate follow-ups** only if the live run
+exercises them:
+
+1. **Empty-mode read shape.** stellar-core returns `"mode required"` on empty
+   mode and serializes `getUpgradesJson()` (`{time,version,fee,maxtxsize,reserve}`)
+   only under `mode=get`. Henyey returns a bespoke `{current,scheduled}` body on
+   the empty/default mode. If the live mission reads upgrade state via
+   `/upgrades?mode=get`, file a follow-up.
+2. **SET-time `configupgradesetkey` validation.** stellar-core validates the key
+   via `ConfigUpgradeSetFrame::makeFromKey` + `isValidForApply` at SET time and
+   rejects an invalid key with `"Error setting configUpgradeSet"`
+   (`CommandHandler.cpp:648-655`). Henyey decodes the key but **defers** validity
+   to nomination/apply (an invalid key simply never nominates). Likely benign,
+   but loud-vs-silent rejection differs. If the live mission relies on SET-time
+   rejection feedback, file a follow-up.
+
+## Autonomous deliverable vs. operator-executed run
+
+This is a **validation mission**: the autonomous deliverable is *offline
+regression tests + parity docs + this runbook + a follow-up-on-failure handoff*,
+not production code. The live multi-hour k8s mission **cannot run inside one
+autonomous task** — it needs an interactive `nsc login` (browser OAuth), a
+long-lived k8s cluster, and the external `stellar/supercluster` dotnet harness
+(not vendored here).
+
+**Shipped autonomously (in the PR):**
+
+- `crates/app/src/compat_http/handlers/plaintext.rs` — `/upgrades?mode=set` full
+  SSC param-set pinning (10 params + base64 `configupgradesetkey`), `mode=clear`
+  reset, ISO 8601 `upgradetime`, default-GET shape.
+- `crates/ledger/tests/upgrade_sequence_integration.rs` — per-variant
+  application driven through the real close-loop dispatcher seam, asserting
+  header/state mutation for every `LedgerUpgrade` variant.
+- `crates/herder/src/upgrades.rs` — per-variant schedule → nominate emission +
+  no-op suppression + `is_valid_for_nomination` acceptance at/after
+  `upgrade_time`.
+- parity-doc updates (`crates/{app,herder,ledger}/PARITY_STATUS.md`,
+  `docs/supercluster-feasibility.md`) including the two documented divergences.
+- this runbook.
+
+**Operator-executed (NOT done in the PR):** the mission RUN itself — see the
+checklist below.
+
+## OPERATOR CHECKLIST — the live mission RUN
+
+> Everything below is **operator-executed** against live infra. The PR does NOT
+> run any of it and does NOT fabricate a mission transcript.
+
+1. **Auth + bring up the mixed network** (one-time per session): `nsc login`
+   (interactive browser OAuth). Reuse the #3292 mixed-image topology (stellar-core
+   validators + ≥1 henyey node, core-majority quorum). Confirm baseline:
+   `/info.state == "Synced!"` and seq+hash agreement (run `assert-mission-3292.sh`).
+2. **Capture the pre-upgrade baseline.** Record henyey + stellar-core `/info`
+   (ledger num/hash, `protocol_version`, `base_fee`, `base_reserve`,
+   `max_tx_set_size`, flags) so the post-upgrade diff is unambiguous.
+3. **Drive the upgrade** via the SSC dotnet harness (`stellar/supercluster`,
+   external) or directly against a validator's admin port. Pick the variant(s)
+   the mission targets, e.g. a protocol-version bump:
+   ```
+   GET /upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=<N>
+   ```
+   For a config upgrade, pass the base64 `configupgradesetkey` (the SSC harness
+   constructs and uploads the `ConfigUpgradeSet` first). Confirm each `mode=set`
+   request returns `status: ok` (AC#1). Drive the upgrade on the validators the
+   mission designates (typically the stellar-core majority; henyey follows).
+4. **Observe nominate → externalize → apply** (AC#2/#3): watch `/scp` and `/info`
+   on henyey across the scheduled upgrade ledger. The upgraded header/state field
+   must change exactly at the upgrade ledger and persist after.
+5. **Validate agreement** (AC#4/#5): compare henyey vs. stellar-core `/info`
+   ledger num/hash AND the upgraded field at a common post-upgrade seq; confirm
+   henyey stays `Synced!` throughout.
+6. **Capture artifacts** into `runs/<date>-mission-3300/` and onto #3300:
+   - `image-digest.txt` (the immutable `sha256:` reference),
+   - `instance.json` (nsc instance metadata),
+   - the exact `/upgrades?mode=set` invocation(s) + params,
+   - **before/after ledger headers** (the upgrade-ledger diff),
+   - per-pod henyey/stellar-core logs spanning the upgrade ledger,
+   - seq+hash agreement output.
+7. **Teardown:** `nsc destroy <instance-id> --force`, then `nsc list -o json` to
+   confirm the ephemeral cluster is gone.
+8. **On any failure or surfaced param/parity gap:** file a **concrete follow-up
+   issue** (AC#7) with the captured artifacts — do NOT silently patch henyey or
+   the tests to make the run pass. In particular, watch for the two documented
+   divergences above if the mission reads via `mode=get` or relies on SET-time
+   config-key rejection.


### PR DESCRIPTION
Closes #3300

## Summary

Validation mission (mirrors #3292/#3295): the `/upgrades` → herder-nominate →
ledger-apply pipeline is already **Full** parity end-to-end, so this PR ships the
maximal DURABLE offline artifact — CI-enforced regression tests + parity docs —
and hands the live multi-node SSC protocol-upgrade RUN to the operator via a
non-faked runbook + checklist. **No upgrade machinery is modified.**

Offline coverage of the schedule → nominate → apply path for every
`LedgerUpgrade` variant:

- **app** (`compat_http/handlers/plaintext.rs`): drive the real
  `compat_upgrades_handler` with the exact SSC `mode=set` parameter set (10
  params + base64 `configupgradesetkey`), pinned 1:1 to stellar-core
  `CommandHandler.cpp:613-671`, asserting each maps to the right
  `UpgradeParameters` field; `mode=clear` reset; ISO 8601 `upgradetime`;
  default-GET `{current,scheduled}` shape.
- **ledger** (`tests/upgrade_sequence_integration.rs`): per-variant application
  driven through the REAL close-loop dispatcher (`close_ledger` →
  `apply_upgrades_to_delta` → `apply_to_header` / `apply_config_upgrades` /
  `apply_max_soroban_tx_set_size`) for Version/BaseFee/BaseReserve/MaxTxSetSize/
  Flags/MaxSorobanTxSetSize/Config — covers the dispatcher seam, not just the
  leaves.
- **herder** (`src/upgrades.rs`): per-variant `create_upgrades_for` emission +
  no-op suppression + `is_valid_for_nomination` acceptance at/after
  `upgrade_time`.

Plus parity-doc updates (`crates/{app,herder,ledger}/PARITY_STATUS.md`,
`docs/supercluster-feasibility.md`) recording the two **documented divergences**
(candidate follow-ups, not fixed here): (a) empty-mode read shape vs
stellar-core's `"mode required"` / `getUpgradesJson`-only-on-`mode=get`; (b)
henyey defers `configupgradesetkey` validity to nomination/apply vs stellar-core
validating at SET time. New operator runbook `docs/supercluster-mission-3300.md`
+ a checklist comment on #3300 for the live mission.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3300#issuecomment-4724231168)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (the CI command — clean)
- [x] `cargo test -p henyey-ledger --test upgrade_sequence_integration` — 19 passed
- [x] `cargo test -p henyey-app --lib compat_http::handlers::plaintext` — 26 passed
- [x] `cargo test -p henyey-herder --lib upgrades` — 43 passed

## Deviations from plan

- The per-variant ledger test drives the full `close_ledger` dispatcher for
  every variant (rather than calling the leaf functions directly). This is a
  strictly stronger form of Critic A's "cover the dispatcher seam" item — it
  exercises `apply_upgrades_to_delta`'s routing to `apply_to_header` /
  `apply_config_upgrades` / the delta path for real, not by citation.
- This is a `kind: feature` validation PR over already-Full machinery, so the
  new tests pass on first run (there is no pre-existing bug to fail against).
  The param-set pinning and per-variant coverage are genuine new coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)