### PR TITLE
Return BalanceError::Underflow for negative subtraction amount

### DIFF
--- a/crates/common/src/checked_types.rs
+++ b/crates/common/src/checked_types.rs
@@ -291,12 +291,12 @@ pub fn add_trustline_balance(tl: &mut TrustLineEntry, delta: i64) -> Result<(), 
 ///
 /// `amount` must be non-negative (use [`add_account_balance`] for credits).
 ///
-/// Returns `BalanceError::Overflow` if `amount` is negative,
+/// Returns `BalanceError::Underflow` if `amount` is negative,
 /// `BalanceError::Underflow` if the result would be negative.
 /// No liability checks — used for debits where the caller has already validated.
 pub fn sub_account_balance(account: &mut AccountEntry, amount: i64) -> Result<(), BalanceError> {
     if amount < 0 {
-        return Err(BalanceError::Overflow);
+        return Err(BalanceError::Underflow);
     }
     let new_balance = CheckedAmount::new(account.balance)
         .checked_sub(amount)
@@ -312,12 +312,12 @@ pub fn sub_account_balance(account: &mut AccountEntry, amount: i64) -> Result<()
 ///
 /// `amount` must be non-negative (use [`add_trustline_balance`] for credits).
 ///
-/// Returns `BalanceError::Overflow` if `amount` is negative,
+/// Returns `BalanceError::Underflow` if `amount` is negative,
 /// `BalanceError::Underflow` if the result would be negative.
 /// No liability or limit checks.
 pub fn sub_trustline_balance(tl: &mut TrustLineEntry, amount: i64) -> Result<(), BalanceError> {
     if amount < 0 {
-        return Err(BalanceError::Overflow);
+        return Err(BalanceError::Underflow);
     }
     let new_balance = CheckedAmount::new(tl.balance)
         .checked_sub(amount)
@@ -635,7 +635,7 @@ mod tests {
         let mut acc = make_account(100);
         assert_eq!(
             sub_account_balance(&mut acc, -1),
-            Err(BalanceError::Overflow)
+            Err(BalanceError::Underflow)
         );
         assert_eq!(acc.balance, 100); // unchanged
     }
@@ -662,7 +662,7 @@ mod tests {
         let mut tl = make_trustline(100, 1000);
         assert_eq!(
             sub_trustline_balance(&mut tl, -1),
-            Err(BalanceError::Overflow)
+            Err(BalanceError::Underflow)
         );
         assert_eq!(tl.balance, 100); // unchanged
     }


### PR DESCRIPTION
Closes #3354

## Summary

`sub_account_balance` and `sub_trustline_balance` returned `BalanceError::Overflow` on the negative-`amount` early-return, mislabeling a wrong-signed argument as an arithmetic overflow. The `add_*` mirror functions already return `Underflow` for a negative `delta`. This switches both `sub_*` guards to `BalanceError::Underflow`, so all four balance-direction functions map a wrong-signed argument uniformly to `Underflow`, while `Overflow` keeps its true meaning (a checked add exceeding `i64::MAX`). The two matching doc strings and the two existing negative-amount tests are updated to match.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3354#issuecomment-4733642041)

## Test plan

- [x] cargo fmt --check
- [x] cargo build --all
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-common passes (38 doctests + 219 lib tests, 0 failed)
- [x] cargo test -p henyey-ledger -p henyey-tx passes (the two `#[from]` consumers, unaffected)

## Parity

Behavior-neutral. The `BalanceError` variant is unobservable: a workspace audit (re-verified on this PR's base, origin/main `d2fd2202`) finds **zero** `BalanceError::<Variant>` matches outside `checked_types.rs`; the only two external references (`crates/ledger/src/error.rs:106`, `crates/tx/src/error.rs:86`) are opaque `Balance(#[from] ...)` wraps, and the variant is never projected into an XDR ResultCode. stellar-core's analog `addBalance` returns a plain `bool` with no error-kind taxonomy. No transaction result code changes.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)