### PR TITLE
Replace no-op empty if with bare start_work statement call

### DIFF
--- a/crates/work/src/scheduler.rs
+++ b/crates/work/src/scheduler.rs
@@ -452,9 +452,7 @@ impl WorkScheduler {
                 if running.contains(id) {
                     continue;
                 }
-                if self.start_work(id, &mut join_set, &mut running) {
-                    // started successfully
-                }
+                self.start_work(id, &mut join_set, &mut running);
             }
 
             if running.is_empty() && queue.is_empty() && retry_timers.is_empty() {


### PR DESCRIPTION
Closes #3400

## Summary

`crates/work/src/scheduler.rs` had a no-op `if self.start_work(...) { /* started successfully */ }` — an empty body, no `else`, and the `bool` return discarded. `start_work` is a private method that is not `#[must_use]` and applies its side effects internally, so the empty `if` was dead scaffolding. This replaces it with a bare statement call `self.start_work(...);`. Control flow and behavior are identical: `start_work` is still invoked exactly once with the same arguments, and its return value is still discarded.

## Plan reference

[Triage Report (trivial short-circuit)](https://github.com/stellar-experimental/henyey/issues/3400#issuecomment-4734313556)

## Test plan

- [x] cargo fmt --check
- [x] cargo build --all
- [x] cargo clippy --all -- -D warnings (clean — bare-statement discard of a non-`#[must_use]` bool is warning-free)
- [x] cargo test -p henyey-work passes (12 tests)

## Deviations from plan

None. Plan suggested `let _ = ...` or a bare statement "as appropriate"; since `start_work` is not `#[must_use]`, the bare statement is the cleaner form and compiles warning-free under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)