### PR TITLE
Dedup download tuning constants into henyey-common

### DIFF
--- a/crates/common/src/history_download.rs
+++ b/crates/common/src/history_download.rs
@@ -1,0 +1,15 @@
+//! Shared tuning constants for history-archive downloads.
+//!
+//! These values govern the concurrency and progress-logging cadence of
+//! history-archive download work (bucket downloads, checkpoint fetches, and
+//! catchup downloads). They live here as a single source of truth so a future
+//! upstream change only requires one edit; previously the same values were
+//! duplicated across `henyey-historywork`, `henyey-history`, and the `henyey`
+//! binary.
+
+/// Maximum number of concurrent download requests, mirroring stellar-core's
+/// `MAX_CONCURRENT_SUBPROCESSES` limit.
+pub const MAX_CONCURRENT_DOWNLOADS: usize = 16;
+
+/// Log download progress every N items (and always on the last item).
+pub const PROGRESS_REPORT_INTERVAL: u32 = 5;

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -55,6 +55,7 @@ pub mod config;
 pub mod error;
 pub mod fs_utils;
 pub mod header_validation;
+pub mod history_download;
 pub mod ledger_type_utils;
 pub mod math;
 pub mod memory;

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -2892,10 +2892,10 @@ async fn download_buckets_parallel(
     hashes: Vec<&henyey_common::Hash256>,
 ) -> anyhow::Result<(usize, usize)> {
     use futures::stream::{self, StreamExt};
+    use henyey_common::history_download::MAX_CONCURRENT_DOWNLOADS;
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicU32, Ordering};
 
-    const MAX_CONCURRENT_DOWNLOADS: usize = 16;
     const MAX_CONCURRENT_LOADS: usize = 4;
 
     let total_count = hashes.len();

--- a/crates/history/src/catchup/download.rs
+++ b/crates/history/src/catchup/download.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use henyey_bucket::canonical_bucket_filename;
 use henyey_common::fs_utils::atomic_write_bytes;
+use henyey_common::history_download::{MAX_CONCURRENT_DOWNLOADS, PROGRESS_REPORT_INTERVAL};
 use henyey_common::protocol::LclContext;
 use henyey_common::Hash256;
 use std::collections::HashMap;
@@ -18,13 +19,6 @@ use stellar_xdr::curr::{
 use tracing::{debug, info, warn};
 
 use super::{CatchupManager, LedgerData};
-
-/// Maximum number of concurrent bucket downloads, mirroring stellar-core's
-/// `MAX_CONCURRENT_SUBPROCESSES`.
-pub(super) const MAX_CONCURRENT_DOWNLOADS: usize = 16;
-
-/// Log download progress every N items (and always on the last item).
-const PROGRESS_REPORT_INTERVAL: u32 = 5;
 
 /// Run a future to completion from a synchronous context.
 ///

--- a/crates/historywork/src/download.rs
+++ b/crates/historywork/src/download.rs
@@ -12,6 +12,7 @@ use futures::stream::{self, StreamExt};
 
 use henyey_bucket::canonical_bucket_filename;
 use henyey_common::fs_utils::atomic_write_bytes;
+use henyey_common::history_download::{MAX_CONCURRENT_DOWNLOADS, PROGRESS_REPORT_INTERVAL};
 use henyey_common::Hash256;
 use henyey_history::{archive::HistoryArchive, archive_state::HistoryArchiveState, verify};
 use henyey_ledger::TransactionSetVariant;
@@ -19,13 +20,6 @@ use henyey_work::{Work, WorkContext, WorkOutcome};
 use stellar_xdr::curr::{LedgerHeaderHistoryEntry, TransactionHistoryEntryExt, WriteXdr};
 
 use crate::{set_progress, HistoryWorkStage, SharedHistoryState};
-
-/// Maximum number of concurrent download requests, matching stellar-core's
-/// `MAX_CONCURRENT_SUBPROCESSES` limit.
-pub(crate) const MAX_CONCURRENT_DOWNLOADS: usize = 16;
-
-/// Log download progress every N items (and always on the last item).
-const PROGRESS_REPORT_INTERVAL: u32 = 5;
 
 // ============================================================================
 // Work Items


### PR DESCRIPTION
Closes #3360

## Summary

The download-tuning constants `MAX_CONCURRENT_DOWNLOADS` (`16`) and `PROGRESS_REPORT_INTERVAL` (`5`) were duplicated across three locations (`henyey-historywork`, `henyey-history`, and the `henyey` binary), all mirroring stellar-core's `MAX_CONCURRENT_SUBPROCESSES`. This PR hoists them into a single canonical home — a new `henyey_common::history_download` module — and re-imports them at each site via a qualified `use`. A future upstream value change now needs only one edit. Behavior-neutral: every site already held the identical values feeding the same `buffer_unordered` concurrency and progress-log cadence, so net diff = 0.

Carve-outs left untouched per the plan: `main.rs` `MAX_CONCURRENT_LOADS = 4` (distinct constant) and `main.rs` bare literal `% 5` (not the named constant).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3360#issuecomment-4732708337)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all
- [x] cargo test -p henyey-historywork passes
- [x] cargo test -p henyey-history passes

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)