### PR TITLE
Narrow externally-unused SCP re-exports out of the public API

### DIFF
--- a/crates/scp/src/lib.rs
+++ b/crates/scp/src/lib.rs
@@ -59,7 +59,7 @@ mod slot;
 pub(crate) mod test_utils;
 
 // Re-export main types
-pub use ballot::{get_companion_quorum_set_hash, get_working_ballot, BallotPhase};
+pub use ballot::BallotPhase;
 pub use compare::is_newer_nomination_or_ballot_st;
 pub use driver::{base_get_node_weight, SCPDriver, SCPTimerType, ValidationLevel};
 pub use error::ScpError;
@@ -70,10 +70,13 @@ pub use info::{
 };
 pub use quorum::{
     find_closest_v_blocking, get_all_nodes, hash_quorum_set, is_quorum, is_quorum_set_sane,
-    is_quorum_slice, is_v_blocking, is_valid_quorum_set, normalize_quorum_set,
-    normalize_quorum_set_with_remove, simple_quorum_set, singleton_quorum_set,
-    SingletonQuorumSetCache, MAXIMUM_QUORUM_NESTING_LEVEL, MAXIMUM_QUORUM_NODES,
+    is_quorum_slice, is_v_blocking, normalize_quorum_set, normalize_quorum_set_with_remove,
+    singleton_quorum_set, MAXIMUM_QUORUM_NESTING_LEVEL, MAXIMUM_QUORUM_NODES,
 };
+// `is_valid_quorum_set` is reached internally via the crate-root path
+// (`crate::is_valid_quorum_set` in quorum_config.rs); keep a crate-private
+// re-export so that path resolves while removing it from the external API.
+pub(crate) use quorum::is_valid_quorum_set;
 pub use quorum_config::{
     config_to_quorum_set, node_id_to_strkey, parse_node_id, testnet_quorum_config,
     validate_quorum_config, QuorumConfigError,

--- a/crates/scp/src/quorum.rs
+++ b/crates/scp/src/quorum.rs
@@ -530,11 +530,18 @@ pub fn singleton_quorum_set(node_id: NodeId) -> ScpQuorumSet {
 ///
 /// This struct provides efficient caching of singleton quorum sets,
 /// matching the stellar-core `getSingletonQSet()` optimization.
+// Retained as an intentional internal/test utility: it has no non-test
+// in-crate caller, and #3329 removed it from the crate's public API
+// (crate-root `pub use`), so without this allow the lib build would flag
+// it (and its inherent methods) as dead code. It remains exercised by the
+// `quorum` test module and mirrors stellar-core's `getSingletonQSet()`.
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct SingletonQuorumSetCache {
     cache: std::sync::RwLock<std::collections::HashMap<NodeId, ScpQuorumSet>>,
 }
 
+#[allow(dead_code)]
 impl SingletonQuorumSetCache {
     /// Create a new empty cache.
     pub fn new() -> Self {


### PR DESCRIPTION
Closes #3329

## Summary

Shrinks the `henyey-scp` crate's public surface by removing five re-exports that are unused by every other crate (`cargo build --all` proves it). `crates/scp/src/lib.rs` had two multi-symbol `pub use` lines bundling genuinely-external symbols together with these dead ones; both lines are split so the external symbols stay `pub use`. Net behavioral diff = 0 — no symbol body changes, pure visibility hygiene.

Per-symbol actions (per the converged plan's table):

| Symbol | Action |
|---|---|
| `BallotPhase` | stays `pub use` (external — app/types.rs:1337) |
| `hash_quorum_set` / `is_quorum` / `is_v_blocking` / etc. | stay `pub use` (external quorum API) |
| `is_valid_quorum_set` | → `pub(crate) use` (reached via crate-root path in quorum_config.rs:38) |
| `get_companion_quorum_set_hash` | dropped from lib.rs (reached only via `crate::ballot::`) |
| `get_working_ballot` | dropped from lib.rs (reached only via `crate::ballot::`) |
| `simple_quorum_set` | dropped from lib.rs (reached only via `crate::quorum::`) |
| `SingletonQuorumSetCache` | dropped from lib.rs (reached only via `crate::quorum::`) |

The four dropped symbols remain `pub` inside their private defining modules (`mod ballot;`, `mod quorum;`), so every in-crate caller still reaches them via the unchanged module paths; they are simply no longer part of the external API.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3329#issuecomment-4726422512)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build --all` (proves no external consumer needed the dropped re-exports)
- [x] `cargo test -p henyey-scp` — 124 passed, 0 failed
- [x] `cargo clippy --all -- -D warnings` — clean

## Deviations from plan

- The converged plan stated `SingletonQuorumSetCache` was "reached via `crate::quorum::` (tests)". That is accurate but those references are all `#[cfg(test)]`-gated, so once the crate-root `pub use` is dropped the struct has no non-test consumer in the lib build and `-D dead-code` flags it (and its inherent methods). Resolved within scope by annotating the struct and its `impl` with `#[allow(dead_code)]` plus an explanatory comment, retaining it as an intentional internal/test utility. Zero behavioral change; the symbol is removed from the public API exactly as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)