### PR TITLE
Remove dead public API in henyey-history

### DIFF
--- a/crates/history/src/archive.rs
+++ b/crates/history/src/archive.rs
@@ -325,16 +325,6 @@ impl HistoryArchive {
         self.base_url.join(path).map_err(HistoryError::UrlParse)
     }
 
-    /// Check if the archive is accessible by fetching the root HAS.
-    ///
-    /// # Returns
-    ///
-    /// `Ok(())` if the archive is accessible, or an error otherwise.
-    pub async fn check_accessible(&self) -> Result<(), HistoryError> {
-        self.fetch_root_has().await?;
-        Ok(())
-    }
-
     /// Get the current ledger from this archive.
     ///
     /// This is a convenience method that fetches the root HAS and returns
@@ -342,26 +332,6 @@ impl HistoryArchive {
     pub async fn fetch_current_ledger(&self) -> Result<u32, HistoryError> {
         let has = self.fetch_root_has().await?;
         Ok(has.current_ledger())
-    }
-
-    /// Download a single ledger header by sequence.
-    ///
-    /// This downloads the checkpoint containing the ledger and extracts
-    /// the specific header. For bulk downloads, use `fetch_ledger_headers`.
-    ///
-    /// # Arguments
-    ///
-    /// * `seq` - The ledger sequence number
-    ///
-    /// # Returns
-    ///
-    /// The ledger header for the specified sequence.
-    pub async fn fetch_ledger_header(
-        &self,
-        seq: u32,
-    ) -> Result<stellar_xdr::curr::LedgerHeader, HistoryError> {
-        let (header, _hash) = self.fetch_ledger_header_with_hash(seq).await?;
-        Ok(header)
     }
 
     /// Download a single ledger header with its pre-computed hash by sequence.
@@ -393,35 +363,6 @@ impl HistoryArchive {
             "Ledger header {} not found in checkpoint",
             seq
         )))
-    }
-
-    /// Download a transaction set for a specific ledger.
-    ///
-    /// This downloads the checkpoint containing the ledger and extracts
-    /// the transactions for that specific ledger.
-    ///
-    /// # Arguments
-    ///
-    /// * `seq` - The ledger sequence number
-    ///
-    /// # Returns
-    ///
-    /// The transaction set for the specified ledger.
-    pub async fn fetch_transaction_set(
-        &self,
-        seq: u32,
-    ) -> Result<stellar_xdr::curr::TransactionSet, HistoryError> {
-        let transactions = self.fetch_transactions(seq).await?;
-
-        // Find the transaction set with the matching ledger sequence
-        for entry in transactions {
-            if entry.ledger_seq == seq {
-                return Ok(entry.tx_set);
-            }
-        }
-
-        // Return empty transaction set if no transactions for this ledger
-        Ok(crate::make_empty_tx_set())
     }
 }
 

--- a/crates/history/src/checkpoint_builder.rs
+++ b/crates/history/src/checkpoint_builder.rs
@@ -725,7 +725,10 @@ mod tests {
     fn make_tx_entry(seq: u32) -> TransactionHistoryEntry {
         TransactionHistoryEntry {
             ledger_seq: seq,
-            tx_set: crate::make_empty_tx_set(),
+            tx_set: stellar_xdr::curr::TransactionSet {
+                previous_ledger_hash: Hash([0u8; 32]),
+                txs: VecM::default(),
+            },
             ext: TransactionHistoryEntryExt::default(),
         }
     }

--- a/crates/history/src/download.rs
+++ b/crates/history/src/download.rs
@@ -237,59 +237,6 @@ pub fn parse_xdr_stream<T: ReadXdr>(data: &[u8]) -> Result<Vec<T>, HistoryError>
     Ok(entries)
 }
 
-/// Parse an XDR stream that uses length-prefixed framing.
-///
-/// Some XDR streams use explicit 4-byte length prefixes before each entry.
-/// This function handles that format.
-///
-/// # Type Parameters
-///
-/// * `T` - The XDR type to parse. Must implement `ReadXdr`.
-///
-/// # Arguments
-///
-/// * `data` - The raw XDR bytes with length prefixes
-///
-/// # Returns
-///
-/// A vector of parsed entries, or an error if parsing fails.
-pub fn parse_length_prefixed_xdr_stream<T: ReadXdr>(data: &[u8]) -> Result<Vec<T>, HistoryError> {
-    let mut entries = Vec::new();
-    let mut offset = 0;
-
-    while offset + 4 <= data.len() {
-        // Read 4-byte big-endian length
-        let len = u32::from_be_bytes([
-            data[offset],
-            data[offset + 1],
-            data[offset + 2],
-            data[offset + 3],
-        ]) as usize;
-        offset += 4;
-
-        if offset + len > data.len() {
-            return Err(HistoryError::XdrParsing(format!(
-                "Invalid XDR length: {} exceeds remaining data {}",
-                len,
-                data.len() - offset
-            )));
-        }
-
-        let entry_data = &data[offset..offset + len];
-        let entry = T::from_xdr(entry_data, stellar_xdr::curr::Limits::none())
-            .map_err(HistoryError::Xdr)?;
-        entries.push(entry);
-
-        offset += len;
-
-        // XDR padding to 4-byte boundary
-        let padding = (4 - (len % 4)) % 4;
-        offset += padding;
-    }
-
-    Ok(entries)
-}
-
 /// Parse an XDR stream that uses XDR Record Marking Standard (RFC 5531).
 ///
 /// The record marking format uses 4-byte record marks where:
@@ -378,56 +325,6 @@ pub fn parse_record_marked_xdr_stream_or_empty<T: ReadXdr>(
     // History/bucket files always use XDR record marks (RFC 5531).
     // No format detection needed — always parse with record marks.
     parse_record_marked_xdr_stream(data)
-}
-
-/// Download and decompress a gzipped file.
-///
-/// This is a convenience function that combines downloading with retries
-/// and gzip decompression.
-///
-/// # Arguments
-///
-/// * `client` - The HTTP client to use
-/// * `url` - The URL to download from
-/// * `config` - Download configuration
-///
-/// # Returns
-///
-/// The decompressed bytes, or an error.
-pub async fn download_and_decompress(
-    client: &Client,
-    url: &str,
-    config: &DownloadConfig,
-) -> Result<Vec<u8>, HistoryError> {
-    let compressed = download_with_retries(client, url, config).await?;
-    decompress_gzip(&compressed)
-}
-
-/// Download, decompress, and parse an XDR file.
-///
-/// This is a convenience function for the common case of downloading
-/// a gzipped XDR file and parsing it into a vector of entries.
-///
-/// # Type Parameters
-///
-/// * `T` - The XDR type to parse. Must implement `ReadXdr`.
-///
-/// # Arguments
-///
-/// * `client` - The HTTP client to use
-/// * `url` - The URL to download from
-/// * `config` - Download configuration
-///
-/// # Returns
-///
-/// A vector of parsed entries, or an error.
-pub async fn download_and_parse_xdr<T: ReadXdr>(
-    client: &Client,
-    url: &str,
-    config: &DownloadConfig,
-) -> Result<Vec<T>, HistoryError> {
-    let data = download_and_decompress(client, url, config).await?;
-    parse_xdr_stream(&data)
 }
 
 #[cfg(test)]

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -188,14 +188,6 @@ pub use verify::{
 /// Result type for history operations.
 pub type Result<T> = std::result::Result<T, HistoryError>;
 
-/// Construct an empty `TransactionSet` with a zeroed previous-ledger hash.
-pub fn make_empty_tx_set() -> stellar_xdr::curr::TransactionSet {
-    stellar_xdr::curr::TransactionSet {
-        previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-        txs: stellar_xdr::curr::VecM::default(),
-    }
-}
-
 // Re-export archive manager types (added at end of file)
 
 /// Configuration for a single history archive.

--- a/crates/history/src/remote_archive.rs
+++ b/crates/history/src/remote_archive.rs
@@ -214,29 +214,6 @@ impl RemoteArchive {
         self.execute_command(&command).await
     }
 
-    /// Download a remote file to a local path.
-    ///
-    /// # Arguments
-    ///
-    /// * `remote_url` - URL of the remote file
-    /// * `local_path` - Destination path for the downloaded file
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - No get command is configured
-    /// - The command execution fails
-    pub async fn download_file(&self, remote_url: &str, local_path: &Path) -> Result<()> {
-        let get_cmd = self.config.get_cmd.as_ref().ok_or_else(|| {
-            HistoryError::RemoteNotConfigured("get command not configured".to_string())
-        })?;
-
-        let local_str = local_path.to_string_lossy();
-        let command = Self::format_command(get_cmd, &[remote_url, &local_str]);
-
-        self.execute_command(&command).await
-    }
-
     /// Ensure a remote directory exists, creating it if necessary.
     ///
     /// This is a no-op if no mkdir command is configured.

--- a/crates/history/src/replay/metadata.rs
+++ b/crates/history/src/replay/metadata.rs
@@ -4,14 +4,22 @@
 //! entry changes. This produces identical results to the original execution
 //! and is used for testing and specialized replay scenarios.
 
+// `metadata.rs` provides metadata-based ledger replay, which is currently
+// exercised only by tests. All items below are therefore `#[cfg(test)]`-gated,
+// along with the imports that support them.
+#[cfg(test)]
 use crate::{verify, HistoryError, Result};
+#[cfg(test)]
 use henyey_ledger::TransactionSetVariant;
+#[cfg(test)]
 use stellar_xdr::curr::{
     LedgerEntry, LedgerHeader, LedgerKey, TransactionMeta, TransactionResultPair,
     TransactionResultSet, WriteXdr,
 };
 
+#[cfg(test)]
 use super::execution::soroban_entry_size;
+#[cfg(test)]
 use super::{LedgerReplayResult, ReplayConfig};
 
 /// Replays a single ledger from history data.
@@ -30,6 +38,7 @@ use super::{LedgerReplayResult, ReplayConfig};
 /// # Returns
 ///
 /// A `LedgerReplayResult` containing the changes to apply to ledger state.
+#[cfg(test)]
 pub(crate) fn replay_ledger(
     header: &LedgerHeader,
     tx_set: &TransactionSetVariant,
@@ -101,12 +110,14 @@ pub(crate) fn replay_ledger(
 /// - live_entries: Entries that were updated or restored
 /// - dead_entries: Keys of entries that were deleted
 /// Accumulated ledger entry changes from transaction meta.
+#[cfg(test)]
 struct LedgerChanges {
     init: Vec<LedgerEntry>,
     live: Vec<LedgerEntry>,
     dead: Vec<LedgerKey>,
 }
 
+#[cfg(test)]
 impl LedgerChanges {
     fn new() -> Self {
         Self {
@@ -132,6 +143,7 @@ impl LedgerChanges {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn extract_ledger_changes(
     tx_metas: &[TransactionMeta],
 ) -> Result<(Vec<LedgerEntry>, Vec<LedgerEntry>, Vec<LedgerKey>)> {
@@ -141,6 +153,7 @@ pub(crate) fn extract_ledger_changes(
 }
 
 /// Count the total number of operations in a transaction set.
+#[cfg(test)]
 fn count_operations(tx_set: &TransactionSetVariant) -> u32 {
     tx_set
         .transactions()

--- a/crates/history/src/replay/mod.rs
+++ b/crates/history/src/replay/mod.rs
@@ -49,19 +49,16 @@ pub(crate) mod diff;
 pub(crate) mod execution;
 pub(crate) mod metadata;
 
-use crate::{verify, HistoryError, Result};
 use henyey_bucket::EvictionIterator;
 use henyey_common::{Hash256, NetworkId};
-use henyey_ledger::{EntryChange, TransactionSetVariant};
+use henyey_ledger::EntryChange;
 use henyey_tx::soroban::PersistentModuleCache;
 use stellar_xdr::curr::{
-    BucketListType, LedgerEntry, LedgerHeader, LedgerKey, StateArchivalSettings, TransactionMeta,
-    TransactionResultPair,
+    LedgerEntry, LedgerHeader, LedgerKey, StateArchivalSettings, TransactionResultPair,
 };
 
 // Re-export public items from submodules.
 pub use execution::replay_ledger_with_execution;
-pub(crate) use metadata::replay_ledger;
 
 /// The result of replaying a single ledger.
 ///
@@ -248,75 +245,6 @@ impl Default for ReplayConfig {
     }
 }
 
-/// Replay a batch of ledgers.
-///
-/// This is used during catchup to replay all ledgers from a checkpoint
-/// to the target ledger.
-///
-/// # Arguments
-///
-/// * `ledgers` - Slice of (header, tx_set, results, metas) tuples
-/// * `config` - Replay configuration
-/// * `progress_callback` - Optional callback for progress updates
-pub fn replay_ledgers<F>(
-    ledgers: &[(
-        LedgerHeader,
-        TransactionSetVariant,
-        Vec<TransactionResultPair>,
-        Vec<TransactionMeta>,
-    )],
-    config: &ReplayConfig,
-    mut progress_callback: Option<F>,
-) -> Result<Vec<LedgerReplayResult>>
-where
-    F: FnMut(u32, u32), // (current, total)
-{
-    let total = ledgers.len() as u32;
-    let mut results = Vec::with_capacity(ledgers.len());
-
-    for (i, (header, tx_set, tx_results, tx_metas)) in ledgers.iter().enumerate() {
-        let result = replay_ledger(header, tx_set, tx_results, tx_metas, config)?;
-        results.push(result);
-
-        if let Some(ref mut callback) = progress_callback {
-            callback(i as u32 + 1, total);
-        }
-    }
-
-    Ok(results)
-}
-
-/// Verify ledger consistency after replay.
-///
-/// Checks that the final bucket list hash matches the expected hash
-/// from the last replayed ledger header.
-pub fn verify_replay_consistency(
-    final_header: &LedgerHeader,
-    computed_bucket_list_hash: &Hash256,
-) -> Result<()> {
-    verify::verify_ledger_hash(final_header, computed_bucket_list_hash)
-}
-
-/// Apply replay results to the bucket list.
-///
-/// This takes the changes from ledger replay and applies them to the
-/// bucket list to update the ledger state.
-pub fn apply_replay_to_bucket_list(
-    bucket_list: &mut henyey_bucket::BucketList,
-    replay_result: &LedgerReplayResult,
-) -> Result<()> {
-    bucket_list
-        .add_batch(
-            replay_result.sequence,
-            replay_result.protocol_version,
-            BucketListType::Live,
-            replay_result.init_entries.clone(),
-            replay_result.live_entries.clone(),
-            replay_result.dead_entries.clone(),
-        )
-        .map_err(HistoryError::Bucket)
-}
-
 /// Prepare a ledger close based on replay data.
 ///
 /// This is used when we've replayed history and want to set up the
@@ -396,7 +324,10 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn make_empty_tx_set() -> TransactionSet {
-        crate::make_empty_tx_set()
+        TransactionSet {
+            previous_ledger_hash: Hash([0u8; 32]),
+            txs: VecM::default(),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #3325

## Summary

Behavior-preserving deletion of 10 confirmed-dead public functions in `henyey-history` across the download / archive / replay layers, plus resolution of the transitively-dead `crate::make_empty_tx_set`:

- `download.rs`: `parse_length_prefixed_xdr_stream`, `download_and_parse_xdr`, `download_and_decompress`
- `remote_archive.rs`: `download_file`
- `archive.rs`: `check_accessible`, `fetch_ledger_header` (singular — `fetch_ledger_headers` plural and `fetch_ledger_header_with_hash` kept), `fetch_transaction_set`
- `replay/mod.rs`: `replay_ledgers`, `verify_replay_consistency`, `apply_replay_to_bucket_list`

`fetch_transaction_set` was the only non-test caller of `crate::make_empty_tx_set` (lib.rs), so it was deleted first; the empty `TransactionSet` literal was then inlined into the two `#[cfg(test)]` helpers (`replay/mod.rs`, `checkpoint_builder.rs`) and `crate::make_empty_tx_set` removed. The distinct proto-aware `catchup::make_empty_tx_set` is untouched. Net behavioral diff = 0; the successful build is the proof nothing referenced the removed surface.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3325#issuecomment-4726420896)

## Test plan

- [x] `cargo build --all`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-history` (558 lib unit tests + integration + doctests, 0 failures)

## Deviations from plan

- Deleting `replay_ledgers` (its sole non-test caller of `replay_ledger`) left `replay_ledger` and its private helper chain (`extract_ledger_changes`, `LedgerChanges`, `count_operations` in `replay/metadata.rs`) reachable only from `#[cfg(test)]` code. Under the crate's deny-warnings build this triggered `never used` / unused-import errors in a non-test compile. The plan directed keeping `replay_ledger` "as test-used"; to honor that while keeping the build warning-free I `#[cfg(test)]`-gated those items and their now-test-only imports, and dropped the orphaned `pub(crate) use metadata::replay_ledger` re-export (which had no remaining consumers). Behavior-preserving and within the plan's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)