### PR TITLE
Remove dead herder error variants and quorum-intersection accessors

### DIFF
--- a/crates/herder/src/error.rs
+++ b/crates/herder/src/error.rs
@@ -1,8 +1,7 @@
 //! Error types for Herder operations.
 //!
 //! This module defines the error types that can occur during Herder operations,
-//! including transaction validation failures, SCP consensus errors, and internal
-//! processing errors.
+//! including SCP consensus errors and internal processing errors.
 
 use thiserror::Error;
 
@@ -12,13 +11,6 @@ use thiserror::Error;
 /// capacity limits, SCP consensus problems, or internal state errors.
 #[derive(Debug, Error)]
 pub enum HerderError {
-    /// Transaction validation failed.
-    ///
-    /// This occurs when a transaction fails basic structural validation,
-    /// signature verification, or time bounds checking.
-    #[error("transaction validation failed: {0}")]
-    TransactionValidationFailed(String),
-
     /// Transaction queue is at capacity.
     ///
     /// The queue has reached its maximum size and cannot accept additional
@@ -39,13 +31,6 @@ pub enum HerderError {
     /// configured as a validator with a secret key and quorum set.
     #[error("not in validating state")]
     NotValidating,
-
-    /// An error occurred during ledger close processing.
-    ///
-    /// This can occur when applying a transaction set or computing the
-    /// new ledger state after consensus.
-    #[error("ledger close error: {0}")]
-    LedgerClose(String),
 
     /// An internal error occurred.
     ///

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -4481,10 +4481,10 @@ impl Herder {
                             Ok(groups) => groups,
                             Err(_interrupted) => {
                                 debug!("Critical groups computation interrupted");
-                                // Do NOT call clear_checking() here: the state
-                                // was already replaced by the new start_checking()
-                                // that triggered the interrupt. Clearing here
-                                // would race with the new analysis.
+                                // Do NOT clear the in-progress analysis marker
+                                // here: the state was already replaced by the new
+                                // start_checking() that triggered the interrupt.
+                                // Clearing here would race with the new analysis.
                                 return;
                             }
                         };
@@ -4526,9 +4526,10 @@ impl Herder {
                 }
                 henyey_scp::quorum_intersection::IntersectionResult::Interrupted => {
                     debug!("Quorum intersection analysis interrupted (quorum map changed)");
-                    // Do NOT call clear_checking() here: the state was already
-                    // replaced by the new start_checking() that triggered the
-                    // interrupt. Clearing here would race with the new analysis.
+                    // Do NOT clear the in-progress analysis marker here: the state
+                    // was already replaced by the new start_checking() that
+                    // triggered the interrupt. Clearing here would race with the
+                    // new analysis.
                 }
             }
         };

--- a/crates/herder/src/lib.rs
+++ b/crates/herder/src/lib.rs
@@ -122,7 +122,6 @@ pub mod metrics;
 pub(crate) mod parallel_tx_set_builder;
 mod pending;
 mod persistence;
-#[allow(dead_code)] // All types used in herder.rs wiring below
 pub(crate) mod quorum_intersection_state;
 mod quorum_set_tracker;
 mod quorum_tracker;

--- a/crates/herder/src/quorum_intersection_state.rs
+++ b/crates/herder/src/quorum_intersection_state.rs
@@ -120,11 +120,6 @@ impl QuorumIntersectionState {
         }
     }
 
-    /// Whether analysis is currently in progress.
-    pub fn is_analyzing(&self) -> bool {
-        matches!(self.analysis, AnalysisState::Analyzing { .. })
-    }
-
     /// Get the hash from the last completed result.
     pub fn last_result_hash(&self) -> Option<&Hash256> {
         match &self.last_result {
@@ -162,23 +157,6 @@ impl QuorumIntersectionState {
             interrupt_flag: flag,
         };
         flag_clone
-    }
-
-    /// Set the interrupt flag on any in-flight analysis.
-    ///
-    /// Used when the quorum map changes during analysis to signal
-    /// the running checker to abort.
-    pub fn interrupt_stale(&mut self) {
-        if let AnalysisState::Analyzing { interrupt_flag, .. } = &self.analysis {
-            interrupt_flag.store(true, Ordering::Relaxed);
-        }
-    }
-
-    /// Clear the in-progress analysis marker without publishing a result.
-    ///
-    /// Used when the analysis is interrupted or cannot complete.
-    pub fn clear_checking(&mut self) {
-        self.analysis = AnalysisState::Idle;
     }
 
     /// Record a completed analysis result.
@@ -379,51 +357,6 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_checking_unblocks_future_checks() {
-        let mut state = QuorumIntersectionState::new();
-        let hash1 = make_hash(1);
-
-        // Publish an intersecting result.
-        state.start_checking(hash1);
-        state.complete_check(
-            &hash1,
-            QuorumIntersectionResult::Intersecting {
-                check_ledger: 50,
-                num_nodes: 3,
-                quorum_map_hash: hash1,
-                critical_groups: vec![],
-            },
-        );
-
-        // Start a new check, then clear it (simulates TooLarge).
-        let hash2 = make_hash(2);
-        state.start_checking(hash2);
-        assert!(state.checking_hash().is_some());
-
-        state.clear_checking();
-        assert!(state.checking_hash().is_none());
-
-        // Previous result should still be available.
-        assert!(state.has_any_results());
-        assert!(state.enjoys_quorum_intersection());
-        assert_eq!(state.last_good_ledger(), 50);
-    }
-
-    #[test]
-    fn test_interrupt_stale_analysis() {
-        let mut state = QuorumIntersectionState::new();
-        let hash1 = make_hash(1);
-
-        // Start analysis.
-        let flag = state.start_checking(hash1);
-        assert!(!flag.load(Ordering::Relaxed));
-
-        // Interrupt it.
-        state.interrupt_stale();
-        assert!(flag.load(Ordering::Relaxed));
-    }
-
-    #[test]
     fn test_start_checking_interrupts_old_analysis() {
         let mut state = QuorumIntersectionState::new();
         let hash1 = make_hash(1);
@@ -439,17 +372,5 @@ mod tests {
             flag1.load(Ordering::Relaxed),
             "old analysis should be interrupted"
         );
-    }
-
-    #[test]
-    fn test_is_analyzing() {
-        let mut state = QuorumIntersectionState::new();
-        assert!(!state.is_analyzing());
-
-        state.start_checking(make_hash(1));
-        assert!(state.is_analyzing());
-
-        state.clear_checking();
-        assert!(!state.is_analyzing());
     }
 }


### PR DESCRIPTION
Closes #3324

## Summary

Removes five confirmed-dead public items in `henyey-herder` — the `HerderError::TransactionValidationFailed` and `HerderError::LedgerClose` variants (`error.rs`) and the `QuorumIntersectionState::{is_analyzing, interrupt_stale, clear_checking}` methods (`quorum_intersection_state.rs`) — plus their three in-module unit tests (`test_is_analyzing`, `test_interrupt_stale_analysis`, `test_clear_checking_unblocks_future_checks`), and drops the module-level `#[allow(dead_code)]` in `lib.rs` so future dead surface is flagged. The warning-free build after removing the `#[allow]` self-proves these were the only dead items it was masking. Two advisory comments in `herder.rs` that named the deleted `clear_checking()` are reworded, and the now-stale `error.rs` module doc is trimmed.

The live quorum-intersection interrupt mechanism is left fully intact: `start_checking()`, the `complete_check()` stale-hash guard, the `interrupt_flag` plumbing, the `IntersectionResult::Interrupted` arm, and `test_start_checking_interrupts_old_analysis` (the parity guard mirroring stellar-core's `QuorumIntersectionChecker`). Net behavioral diff = 0.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3324#issuecomment-4726282180)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-herder -- -D warnings` clean
- [x] `cargo build -p henyey-herder` warning-free
- [x] `cargo test -p henyey-herder` passes (live-interrupt parity guard `test_start_checking_interrupts_old_analysis` green)
- [x] `cargo build --all` compiles

## Deviations from plan

None. Both optional advisory cleanups (the two `herder.rs` comments and the `error.rs` module doc) were applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)