### PR TITLE
Narrow record module and types to crate-private in bucket

### DIFF
--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -110,7 +110,7 @@ mod manager;
 mod merge;
 mod merge_map;
 mod metrics;
-pub mod record;
+mod record;
 pub mod snapshot;
 
 // ============================================================================

--- a/crates/bucket/src/record.rs
+++ b/crates/bucket/src/record.rs
@@ -11,7 +11,7 @@ use crate::{BucketError, Result};
 
 #[derive(Debug)]
 #[allow(dead_code)]
-pub struct Record<'a> {
+pub(crate) struct Record<'a> {
     pub(crate) offset: u64,
     pub(crate) mark_bytes: [u8; 4],
     pub(crate) declared_len: usize,
@@ -21,7 +21,7 @@ pub struct Record<'a> {
 
 #[derive(Debug)]
 #[allow(dead_code)]
-pub struct SliceRecord<'a> {
+pub(crate) struct SliceRecord<'a> {
     pub(crate) offset: usize,
     pub(crate) mark_bytes: [u8; 4],
     pub(crate) declared_len: usize,


### PR DESCRIPTION
Closes #3322

## Summary

The `record` module in `crates/bucket` and its `Record` / `SliceRecord` types are declared `pub` but have zero out-of-crate consumers — all callers reference them via `crate::record::*` intra-crate (`git grep "henyey_bucket::record"` = 0). This narrows the public surface: `pub mod record` → private `mod record`, and `Record` / `SliceRecord` → `pub(crate)`. Behavior-preserving; net behavioral diff = 0.

## Plan reference

Trivial short-circuit (no separate plan stage). [Triage Report comment](https://github.com/stellar-experimental/henyey/issues/3322#issuecomment-4726615915).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-bucket` (548 tests, all pass)

## Deviations from plan

- `RecordMarkedReader` is kept `pub` rather than narrowed to `pub(crate)`. It is reachable through the public `HotArchiveIter::DiskBacked` enum variant field, so narrowing the struct alone trips the `private_interfaces` lint under `-D warnings`. `HotArchiveIter` is a genuinely public type returned by `pub fn iter`/`try_iter`, so narrowing it would be an out-of-scope public-API change. The triage notes flagged this exact case ("any `pub fn` returning these types that would then trip a private-in-public lint"). With the `record` module now private, `RecordMarkedReader` is unnameable externally regardless, so the effective external surface is still removed.
- `RecordMarkedSliceIter` was already `pub(crate)`; no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)