### PR TITLE
Wire compat survey HTTP handlers to native App survey methods

### DIFF
--- a/crates/app/PARITY_STATUS.md
+++ b/crates/app/PARITY_STATUS.md
@@ -127,8 +127,8 @@ Corresponds to: `CommandHandler.h`
 | `ll()` | native dynamic log control works; compat handler is minimal | Partial |
 | `logRotate()` | placeholder response only | Partial |
 | `banaccounts()` / `unbanaccounts()` | — | None |
-| legacy survey commands (`surveyTopology()`, `stopSurvey()`, `getSurveyResult()`) | — | None |
-| time-sliced survey commands (`startSurveyCollecting()`, `stopSurveyCollecting()`, `surveyTopologyTimeSliced()`) | native handlers implemented; compat endpoints are stubs | Partial |
+| legacy survey commands (`surveyTopology()`) | — (removed upstream in favor of time-sliced) | None |
+| time-sliced survey commands (`startSurveyCollecting()`, `stopSurveyCollecting()`, `surveyTopologyTimeSliced()`, `stopSurvey()`, `getSurveyResult()`) | native handlers implemented; compat endpoints wired to native `App` survey methods with stellar-core param names (`nonce`/`node`/`inboundpeerindex`/`outboundpeerindex`), plain-text `retStr` (JSON for `getsurveyresult` with **strkey**-encoded `backlog`/`badResponseNodes`), and the `Synced`/`Validating` booted gate (#3298). One bounded, documented divergence on `surveytopologytimesliced`'s duplicate/self-peer edge (native fused bool) | Full |
 
 **Intentional compat divergences for `connect` / `dropPeer` / `unban` / `bans`** (CommandHandler.cpp:478/~543/566/553), both documented and deliberate:
 
@@ -236,7 +236,6 @@ Features not yet implemented. These ARE counted against parity %.
 | stellar-core Component | Priority | Notes |
 |------------------------|----------|-------|
 | `BannedAccountsPersistor` and `FILTERED_G_ADDRESSES` flow | High | No persisted banned-account subsystem or admin endpoints |
-| Compat time-sliced survey admin routes | Medium | Native routes work; compat routes are still stubs |
 | `manualclose` explicit sequence/close-time parameters | Medium | Upstream standalone semantics are not exposed by handlers |
 | Scheduled online self-check parity | Medium | Manual self-check exists, but upstream periodic scheduling test is unmatched |
 | `PersistentState` tx-set hash helpers | Medium | Several SCP persistence helpers remain absent |
@@ -271,7 +270,7 @@ Features not yet implemented. These ARE counted against parity %.
 | Area | stellar-core Tests | Rust Tests | Notes |
 |------|-------------------|------------|-------|
 | Config and compat translation | 9 TEST_CASE / 21 SECTION | 64 `#[test]` | Strong coverage for loading, validation, and captive-core translation |
-| Command handler / compat HTTP | 5 TEST_CASE / 27 SECTION | 55 `#[test]` | Includes handler helpers, generateLoad, testacc, and live-App peer-admin tests (connect/droppeer/unban/bans); survey compat routes remain stubs |
+| Command handler / compat HTTP | 5 TEST_CASE / 27 SECTION | 63 `#[test]` | Includes handler helpers, generateLoad, testacc, live-App peer-admin tests (connect/droppeer/unban/bans), and live-App survey tests (start/stop-collecting, surveytopologytimesliced, stopsurvey, getsurveyresult — booted gate, param validation, strkey projection) (#3298) |
 | Query server | 1 TEST_CASE / 9 SECTION | 7 `#[test]` | Good coverage of lookup ordering and validation |
 | Run/catchup utilities | 4 TEST_CASE / 5 SECTION | 19 `#[test]` | Target parsing and run-mode helpers are well covered |
 | Self-check scheduling | 1 TEST_CASE / 0 SECTION | 0 `#[test]` | No dedicated periodic self-check scheduling tests |
@@ -282,7 +281,7 @@ Features not yet implemented. These ARE counted against parity %.
 
 ### Test Gaps
 
-- Compat peer-admin endpoints (`connect`, `droppeer`, `unban`, `bans`) now have live-App tests asserting real overlay/DB side effects; survey-control compat routes still lack parity-style side-effect tests.
+- Compat peer-admin endpoints (`connect`, `droppeer`, `unban`, `bans`) and survey-control endpoints (`startsurveycollecting`, `stopsurveycollecting`, `surveytopologytimesliced`, `stopsurvey`, `getsurveyresult`) now have live-App tests asserting the booted gate, required-param/strkey validation, plain-text-vs-JSON medium, and strkey-encoded peer lists (#3298). The `surveytopologytimesliced` success-token branch (Survey started vs already running) needs a fully-booted App and is covered only by the documented bounded-divergence note.
 - There is no Rust equivalent of upstream's scheduled online self-check test in `SelfCheckTests.cpp`.
 - Account-ban persistence has no Rust tests because the subsystem is not implemented. Upstream has 4 TEST_CASE / 21 SECTION.
 - HTTP threaded server behavior (3 TEST_CASE upstream in `HttpThreadedTests.cpp`) has no direct equivalent.

--- a/crates/app/src/app/survey_impl.rs
+++ b/crates/app/src/app/survey_impl.rs
@@ -256,6 +256,22 @@ impl App {
         true
     }
 
+    /// Test-only seam: seed the reporting backlog with a single peer and mark
+    /// the reporting phase running, without driving the full collecting →
+    /// reporting handshake (which requires an injected overlay and finalized
+    /// node data). Used by the compat `/getsurveyresult` strkey-projection test
+    /// (#3298) to get a deterministic non-empty `backlog`.
+    #[cfg(test)]
+    pub(crate) async fn seed_survey_reporting_backlog_for_test(
+        &self,
+        peer_id: henyey_overlay::PeerId,
+    ) {
+        let mut reporting = self.survey_reporting.write().await;
+        reporting.running = true;
+        reporting.peers.insert(peer_id.clone());
+        reporting.queue.push_back(peer_id);
+    }
+
     async fn start_survey_reporting(&self) -> SurveyReportingStart {
         let nonce = { self.survey_state.read().await.data().nonce() };
         let Some(nonce) = nonce else {

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -1315,6 +1315,204 @@ mod tests {
         assert!(!is_leap_year(1900));
         assert!(!is_leap_year(2023));
     }
+
+    // ── Compat survey-endpoint wiring tests (#3298) ─────────────────────
+    //
+    // These exercise the five compat survey handlers (`/getsurveyresult`,
+    // `/startsurveycollecting`, `/stopsurveycollecting`,
+    // `/surveytopologytimesliced`, `/stopsurvey`) against a live `App`,
+    // mirroring stellar-core `CommandHandler` (v26.0.1) param names, the
+    // booted-state gate, plain-text vs JSON response medium, and the
+    // strkey-encoded peer lists in `getsurveyresult`.
+    //
+    // Each FAILS on `origin/main`: the stub handlers ignore `State` and return
+    // `"done\n"` / `{"survey":"not implemented"}` regardless of app state.
+
+    use axum::body::Body;
+    use http::Request;
+    use tower::ServiceExt;
+
+    use crate::compat_http::build_compat_router;
+
+    /// Send a `GET <uri>` through the full compat router (so axum `Query`
+    /// extraction runs, mirroring stellar-core's `parseRequiredParam`).
+    async fn compat_get(state: Arc<CompatServerState>, uri: &str) -> axum::response::Response {
+        let router = build_compat_router(state);
+        router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// `/startsurveycollecting?nonce=1` on a fresh (pre-Synced) App returns 503
+    /// + the not-booted message. FAILS on main (stub returns 200 `"done\n"`).
+    #[tokio::test]
+    async fn test_compat_startsurveycollecting_gated_when_not_booted() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_get(Arc::clone(&state), "/startsurveycollecting?nonce=1").await;
+        assert_eq!(resp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+        let text = body_text(resp).await;
+        assert!(
+            text.contains("not fully booted"),
+            "expected not-booted message, got {text:?}"
+        );
+        state.app.shutdown();
+    }
+
+    /// `/startsurveycollecting` with no `nonce` is a missing required param →
+    /// 400 (axum Query rejection ≈ stellar-core parseRequiredParam throw).
+    /// FAILS on main (stub returns 200 `"done\n"`).
+    #[tokio::test]
+    async fn test_compat_startsurveycollecting_missing_nonce_400() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_get(Arc::clone(&state), "/startsurveycollecting").await;
+        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+        state.app.shutdown();
+    }
+
+    /// `/stopsurveycollecting` on a fresh App returns 503. FAILS on main.
+    #[tokio::test]
+    async fn test_compat_stopsurveycollecting_gated_when_not_booted() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_get(Arc::clone(&state), "/stopsurveycollecting").await;
+        assert_eq!(resp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+        state.app.shutdown();
+    }
+
+    /// `/surveytopologytimesliced` with a malformed `node` strkey → 400, while
+    /// exercising the stellar-core param names `inboundpeerindex` /
+    /// `outboundpeerindex`. FAILS on main (stub returns 200 `"done\n"`).
+    #[tokio::test]
+    async fn test_compat_surveytopologytimesliced_invalid_node_param() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_get(
+            Arc::clone(&state),
+            "/surveytopologytimesliced?node=not-a-strkey&inboundpeerindex=0&outboundpeerindex=0",
+        )
+        .await;
+        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+        state.app.shutdown();
+    }
+
+    /// `/surveytopologytimesliced` with valid params on a fresh App returns 503
+    /// (booted gate). FAILS on main (stub returns 200 `"done\n"`).
+    #[tokio::test]
+    async fn test_compat_surveytopologytimesliced_gated_when_not_booted() {
+        let (_dir, state) = mk_compat_state().await;
+        let (_peer_id, strkey) = mk_peer();
+        let uri = format!(
+            "/surveytopologytimesliced?node={strkey}&inboundpeerindex=0&outboundpeerindex=0"
+        );
+        let resp = compat_get(Arc::clone(&state), &uri).await;
+        assert_eq!(resp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+        state.app.shutdown();
+    }
+
+    /// `/stopsurvey` returns the verbatim plain-text `"survey stopped"` (NOT
+    /// JSON), invoking `stop_survey_reporting()` (ungated, idempotent). FAILS
+    /// on main (stub returns `"done\n"`).
+    #[tokio::test]
+    async fn test_compat_stopsurvey_returns_plaintext() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_get(Arc::clone(&state), "/stopsurvey").await;
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        let text = body_text(resp).await;
+        assert_eq!(text, "survey stopped");
+        state.app.shutdown();
+    }
+
+    /// `/getsurveyresult` returns JSON shaped like stellar-core
+    /// `SurveyManager::getJsonResults()`: `surveyInProgress` (bool) plus
+    /// `backlog` / `badResponseNodes` as **strkey** arrays (NOT hex). FAILS on
+    /// main (stub returns `{"survey":"not implemented"}`).
+    #[tokio::test]
+    async fn test_compat_getsurveyresult_returns_json_shape() {
+        let (_dir, state) = mk_compat_state().await;
+        let resp = compat_get(Arc::clone(&state), "/getsurveyresult").await;
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(
+            json.get("surveyInProgress").is_some(),
+            "missing surveyInProgress in {json}"
+        );
+        assert!(json["surveyInProgress"].is_boolean());
+        assert!(
+            json.get("backlog").and_then(|v| v.as_array()).is_some(),
+            "backlog must be an array in {json}"
+        );
+        assert!(
+            json.get("badResponseNodes")
+                .and_then(|v| v.as_array())
+                .is_some(),
+            "badResponseNodes must be an array in {json}"
+        );
+        // The stub key must be gone.
+        assert!(
+            json.get("survey").is_none(),
+            "stub key `survey` should not be present in {json}"
+        );
+        state.app.shutdown();
+    }
+
+    /// strkey (not hex) parity for `getsurveyresult`'s `backlog` /
+    /// `badResponseNodes`. We populate the running-survey reporting backlog
+    /// with a known peer via `survey_topology_timesliced`, then assert the
+    /// emitted entries are that peer's G... STRKEY (matching
+    /// `SurveyManager.cpp:682,690` `KeyUtils::toStrKey`), NOT the 64-hex form
+    /// `survey_report()` carries internally. FAILS on main (stub).
+    #[tokio::test]
+    async fn test_compat_getsurveyresult_backlog_is_strkey_not_hex() {
+        let (_dir, state) = mk_compat_state().await;
+        let (peer_id, strkey) = mk_peer();
+        // Seed a running reporting session with a known peer in the backlog so
+        // the projection has a non-empty list to encode (test-only seam — does
+        // not exercise survey logic).
+        state
+            .app
+            .seed_survey_reporting_backlog_for_test(peer_id.clone())
+            .await;
+
+        // Internally the native SurveyReport carries this peer as 64-char hex.
+        let report = state.app.survey_report().await;
+        assert_eq!(report.backlog, vec![peer_id.to_hex()]);
+        assert_ne!(
+            peer_id.to_hex(),
+            strkey,
+            "hex and strkey forms must differ for the test to be meaningful"
+        );
+
+        // The compat handler MUST re-derive strkey, matching stellar-core
+        // SurveyManager.cpp:682,690 (KeyUtils::toStrKey), NOT emit the hex.
+        let resp = compat_get(Arc::clone(&state), "/getsurveyresult").await;
+        let json = body_json(resp).await;
+        let backlog = json["backlog"].as_array().expect("backlog array");
+        assert_eq!(
+            backlog.len(),
+            1,
+            "expected exactly the seeded peer in backlog {json}"
+        );
+        let entry = backlog[0].as_str().unwrap();
+        assert_eq!(
+            entry, strkey,
+            "backlog entry must be the peer's strkey, not hex"
+        );
+        assert!(
+            entry.starts_with('G'),
+            "backlog entry {entry:?} is not a G... strkey"
+        );
+        assert_ne!(
+            entry,
+            peer_id.to_hex(),
+            "backlog entry must NOT be the hex form"
+        );
+        state.app.shutdown();
+    }
 }
 
 // ── Load generation (feature-gated) ─────────────────────────────────────

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -9,10 +9,12 @@
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use serde::Deserialize;
 
+use crate::app::AppState;
 use crate::compat_http::CompatServerState;
 use crate::http::types::{
     CompatSorobanInfoResponse, ConnectParams, DropPeerParams, SorobanInfoResponse, UnbanParams,
@@ -442,40 +444,214 @@ pub(crate) async fn compat_sorobaninfo_handler(
 }
 
 // ── Survey endpoints (stellar-core URL paths) ───────────────────────────
+//
+// These mirror stellar-core `CommandHandler` (v26.0.1) exactly — NOT henyey's
+// native `/survey/*` JSON handlers. stellar-core returns **plain text**
+// `retStr` for start/stop-collecting, surveytopologytimesliced, and stopsurvey,
+// and **JSON** for getsurveyresult. Param names follow stellar-core
+// (`nonce`, `node`, `inboundpeerindex`, `outboundpeerindex`) — these differ
+// from the native handlers' `inbound_index`/`outbound_index`. All survey logic
+// (signing, nonce, reporting state) lives in the native `App` methods; these
+// handlers are pure wiring (#3298, analogous to #3294).
 
-/// GET /getsurveyresult  (stellar-core path for henyey's /survey)
-pub(crate) async fn compat_getsurveyresult_handler(
-    State(_state): State<Arc<CompatServerState>>,
-) -> impl IntoResponse {
-    Json(serde_json::json!({"survey": "not implemented"}))
+/// Query params for `/startsurveycollecting` — `nonce` is required, matching
+/// stellar-core `parseRequiredParam<uint32_t>(map, "nonce")`.
+#[derive(Deserialize)]
+pub(crate) struct CompatStartSurveyParams {
+    nonce: u32,
 }
 
-/// GET /startsurveycollecting
-pub(crate) async fn compat_startsurveycollecting_handler(
-    State(_state): State<Arc<CompatServerState>>,
+/// Query params for `/surveytopologytimesliced`. All three are required,
+/// matching stellar-core `parseRequiredParam` for `node` / `inboundpeerindex`
+/// / `outboundpeerindex`.
+#[derive(Deserialize)]
+pub(crate) struct CompatSurveyTopologyParams {
+    node: String,
+    inboundpeerindex: u32,
+    outboundpeerindex: u32,
+}
+
+/// Booted gate mirroring native `survey_booted`: survey commands run only when
+/// the node is `Synced` or `Validating`.
+async fn compat_survey_booted(state: &CompatServerState) -> bool {
+    matches!(
+        state.app.state().await,
+        AppState::Synced | AppState::Validating
+    )
+}
+
+/// stellar-core does not gate these via a booted check; the native handlers do.
+/// We return HTTP 503 + the verbatim native message when not booted.
+fn compat_survey_not_booted() -> (StatusCode, String) {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Application is not fully booted, try again later.".to_string(),
+    )
+}
+
+/// GET /getsurveyresult  (stellar-core path for henyey's /survey)
+///
+/// Returns JSON in stellar-core `SurveyManager::getJsonResults()` shape
+/// (`CommandHandler::getSurveyResult` → `toStyledString`): `surveyInProgress`
+/// (bool), `backlog` / `badResponseNodes` (arrays of **strkey** peer ids,
+/// matching `KeyUtils::toStrKey`, `SurveyManager.cpp:682,690`), and a
+/// `topology` map keyed by surveyed-peer strkey (matching
+/// `mResults["topology"][toStrKey(peer)]`).
+///
+/// The native `survey_report()` carries `backlog`/`bad_response_nodes` and the
+/// per-peer `peer_id`s as 64-char **hex** (`PeerId::to_hex`); we re-derive the
+/// strkey form here so the compat wire output matches stellar-core (and does
+/// NOT leak henyey's internal hex encoding).
+pub(crate) async fn compat_getsurveyresult_handler(
+    State(state): State<Arc<CompatServerState>>,
 ) -> impl IntoResponse {
-    "done\n"
+    let report = state.app.survey_report().await;
+
+    let backlog: Vec<String> = report.backlog.iter().map(|h| hex_to_strkey(h)).collect();
+    let bad_response_nodes: Vec<String> = report
+        .bad_response_nodes
+        .iter()
+        .map(|h| hex_to_strkey(h))
+        .collect();
+
+    // stellar-core keys per-peer topology results under
+    // mResults["topology"][toStrKey(surveyedPeerID)]. The native report keys
+    // its per-peer results by nonce then peer (hex); flatten to a strkey-keyed
+    // map mirroring stellar-core.
+    let mut topology = serde_json::Map::new();
+    for reports in report.peer_reports.values() {
+        for peer in reports {
+            topology.insert(
+                hex_to_strkey(&peer.peer_id),
+                serde_json::to_value(&peer.response).unwrap_or(serde_json::Value::Null),
+            );
+        }
+    }
+
+    Json(serde_json::json!({
+        "surveyInProgress": report.survey_in_progress,
+        "backlog": backlog,
+        "badResponseNodes": bad_response_nodes,
+        "topology": topology,
+    }))
+}
+
+/// GET /startsurveycollecting?nonce=<u32>
+///
+/// stellar-core `CommandHandler::startSurveyCollecting`: required `nonce`, then
+/// `broadcastStartSurveyCollecting(nonce)` → verbatim success/failure strings.
+pub(crate) async fn compat_startsurveycollecting_handler(
+    State(state): State<Arc<CompatServerState>>,
+    Query(params): Query<CompatStartSurveyParams>,
+) -> impl IntoResponse {
+    if !compat_survey_booted(&state).await {
+        return compat_survey_not_booted();
+    }
+    let ok = state
+        .app
+        .start_survey_collecting(params.nonce)
+        .await
+        .is_ok();
+    let msg = if ok {
+        "Requested network to start survey collecting."
+    } else {
+        "Failed to start survey collecting. Another survey is active on the network."
+    };
+    (StatusCode::OK, msg.to_string())
 }
 
 /// GET /stopsurveycollecting
+///
+/// stellar-core `CommandHandler::stopSurveyCollecting`:
+/// `broadcastStopSurveyCollecting()` → verbatim success/failure strings.
 pub(crate) async fn compat_stopsurveycollecting_handler(
-    State(_state): State<Arc<CompatServerState>>,
+    State(state): State<Arc<CompatServerState>>,
 ) -> impl IntoResponse {
-    "done\n"
+    if !compat_survey_booted(&state).await {
+        return compat_survey_not_booted();
+    }
+    let ok = state.app.stop_survey_collecting().await.is_ok();
+    let msg = if ok {
+        "Requested network to stop survey collecting."
+    } else {
+        "Failed to stop survey collecting. No survey is active on the network."
+    };
+    (StatusCode::OK, msg.to_string())
 }
 
-/// GET /surveytopologytimesliced
+/// GET /surveytopologytimesliced?node=<strkey>&inboundpeerindex=<u32>&outboundpeerindex=<u32>
+///
+/// stellar-core `CommandHandler::surveyTopologyTimeSliced`: parses `node`
+/// (strkey), `inboundpeerindex`, `outboundpeerindex`, then sets
+/// `retStr = "Adding node."` and appends `"Survey started "` when a fresh
+/// reporting session started, else `"Survey already running!"`.
+///
+/// stellar-core performs two independent steps — `startSurveyReporting()`
+/// (bool drives the trailing token) and an UNCONDITIONAL
+/// `addNodeToRunningSurveyBacklog(...)`. Henyey's `survey_topology_timesliced`
+/// fuses both into one bool: it returns `true` only on a fresh `Started`
+/// (≈ stellar-core's `startSurveyReporting()` success), so we use it to select
+/// the trailing token. **Accepted bounded divergence (#3298):** for the
+/// duplicate-peer / self-peer / not-ready edge the native method returns
+/// `false` and SKIPS the insert, whereas stellar-core always adds the node and
+/// only varies the token. This multi-node already-running edge is a documented
+/// reuse limitation of the native fused bool — not reimplemented here.
 pub(crate) async fn compat_surveytopology_handler(
-    State(_state): State<Arc<CompatServerState>>,
+    State(state): State<Arc<CompatServerState>>,
+    Query(params): Query<CompatSurveyTopologyParams>,
 ) -> impl IntoResponse {
-    "done\n"
+    // Validate the `node` strkey before the booted gate: stellar-core parses
+    // required params first (`parseRequiredParam` throws on a bad value), so a
+    // malformed `node` is a 400 regardless of node state.
+    let pubkey = match henyey_crypto::PublicKey::from_strkey(&params.node) {
+        Ok(key) => key,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                "Invalid node public key".to_string(),
+            );
+        }
+    };
+    if !compat_survey_booted(&state).await {
+        return compat_survey_not_booted();
+    }
+    let peer_id = henyey_overlay::PeerId::from_bytes(*pubkey.as_bytes());
+    let started = state
+        .app
+        .survey_topology_timesliced(peer_id, params.inboundpeerindex, params.outboundpeerindex)
+        .await;
+    let msg = if started {
+        "Adding node.Survey started "
+    } else {
+        "Adding node.Survey already running!"
+    };
+    (StatusCode::OK, msg.to_string())
 }
 
 /// GET /stopsurvey (stellar-core path for henyey's /survey/reporting/stop)
+///
+/// stellar-core `CommandHandler::stopSurvey`: `stopSurveyReporting()` then the
+/// verbatim, ungated `retStr = "survey stopped"`.
 pub(crate) async fn compat_stopreporting_handler(
-    State(_state): State<Arc<CompatServerState>>,
+    State(state): State<Arc<CompatServerState>>,
 ) -> impl IntoResponse {
-    "done\n"
+    state.app.stop_survey_reporting().await;
+    (StatusCode::OK, "survey stopped".to_string())
+}
+
+/// Convert a 64-char hex-encoded ed25519 public key (as carried by the native
+/// `SurveyReport`) into its Stellar strkey (`G...`) form, matching
+/// stellar-core `KeyUtils::toStrKey`. Falls back to the original string if it
+/// is not parseable hex (defensive — `SurveyReport` always emits valid hex).
+fn hex_to_strkey(hex_pubkey: &str) -> String {
+    match hex::decode(hex_pubkey) {
+        Ok(bytes) if bytes.len() == 32 => {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            henyey_overlay::PeerId::from_bytes(arr).to_strkey()
+        }
+        _ => hex_pubkey.to_string(),
+    }
 }
 
 /// Parse a simple ISO 8601 datetime string to Unix timestamp.

--- a/crates/overlay/PARITY_STATUS.md
+++ b/crates/overlay/PARITY_STATUS.md
@@ -395,7 +395,7 @@ Corresponds to: `SurveyManager.h`, `SurveyDataManager.h`, `SurveyMessageLimiter.
 | `relayOrProcessResponse()` | `survey_impl::handle_survey_response()` | Full |
 | `relayOrProcessRequest()` | `survey_impl::handle_survey_request()` | Full |
 | `clearOldLedgers()` | `clear_old_ledgers()` | Full |
-| `getJsonResults()` | `get_node_data()` / peer data getters | Partial |
+| `getJsonResults()` | `get_node_data()` / peer data getters; the compat HTTP `/getsurveyresult` handler (`app::compat_http`) now projects the survey report to the stellar-core `getJsonResults()` JSON shape (`surveyInProgress`, strkey `backlog`/`badResponseNodes`, `topology` map) (#3298) | Partial |
 | `broadcastStartSurveyCollecting()` | `survey_impl::handle_survey_start_collecting()` | Full |
 | `relayStartSurveyCollecting()` | `survey_impl::handle_survey_start_collecting()` | Full |
 | `broadcastStopSurveyCollecting()` | `survey_impl::handle_survey_stop_collecting()` | Full |

--- a/docs/supercluster-feasibility.md
+++ b/docs/supercluster-feasibility.md
@@ -164,21 +164,33 @@ Still deferred:
 
 Commits: `fc12e03`, `35a44d8`, `dae8ad9`, plus #3297 (the 3 bounded modes)
 
-### 5. Compat survey endpoints are stubs
+### ~~5. Compat survey endpoints are stubs~~ — CLOSED
 
-The compat survey routes exist, but they are not wired to the native survey implementation.
+The five compat survey routes are now wired to the native survey implementation
+(`crates/app/src/compat_http/handlers/plaintext.rs`), mirroring stellar-core
+`CommandHandler` (v26.0.1) param names and response medium (#3298):
 
-Stub behavior in `crates/app/src/compat_http/handlers/plaintext.rs:328`:
+- `/getsurveyresult` returns JSON in `SurveyManager::getJsonResults()` shape —
+  `surveyInProgress` (bool), `backlog`/`badResponseNodes` as **strkey** arrays
+  (`KeyUtils::toStrKey`, not henyey's internal hex), and a `topology` map keyed
+  by surveyed-peer strkey.
+- `/startsurveycollecting?nonce=<u32>` → `start_survey_collecting(nonce)`;
+  verbatim success/failure `retStr`.
+- `/stopsurveycollecting` → `stop_survey_collecting()`; verbatim success/failure.
+- `/surveytopologytimesliced?node=<strkey>&inboundpeerindex=<u32>&outboundpeerindex=<u32>`
+  → `survey_topology_timesliced(...)`; `retStr = "Adding node." + ("Survey
+  started "|"Survey already running!")`.
+- `/stopsurvey` → `stop_survey_reporting()`; verbatim `"survey stopped"`.
 
-- `/getsurveyresult` returns `{"survey": "not implemented"}`
-- `/startsurveycollecting`, `/stopsurveycollecting`, and `/surveytopologytimesliced` return `done\n`
+start/stop-collecting and surveytopologytimesliced gate on `Synced`/`Validating`
+(503 when not booted). One bounded, documented divergence: the native fused
+`survey_topology_timesliced` bool skips the insert for the duplicate/self-peer
+edge, whereas stellar-core always adds the node — an accepted reuse limitation.
+The native survey handlers remain in `crates/app/src/http/handlers/survey.rs`,
+backed by `crates/app/src/app/survey_impl.rs`.
 
-Meanwhile, real native survey handlers exist in `crates/app/src/http/handlers/survey.rs:1`, backed by application logic in `crates/app/src/app/survey_impl.rs:1`.
-
-Impact:
-
-- survey-related SSC missions should be classified as unsupported today
-- this is not urgent unless network survey missions are in scope
+This was the last SSC compat survey item; survey-related SSC missions are now
+supported through the compat surface.
 
 ### 6. History mission reliability is plausible, but not yet proven
 
@@ -277,7 +289,7 @@ The config parsing layer (`crates/app/src/compat_config.rs`) has 27 unit tests c
 | ProtocolUpgrade missions | LOW (pending live run) | `/upgrades` `mode=set` param set pinned 1:1 to stellar-core and the full schedule→nominate→apply path is covered by offline regression tests for every `LedgerUpgrade` variant (#3300); only the live multi-node SSC run remains (operator hand-off) |
 | VersionMix / mixed images | HIGH | Best near-term path to value |
 | EmitMeta-style missions | HIGH | Existing metadata support is already strong |
-| NetworkSurvey missions | LOW | Compat endpoints are stubs today |
+| NetworkSurvey missions | LOW | Compat survey endpoints wired to the native survey subsystem (#3298) |
 | MaxTPS benchmarking | LOW | Requires deeper loadgen and metrics parity, and possibly other SSC assumptions |
 | DatabaseInplaceUpgrade | N/A | Not relevant to Henyey's SQLite architecture |
 
@@ -383,7 +395,7 @@ Exit criteria:
 
 Candidate work:
 
-- wire compat survey endpoints to the native survey subsystem
+- ~~wire compat survey endpoints to the native survey subsystem~~ — done (#3298)
 - broaden `/generateload` mode coverage further
 - improve metrics parity beyond the minimum SSC-required set
 - pursue MaxTPS/performance-specific missions once correctness missions are stable
@@ -431,7 +443,7 @@ Candidate work:
 
 ### Phase 4 handoff checklist
 
-- [ ] survey scope explicitly decided
+- [x] survey scope explicitly decided — compat survey endpoints wired to native subsystem (#3298)
 - [ ] long-tail mission matrix updated
 - [ ] deferred work separated from active blockers
 - [ ] any new compat endpoints have response-shape parity tests


### PR DESCRIPTION
Closes #3298

## Summary

Wires the five stub compat survey handlers (`/getsurveyresult`,
`/startsurveycollecting`, `/stopsurveycollecting`, `/surveytopologytimesliced`,
`/stopsurvey`) in `crates/app/src/compat_http/handlers/plaintext.rs` to the
existing native `App` survey methods, mirroring stellar-core `CommandHandler`
(v26.0.1). This is the direct analog of #3294 and the last SSC compat survey
item. Pure wiring — no survey logic is reimplemented.

Key parity points honored:
- **stellar-core param names** `nonce` / `node` / `inboundpeerindex` /
  `outboundpeerindex` (differ from native `inbound_index`/`outbound_index`).
- **Plain-text `retStr`** for start/stop-collecting/topology/stopsurvey; **JSON**
  for getsurveyresult. Verbatim success/failure strings from `CommandHandler.cpp`.
- **Booted gate** (`Synced`|`Validating` → 503) for start/stop-collecting and
  surveytopologytimesliced; getsurveyresult/stopsurvey ungated. Malformed `node`
  strkey → 400 (validated before the gate, matching `parseRequiredParam`-first).
- **strkey, not hex** — getsurveyresult re-derives `backlog`/`badResponseNodes`
  to STRKEY (matching `SurveyManager.cpp:682,690` `KeyUtils::toStrKey`) instead
  of the hex strings carried by the native `SurveyReport`. Adds a `topology` map
  keyed by surveyed-peer strkey.
- **surveytopologytimesliced two-clause retStr** pinned verbatim
  (`"Adding node." + "Survey started "|"Survey already running!"`); the native
  fused bool's duplicate/self-peer edge (skips insert) is a documented bounded
  divergence (code comment).

Doc updates: `crates/app/PARITY_STATUS.md`, `crates/overlay/PARITY_STATUS.md`,
`docs/supercluster-feasibility.md`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3298#issuecomment-4724630023)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] `cargo test -p henyey-app` passes (1069 lib tests + integration + doctests, 0 failures)

8 new inline tests in `plaintext.rs::tests` (committed first as a failing-test
commit, then made to pass):
- `test_compat_startsurveycollecting_gated_when_not_booted` (503)
- `test_compat_startsurveycollecting_missing_nonce_400` (400)
- `test_compat_stopsurveycollecting_gated_when_not_booted` (503)
- `test_compat_surveytopologytimesliced_invalid_node_param` (400)
- `test_compat_surveytopologytimesliced_gated_when_not_booted` (503)
- `test_compat_stopsurvey_returns_plaintext` (`"survey stopped"`, not JSON)
- `test_compat_getsurveyresult_returns_json_shape` (`surveyInProgress`/`backlog`/`badResponseNodes`)
- `test_compat_getsurveyresult_backlog_is_strkey_not_hex` (asserts strkey, not hex)

**Pre-fix:** all 8 verified FAILED on the failing-test commit `72fe42ab` (stub
handlers ignore `State` and return `"done\n"` / `{"survey":"not implemented"}`).
**Post-fix:** all 8 verified PASS after `1fc3da21`.

## Deviations from plan

- Added a small `#[cfg(test)]` seam `App::seed_survey_reporting_backlog_for_test`
  to populate the reporting backlog deterministically for the strkey-projection
  test (the full collecting→reporting handshake needs an injected overlay and
  finalized node data). Test-only infrastructure; no production survey logic
  changed.
- The strkey projection re-derives from the report's hex (hex → bytes →
  `PeerId::to_strkey`), which reconstructs the same underlying public key the
  plan means by "the underlying `PeerId`s" — semantically identical to encoding
  the PeerId directly, and keeps the change confined to the compat handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)