### PR TITLE
Drop redundant per-node HashMap lookup in scp process_envelopes_current_state

### DIFF
--- a/crates/scp/src/format.rs
+++ b/crates/scp/src/format.rs
@@ -21,6 +21,14 @@ pub fn node_id_to_short_string(node_id: &NodeId) -> String {
 }
 
 /// Format a ballot for display.
+///
+/// Intentional parity-mapped debug-format surface mirroring stellar-core's
+/// `SCPDriver::ballotToStr` (`SCPDriver.h`). Kept `pub` despite having no
+/// current external caller: narrowing it (and `envelope_to_str`) to
+/// `pub(crate)` makes both — and the `VALUE_SHORT_BYTES` constant they
+/// transitively depend on — dead code, which is a hard compile error under the
+/// repo-wide `-Dwarnings`. Deleting it would erase a documented parity surface.
+/// Do not narrow or delete (proved infeasible under `-Dwarnings` in #3365).
 pub fn ballot_to_str(ballot: &ScpBallot) -> String {
     format!(
         "({},{})",
@@ -35,6 +43,13 @@ pub fn value_to_str(value: &Value) -> String {
 }
 
 /// Format an envelope for display.
+///
+/// Intentional parity-mapped debug-format surface mirroring stellar-core's
+/// `SCPDriver::envToStr` (`SCPDriver.h`). Kept `pub` for the same reason as
+/// [`ballot_to_str`]: narrowing to `pub(crate)` makes it dead code under the
+/// repo-wide `-Dwarnings`, and deleting it would erase a documented parity
+/// surface. Do not narrow or delete (proved infeasible under `-Dwarnings` in
+/// #3365).
 pub fn envelope_to_str(envelope: &ScpEnvelope) -> String {
     let node = node_id_to_short_string(&envelope.statement.node_id);
     let slot = envelope.statement.slot_index;

--- a/crates/scp/src/info.rs
+++ b/crates/scp/src/info.rs
@@ -4,6 +4,19 @@
 //! nomination, and quorum state that can be serialized to JSON. These types
 //! match the stellar-core `getJsonInfo()` and `getJsonQuorumInfo()` output
 //! format, enabling compatible diagnostics and monitoring tooling.
+//!
+//! These structs — together with the `get_info` / `get_quorum_info` /
+//! `get_quorum_info_for_node` / `get_all_slot_info` accessors on `Slot`,
+//! `SCP`, `NominationProtocol`, and `BallotProtocol` — are an intentional
+//! parity-mirrored surface for stellar-core's `getJsonInfo()` /
+//! `getJsonQuorumInfo()` (see `crates/scp/PARITY_STATUS.md`), kept `pub` for
+//! the deferred fuller `/info`-endpoint parity work. They have no live external
+//! caller today (the live `/info` and compat handlers consume only
+//! `get_info_quorum_summary` / `get_reporting_summary`), so narrowing them to
+//! `pub(crate)` makes them dead code — a hard compile error under the
+//! repo-wide `-Dwarnings` — and deleting them would erase documented parity
+//! coverage. Do not narrow or delete (proved infeasible under `-Dwarnings` in
+//! #3365).
 
 /// JSON-serializable SCP slot information for debugging and monitoring.
 ///

--- a/crates/scp/src/lib.rs
+++ b/crates/scp/src/lib.rs
@@ -323,4 +323,72 @@ mod tests {
         assert!(!QuorumInfoNodeState::Preparing.is_externalized());
         assert!(QuorumInfoNodeState::Externalized.is_externalized());
     }
+
+    /// Guard test pinning the sorted-`NodeId`-iteration contract of
+    /// `process_envelopes_current_state`.
+    ///
+    /// `process_*` mirrors stellar-core's `processCurrentState`, which iterates
+    /// `mLatestEnvelopes` — a `std::map<NodeID, ...>` whose iteration is
+    /// NodeID-sorted. Henyey stores a `HashMap` and must reconstruct that exact
+    /// order. This test inserts envelopes in deliberately non-sorted insertion
+    /// order and asserts the visited node order equals the nodes sorted by
+    /// `NodeId` `Ord` (bytewise-lexicographic), so any future refactor that
+    /// breaks the sorted-order contract fails here. (Guard test — passes both
+    /// before and after the F1 double-lookup cleanup.)
+    #[test]
+    fn test_process_envelopes_current_state_sorted_node_order() {
+        use std::collections::HashMap;
+
+        let quorum_set = make_quorum_set(vec![make_node_id(1)], 1);
+
+        // Build a minimal nomination envelope for the given node.
+        let make_env = |node: NodeId| -> ScpEnvelope {
+            let nomination = ScpNomination {
+                quorum_set_hash: hash_quorum_set(&quorum_set).into(),
+                votes: vec![make_value(&[1])].try_into().unwrap(),
+                accepted: vec![].try_into().unwrap(),
+            };
+            ScpEnvelope {
+                statement: ScpStatement {
+                    node_id: node,
+                    slot_index: 1,
+                    pledges: ScpStatementPledges::Nominate(nomination),
+                },
+                signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap()),
+            }
+        };
+
+        // Insert in deliberately non-sorted insertion order. HashMap insertion
+        // order is unspecified, so the sort in `process_envelopes_current_state`
+        // is what establishes the deterministic visited order.
+        let seeds: [u8; 5] = [3, 1, 5, 2, 4];
+        let mut envelopes: HashMap<NodeId, ScpEnvelope> = HashMap::new();
+        for &s in &seeds {
+            let node = make_node_id(s);
+            envelopes.insert(node.clone(), make_env(node));
+        }
+
+        // A non-member local node so the self-skip branch never fires.
+        let local = make_node_id(200);
+
+        let mut visited: Vec<NodeId> = Vec::new();
+        let completed = process_envelopes_current_state(
+            &envelopes,
+            |env| {
+                visited.push(env.statement.node_id.clone());
+                true
+            },
+            &local,
+            true,  // fully_validated
+            false, // force_self
+        );
+        assert!(completed, "iteration should run to completion");
+
+        let mut expected: Vec<NodeId> = seeds.iter().map(|&s| make_node_id(s)).collect();
+        expected.sort();
+        assert_eq!(
+            visited, expected,
+            "envelopes must be visited in sorted NodeId order"
+        );
+    }
 }

--- a/crates/scp/src/lib.rs
+++ b/crates/scp/src/lib.rs
@@ -114,18 +114,16 @@ pub(crate) fn process_envelopes_current_state<F>(
 where
     F: FnMut(&ScpEnvelope) -> bool,
 {
-    let mut nodes: Vec<_> = envelopes.keys().collect();
-    nodes.sort();
+    let mut entries: Vec<_> = envelopes.iter().collect();
+    entries.sort_by_key(|(id, _)| *id);
 
-    for node_id in nodes {
+    for (node_id, envelope) in entries {
         if !force_self && node_id == local_node_id && !fully_validated {
             continue;
         }
 
-        if let Some(envelope) = envelopes.get(node_id) {
-            if !f(envelope) {
-                return false;
-            }
+        if !f(envelope) {
+            return false;
         }
     }
 


### PR DESCRIPTION
Closes #3365

## Summary

Three behavior-neutral `henyey-scp` cleanups from the converged re-plan, in one PR:

- **F1 (the only behavioral change — a proven order-identical micro-opt):** rewrite the shared `process_envelopes_current_state` helper (`crates/scp/src/lib.rs`) to iterate `(node_id, envelope)` pairs directly via `envelopes.iter().collect()` + `sort_by_key(|(id, _)| *id)` instead of `keys().collect()` + `sort()` followed by a redundant per-node `envelopes.get(node_id)`. The old `if let Some(envelope) = envelopes.get(node_id)` arm was unreachable-`None` (we iterate the map's own keys), so binding the value at iteration time is exactly equivalent and drops a hash+probe per node. The `force_self`/`local_node_id`/`fully_validated` skip predicate is preserved verbatim.
- **F2/F3 (docs-only):** add doc notes on `ballot_to_str`/`envelope_to_str` (`format.rs`) and the `info.rs` module header recording that these — and the `get_info`/`get_quorum_info`/`get_quorum_info_for_node`/`get_all_slot_info` accessors plus the 7 info structs — are an intentional parity-mirrored `getJsonInfo`/`getJsonQuorumInfo` surface kept `pub` for the deferred `/info`-endpoint parity work. **No visibility change.**

### Why F2/F3 are docs-only, not `pub(crate)` narrowing

The original plan's `pub(crate)` narrowing was twice proven infeasible (see the `## Do: Plan Wrong` bounce and the RE-PLAN): under the repo-wide `-Dwarnings`, demoting these zero-external-caller items produces **15 dead-code compile errors** (`#[cfg(test)]` callers do not keep an item alive in a normal build). Deleting them instead would erase documented Full-parity coverage rows in `crates/scp/PARITY_STATUS.md`. The doc notes reference #3365 so a future cleanup doesn't re-attempt the narrowing. The live `/info` + compat handlers consume only `get_info_quorum_summary`/`get_reporting_summary` (kept `pub`).

## Parity (consensus/parity-critical crate:scp)

F1 is **provably order-identical** to stellar-core's `processCurrentState`, which iterates `mLatestEnvelopes : std::map<NodeID, ...>` (NodeID-sorted). `NodeId` derives a total bytewise-lexicographic `Ord` identical to C++ `NodeID operator<`; `HashMap` keys are unique, so both the old `keys().sort()` and the new `iter().sort_by_key` sort by the same Ord over the same key set and yield a provably identical sequence — matching upstream's natural map order. SCP emission/nomination/ballot order preserved bit-for-bit. F2/F3 touch only comments — no XDR, no wire bytes, no message ordering, no `/info` output-shape change; PARITY_STATUS.md rows are preserved verbatim.

## Plan reference

[Converged Plan (RE-PLAN) comment](https://github.com/stellar-experimental/henyey/issues/3365#issuecomment-4733936816)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (clean)
- [x] cargo build --all (clean)
- [x] cargo test -p henyey-scp — **565 pass, 0 fail** (384 lib incl. the new guard test + scp_parity_tests 124 + multi_node_simulation 50 + quorum_intersection_json 7)
- [x] New guard test `test_process_envelopes_current_state_sorted_node_order` passes (pins sorted-NodeId iteration order)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)