### PR TITLE
Narrow visibility of internal history helpers

### DIFF
--- a/crates/history/src/cdp.rs
+++ b/crates/history/src/cdp.rs
@@ -857,7 +857,7 @@ pub fn extract_transaction_processing(
 
 /// Build a map from transaction hash to envelope for matching.
 /// This version uses the network-aware hash (network_id || ENVELOPE_TYPE || tx).
-pub fn build_tx_hash_map_with_network(
+fn build_tx_hash_map_with_network(
     txs: &[stellar_xdr::curr::TransactionEnvelope],
     network_id: &Hash,
 ) -> std::collections::HashMap<Hash, stellar_xdr::curr::TransactionEnvelope> {
@@ -910,7 +910,7 @@ pub fn extract_transaction_results(
 ///
 /// Returns either a Classic TransactionSet (V0) or Generalized set (V1/V2).
 /// This is useful for passing to `close_ledger` when replaying from CDP.
-pub fn extract_transaction_set(meta: &LedgerCloseMeta) -> henyey_ledger::TransactionSetVariant {
+fn extract_transaction_set(meta: &LedgerCloseMeta) -> henyey_ledger::TransactionSetVariant {
     use henyey_ledger::TransactionSetVariant;
     match meta {
         LedgerCloseMeta::V0(v0) => TransactionSetVariant::Classic(v0.tx_set.clone()),

--- a/crates/history/src/ledger_apply_manager.rs
+++ b/crates/history/src/ledger_apply_manager.rs
@@ -25,8 +25,7 @@
 use std::collections::BTreeMap;
 
 use crate::checkpoint::{
-    checkpoint_frequency, checkpoint_start, first_ledger_after_checkpoint_containing,
-    is_checkpoint_start,
+    checkpoint_start, first_ledger_after_checkpoint_containing, is_checkpoint_start,
 };
 
 /// Maximum allowed drift, in ledgers, between the next ledger queued for
@@ -188,13 +187,6 @@ pub fn trim_boundary_for_last_buffered(last_buffered: u32) -> Option<u32> {
     }
 }
 
-/// The §7.1(c) buffer-size invariant bound: at most one full checkpoint plus the
-/// following checkpoint's first ledger.
-#[inline]
-pub fn max_buffer_invariant_entries() -> usize {
-    (checkpoint_frequency() + 1) as usize
-}
-
 /// The §7.2 buffered-catchup *trigger* decision over the syncing buffer's span.
 ///
 /// This is distinct from [`ProcessLedgerDecision`] (the §7.2 step-3/5/6
@@ -313,7 +305,9 @@ mod tests {
     fn trim_buffer_respects_invariant() {
         let mut buf: BTreeMap<u32, ()> = (10u32..=192).map(|s| (s, ())).collect();
         trim_syncing_buffer(&mut buf, 9);
-        assert!(buf.len() <= max_buffer_invariant_entries());
+        // §7.1(c) buffer-size invariant bound: at most one full checkpoint plus
+        // the following checkpoint's first ledger.
+        assert!(buf.len() <= (crate::checkpoint::checkpoint_frequency() + 1) as usize);
         assert_eq!(*buf.keys().next().unwrap(), 128);
     }
 

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -165,8 +165,8 @@ pub use error::{
 };
 pub use ledger_apply_manager::{
     apply_drift_exceeded, classify_buffered_catchup_trigger, classify_process_ledger,
-    max_buffer_invariant_entries, trim_boundary_for_last_buffered, trim_syncing_buffer,
-    BufferedCatchupTrigger, ProcessLedgerDecision, MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT,
+    trim_boundary_for_last_buffered, trim_syncing_buffer, BufferedCatchupTrigger,
+    ProcessLedgerDecision, MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT,
 };
 pub use paths::{
     bucket_path, checkpoint_path, checkpoint_path_dirty, dirty_to_final_path, final_to_dirty_path,


### PR DESCRIPTION
Closes #3359

## Summary

Behavior-neutral visibility narrowing in `crate:history` (two findings, triage-confirmed intact through the #3338 dead-fn purge):

- `crates/history/src/cdp.rs`: drop `pub` from `build_tx_hash_map_with_network` and `extract_transaction_set`. Both are module-internal helpers (sole callers in the same module: cdp.rs:747 and cdp.rs:949) with no cross-crate consumers; cdp.rs is a Rust-native helper module (not parity-mapped).
- `crates/history/src/ledger_apply_manager.rs` + `lib.rs`: `max_buffer_invariant_entries` had exactly one `#[cfg(test)]` caller plus a `pub use` re-export and no non-test callers. Downgrading to `pub(crate)` left it dead in non-test builds (`-D dead-code`), so per the plan's explicit alternative the helper is removed: the `checkpoint_frequency() + 1` bound is inlined into the test assertion (with the §7.1(c) invariant comment preserved) and the `lib.rs` re-export is dropped.

Net behavioral diff = 0. History catchup/replay logic is untouched (visibility only).

## Plan reference

Trivial short-circuit — no separate `/plan`. [Triage Report (Implementation Notes)](https://github.com/stellar-experimental/henyey/issues/3359#issuecomment-4732315339).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all
- [x] cargo test -p henyey-history (558 lib tests pass, incl. `trim_buffer_respects_invariant`)

## Deviations from plan

The plan offered two routes for `max_buffer_invariant_entries`: (a) `pub(crate)`, or (b) inline + delete (implementer's choice). Route (a) fails the workspace build under `-D dead-code` because the function has no non-test callers, so route (b) — the plan's documented alternative — was taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)