### PR TITLE
Part of #3319: fix clippy --all-targets in crate:simulation

### DIFF
--- a/crates/simulation/src/loadgen_soroban.rs
+++ b/crates/simulation/src/loadgen_soroban.rs
@@ -1415,7 +1415,7 @@ mod tests {
             .unwrap();
 
         // Hand-computed expected guest_cycles.
-        let num_entries = rw_entries + 0 + instance.read_only_keys.len() as u32; // = 4
+        let num_entries = rw_entries + instance.read_only_keys.len() as u32; // = 4
         let instructions_for_entries =
             205 * num_entries * num_entries + 12_000 * num_entries + 65_485;
         let entries_write_size = 0u32; // data_entry_size = 0


### PR DESCRIPTION
Part of stellar-experimental/henyey#3319 (4th of 6 serialized per-crate clippy PRs). This intentionally does NOT close the parent tracking issue — it stays open until all per-crate PRs merge.

## Summary

Clears the sole `cargo clippy -p henyey-simulation --all-targets -- -D warnings` finding: a `clippy::identity_op` (`+ 0`) in the `loadgen_soroban` test's hand-computed `num_entries` formula. The `+ 0` was a leftover placeholder term; removing it is value-identical (`x + 0 == x`) and behavior-preserving. Net behavioral diff = 0.

## Plan reference

Converged Plan comment: https://github.com/stellar-experimental/henyey/issues/3319#issuecomment-4726679091

## Test plan

- [x] `cargo clippy -p henyey-simulation --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p henyey-simulation` — green (2 + 10 tests pass)
- [x] `cargo build --all` — green

## Deviations from plan

None. The plan-flagged `+ 0` finding was re-discovered via fresh clippy (line had drifted to 1418) and fixed exactly as reported via `--fix`, hand-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)