### PR TITLE
Narrow internal metrics types in crate:app to pub(crate)

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -3230,7 +3230,7 @@ impl App {
     }
 
     /// Overlay connection breakdown by direction and state.
-    pub async fn overlay_connection_breakdown(
+    pub(crate) async fn overlay_connection_breakdown(
         &self,
     ) -> Option<crate::app::types::ConnectionBreakdown> {
         let overlay = self.overlay.read().await;
@@ -3246,7 +3246,7 @@ impl App {
     }
 
     /// Quorum health summary (None when not tracking).
-    pub fn quorum_health(&self) -> Option<crate::app::types::QuorumHealthMetrics> {
+    pub(crate) fn quorum_health(&self) -> Option<crate::app::types::QuorumHealthMetrics> {
         let (agree, missing, disagree, fail_at, delayed) = self.herder.quorum_health()?;
         Some(crate::app::types::QuorumHealthMetrics {
             agree,
@@ -3271,7 +3271,7 @@ impl App {
     }
 
     /// SCP timing for the most recently externalized slot.
-    pub fn scp_timing(&self) -> Option<crate::app::types::ScpTimingMetrics> {
+    pub(crate) fn scp_timing(&self) -> Option<crate::app::types::ScpTimingMetrics> {
         let snapshot = self.herder.scp_timing()?;
         Some(crate::app::types::ScpTimingMetrics {
             externalize_duration_secs: Some(snapshot.externalize_duration.as_secs_f64()),

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -443,43 +443,43 @@ pub struct ScpVerifyMetrics {
 
 /// Overlay connection breakdown by direction and state.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ConnectionBreakdown {
-    pub inbound_authenticated: u64,
-    pub outbound_authenticated: u64,
-    pub inbound_pending: u64,
-    pub outbound_pending: u64,
+pub(crate) struct ConnectionBreakdown {
+    pub(crate) inbound_authenticated: u64,
+    pub(crate) outbound_authenticated: u64,
+    pub(crate) inbound_pending: u64,
+    pub(crate) outbound_pending: u64,
 }
 
 /// Quorum health summary for metrics.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct QuorumHealthMetrics {
+pub(crate) struct QuorumHealthMetrics {
     /// Nodes in Confirming or Externalized state.
-    pub agree: u64,
+    pub(crate) agree: u64,
     /// Nodes in Missing state.
-    pub missing: u64,
+    pub(crate) missing: u64,
     /// Nodes disagreeing (placeholder — not yet detectable from QuorumInfo).
-    pub disagree: u64,
+    pub(crate) disagree: u64,
     /// Minimum nodes that can fail before quorum is lost, computed via
     /// `find_closest_v_blocking` (excludes self). More precise than
     /// `total - threshold` for nested quorum sets.
-    pub fail_at: u64,
+    pub(crate) fail_at: u64,
     /// Nodes that are participating but lagging behind the local node's
     /// latest ledger. A subset of `agree` (delayed peers count as agreeing).
-    pub delayed: u64,
+    pub(crate) delayed: u64,
 }
 
 /// SCP timing for the most recently externalized slot.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ScpTimingMetrics {
+pub(crate) struct ScpTimingMetrics {
     /// Duration from slot creation to externalize (seconds).
-    pub externalize_duration_secs: Option<f64>,
+    pub(crate) externalize_duration_secs: Option<f64>,
     /// Duration from first local nomination vote to ballot protocol start (seconds).
     /// Matches stellar-core's `mNominateToPrepare`.
     /// None if either nomination start or ballot start was not recorded for this slot.
-    pub nomination_duration_secs: Option<f64>,
+    pub(crate) nomination_duration_secs: Option<f64>,
     /// Duration from first EXTERNALIZE seen (any node) to self-externalize (seconds).
     /// None on catchup/fast-forward paths where no externalize events were recorded.
-    pub first_to_self_externalize_secs: Option<f64>,
+    pub(crate) first_to_self_externalize_secs: Option<f64>,
 }
 
 impl std::fmt::Display for AppInfo {


### PR DESCRIPTION
Closes #3352

## Summary

Narrows three internal metrics structs in `crates/app/src/app/types.rs` from `pub` to `pub(crate)` (structs and fields): `ConnectionBreakdown`, `QuorumHealthMetrics`, and `ScpTimingMetrics`. Their three crate-internal `App` accessors (`overlay_connection_breakdown`, `quorum_health`, `scp_timing`) are narrowed to `pub(crate)` to match, since a `pub fn` returning a `pub(crate)` type trips the `private_interfaces` lint under `-D warnings`. All three types are produced and consumed entirely within `crates/app/src/metrics.rs` — zero external consumers. Behavior-neutral.

## Plan reference

Trivial short-circuit (Triage Report ACCEPT, size S). See issue #3352.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (clean)
- [x] `cargo build --all` (clean — proves no external references to the narrowed types/accessors, including crates/rpc)
- [x] `cargo test -p henyey-app` passes

## Deviations from plan

The plan named **four** structs. Three were narrowed; **`OverlayFetchChannelMetrics` was intentionally left `pub`** because it is genuinely part of the public API surface:

- It is the type of the **public field** `AppInfo.overlay_fetch_channel` (and `AppMetricsSnapshot.overlay_fetch_channel`).
- `AppInfo` is constructed **externally** by `crates/rpc` (`crates/rpc/tests/common/fake_app.rs` uses `..AppInfo::test_default()` struct-update syntax). Struct-update across crates requires every `..`-filled field to be visible at the use site, so narrowing `overlay_fetch_channel` to `pub(crate)` would fail to compile `crates/rpc`.

Narrowing `OverlayFetchChannelMetrics` is therefore **not** behavior-neutral and would require expanding scope to a public-API change on `AppInfo`/`AppMetricsSnapshot`. That is out of scope for this S-sized, behavior-neutral change. The triage re-confirmation checked for *direct named* references but missed this indirect public exposure via a struct field plus cross-crate struct-update construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)