### PR TITLE
Remove dead Simulation::app_latest_externalized_slot

### DIFF
--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -580,12 +580,6 @@ impl Simulation {
             .map(|n| n.app.ledger_info().ledger_seq)
     }
 
-    pub fn app_latest_externalized_slot(&self, node_id: &str) -> Option<u64> {
-        self.running_apps
-            .get(node_id)
-            .and_then(|n| n.app.latest_externalized_slot())
-    }
-
     pub fn app(&self, node_id: &str) -> Option<Arc<App>> {
         self.running_apps.get(node_id).map(|n| Arc::clone(&n.app))
     }


### PR DESCRIPTION
Closes #3330

## Summary

Deletes the unused `pub fn Simulation::app_latest_externalized_slot(&self, node_id: &str) -> Option<u64>` in `crates/simulation/src/lib.rs`. It was a thin pass-through wrapper with zero callers anywhere in the workspace — pure dead-code removal. The separate `App::latest_externalized_slot()` (the parity-relevant method) is untouched, as are the sibling accessors `app_ledger_seq` and `app`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3330#issuecomment-4726419061)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all passes
- [x] cargo test -p henyey-simulation passes (12 tests across 3 test binaries)
- [x] Pre-deletion `git grep -nw app_latest_externalized_slot` returned exactly one hit (the definition); post-deletion returns none

## Deviations from plan

- The method's actual line numbers were 583–587 (the plan/issue cited 578–582 / :583); a harmless offset. The exact method body matched the plan and was deleted as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)