### PR TITLE
Part of #3319: fix clippy --all-targets in crate:app

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -7362,7 +7362,7 @@ mod tests {
             .await;
 
         // Assert that set_trusted_scp_anchor was actually called with expected values.
-        let installed = app.last_installed_scp_anchor.lock().unwrap().clone();
+        let installed = *app.last_installed_scp_anchor.lock().unwrap();
         assert_eq!(
             installed,
             Some((target_ledger, expected_prev_hash)),
@@ -7426,7 +7426,7 @@ mod tests {
             .await;
 
         // The anchor must NOT have been installed for OfflineBasic.
-        let installed = app.last_installed_scp_anchor.lock().unwrap().clone();
+        let installed = *app.last_installed_scp_anchor.lock().unwrap();
         assert_eq!(
             installed, None,
             "Offline catchup must NOT call set_trusted_scp_anchor() even when \

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -3901,7 +3901,7 @@ mod publish_skip_marker_tests {
     }
 
     fn run_consumer(db: &Database, closing_seq: u32) -> bool {
-        db.transaction(|conn| Ok(consume_skip_marker_if_matches(conn, closing_seq)?))
+        db.transaction(|conn| consume_skip_marker_if_matches(conn, closing_seq))
             .unwrap()
     }
 
@@ -3926,7 +3926,7 @@ mod publish_skip_marker_tests {
             c.set_state(state_keys::PUBLISH_SKIP_FIRST_CHECKPOINT, "not-a-number")
         })
         .unwrap();
-        let res = db.transaction(|conn| Ok(consume_skip_marker_if_matches(conn, 127)?));
+        let res = db.transaction(|conn| consume_skip_marker_if_matches(conn, 127));
         match res {
             Err(henyey_db::DbError::Integrity(msg)) => {
                 assert!(

--- a/crates/app/src/app/persist.rs
+++ b/crates/app/src/app/persist.rs
@@ -741,16 +741,15 @@ mod tests {
             // Clone db for the write_fn closure (it receives &Database from
             // run_blocking, but we need our handle for assertions later).
             let db_for_write = db.clone();
-            let write_fn: Box<dyn FnOnce(&Database) -> anyhow::Result<()> + Send> =
-                Box::new(move |db| {
-                    use henyey_db::queries::*;
-                    db.with_connection(|conn| {
-                        conn.store_ledger_header(&header, &header_xdr)?;
-                        conn.set_last_closed_ledger(test_seq)?;
-                        Ok(())
-                    })
-                    .map_err(|e| anyhow::anyhow!(e))
-                });
+            let write_fn: PersistWriteFn = Box::new(move |db| {
+                use henyey_db::queries::*;
+                db.with_connection(|conn| {
+                    conn.store_ledger_header(&header, &header_xdr)?;
+                    conn.set_last_closed_ledger(test_seq)?;
+                    Ok(())
+                })
+                .map_err(|e| anyhow::anyhow!(e))
+            });
 
             let job = PersistJob::LedgerClose {
                 write_fn,

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -3627,8 +3627,7 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
 
     #[test]
     fn test_translate_surveyor_keys() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/stellar-core.db"
             UNSAFE_QUORUM = true
@@ -3637,7 +3636,7 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
                 "GCGB2S2KBER5MNQNJTNF5N3Y4PEPFMHONPIGXNOYIREMYCMJZ3GAVDXQ"
             ]
             "#
-        );
+        .to_string();
         let app_config = translate(&cfg).unwrap();
         assert_eq!(app_config.overlay.surveyor_keys.len(), 2);
         assert_eq!(
@@ -3652,28 +3651,26 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
 
     #[test]
     fn test_translate_surveyor_keys_empty() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/stellar-core.db"
             UNSAFE_QUORUM = true
             SURVEYOR_KEYS = []
             "#
-        );
+        .to_string();
         let app_config = translate(&cfg).unwrap();
         assert!(app_config.overlay.surveyor_keys.is_empty());
     }
 
     #[test]
     fn test_translate_surveyor_keys_rejects_non_string() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/stellar-core.db"
             UNSAFE_QUORUM = true
             SURVEYOR_KEYS = ["GDEX3JU2AUGVPQFGFKMEOGHEUQ4YGRIYDJIKQSC7QLHAJ4RV63MJKGAS", 42]
             "#
-        );
+        .to_string();
         let err = translate(&cfg).unwrap_err();
         assert!(
             err.to_string().contains("SURVEYOR_KEYS[1]"),
@@ -3684,14 +3681,13 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
 
     #[test]
     fn test_translate_surveyor_keys_rejects_non_array() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/stellar-core.db"
             UNSAFE_QUORUM = true
             SURVEYOR_KEYS = "GDEX3JU2AUGVPQFGFKMEOGHEUQ4YGRIYDJIKQSC7QLHAJ4RV63MJKGAS"
             "#
-        );
+        .to_string();
         let err = translate(&cfg).unwrap_err();
         assert!(
             err.to_string().contains("SURVEYOR_KEYS: expected array"),
@@ -3702,8 +3698,7 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
 
     #[test]
     fn test_translate_preferred_peer_keys() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/core.db"
             HTTP_PORT = 11626
@@ -3714,7 +3709,7 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
             ]
             PREFERRED_PEERS_ONLY = true
             "#
-        );
+        .to_string();
         let config = translate(&cfg).unwrap();
         assert_eq!(config.overlay.preferred_peer_keys.len(), 2);
         assert!(config
@@ -3730,15 +3725,14 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
 
     #[test]
     fn test_translate_preferred_peer_keys_invalid_element() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/core.db"
             HTTP_PORT = 11626
             UNSAFE_QUORUM = true
             PREFERRED_PEER_KEYS = ["valid-string", 42]
             "#
-        );
+        .to_string();
         let err = translate(&cfg).unwrap_err();
         assert!(
             err.to_string().contains("PREFERRED_PEER_KEYS[1]"),
@@ -3749,15 +3743,14 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
 
     #[test]
     fn test_translate_preferred_peers_only_wrong_type() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/core.db"
             HTTP_PORT = 11626
             UNSAFE_QUORUM = true
             PREFERRED_PEERS_ONLY = "yes"
             "#
-        );
+        .to_string();
         let err = translate(&cfg).unwrap_err();
         assert!(
             err.to_string().contains("PREFERRED_PEERS_ONLY"),
@@ -3768,14 +3761,13 @@ NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
 
     #[test]
     fn test_translate_preferred_peers_only_default_false() {
-        let cfg = format!(
-            r#"
+        let cfg = r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
             DATABASE = "sqlite3:///tmp/core.db"
             HTTP_PORT = 11626
             UNSAFE_QUORUM = true
             "#
-        );
+        .to_string();
         let config = translate(&cfg).unwrap();
         assert!(!config.overlay.preferred_peers_only);
         assert!(config.overlay.preferred_peer_keys.is_empty());


### PR DESCRIPTION
Part of #3319 (6th and last of 6 serialized per-crate clippy PRs). This PR does **not** close the parent issue — #3319 stays open until all per-crate PRs merge.

## Summary

Clears the test-scope `cargo clippy -p henyey-app --all-targets -- -D warnings` failures in crate:app. All 13 findings are in `#[cfg(test)]` modules; net behavioral diff = 0, no live event-loop/consensus logic touched.

- **8× `useless_format`** in `compat_config.rs`: drop no-arg `format!(r#"…"#)` → `r#"…"#.to_string()` (no interpolation args, value-identical).
- **2× `clone_on_copy`** in `catchup_impl.rs`: `*guard` copy of `Copy` `Option<(u32, Hash256)>` instead of `.clone()`.
- **2× `needless_question_mark`** in `ledger_close.rs`: `Ok(consume_skip_marker_if_matches(conn, …)?)` → `consume_skip_marker_if_matches(conn, …)` (closure return type unchanged; compiles clean).
- **1× `type_complexity`** in `persist.rs`: reuse the existing `PersistWriteFn` type alias (identical type to the `PersistJob::write_fn` field) instead of spelling the boxed `FnOnce` inline.

The 3× `await_holding_lock` items from the original audit are already fixed on main (#3333) — not re-touched, and clippy no longer flags them.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3319#issuecomment-4726679091)

## Test plan

- [x] `cargo clippy -p henyey-app --all-targets -- -D warnings` — clean (exit 0)
- [x] `cargo test -p henyey-app` — green (1071 + integration/doc tests, 0 failed)
- [x] `cargo build --all` — clean
- [x] `cargo fmt` — clean

## Deviations from plan

For `type_complexity`, the plan said to hand-author a `type` alias. There is already an identical, purpose-built `PersistWriteFn` alias at `persist.rs:227` (used by the production `PersistJob::write_fn` field), so the test now reuses it rather than introducing a duplicate alias. Type is identical; zero codegen difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)