### PR TITLE
Remove dead new() impls on invariant unit structs

### DIFF
--- a/crates/invariant/src/entry_valid.rs
+++ b/crates/invariant/src/entry_valid.rs
@@ -21,12 +21,6 @@ use crate::{Invariant, OperationDelta};
 
 pub struct LedgerEntryIsValid;
 
-impl LedgerEntryIsValid {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 impl Invariant for LedgerEntryIsValid {
     fn name(&self) -> &str {
         "LedgerEntryIsValid"

--- a/crates/invariant/src/sponsorship.rs
+++ b/crates/invariant/src/sponsorship.rs
@@ -19,12 +19,6 @@ use crate::{Invariant, OperationDelta};
 
 pub struct SponsorshipCountIsValid;
 
-impl SponsorshipCountIsValid {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 /// Get the multiplier for sponsorship counting.
 /// Accounts count as 2 (account + base reserve), pool share trustlines as 2,
 /// claimable balances as claimant count, others as 1.

--- a/crates/invariant/src/sub_entries.rs
+++ b/crates/invariant/src/sub_entries.rs
@@ -20,12 +20,6 @@ use crate::{Invariant, OperationDelta};
 
 pub struct AccountSubEntriesCountIsValid;
 
-impl AccountSubEntriesCountIsValid {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
 /// Tracks the delta for a single account.
 #[derive(Default)]
 struct SubEntriesChange {


### PR DESCRIPTION
Closes #3327

## Summary

Removes the dead `pub fn new() -> Self` impls on the three invariant unit
structs `LedgerEntryIsValid` (`entry_valid.rs`), `SponsorshipCountIsValid`
(`sponsorship.rs`), and `AccountSubEntriesCountIsValid` (`sub_entries.rs`).
All three are registered as unit-struct literals in
`crates/app/src/app/mod.rs` (e.g. `Arc::new(henyey_invariant::LedgerEntryIsValid)`),
and a workspace-wide grep confirms zero `::new()` callers for any of them.
`ConservationOfLumens::new()` IS called (app registration + conservation tests)
and is deliberately left untouched. Pure dead-code removal — net behavioral
diff = 0 (18 deletions, no other changes).

## Plan reference

Trivial short-circuit per the `## Implementation Notes` in the [triage report](https://github.com/stellar-experimental/henyey/issues/3327).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (no `new_without_default` regressions)
- [x] `cargo build --all`
- [x] `cargo test -p henyey-invariant` passes (10 + 16 tests)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)