### PR TITLE
Part of #3319: fix clippy --all-targets in crate:scp

### DIFF
--- a/crates/scp/src/nomination.rs
+++ b/crates/scp/src/nomination.rs
@@ -1353,7 +1353,9 @@ mod tests {
             v_short.clone()
         ]));
         // Single element and empty are sorted-unique.
-        assert!(NominationProtocol::is_sorted_unique(&[v_short.clone()]));
+        assert!(NominationProtocol::is_sorted_unique(std::slice::from_ref(
+            &v_short
+        )));
         assert!(NominationProtocol::is_sorted_unique(&[]));
     }
 
@@ -3199,7 +3201,7 @@ mod tests {
         );
         // No record into latest_nominations (gate returns before record).
         assert!(
-            nom.latest_nominations.get(&node).is_none(),
+            !nom.latest_nominations.contains_key(&node),
             "non-sane self-statement must not be recorded"
         );
         // No promotion / state growth.


### PR DESCRIPTION
Part of #3319 (3rd of 6 serialized per-crate clippy PRs). Refs #3319 — does NOT close it; the parent stays open until all 6 per-crate PRs merge.

## Summary

Clears the two test-scope `cargo clippy --all-targets` failures in `crates/scp/src/nomination.rs` that fire under the workspace's `-D warnings` setting. Both sites are inside the `#[cfg(test)] mod tests` block (starting at L1213) and are not compiled into the production binary, so no live SCP nomination/ballot/quorum logic is touched. Behavior-preserving, net behavioral diff = 0.

Lints fixed (re-discovered via fresh `cargo clippy -p henyey-scp --all-targets`; line numbers had drifted from the issue audit):
- `clippy::cloned_ref_to_slice_refs` — `&[v_short.clone()]` → `std::slice::from_ref(&v_short)` (value-identical single-element slice, no clone)
- `clippy::unnecessary_get_then_check` — `get(&node).is_none()` → `!contains_key(&node)` (value-identical boolean, lookup-only)

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3319#issuecomment-4726679091)

## Test plan

- [x] `cargo clippy -p henyey-scp --all-targets -- -D warnings` clean
- [x] `cargo test -p henyey-scp` green (383 + 50 + 7 + 124 passed, 0 failed)
- [x] `cargo build --all` succeeds
- [x] `cargo fmt --check` clean

## Parity

Non-parity path. Both rewrites are value-identical and live entirely in test code; zero observable-behavior change vs stellar-core SCP. No live nomination/ballot/quorum logic modified.

## Deviations from plan

The plan flagged only the `get().is_none()` site. Fresh `--all-targets` clippy surfaced one additional test-scope lint (`cloned_ref_to_slice_refs` at the former L1356) — in-scope per the plan ("make `-p scp --all-targets` clean"; line drift implies the audit was slightly stale). Both cleared in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)