### PR TITLE
Drop inaccurate "periodic intervals" from clock module docstring

### DIFF
--- a/crates/clock/src/lib.rs
+++ b/crates/clock/src/lib.rs
@@ -1,4 +1,4 @@
-//! Clock abstractions for monotonic timing, async sleep, and periodic intervals.
+//! Clock abstractions for monotonic timing, wall-clock reads, and async sleep.
 
 use std::time::{Duration, Instant, SystemTime};
 


### PR DESCRIPTION
Closes #3387

## Summary

The `henyey-clock` module docstring claimed the crate provides "periodic intervals," but the `Clock` trait declares only `now`, `system_now`, and `sleep`. Periodic/interval handling is intentionally delegated to async futures (per the crate's PARITY_STATUS.md), so the phrasing was inaccurate by design. This replaces "periodic intervals" with "wall-clock reads," which reflects the existing `system_now` method. Behavior-neutral, single-line, single-file.

## Plan reference

[Triage Implementation Notes](https://github.com/stellar-experimental/henyey/issues/3387#issuecomment-4734313570) (trivial short-circuit — no separate /plan stage)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all
- [x] cargo test -p henyey-clock passes (4 passed; 0 failed)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)