### PR TITLE
Drop RwLock guards before await in sync-recovery test helper

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -13215,11 +13215,13 @@ mod tests {
 
         // Arm the tracking timer.
         {
-            let guard = app.sync_recovery_handle.read();
-            let handle = guard
-                .as_ref()
-                .expect("handle should be set after start_sync_recovery");
-            handle.start_tracking().await;
+            // Clone the handle out of a temporary guard so no parking_lot
+            // guard is held across the `.await` (clippy::await_holding_lock).
+            let handle = app.sync_recovery_handle.read().clone();
+            handle
+                .expect("handle should be set after start_sync_recovery")
+                .start_tracking()
+                .await;
         }
         // Drain: let the manager process StartTracking and arm the deadline.
         tokio::task::yield_now().await;
@@ -13246,16 +13248,18 @@ mod tests {
             "on_out_of_sync_recovery() should set sync_recovery_pending"
         );
 
-        // Cleanup: shutdown the manager and await its task.
+        // Cleanup: shutdown the manager and await its task. Clone/take out of
+        // temporary guards so no parking_lot guard is held across the `.await`
+        // (clippy::await_holding_lock).
         {
-            let guard = app.sync_recovery_handle.read();
-            if let Some(handle) = guard.as_ref() {
+            let handle = app.sync_recovery_handle.read().clone();
+            if let Some(handle) = handle {
                 handle.shutdown().await;
             }
         }
         {
-            let mut guard = app.sync_recovery_task.write();
-            if let Some(task) = guard.take() {
+            let task = app.sync_recovery_task.write().take();
+            if let Some(task) = task {
                 let _ = task.await;
             }
         }


### PR DESCRIPTION
Closes #3320

## Summary

Three sites in the sync-recovery tracking-timeout test helper (`crates/app/src/app/mod.rs`) held a `parking_lot` `RwLock` guard via a named `let guard` binding across an `.await`, tripping `clippy::await_holding_lock`. Each site now clones the `SyncRecoveryHandle` (read) or `take()`s the `JoinHandle` (write) out of a *temporary* guard dropped at the statement's `;`, then awaits outside the guard — the same shape already used in production at `lifecycle.rs:1924`. Test-only; behavior is byte-identical (same handle cloned, same task taken/awaited, same order, same assertions).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3320#issuecomment-4726282062)

## Test plan

- [x] cargo fmt (applied)
- [x] `cargo clippy -p henyey-app --all-targets 2>&1 | grep await_holding_lock` is EMPTY (fired at all 3 sites before)
- [x] `cargo test -p henyey-app test_sync_recovery_manager_tracking_timeout_increments_lost_sync_count` passes

## Deviations from plan

None. (The plan's ~12388/12421/12427 line numbers were stale; the actual sites are mod.rs:13218/13251/13257, matching the original issue. Same three sites, same fix shape.)

## Note

A full `cargo clippy --all-targets -- -D warnings` run remains red due to **pre-existing, unrelated** lints (`useless use of format!` at compat_config.rs:3170, `clone on Copy`, etc.) tracked by #3319 — none in the edited region. This PR scopes its check to `await_holding_lock` per the converged plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)