### PR TITLE
Part of #3357: narrow verify CLI internal visibility

### DIFF
--- a/crates/henyey/src/quorum_intersection.rs
+++ b/crates/henyey/src/quorum_intersection.rs
@@ -99,7 +99,7 @@ fn load_quorum_map(path: &Path) -> anyhow::Result<HashMap<NodeId, Option<ScpQuor
 /// * `Ok(true)` - Network enjoys quorum intersection (safe)
 /// * `Ok(false)` - Network does NOT enjoy quorum intersection (unsafe!)
 /// * `Err(_)` - Configuration error or unsatisfiable quorum slice
-pub fn check_quorum_intersection_from_json(path: &Path) -> anyhow::Result<bool> {
+pub(crate) fn check_quorum_intersection_from_json(path: &Path) -> anyhow::Result<bool> {
     let qmap = load_quorum_map(path)?;
 
     if let Some(node) = find_unsatisfiable_node(&qmap) {

--- a/crates/henyey/src/settings_upgrade.rs
+++ b/crates/henyey/src/settings_upgrade.rs
@@ -424,7 +424,7 @@ fn sign_tx(
 }
 
 /// Parameters for the `get-settings-upgrade-txs` CLI command.
-pub struct SettingsUpgradeParams<'a> {
+pub(crate) struct SettingsUpgradeParams<'a> {
     pub public_key_str: &'a str,
     pub seq_num: i64,
     pub network_passphrase: &'a str,
@@ -434,7 +434,7 @@ pub struct SettingsUpgradeParams<'a> {
 }
 
 /// Execute the `get-settings-upgrade-txs` command.
-pub fn run(params: &SettingsUpgradeParams<'_>) -> anyhow::Result<()> {
+pub(crate) fn run(params: &SettingsUpgradeParams<'_>) -> anyhow::Result<()> {
     // Decode the ConfigUpgradeSet from base64 XDR
     let xdr_bytes = BASE64
         .decode(params.xdr_base64)


### PR DESCRIPTION
Part of #3357 (does not close it — the module split lands in a separate PR).

## Summary

Narrow three binary-crate public items to `pub(crate)`. The `henyey` crate is `[[bin]]`-only (no `src/lib.rs`), so these items can have no external consumers; their sole callers are in `main.rs` (same crate):

- `SettingsUpgradeParams` / `run` (`settings_upgrade.rs:427/437`) — sole caller `main.rs:1398`
- `check_quorum_intersection_from_json` (`quorum_intersection.rs:102`) — sole caller `main.rs:3238`, the `runCheckQuorumIntersection` CLI command (`cmd_check_quorum_intersection`), NOT live SCP/herder quorum logic

`pub(crate)` keeps all same-crate callers and the same-file `quorum_intersection` tests working unchanged. Behavior-neutral (3 token edits).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3357#issuecomment-4733657233)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo build --all`
- [x] `cargo test -p henyey` — 62 + integration tests pass, incl. all 6 `quorum_intersection::tests`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)