### PR TITLE
Deduplicate RPC handler boilerplate via param_object_or_null helper

### DIFF
--- a/crates/rpc/src/methods/get_events.rs
+++ b/crates/rpc/src/methods/get_events.rs
@@ -37,9 +37,7 @@ pub async fn handle(
     let (event_type, contract_ids, topic_filters) = parse_event_filters(filters_array)?;
 
     // Parse pagination
-    let pagination = util::param_object(&params, "pagination")?;
-    let empty_obj = serde_json::Value::Null;
-    let pag = pagination.unwrap_or(&empty_obj);
+    let pag = util::param_object_or_null(&params, "pagination")?;
     let limit = util::param_u32(pag, "limit")?
         .map(|v| v as u64)
         .unwrap_or(DEFAULT_EVENTS_LIMIT)
@@ -159,14 +157,16 @@ pub async fn handle(
 
     let last_cursor = events.last().map(|e| e.id.as_str()).unwrap_or("");
 
-    let mut result = json!({
-        "events": event_json,
-        "cursor": last_cursor,
-    });
-    lctx.insert_json_fields(result.as_object_mut().unwrap());
+    let mut result = serde_json::Map::new();
+    result.insert("events".into(), json!(event_json));
+    result.insert("cursor".into(), json!(last_cursor));
+    lctx.insert_json_fields(&mut result);
     // get_events formats oldestLedgerCloseTime as ISO 8601 (unlike other handlers)
-    result["oldestLedgerCloseTime"] = json!(format_unix_timestamp_utc(lctx.oldest_close_time));
-    Ok(result)
+    result.insert(
+        "oldestLedgerCloseTime".into(),
+        json!(format_unix_timestamp_utc(lctx.oldest_close_time)),
+    );
+    Ok(serde_json::Value::Object(result))
 }
 
 /// Maximum number of filters allowed per request.

--- a/crates/rpc/src/methods/get_ledgers.rs
+++ b/crates/rpc/src/methods/get_ledgers.rs
@@ -27,9 +27,7 @@ pub async fn handle(
     // Parse parameters
     let start_ledger = util::param_u32(&params, "startLedger")?;
 
-    let pagination = util::param_object(&params, "pagination")?;
-    let empty_obj = serde_json::Value::Null;
-    let pag = pagination.unwrap_or(&empty_obj);
+    let pag = util::param_object_or_null(&params, "pagination")?;
     let cursor_str = util::param_str(pag, "cursor")?;
     let limit = util::param_u32(pag, "limit")?;
 
@@ -94,12 +92,11 @@ pub async fn handle(
         ledgers.push(serde_json::Value::Object(obj));
     }
 
-    let mut result = json!({
-        "ledgers": ledgers,
-        "cursor": last_cursor
-    });
-    lctx.insert_json_fields(result.as_object_mut().unwrap());
-    Ok(result)
+    let mut result = serde_json::Map::new();
+    result.insert("ledgers".into(), json!(ledgers));
+    result.insert("cursor".into(), json!(last_cursor));
+    lctx.insert_json_fields(&mut result);
+    Ok(serde_json::Value::Object(result))
 }
 
 /// Validate getLedgers pagination. Cursor is a plain ledger sequence.

--- a/crates/rpc/src/methods/get_transaction.rs
+++ b/crates/rpc/src/methods/get_transaction.rs
@@ -74,9 +74,10 @@ pub async fn handle(
             Ok(serde_json::Value::Object(obj))
         }
         None => {
-            let mut result = json!({ "status": "NOT_FOUND" });
-            lctx.insert_json_fields(result.as_object_mut().unwrap());
-            Ok(result)
+            let mut result = serde_json::Map::new();
+            result.insert("status".into(), json!("NOT_FOUND"));
+            lctx.insert_json_fields(&mut result);
+            Ok(serde_json::Value::Object(result))
         }
     }
 }

--- a/crates/rpc/src/methods/get_transactions.rs
+++ b/crates/rpc/src/methods/get_transactions.rs
@@ -41,9 +41,7 @@ pub async fn handle(
     // Parse parameters
     let start_ledger = util::param_u32(&params, "startLedger")?;
 
-    let pagination = util::param_object(&params, "pagination")?;
-    let empty_obj = serde_json::Value::Null;
-    let pag = pagination.unwrap_or(&empty_obj);
+    let pag = util::param_object_or_null(&params, "pagination")?;
     let cursor = util::param_str(pag, "cursor")?;
     let limit = util::param_u32(pag, "limit")?;
 
@@ -153,10 +151,9 @@ pub async fn handle(
         })
         .unwrap_or_default();
 
-    let mut result = serde_json::json!({
-        "transactions": transactions,
-        "cursor": last_cursor
-    });
-    lctx.insert_json_fields(result.as_object_mut().unwrap());
-    Ok(result)
+    let mut result = serde_json::Map::new();
+    result.insert("transactions".into(), serde_json::json!(transactions));
+    result.insert("cursor".into(), serde_json::json!(last_cursor));
+    lctx.insert_json_fields(&mut result);
+    Ok(serde_json::Value::Object(result))
 }

--- a/crates/rpc/src/simulate/mod.rs
+++ b/crates/rpc/src/simulate/mod.rs
@@ -391,9 +391,7 @@ pub async fn handle(
     let auth_mode_str = util::param_str(&params, "authMode")?.unwrap_or("");
 
     // Parse resourceConfig parameter
-    let resource_config = util::param_object(&params, "resourceConfig")?;
-    let empty_obj = serde_json::Value::Null;
-    let rc = resource_config.unwrap_or(&empty_obj);
+    let rc = util::param_object_or_null(&params, "resourceConfig")?;
     let instruction_leeway: u32 = util::param_u32(rc, "instructionLeeway")?.unwrap_or(0);
 
     let sim = SimulationContext::from_app(&*ctx.app).await?;

--- a/crates/rpc/src/util.rs
+++ b/crates/rpc/src/util.rs
@@ -301,6 +301,17 @@ pub(crate) fn param_object<'a>(
     }
 }
 
+/// Like [`param_object`], but returns a borrowable `&Value` even when the key
+/// is absent/null — falls back to a static `Null` so callers can read sub-keys
+/// uniformly. A present-but-non-object value still returns `invalid_params`.
+pub(crate) fn param_object_or_null<'a>(
+    params: &'a serde_json::Value,
+    key: &str,
+) -> Result<&'a serde_json::Value, JsonRpcError> {
+    const NULL: serde_json::Value = serde_json::Value::Null;
+    Ok(param_object(params, key)?.unwrap_or(&NULL))
+}
+
 /// Validate that the top-level params value is an object (or null, treated as empty object).
 /// Returns `Err(invalid_params)` if params is an array, string, number, or bool.
 pub(crate) fn require_params_object(params: &serde_json::Value) -> Result<(), JsonRpcError> {
@@ -895,6 +906,27 @@ mod tests {
         assert_eq!(toid_parse_cursor(&s).unwrap(), toid);
 
         assert!(toid_parse_cursor("not_a_number").is_err());
+    }
+
+    #[test]
+    fn test_param_object_or_null() {
+        // Absent key → static Null.
+        let params = serde_json::json!({});
+        assert_eq!(
+            param_object_or_null(&params, "pagination").unwrap(),
+            &serde_json::Value::Null
+        );
+
+        // Present object → that object.
+        let params = serde_json::json!({ "pagination": { "limit": 10 } });
+        assert_eq!(
+            param_object_or_null(&params, "pagination").unwrap(),
+            &serde_json::json!({ "limit": 10 })
+        );
+
+        // Present non-object → invalid_params.
+        let params = serde_json::json!({ "pagination": "oops" });
+        assert!(param_object_or_null(&params, "pagination").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes #3364

## Summary

Behavior-neutral cleanup of two repeated idioms in the crate:rpc method handlers. (1) The `empty_obj = Value::Null` + `unwrap_or` pagination borrow (4 sites: get_events, get_ledgers, get_transactions, simulate) is replaced by a new `util::param_object_or_null` helper that returns a borrowable `&Value`, falling back to a `const NULL` static and preserving `param_object`'s invalid_params error for present-but-non-object values. (2) The infallible `result.as_object_mut().unwrap()` + `insert_json_fields` idiom (4 sites: get_events, get_ledgers, get_transaction NOT_FOUND, get_transactions) is replaced by the existing build-Map-first pattern already used at get_transaction.rs.

## RPC output invariant

No field name, value, type, count, or ordering changes in any JSON-RPC response. The get_events `oldestLedgerCloseTime` ISO-8601 override is preserved byte-for-byte (same key, same `format_unix_timestamp_utc` value). serde_json's Map serializes deterministically (sorted BTreeMap, no `preserve_order`), so build-Map vs index-assign yield identical output.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3364#issuecomment-4732714024)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all
- [x] cargo test -p henyey-rpc (233 lib + 28 + 37 + 1 integration tests pass)

## New coverage

- `crates/rpc/src/util.rs::test_param_object_or_null` — absent key → `&Value::Null`; present object → that object; present non-object → `Err(invalid_params)`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)