### PR TITLE
Replace bare 0x4 trustline flag literal with named XDR constant

### DIFF
--- a/crates/invariant/src/entry_valid.rs
+++ b/crates/invariant/src/entry_valid.rs
@@ -14,7 +14,7 @@
 use stellar_xdr::curr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, ContractEvent, DataEntry,
     LedgerEntry, LedgerEntryData, OfferEntry, Operation, OperationResult, TrustLineAsset,
-    TrustLineEntry, TrustLineEntryExt, TrustLineEntryV1Ext,
+    TrustLineEntry, TrustLineEntryExt, TrustLineEntryV1Ext, TrustLineFlags,
 };
 
 use crate::{Invariant, OperationDelta};
@@ -199,8 +199,10 @@ fn check_trustline(tl: &TrustLineEntry, previous: Option<&LedgerEntry>) -> Resul
     // Clawback flag must not be enabled if it wasn't enabled before.
     if let Some(prev) = previous {
         if let LedgerEntryData::Trustline(prev_tl) = &prev.data {
-            let prev_clawback = (prev_tl.flags & 0x4) != 0; // AUTHORIZED_TO_MAINTAIN_LIABILITIES clawback bit
-            let cur_clawback = (tl.flags & 0x4) != 0;
+            // 0x4 is the trustline clawback bit (TRUSTLINE_CLAWBACK_ENABLED_FLAG).
+            const CLAWBACK_FLAG: u32 = TrustLineFlags::TrustlineClawbackEnabledFlag as u32;
+            let prev_clawback = (prev_tl.flags & CLAWBACK_FLAG) != 0;
+            let cur_clawback = (tl.flags & CLAWBACK_FLAG) != 0;
             if !prev_clawback && cur_clawback {
                 return Err("TrustLine clawback flag was enabled".to_string());
             }


### PR DESCRIPTION
Closes #3326

## Summary

The inline comment in `check_trustline` (`crates/invariant/src/entry_valid.rs`) mislabeled the `0x4` clawback bit as `AUTHORIZED_TO_MAINTAIN_LIABILITIES` — but that flag is `0x2`; `0x4` is `TRUSTLINE_CLAWBACK_ENABLED_FLAG`. This replaces the two bare `0x4` literals with the named XDR constant `TrustLineFlags::TrustlineClawbackEnabledFlag` (via a local `const`, mirroring the existing idiom in `crates/tx`) and corrects the comment. Behavior-preserving: the constant is `4`, so `0x4` stays `0x4`.

Parity: `TrustLineFlags::TrustlineClawbackEnabledFlag = 4` in rs-stellar-xdr matches upstream stellar-core `TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4`; the clawback check semantics are unchanged.

## Plan reference

Trivial short-circuit — implemented from the `## Implementation Notes` of the triage report on #3326 (no separate `/plan` stage).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-invariant
- [x] cargo test -p henyey-invariant (16 passed)

## Deviations from plan

None. Scope intentionally limited to the comment/constant; `LedgerEntryIsValid::new()` left untouched (coupled work tracked in #3327, serialized after this PR merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)