### PR TITLE
Remove orphaned module-level doc comment in ballot/mod.rs

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -59,8 +59,6 @@ use crate::quorum::{
 use crate::EnvelopeState;
 use crate::SlotContext;
 
-/// Phase of the ballot protocol.
-///
 mod envelope;
 mod state_machine;
 mod statements;


### PR DESCRIPTION
Closes #3397

## Summary

Deletes an orphaned two-line module-level doc comment (`/// Phase of the ballot protocol.` followed by `///`) that sat immediately before `mod envelope;` in `crates/scp/src/ballot/mod.rs`. The comment documented nothing meaningful — `mod envelope;` is not the ballot phase, and the `BallotPhase` enum further down already carries its own complete doc block. Pure docs-only deletion with zero behavior, signature, iteration-order, or API impact; SCP parity with stellar-core is unaffected.

## Plan reference

Trivial short-circuit (no separate plan): [Triage Report](https://github.com/stellar-experimental/henyey/issues/3397#issuecomment-4734306097)

## Test plan

- [x] cargo fmt --check
- [x] cargo build -p henyey-scp
- [x] cargo build --all
- [x] cargo clippy --all -- -D warnings (no warnings)
- [x] cargo test -p henyey-scp — 124 passed, 0 failed

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)