### PR TITLE
Reclassify container-image paths to no-impact in deploy-gate classifier

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1702,8 +1702,13 @@ Otherwise enter the deploy path:
    - **`no-impact`** (allowlisted — never compiles into the release binary):
      `.github/`, `.claude/`, `scripts/`, `docs/`, `metrics/`, root-level `*.md`
      (e.g. `README.md`, `CLAUDE.md`), root-level git metadata dotfiles
-     (`.gitignore`, `.gitattributes`, `.gitmodules`), and `stellar-specs` /
-     `stellar-specs/` submodule pointer changes.
+     (`.gitignore`, `.gitattributes`, `.gitmodules`), `stellar-specs` /
+     `stellar-specs/` submodule pointer changes, and container-image files
+     (`Dockerfile`, `.dockerignore`, `*.dockerfile`) — `cargo` never reads them,
+     so they cannot change the compiled binary; safe ONLY because the monitor
+     runs the locally-compiled `release/henyey`, not the Docker image (the
+     Dockerfile builds the separate SSC integration image). `docker-compose*.yml`
+     is deliberately NOT allowlisted — it stays on the `rebuild` fail-safe.
    - **`test-only`**: `crates/<crate>/tests/**` — integration tests, a separate
      compilation target never linked into the `--release` lib/bin.
    - **`needs-hunk-check`**: `crates/**/src/**.rs` — defer to `diff_is_test_only`

--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -704,6 +704,25 @@ classify_path_binary_relevance() {
       echo "no-impact"; return 0 ;;
     stellar-specs|stellar-specs/*)
       echo "no-impact"; return 0 ;;
+    # Container-image files (#3307): never read by `cargo build --release -p
+    # henyey`, so they cannot change the compiled binary. Routing them through
+    # no-impact makes a Dockerfile-only delta a skip *candidate* that the
+    # §10-step-2a release-binary byte-compare then confirms, instead of forcing
+    # a needless rebuild + validator restart (or re-tripping every tick).
+    #
+    # SAFE ONLY because the monitor runs the validator as the locally-compiled
+    # binary (`release/henyey run ...`), NOT the Docker image — the Dockerfile
+    # builds the SEPARATE Stellar Supercluster (SSC) integration image, which is
+    # not the artifact this gate deploys. REVISIT this carve-out if the deploy
+    # model ever becomes image-based (validator run from the Docker image): then
+    # a Dockerfile change WOULD alter the deployed runtime and must rebuild.
+    #
+    # `*.dockerfile` matches slashed paths too (e.g. `ci/foo.dockerfile`); that
+    # is fine — no `.dockerfile`-suffixed file is in the cargo build graph.
+    # docker-compose*.yml is deliberately NOT allowlisted (stays on the rebuild
+    # fail-safe); see the contrast assertion in test-monitor-skill-snippets.sh.
+    Dockerfile|.dockerignore|*.dockerfile)
+      echo "no-impact"; return 0 ;;
   esac
   # Root-level *.md (e.g. README.md, CLAUDE.md) — no slash, .md suffix.
   if [[ "$path" != */* && "$path" == *.md ]]; then

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -9790,6 +9790,35 @@ BOARDEOF
   else
     tap_not_ok "classify_path: stellar-specs submodule → no-impact" "got '$(_cls "stellar-specs")'"
   fi
+  # Container-image files (#3307): Dockerfile / .dockerignore / *.dockerfile are
+  # never read by `cargo build --release -p henyey`, so they cannot change the
+  # compiled binary. Route them through no-impact so a Dockerfile-only delta hits
+  # the authoritative §10-step-2a binary byte-compare instead of a needless
+  # rebuild+restart. (Safe ONLY because the monitor runs the locally-compiled
+  # release/henyey, not the Docker image — see monitor-decisions.sh comment.)
+  if [[ "$(_cls "Dockerfile")" == "no-impact" ]]; then
+    tap_ok "classify_path: Dockerfile → no-impact"
+  else
+    tap_not_ok "classify_path: Dockerfile → no-impact" "got '$(_cls "Dockerfile")'"
+  fi
+  if [[ "$(_cls ".dockerignore")" == "no-impact" ]]; then
+    tap_ok "classify_path: .dockerignore → no-impact"
+  else
+    tap_not_ok "classify_path: .dockerignore → no-impact" "got '$(_cls ".dockerignore")'"
+  fi
+  if [[ "$(_cls "foo.dockerfile")" == "no-impact" ]]; then
+    tap_ok "classify_path: *.dockerfile → no-impact"
+  else
+    tap_not_ok "classify_path: *.dockerfile → no-impact" "got '$(_cls "foo.dockerfile")'"
+  fi
+  # CONTRAST / deliberate boundary (#3307): docker-compose*.yml is intentionally
+  # NOT allowlisted — it stays on the rebuild fail-safe. This assertion locks
+  # that scope boundary so a future allowlist edit can't silently absorb it.
+  if [[ "$(_cls "docker-compose.yml")" == "rebuild" ]]; then
+    tap_ok "classify_path: docker-compose.yml → rebuild (deliberate boundary)"
+  else
+    tap_not_ok "classify_path: docker-compose.yml → rebuild (deliberate boundary)" "got '$(_cls "docker-compose.yml")'"
+  fi
   if [[ "$(_cls "crates/app/tests/publish_tests.rs")" == "test-only" ]]; then
     tap_ok "classify_path: crates/*/tests/** → test-only"
   else


### PR DESCRIPTION
Closes #3307

## Summary

`classify_path_binary_relevance` (`scripts/lib/monitor-decisions.sh`) now routes root-level container-image paths — `Dockerfile`, `.dockerignore`, `*.dockerfile` — through the `no-impact` allowlist instead of the `rebuild` fail-safe. `cargo build --release -p henyey` never reads these files, so they cannot change the compiled binary. Routing them to `no-impact` makes a Dockerfile-only delta a skip *candidate* that the authoritative §10-step-2a release-binary byte-compare confirms, instead of forcing a needless rebuild + validator restart (~1-2m consensus downtime) or re-tripping every tick.

This is safe ONLY because the monitor runs the validator as the locally-compiled `release/henyey` binary, NOT the Docker image (the Dockerfile builds the separate SSC integration image). A code comment flags this to revisit if the deploy model ever becomes image-based. `docker-compose*.yml` is deliberately kept on the `rebuild` fail-safe; a contrast test locks that boundary. The allowlist prose in `monitor-tick/SKILL.md` §10 step 2 is mirrored to match.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3307#issuecomment-4725311443)

## Test plan

- [x] `bash -n scripts/lib/monitor-decisions.sh` clean
- [x] `bash -n scripts/test-monitor-skill-snippets.sh` clean
- [x] `bash scripts/test-monitor-skill-snippets.sh` — all 410 tests pass
- [x] cargo fmt --check / clippy (pre-commit hook) pass

## Regression test (kind: bug-fix)

- **Tests:** `scripts/test-monitor-skill-snippets.sh` — `classify_path: Dockerfile/.dockerignore/*.dockerfile → no-impact` (+ `docker-compose.yml → rebuild` contrast)
- **Pre-fix:** committed as `d8763b4b` — verified FAILED: `not ok 385/386/387` (Dockerfile/.dockerignore/foo.dockerfile classified `rebuild`); contrast `ok 388` already passing
- **Post-fix:** verified PASSES after `50353bd2` — `ok 385/386/387/388`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)