### PR TITLE
Narrow SEALED_BOX_OVERHEAD and drop no-op map_err in crate:crypto

### DIFF
--- a/crates/crypto/src/sealed_box.rs
+++ b/crates/crypto/src/sealed_box.rs
@@ -62,7 +62,7 @@ use crate::CryptoError;
 use crate::{PublicKey as EdPublicKey, SecretKey as EdSecretKey};
 
 /// Overhead added to plaintext: 32-byte ephemeral public key + 16-byte Poly1305 tag.
-pub const SEALED_BOX_OVERHEAD: usize = 32 + 16;
+pub(crate) const SEALED_BOX_OVERHEAD: usize = 32 + 16;
 
 /// Performs X25519 DH, checks the result is contributory, and derives the
 /// XSalsa20 symmetric key via HSalsa20 (standard NaCl crypto_box key derivation).
@@ -163,10 +163,9 @@ pub fn seal_to_curve25519_public_key(
     recipient: &[u8; 32],
     plaintext: &[u8],
 ) -> Result<Vec<u8>, CryptoError> {
-    seal(recipient, plaintext).map_err(|e| match e {
-        CryptoError::SmallOrderPublicKey => CryptoError::SmallOrderPublicKey,
-        _ => CryptoError::EncryptionFailed,
-    })
+    // `seal` already returns the exact error variants this function documents
+    // (`SmallOrderPublicKey` or `EncryptionFailed`), so no remapping is needed.
+    seal(recipient, plaintext)
 }
 
 /// Decrypts a sealed payload using the recipient's Ed25519 secret key.


### PR DESCRIPTION
Closes #3355

## Summary

Two behavior-neutral cleanups in `crates/crypto/src/sealed_box.rs`:

1. **Narrow `SEALED_BOX_OVERHEAD`** from `pub const` to `pub(crate) const`. Workspace grep confirms zero consumers outside `crate:crypto` (only the definition, one production length check, and three test references — all in `sealed_box.rs`). Although `lib.rs` glob-re-exports the module (`pub use sealed_box::*;`), nothing external uses the constant, so narrowing the visibility is safe.
2. **Drop the no-op `map_err`** in `seal_to_curve25519_public_key`. The closure mapped `SmallOrderPublicKey => SmallOrderPublicKey` and `_ => EncryptionFailed`. `seal()` can only return those two variants (`SmallOrderPublicKey` via `derive_shared_key?`, `EncryptionFailed` via the inner `encrypt` map_err), so the remap is a pure identity. Removing it changes no observable error value or type — the function still returns `Result<Vec<u8>, CryptoError>` with identical variants.

## Plan reference

[Triage Report / Implementation Notes](https://github.com/stellar-experimental/henyey/issues/3355#issuecomment-4732289957)

## Parity

Crypto primitives unchanged. The `map_err` removal is verified behavior-neutral: same error variants, same type, same values. No protocol-observable behavior changes.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build --all`
- [x] `cargo clippy --all -- -D warnings` (exit 0)
- [x] `cargo test -p henyey-crypto` — 82 unit + 10 doc-tests pass

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)