### PR TITLE
Remove dead MemoryEstimate trait and Resource::try_set_val

### DIFF
--- a/crates/common/README.md
+++ b/crates/common/README.md
@@ -50,7 +50,6 @@ graph TD
 | `XdrOutputStream` | Buffered writer for stellar-core-compatible size-prefixed XDR frames |
 | `DurableXdrOutputStream` | XDR frame writer that flushes and fsyncs each entry for crash safety |
 | `XdrInputStream` | Reader for the same framed XDR format used by stellar-core streams |
-| `MemoryEstimate` | Trait for O(1) approximate heap accounting of components |
 | `ComponentMemory` | Named memory measurement used for reporting heap or file-backed component usage |
 
 ## Usage

--- a/crates/common/src/memory.rs
+++ b/crates/common/src/memory.rs
@@ -1,37 +1,15 @@
-//! Memory estimation trait and helpers for per-component heap tracking.
+//! Heap-estimation helpers for per-component memory tracking.
 //!
-//! This module provides the [`MemoryEstimate`] trait for types that can report
-//! their approximate heap memory usage, plus helper functions for estimating
-//! the heap footprint of standard collections.
+//! This module provides [`ComponentMemory`] for reporting a component's
+//! memory usage, plus helper functions for estimating the heap footprint of
+//! standard collections.
 //!
 //! # Design
 //!
-//! Implementations should be O(1) — read capacities, lengths, and atomic
+//! Estimates should be O(1) — read capacities, lengths, and atomic
 //! counters, never iterate entries. Estimates should be conservative
 //! (slight over-count is acceptable) and exclude shared references (`Arc`)
 //! that may be counted by other components.
-//!
-//! # Usage
-//!
-//! ```ignore
-//! use henyey_common::memory::{MemoryEstimate, ComponentMemory, hashmap_heap_bytes};
-//!
-//! impl MemoryEstimate for MyCache {
-//!     fn estimate_heap_bytes(&self) -> usize {
-//!         hashmap_heap_bytes(self.map.capacity(), 32, 64)
-//!     }
-//! }
-//! ```
-
-/// Trait for types that can estimate their heap memory usage.
-///
-/// Implementations should return a conservative estimate of the heap
-/// bytes owned by this value, excluding shared references (Arc) that
-/// may be counted elsewhere. The estimate must be O(1) — read
-/// capacities, lengths, and atomic counters, never iterate entries.
-pub trait MemoryEstimate {
-    fn estimate_heap_bytes(&self) -> usize;
-}
 
 /// A named memory measurement from a single component.
 #[derive(Debug, Clone)]

--- a/crates/common/src/resource.rs
+++ b/crates/common/src/resource.rs
@@ -211,18 +211,6 @@ impl Resource {
         self.values[ty as usize]
     }
 
-    /// Sets the value for a specific resource type, returning `false` if out of bounds.
-    ///
-    /// This is the safe variant that does not panic.
-    pub fn try_set_val(&mut self, ty: ResourceType, val: i64) -> bool {
-        if let Some(slot) = self.values.get_mut(ty as usize) {
-            *slot = val;
-            true
-        } else {
-            false
-        }
-    }
-
     /// Sets the value for a specific resource type.
     ///
     /// # Panics


### PR DESCRIPTION
Closes #3323

## Summary

Removes two pieces of confirmed-dead public API surface in `henyey-common`: the `MemoryEstimate` trait (`crates/common/src/memory.rs`, zero `impl` blocks workspace-wide) and `Resource::try_set_val` (`crates/common/src/resource.rs`, zero call sites). Also removes the orphaned module doc-example, the `[`MemoryEstimate`]` intra-doc link, and the README table row that referenced the trait. Net behavioral diff = 0. The ~15 inherent `estimate_heap_bytes` methods across bucket/ledger/tx/herder are NOT trait impls (mismatched signatures) and are left untouched.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3323#issuecomment-4726275878)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo build --all` — full workspace builds
- [x] `cargo test --all` — full workspace green (henyey-common: 219+38 pass, 0 fail; five memory + all Resource tests preserved)
- [x] `cargo doc -p henyey-common --no-deps` — succeeds; the `MemoryEstimate` intra-doc link is gone. The 4 remaining doc warnings (`hash_xdr` x2, `LedgerKey`, `LedgerEntry` in `types.rs`) are pre-existing on `origin/main` and unrelated to this change.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)