### PR TITLE
Return &[u8] from SorobanStorage::get_code

### DIFF
--- a/crates/tx/src/soroban/storage.rs
+++ b/crates/tx/src/soroban/storage.rs
@@ -147,8 +147,8 @@ impl SorobanStorage {
     }
 
     /// Get contract code.
-    pub fn get_code(&self, hash: &Hash) -> Option<&Vec<u8>> {
-        self.code_entries.get(hash).and_then(|c| c.as_ref())
+    pub fn get_code(&self, hash: &Hash) -> Option<&[u8]> {
+        self.code_entries.get(hash).and_then(|c| c.as_deref())
     }
 
     // SECURITY: HashMap iteration in test helpers only; production path uses Vec with deterministic ordering


### PR DESCRIPTION
Closes #3367

## Summary

Changes `SorobanStorage::get_code` from `Option<&Vec<u8>>` to `Option<&[u8]>` (via `Option::as_deref`), following the Rust API guideline of not exposing the container type. `get_code` is an inherent method (no trait, no impl fan-out) and its only four callers are in-file `#[cfg(test)]` unit tests, all of which compile unchanged because slice/`Vec` equality holds via std `PartialEq`. Strictly behavior-neutral: the same backing bytes are returned, and `get_code` is a test-only accessor with no production caller (the production code-read path is `record_code_read`).

Findings 1 and 2 from the issue are **dropped per the converged plan**: build-verification under `-Dwarnings` proves the proposed narrowings/removals (`apply_from_history`, `reconcile_events`, `extract_inner_hash_from_result`) trip `dead_code` (the #3384 trap), so keep-as-is is the lowest-risk disposition.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3367#issuecomment-4734030276)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (clean)
- [x] cargo build --all (clean)
- [x] cargo test -p henyey-tx — 1365 + 12 tests pass, incl. the 13 soroban storage tests (`test_storage_code_entries` exercises the new `&[u8]` return)
- [x] RUSTFLAGS="-Dwarnings" cargo build -p henyey-tx (clean — reconfirms the dead-code reachability behavior that justifies dropping Findings 1 & 2)

## Parity considerations

crate:tx is consensus/parity-critical. This touches a **test-only accessor** with no production or host-function path; the return is byte-identical. Mirrors stellar-core v26.0.1 host storage semantics — no observable behavior change. Findings 1/2 dropped, so no parity-bearing code is touched (`reconcileEvents()` PARITY_STATUS Full row and the `apply_from_history` catchup path are untouched).

## Deviations from plan

None. The `assert_eq!(retrieved.expect(...), &code)` test caller compiled unchanged, so no call-site edit was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)