### PR TITLE
Clean up crate:db dead state-key consts and stale PARITY_STATUS docs

### DIFF
--- a/crates/db/PARITY_STATUS.md
+++ b/crates/db/PARITY_STATUS.md
@@ -10,7 +10,7 @@
 | Area | Status | Notes |
 |------|--------|-------|
 | Connection pool and initialization | Full | r2d2/rusqlite covers open, pool, schema bootstrap |
-| Schema migrations | Full | Independent SQLite schema versioning through v8 |
+| Schema migrations | Full | Independent SQLite schema versioning through v10 (post-v8 index migrations: 8→9 `events_topic1_id`, 9→10 `txhistory_status_ledger`) |
 | Persistent state (`storestate`) | Full | Key-value reads, writes, deletes, and LCL helpers |
 | Ledger header storage | Full | Store/load/hash/stream/delete + field validation matching `LedgerHeaderUtils::isValid()` |
 | Transaction history storage | Full | Tx rows, txsets, txresults, range queries, cleanup |
@@ -134,7 +134,7 @@ Corresponds to: `PeerManager.h` SQL subset
 | `PeerManager::ensureExists()` | `PeerQueries::store_peer()` | Full |
 | `PeerManager::load()` | `PeerQueries::load_peer()` | Full |
 | `PeerManager::store()` | `PeerQueries::store_peer()` | Full |
-| `PeerManager::loadRandomPeers()` | `load_random_peers()` and specialized variants | Full |
+| `PeerManager::loadRandomPeers()` | `query_random_peers()` | Full |
 | `PeerManager::removePeersWithManyFailures()` | `remove_peers_with_failures()` | Full |
 | `PeerManager::getPeersToSend()` | Random-peer query helpers | Full |
 | `PeerManager::loadAllPeers()` | `load_peers(None)` | Full |
@@ -177,7 +177,6 @@ Features excluded by design. These are NOT counted against parity %.
 | `PersistentState::createMisc()`, `PersistentState::setMiscState()` | No separate misc database |
 | `shouldRebuildForOfferTable()`, `clearRebuildForOfferTable()`, `setRebuildForOfferTable()` | Offer-table rebuild flow is not modeled in Rust DB state |
 | `dropTxMetaIfExists()` | No separate legacy txmeta table exists in the Rust schema |
-| `LedgerHeaderUtils::getFlags()`, `LedgerHeaderUtils::isValid()` | Validation belongs in ledger logic, not the DB crate |
 | `PeerManager::update()` (type/backoff logic) | Higher-level peer heuristics live in the overlay crate, not in DB |
 | `PeerManager::countPeers()` | Not needed; peer loading handles limits directly |
 
@@ -210,7 +209,7 @@ Features not yet implemented. These ARE counted against parity %.
 
 4. **Schema versioning**
    - **stellar-core**: Main schema version 28 plus misc schema version 2.
-   - **Rust**: Independent schema version 8 with fresh-schema assumptions.
+   - **Rust**: Independent schema version 10 with fresh-schema assumptions.
    - **Rationale**: The Rust node does not preserve legacy upgrade history from older stellar-core releases.
 
 5. **SCP recovery tables**

--- a/crates/db/src/schema.rs
+++ b/crates/db/src/schema.rs
@@ -157,26 +157,11 @@ pub mod state_keys {
     /// state of the bucket list at that point.
     pub const HISTORY_ARCHIVE_STATE: &str = "historyarchivestate";
 
-    /// Current database schema version.
-    ///
-    /// Used by the migration system to track schema upgrades.
-    pub const DATABASE_SCHEMA: &str = "databaseschema";
-
     /// Network passphrase for transaction signing.
     ///
     /// Identifies which Stellar network this node is connected to
     /// (e.g., "Public Global Stellar Network ; September 2015" for mainnet).
     pub const NETWORK_PASSPHRASE: &str = "networkpassphrase";
-
-    /// Target ledger version for protocol upgrades.
-    ///
-    /// Set when a protocol upgrade is pending.
-    pub const LEDGER_UPGRADE_VERSION: &str = "ledgerupgradeversion";
-
-    /// Serialized SCP state for crash recovery.
-    ///
-    /// Contains the last known SCP state to resume consensus after restart.
-    pub const LAST_SCP_DATA: &str = "lastscpdata";
 
     /// Current SCP nomination/ballot state.
     ///


### PR DESCRIPTION
Closes #3356

## Summary

Pure `crate:db` accuracy pass (net runtime diff = 0). Deletes three unreferenced `state_keys` constants in `schema.rs` (`DATABASE_SCHEMA`, `LEDGER_UPGRADE_VERSION`, `LAST_SCP_DATA`) — confirmed zero code references; the only `databaseschema` use is a hardcoded literal in `migrations.rs` SQL. The six live consts are kept. Reconciles four stale `PARITY_STATUS.md` entries.

Behavior-preserving: no schema migration, no `CURRENT_VERSION` change, no stored-format change. The deleted consts were never read/written, so the `storestate` keyspace is unchanged.

## Findings addressed

1. **Dead consts** — deleted the three unreferenced consts (with doc comments).
2. **Schema version** — `PARITY_STATUS.md` updated v8 → v10 (lines ~13, ~213); `CURRENT_VERSION = 10` already, index migrations 8→9 / 9→10 present.
3. **Header-validation omission (doc-fix only)** — removed the self-contradictory `getFlags()`/`isValid()` row from the Intentional Omissions table. Validation stays in the DB load/store path (`queries/ledger.rs`), mirroring stellar-core's `LedgerHeaderUtils` (`isValid` in `decodeFromData` + store). No code moved — moving it out would diverge from stellar-core. Line ~15 already documents the validation, so no information is lost.
4. **Peer-query rename** — `load_random_peers()` → `query_random_peers()` and dropped the inaccurate "specialized variants" phrasing.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3356#issuecomment-4733165576)

## Test plan

- [x] cargo fmt --check
- [x] cargo build --all
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-db (109 passed, 0 failed)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)