### PR TITLE
Narrow crate:bucket public surface to pub(crate) where unused externally

### DIFF
--- a/crates/bucket/src/applicator.rs
+++ b/crates/bucket/src/applicator.rs
@@ -52,7 +52,7 @@ use crate::Result;
 /// granularity and per-batch memory footprint during catchup. It does NOT
 /// affect the `bucketListHash` or any other consensus-deterministic output —
 /// the applicator yields identical entries regardless of batch size.
-pub const DEFAULT_CHUNK_SIZE: usize = 4095;
+pub(crate) const DEFAULT_CHUNK_SIZE: usize = 4095;
 
 // ============================================================================
 // Applicator Counters

--- a/crates/bucket/src/bloom_filter.rs
+++ b/crates/bucket/src/bloom_filter.rs
@@ -52,7 +52,7 @@ use xorf::{BinaryFuse16, Filter};
 use crate::{BucketError, Result};
 
 /// Size of the SipHash key in bytes (128 bits).
-pub const HASH_KEY_BYTES: usize = 16;
+pub(crate) const HASH_KEY_BYTES: usize = 16;
 
 /// Type alias for the hash seed used in bloom filter construction.
 pub type HashSeed = [u8; HASH_KEY_BYTES];

--- a/crates/bucket/src/bucket.rs
+++ b/crates/bucket/src/bucket.rs
@@ -841,7 +841,10 @@ impl Bucket {
     ///
     /// Each item is `(BucketEntry, record_size)` where `record_size` is the total
     /// bytes this entry occupies on disk.
-    pub fn iter_from_offset_with_sizes(&self, start_offset: u64) -> Result<BucketOffsetIter<'_>> {
+    pub(crate) fn iter_from_offset_with_sizes(
+        &self,
+        start_offset: u64,
+    ) -> Result<BucketOffsetIter<'_>> {
         match &self.storage {
             BucketStorage::InMemory { entries, .. } => {
                 Ok(BucketOffsetIter::InMemory(InMemoryOffsetIter {
@@ -1153,17 +1156,15 @@ impl Iterator for BucketIter<'_> {
 /// reads record sizes from the file format (no re-serialization needed).
 /// For in-memory buckets, it computes record sizes via XDR serialization
 /// (acceptable since in-memory buckets are small).
-pub enum BucketOffsetIter<'a> {
+pub(crate) enum BucketOffsetIter<'a> {
     /// In-memory variant that computes sizes on the fly.
     InMemory(InMemoryOffsetIter<'a>),
     /// Disk-backed variant that reads sizes from record marks.
     DiskBacked(crate::disk_bucket::DiskBucketOffsetIter),
-    /// Empty iterator (used for error recovery).
-    Empty,
 }
 
 /// In-memory offset iterator state.
-pub struct InMemoryOffsetIter<'a> {
+pub(crate) struct InMemoryOffsetIter<'a> {
     entries: &'a [BucketEntry],
     index: usize,
     current_offset: u64,
@@ -1203,7 +1204,6 @@ impl Iterator for BucketOffsetIter<'_> {
                 None
             }
             BucketOffsetIter::DiskBacked(iter) => iter.next(),
-            BucketOffsetIter::Empty => None,
         }
     }
 }

--- a/crates/bucket/src/disk_bucket.rs
+++ b/crates/bucket/src/disk_bucket.rs
@@ -886,7 +886,10 @@ impl DiskBucket {
     ///
     /// Each item is `(BucketEntry, record_size)` where `record_size` includes
     /// the 4-byte record mark.
-    pub fn iter_from_offset_with_sizes(&self, start_offset: u64) -> Result<DiskBucketOffsetIter> {
+    pub(crate) fn iter_from_offset_with_sizes(
+        &self,
+        start_offset: u64,
+    ) -> Result<DiskBucketOffsetIter> {
         let file = File::open(&self.file_path)?;
         let file_len = file.metadata()?.len();
         let mut reader = BufReader::new(file);
@@ -980,7 +983,7 @@ impl Iterator for DiskBucketIter {
 /// just to compute entry byte sizes.
 ///
 /// All bucket files at this point use XDR record marks (RFC 5531 format).
-pub struct DiskBucketOffsetIter {
+pub(crate) struct DiskBucketOffsetIter {
     records: crate::record::RecordMarkedReader<BufReader<File>>,
     failed: bool,
 }

--- a/crates/bucket/src/disk_bucket.rs
+++ b/crates/bucket/src/disk_bucket.rs
@@ -58,7 +58,7 @@ const BLOOM_FILTER_MIN_ENTRIES: usize = 2;
 
 /// Default hash seed for bloom filter construction.
 /// This is used when no custom seed is provided.
-pub const DEFAULT_BLOOM_SEED: HashSeed = [0u8; 16];
+pub(crate) const DEFAULT_BLOOM_SEED: HashSeed = [0u8; 16];
 
 /// A disk-backed bucket that stores entries on disk with an in-memory index.
 ///

--- a/crates/bucket/src/entry.rs
+++ b/crates/bucket/src/entry.rs
@@ -147,21 +147,21 @@ impl BucketEntryExt for BucketEntry {
 /// The rs-stellar-xdr crate declares enum variants in discriminant order and
 /// struct fields in XDR order, so Rust's `derive(Ord)` produces identical
 /// ordering to xdrpp's recursive field-by-field `operator<`.
-pub fn compare_keys(a: &LedgerKey, b: &LedgerKey) -> Ordering {
+pub(crate) fn compare_keys(a: &LedgerKey, b: &LedgerKey) -> Ordering {
     a.cmp(b)
 }
 
 /// Returns the ledger entry type for a given ledger key.
 ///
 /// Delegates to the XDR crate's inherent `LedgerKey::discriminant()` method.
-pub fn ledger_key_type(key: &LedgerKey) -> stellar_xdr::curr::LedgerEntryType {
+pub(crate) fn ledger_key_type(key: &LedgerKey) -> stellar_xdr::curr::LedgerEntryType {
     key.discriminant()
 }
 
 /// Returns the ledger entry type for a given entry data variant.
 ///
 /// Delegates to the XDR crate's inherent `LedgerEntryData::discriminant()` method.
-pub fn ledger_entry_data_type(
+pub(crate) fn ledger_entry_data_type(
     data: &stellar_xdr::curr::LedgerEntryData,
 ) -> stellar_xdr::curr::LedgerEntryType {
     data.discriminant()
@@ -171,7 +171,7 @@ pub fn ledger_entry_data_type(
 ///
 /// Metadata entries are always sorted first.
 /// Returns None if either entry is metadata and the other is not.
-pub fn compare_entries(a: &BucketEntry, b: &BucketEntry) -> Ordering {
+pub(crate) fn compare_entries(a: &BucketEntry, b: &BucketEntry) -> Ordering {
     match (a.key(), b.key()) {
         (Some(key_a), Some(key_b)) => compare_keys(&key_a, &key_b),
         (None, Some(_)) => Ordering::Less, // Metadata comes first
@@ -320,7 +320,7 @@ pub fn get_ttl_key(key: &LedgerKey) -> Option<LedgerKey> {
 ///
 /// An entry is expired when its `live_until_ledger_seq` is less than the current ledger.
 /// Returns None if the entry is not a TTL entry.
-pub fn is_ttl_expired(ttl_entry: &LedgerEntry, current_ledger: u32) -> Option<bool> {
+pub(crate) fn is_ttl_expired(ttl_entry: &LedgerEntry, current_ledger: u32) -> Option<bool> {
     get_ttl_live_until(ttl_entry).map(|live_until| live_until < current_ledger)
 }
 

--- a/crates/bucket/src/eviction.rs
+++ b/crates/bucket/src/eviction.rs
@@ -88,11 +88,11 @@ use crate::entry::{get_ttl_key, is_ttl_expired, BucketEntry};
 use henyey_common::{is_soroban_entry, is_temporary_entry};
 
 /// Default eviction scan size in bytes per ledger (100 KB).
-pub const DEFAULT_EVICTION_SCAN_SIZE: u32 = 100_000;
+pub(crate) const DEFAULT_EVICTION_SCAN_SIZE: u32 = 100_000;
 
 /// Default starting eviction scan level (level 6).
 /// Lower levels update too frequently, so we start from level 6.
-pub const DEFAULT_STARTING_EVICTION_SCAN_LEVEL: u32 = 6;
+pub(crate) const DEFAULT_STARTING_EVICTION_SCAN_LEVEL: u32 = 6;
 
 /// Re-export XDR EvictionIterator as the canonical type.
 ///
@@ -513,7 +513,7 @@ impl EvictionResult {
 }
 
 /// Default maximum entries to archive per ledger.
-pub const DEFAULT_MAX_ENTRIES_TO_ARCHIVE: u32 = 1000;
+pub(crate) const DEFAULT_MAX_ENTRIES_TO_ARCHIVE: u32 = 1000;
 
 /// Create default `StateArchivalSettings` for eviction scanning.
 ///

--- a/crates/bucket/src/index_persistence.rs
+++ b/crates/bucket/src/index_persistence.rs
@@ -50,7 +50,7 @@ use crate::BucketError;
 /// Version 3: Page size changed from entry-count to byte-offset semantics.
 /// Version 4: Added entry_type_sizes to counters.
 /// Version 5: Added bucket_hash, bucket_file_size, and data_checksum for integrity.
-pub const BUCKET_INDEX_VERSION: u32 = 5;
+pub(crate) const BUCKET_INDEX_VERSION: u32 = 5;
 
 // ============================================================================
 // Serializable Types

--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -143,16 +143,13 @@ pub use disk_bucket::{DiskBucket, DiskBucketIter, DEFAULT_BLOOM_SEED};
 // Bloom filter for fast negative lookups
 // ============================================================================
 
-pub use bloom_filter::{BucketBloomFilter, HashSeed, HASH_KEY_BYTES};
+pub use bloom_filter::{BucketBloomFilter, HashSeed};
 
 // ============================================================================
 // Entry types and comparison
 // ============================================================================
 
-pub use entry::{
-    compare_entries, compare_keys, get_ttl_key, get_ttl_live_until, is_ttl_expired,
-    ledger_entry_data_type, ledger_key_type, BucketEntry, BucketEntryExt,
-};
+pub use entry::{get_ttl_key, get_ttl_live_until, BucketEntry, BucketEntryExt};
 // Re-export classification helpers from henyey-common for backward compatibility.
 pub use henyey_common::{
     is_persistent_entry, is_persistent_key, is_soroban_entry, is_soroban_key, is_temporary_entry,

--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -137,7 +137,7 @@ pub use fan_out_limiter::{FanOutLimiter, FanOutPermit};
 // Disk-backed storage
 // ============================================================================
 
-pub use disk_bucket::{DiskBucket, DiskBucketIter, DEFAULT_BLOOM_SEED};
+pub use disk_bucket::{DiskBucket, DiskBucketIter};
 
 // ============================================================================
 // Bloom filter for fast negative lookups
@@ -168,8 +168,7 @@ pub use error::BucketError;
 pub use eviction::{
     bucket_update_period, default_state_archival_settings, level_half, level_should_spill,
     level_size, update_starting_eviction_iterator, EvictionCandidate, EvictionIterator,
-    EvictionIteratorExt, EvictionResult, ResolvedEviction, DEFAULT_EVICTION_SCAN_SIZE,
-    DEFAULT_MAX_ENTRIES_TO_ARCHIVE, DEFAULT_STARTING_EVICTION_SCAN_LEVEL,
+    EvictionIteratorExt, EvictionResult, ResolvedEviction,
 };
 
 // ============================================================================
@@ -226,8 +225,7 @@ pub use index::{
 // ============================================================================
 
 pub use index_persistence::{
-    cleanup_orphaned_indexes, delete_index, index_path_for_bucket, load_disk_index,
-    save_disk_index, BUCKET_INDEX_VERSION,
+    cleanup_orphaned_indexes, delete_index, index_path_for_bucket, load_disk_index, save_disk_index,
 };
 
 // ============================================================================
@@ -246,7 +244,7 @@ pub use merge_map::{BucketMergeMap, InFlightGuard, MergeResult, MergeSlot, Share
 // Bucket applicator (catchup)
 // ============================================================================
 
-pub use applicator::{ApplicatorCounters, BucketApplicator, EntryToApply, DEFAULT_CHUNK_SIZE};
+pub use applicator::{ApplicatorCounters, BucketApplicator, EntryToApply};
 
 // ============================================================================
 // Metrics and counters


### PR DESCRIPTION
Closes #3353

## Summary

Behavior-preserving `crate:bucket` visibility cleanup. Narrows `pub` symbols that have zero real external references (build-verified, not grep-inferred) to `pub(crate)`, trims them from the `lib.rs` re-export lists, and removes the provably-dead `BucketOffsetIter::Empty` variant. Net behavioral diff = 0.

Worked per-symbol with a `RUSTFLAGS=-Dwarnings cargo build -p henyey-bucket --all-targets` gate after each, reverting any symbol that tripped `private_interfaces` or dead-code. Grouped into three commits by theme.

### Narrowed to `pub(crate)` (survived the build gate)
- **Finding 2 cascade** (commit 1): the offset-iterator chain — `Bucket::iter_from_offset_with_sizes`, `BucketOffsetIter`, `InMemoryOffsetIter`, `DiskBucket::iter_from_offset_with_sizes`, `DiskBucketOffsetIter` — plus **deletion of the never-constructed `BucketOffsetIter::Empty` variant and its `=> None` match arm**.
- **entry/bloom subset** (commit 2): `compare_entries`, `compare_keys`, `is_ttl_expired`, `ledger_entry_data_type`, `ledger_key_type`, `HASH_KEY_BYTES`.
- **Constants** (commit 3): `DEFAULT_BLOOM_SEED`, `DEFAULT_CHUNK_SIZE`, `DEFAULT_EVICTION_SCAN_SIZE`, `DEFAULT_MAX_ENTRIES_TO_ARCHIVE`, `DEFAULT_STARTING_EVICTION_SCAN_LEVEL`, `BUCKET_INDEX_VERSION`.

### Kept `pub` — must stay (real external use)
`BucketEntryExt` (ledger/manager.rs), `get_ttl_key` / `get_ttl_live_until` (app/query.rs, ledger/apply.rs).

### Kept `pub` — public-signature-reachable (`private_interfaces`)
`DeadEntryPolicy`, `InitEntryPolicy`, `MetadataPolicy`, `MergeOptions` (untouched).

### Kept `pub` — live `#[cfg(test)]` fixtures
`merge_multiple`, `MergeIterator` (untouched).

### Reverted from the UNVERIFIED-ZERO list (build gate tripped)
- `private_interfaces` (in a still-public signature): `EntryToApply`, `EntryCountType`, `LiveEntriesIterator`, `FanOutPermit`.
- dead-code (only kept alive internally by the `pub use`): `DEFAULT_PAGE_SIZE`, `DEFAULT_INDEX_CUTOFF`, `BucketListStats`, `BucketListMetricsSnapshot`, `LiveEntriesStats`.

### Deliberate no-ops (documented in the plan)
- **Finding 1** (record.rs `#[allow(dead_code)]`): load-bearing — removing them re-fires dead-code on `Record.declared_len` / `SliceRecord.{mark_bytes,next_offset}`. **No change.**
- **Finding 4** (iterator.rs re-exports): dropping the `pub use` would surface 11 dead-code errors on the parity-mapped legacy module; the only clean form trades 5 exports for a module-wide `#![allow(dead_code)]` (a wash). **No change.**
- `FanOutLimiter`: defaulted to KEEP `pub` (only non-doc external refs are two plain-backtick doc mentions). **No change.**

So only 2 of the issue's 4 findings produce diffs; Findings 1 and 4 are intentional documented no-ops.

## Plan reference

[Converged Plan (Round 2) comment](https://github.com/stellar-experimental/henyey/issues/3353#issuecomment-4733253887)

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS=-Dwarnings cargo build -p henyey-bucket --all-targets` (clean)
- [x] `cargo build --all` (no external consumer broke)
- [x] `cargo test -p henyey-bucket` — 548 passed, 0 failed
- [x] `cargo clippy --all -- -D warnings` (clean)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)