### PR TITLE
Part of #3319: fix clippy --all-targets in crate:common

### DIFF
--- a/crates/common/src/fs_utils.rs
+++ b/crates/common/src/fs_utils.rs
@@ -706,7 +706,7 @@ mod tests {
         let items: Vec<Result<Hash, TestError>> =
             vec![Ok(Hash([0u8; 32])), Ok(Hash([1u8; 32])), Err(TestError)];
 
-        let result = atomic_gzip_xdr_write_iter(&path, items.into_iter());
+        let result = atomic_gzip_xdr_write_iter(&path, items);
         assert!(result.is_err());
         assert!(!path.exists(), "final_path must not exist on error");
         assert_eq!(


### PR DESCRIPTION
Part of #3319

This is the **first of 6 serialized per-crate PRs** in the converged clippy-sweep plan. The parent issue #3319 stays open until all 6 crate PRs merge — this PR does **not** close it.

## Summary

Clears the only `cargo clippy -p henyey-common --all-targets -- -D warnings` finding: a redundant `.into_iter()` in the `fs_utils` test module (`clippy::useless_conversion`). The test passes a `Vec<Result<Hash, TestError>>` to `atomic_gzip_xdr_write_iter`, whose parameter already accepts any `IntoIterator`, so the explicit `.into_iter()` is a no-op. Removing it is behavior-preserving (net diff = 0); the site is under `#[cfg(test)]` and not compiled into the production binary.

No inner real conversions were touched — this `Vec` is already `IntoIterator`, so only the redundant outer conversion was removed.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3319#issuecomment-4726679091)

## Test plan

- [x] `cargo clippy -p henyey-common --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p henyey-common` — 38 passed, 0 failed
- [x] `cargo build --all` — finished

## Regression test

N/A — refactor (stylistic lint cleanup), net behavioral diff = 0. Per the converged plan, the per-crate clippy-clean gate is the verification; no new tests.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)