### PR TITLE
Part of #3319: fix clippy --all-targets in crate:db

### DIFF
--- a/crates/db/src/queries/ledger_close_meta.rs
+++ b/crates/db/src/queries/ledger_close_meta.rs
@@ -250,9 +250,9 @@ mod tests {
     #[test]
     fn test_bounded_range_excludes_oversized_second_row() {
         let conn = setup_db();
-        conn.store_ledger_close_meta(100, &vec![0u8; 100]).unwrap();
+        conn.store_ledger_close_meta(100, &[0u8; 100]).unwrap();
         conn.store_ledger_close_meta(101, &vec![1u8; 5000]).unwrap();
-        conn.store_ledger_close_meta(102, &vec![2u8; 100]).unwrap();
+        conn.store_ledger_close_meta(102, &[2u8; 100]).unwrap();
 
         // Budget of 200 → first row (100 B) included, second (5000 B) excluded.
         let results = conn


### PR DESCRIPTION
Part of #3319 — 2nd of 6 serialized per-crate clippy-sweep PRs. The parent issue stays open until all per-crate PRs merge; this PR intentionally does NOT close it.

## Summary

Clears the `cargo clippy -p henyey-db --all-targets -- -D warnings` failures in crate:db. The only live findings (re-discovered fresh; the issue's line numbers had drifted) were two `clippy::useless_vec` lints in a test in `crates/db/src/queries/ledger_close_meta.rs`. Both `&vec![…]` arguments were converted to slice literals (`&[…]`). Each site passes a `&[u8]` to `store_ledger_close_meta`, so the slice literal is value-identical — behavior-preserving, test-scope only.

```
-        conn.store_ledger_close_meta(100, &vec![0u8; 100]).unwrap();
+        conn.store_ledger_close_meta(100, &[0u8; 100]).unwrap();
...
-        conn.store_ledger_close_meta(102, &vec![2u8; 100]).unwrap();
+        conn.store_ledger_close_meta(102, &[2u8; 100]).unwrap();
```

Applied via `cargo clippy --fix` and hand-verified: net diff is exactly the two reported sites; no inner real conversion was stripped.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3319#issuecomment-4726679091)

## Test plan

- [x] `cargo clippy -p henyey-db --all-targets -- -D warnings` — clean
- [x] `cargo test -p henyey-db` — 109 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo build --all` — succeeds

## Deviations from plan

None.

## Parity

Stylistic lint only; zero observable-behavior change. The fixed sites are inside a `#[cfg(test)]` module and not compiled into the production binary. No stellar-core-mirrored path is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)