### PR TITLE
Clean up crate:ledger: remove offer_store shim, use parking_lot mutex

### DIFF
--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -79,7 +79,6 @@ mod header;
 mod manager;
 pub mod memory_report;
 pub mod offer;
-pub mod offer_store;
 pub mod p23_hot_archive_bug;
 mod p23_hot_archive_bug_data;
 pub mod peak_rss_sampler;

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -25,7 +25,6 @@
 //! for state archival. This stores archived/evicted entries separately from
 //! the live bucket list, and both contribute to the header's bucket list hash.
 
-use crate::offer_store::OfferStore;
 use crate::{
     close::{
         LedgerCloseData, LedgerCloseResult, LedgerCloseStats, SortState, TransactionSetVariant,
@@ -52,6 +51,7 @@ use henyey_common::protocol::{
 use henyey_common::{BucketListDbConfig, Hash256, NetworkId};
 use henyey_tx::envelope_utils::envelope_operation_count;
 use henyey_tx::soroban::PersistentModuleCache;
+use henyey_tx::state::offer_store::OfferStore;
 use henyey_tx::{ClassicEventConfig, LedgerContext, TxEventManager};
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, HashSet};
@@ -1545,7 +1545,7 @@ pub struct LedgerManager {
     ///
     /// Used to compute `stellar_ledger_age_closed_seconds` — the time elapsed
     /// between consecutive close_ledger calls, matching stellar-core's mLastClose.
-    last_close_wall_time: std::sync::Mutex<std::time::Instant>,
+    last_close_wall_time: Mutex<std::time::Instant>,
 }
 
 // Compile-time assertion: LedgerManager must be Send + Sync for spawn_blocking.
@@ -1584,7 +1584,7 @@ impl LedgerManager {
             #[cfg(any(test, feature = "test-utils"))]
             snapshot_count: std::sync::atomic::AtomicU64::new(0),
             invariant_manager: None,
-            last_close_wall_time: std::sync::Mutex::new(std::time::Instant::now()),
+            last_close_wall_time: Mutex::new(std::time::Instant::now()),
         }
     }
 
@@ -2191,14 +2191,9 @@ impl LedgerManager {
         runtime_handle: Option<tokio::runtime::Handle>,
     ) -> Result<LedgerCloseResult> {
         // Emit ledger age metric: time since last close_ledger entry.
-        let age_secs = self
-            .last_close_wall_time
-            .lock()
-            .unwrap()
-            .elapsed()
-            .as_secs_f64();
+        let age_secs = self.last_close_wall_time.lock().elapsed().as_secs_f64();
         metrics::histogram!("stellar_ledger_age_closed_seconds").record(age_secs);
-        *self.last_close_wall_time.lock().unwrap() = std::time::Instant::now();
+        *self.last_close_wall_time.lock() = std::time::Instant::now();
 
         let rss_before = get_rss_bytes();
         let begin_start = std::time::Instant::now();

--- a/crates/ledger/src/offer_store.rs
+++ b/crates/ledger/src/offer_store.rs
@@ -1,2 +1,0 @@
-//! Re-export of the unified offer store from `henyey-tx`.
-pub use henyey_tx::state::offer_store::*;


### PR DESCRIPTION
Closes #3362

## Summary

Two behavior-neutral cleanups in `henyey-ledger`:

1. **Module removal (Finding 1):** Delete the redundant `crates/ledger/src/offer_store.rs` re-export shim (`pub use henyey_tx::state::offer_store::*;`) and remove `pub mod offer_store;` from `lib.rs`. Its sole consumer, `manager.rs`, is rewired to import the canonical `henyey_tx::state::offer_store::OfferStore` — the same path `execution/mod.rs` already uses. A workspace-wide grep confirmed `manager.rs:28` was the only consumer of the shim path, and `cargo build --all` confirms no stale references remain.
2. **Mutex type (Finding 2):** Switch `LedgerManager::last_close_wall_time` from `std::sync::Mutex` to `parking_lot::Mutex` (already imported; every sibling lock on `LedgerManager` uses parking_lot), dropping the two `.unwrap()`s at the read/write sites in `close_ledger`.

Net behavioral diff = 0. The field backs only the observability-only `stellar_ledger_age_closed_seconds` metric. `close_ledger` is a synchronous `fn` (no `.await` between lock and guard-drop), so parking_lot's `!Send`-across-await is a non-issue and the `LedgerManager: Send + Sync` assertion still holds. No code uses poison detection on this field, so dropping std poisoning is observably inert.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3362#issuecomment-4733160515)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all (compiles — confirms no stale shim reference)
- [x] cargo test -p henyey-ledger passes (640 tests, 0 failed)

## Parity

`crate:ledger` mirrors stellar-core v26.0.1 ledger close. Neither change alters close semantics or timing observability. The matching stellar-core symbol `mLastClose` is a plain timestamp (core's ledger close is single-threaded, no mutex); the lock primitive is a henyey-only implementation detail with zero parity weight. `offer_store` is a pure re-export alias — deletion changes neither the `OfferStore` type nor any ledger-close path.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)