### PR TITLE
Clean up crate:simulation: dedup peer-set computation, out-param to return

### DIFF
--- a/crates/simulation/src/applyload.rs
+++ b/crates/simulation/src/applyload.rs
@@ -1006,8 +1006,8 @@ impl ApplyLoad {
             }
             header.ledger_seq += 1;
 
-            let mut live_entries: Vec<LedgerEntry> = Vec::new();
-            let mut archived_entries: Vec<LedgerEntry> = Vec::new();
+            let live_entries: Vec<LedgerEntry>;
+            let archived_entries: Vec<LedgerEntry>;
 
             let is_last_batch = i
                 >= self
@@ -1022,12 +1022,11 @@ impl ApplyLoad {
                     self.config.bl_batch_size
                 };
 
-                generate_live_entries(
+                live_entries = generate_live_entries(
                     &base_live_entry,
                     header.ledger_seq,
                     entry_count,
                     &mut current_live_key,
-                    &mut live_entries,
                 );
 
                 let archived_entry_count = if is_last_batch {
@@ -1036,12 +1035,14 @@ impl ApplyLoad {
                     hot_archive_batch_size
                 };
 
-                generate_archived_entries(
+                archived_entries = generate_archived_entries(
                     header.ledger_seq,
                     archived_entry_count,
                     &mut current_hot_archive_key,
-                    &mut archived_entries,
                 );
+            } else {
+                live_entries = Vec::new();
+                archived_entries = Vec::new();
             }
 
             // Add to live bucket list.
@@ -1647,8 +1648,8 @@ fn generate_live_entries(
     ledger_seq: u32,
     count: u32,
     current_key: &mut u64,
-    entries: &mut Vec<LedgerEntry>,
-) {
+) -> Vec<LedgerEntry> {
+    let mut entries = Vec::new();
     for _ in 0..count {
         let mut le = base_entry.clone();
         le.last_modified_ledger_seq = ledger_seq;
@@ -1672,6 +1673,7 @@ fn generate_live_entries(
         entries.push(le);
         entries.push(ttl_entry);
     }
+    entries
 }
 
 /// Generate archived entries for a hot archive bucket list batch.
@@ -1679,8 +1681,8 @@ fn generate_archived_entries(
     ledger_seq: u32,
     count: u32,
     current_key: &mut u64,
-    entries: &mut Vec<LedgerEntry>,
-) {
+) -> Vec<LedgerEntry> {
+    let mut entries = Vec::new();
     for _ in 0..count {
         let lk = ApplyLoad::key_for_archived_entry(*current_key);
         let LedgerKey::ContractData(cd) = &lk else {
@@ -1700,6 +1702,7 @@ fn generate_archived_entries(
         entries.push(le);
         *current_key += 1;
     }
+    entries
 }
 
 /// Print a detailed performance breakdown for a benchmark run.

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -925,6 +925,20 @@ impl Simulation {
             .collect()
     }
 
+    /// Returns `(expected, actual)` authenticated-peer sets for `id`:
+    /// topology-expected peers and currently-connected peers.
+    async fn peer_set_for(&self, id: &str) -> (HashSet<PeerId>, HashSet<PeerId>) {
+        let expected = self.expected_peer_ids(id);
+        let actual: HashSet<PeerId> = self.running_apps[id]
+            .app
+            .peer_snapshots()
+            .await
+            .into_iter()
+            .map(|s| s.info.peer_id)
+            .collect();
+        (expected, actual)
+    }
+
     /// Wait until every running node is connected to **exactly** the set of
     /// peers defined by the configured topology.
     ///
@@ -946,14 +960,7 @@ impl Simulation {
                 let mut ids: Vec<&String> = self.running_apps.keys().collect();
                 ids.sort();
                 for id in &ids {
-                    let expected = self.expected_peer_ids(id);
-                    let actual: HashSet<PeerId> = self.running_apps[*id]
-                        .app
-                        .peer_snapshots()
-                        .await
-                        .into_iter()
-                        .map(|s| s.info.peer_id)
-                        .collect();
+                    let (expected, actual) = self.peer_set_for(id).await;
                     if expected != actual {
                         return Ok(None);
                     }
@@ -976,14 +983,7 @@ impl Simulation {
                 let mut ids: Vec<&String> = self.running_apps.keys().collect();
                 ids.sort();
                 for id in &ids {
-                    let expected = self.expected_peer_ids(id);
-                    let actual: HashSet<PeerId> = self.running_apps[*id]
-                        .app
-                        .peer_snapshots()
-                        .await
-                        .into_iter()
-                        .map(|s| s.info.peer_id)
-                        .collect();
+                    let (expected, actual) = self.peer_set_for(id).await;
                     let mut missing: Vec<String> = expected
                         .difference(&actual)
                         .map(|p| p.to_strkey())


### PR DESCRIPTION
Closes #3366

## Summary

Two behavior-neutral cleanups in `henyey-simulation` (net diff = 0; same values, same push order):

1. **Dedup (lib.rs):** extract the duplicated `(expected, actual)` peer-set computation in `wait_for_topology_connectivity` into a private `async fn peer_set_for(&self, id: &str) -> (HashSet<PeerId>, HashSet<PeerId>)` (preserving the `.await` on `peer_snapshots()`), shared by the poll-satisfaction branch and the `PollOutcome::TimedOut` diagnostics branch.
2. **Out-param → return (applyload.rs):** convert the two `&mut Vec<LedgerEntry>` out-params in `generate_live_entries`/`generate_archived_entries` to plain return values. The two `setup_bucket_list` call sites bind `live_entries`/`archived_entries` from the returns inside the write block and to empty `Vec`s in an `else`, preserving the empty-Vec case consumed unconditionally by `add_batch` and behind the `!is_empty()` hot-archive guard.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3366#issuecomment-4733153192)

## Test plan

- [x] cargo fmt --check
- [x] cargo build --all
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-simulation passes (54 tests across unit + serious_simulation + simulation, incl. topology satisfied/timeout paths and applyload bucket-list setup)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)