### PR TITLE
Remove dead BucketError::Database variant and unused henyey-db dep

### DIFF
--- a/crates/bucket/Cargo.toml
+++ b/crates/bucket/Cargo.toml
@@ -10,7 +10,6 @@ rust-version.workspace = true
 stellar-xdr.workspace = true
 henyey-common.workspace = true
 henyey-crypto.workspace = true
-henyey-db.workspace = true
 
 # Compression
 flate2.workspace = true

--- a/crates/bucket/src/error.rs
+++ b/crates/bucket/src/error.rs
@@ -56,13 +56,6 @@ pub enum BucketError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// Database operation failed.
-    ///
-    /// Occurs when bucket operations interact with the ledger database,
-    /// such as during eviction or state verification.
-    #[error("database error: {0}")]
-    Database(#[from] henyey_db::DbError),
-
     /// Bloom filter construction or lookup failed.
     ///
     /// This can occur when:


### PR DESCRIPTION
Closes #3321

## Summary

Removes the dead `BucketError::Database(#[from] henyey_db::DbError)` variant from `crates/bucket/src/error.rs` and drops the now-unused `henyey-db` dependency from `crates/bucket/Cargo.toml`. The variant was never constructed or matched anywhere in the workspace, so its compiler-generated `From<henyey_db::DbError>` impl was dead surface and `henyey-db` was an unnecessary inter-crate dependency edge. Removing the variant leaves `henyey-db` entirely unreferenced by the crate (confirmed: the only two references were the variant decl and the dep line), so it is dropped in the same change. Pure dead-code cleanup with zero behavioral diff.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3321#issuecomment-4726274866)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all (whole workspace compiles — proves nothing references the removed surface)
- [x] cargo test -p henyey-bucket passes (548 tests, 0 failures)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)