### PR TITLE
Narrow FailureInfo to pub(crate) in henyey-invariant

### DIFF
--- a/crates/invariant/src/lib.rs
+++ b/crates/invariant/src/lib.rs
@@ -109,7 +109,7 @@ pub trait Invariant: Send + Sync {
 
 /// Information about the last failure of an invariant.
 #[derive(Debug, Clone)]
-pub struct FailureInfo {
+pub(crate) struct FailureInfo {
     pub last_failed_on_ledger: u32,
     pub last_failed_with_message: String,
 }


### PR DESCRIPTION
Closes #3394

## Summary

`FailureInfo` in `crates/invariant/src/lib.rs` was declared `pub` but has zero external callers. It is used only internally — as the `HashMap` value type behind the private `InvariantManager.failure_info` field (lib.rs:132) and constructed within the crate (lib.rs:286). Its data reaches consumers only via `get_json_info()`'s `serde_json::Value`, so narrowing the struct to `pub(crate)` tightens the public surface with no behavior change.

## Plan reference

[Triage Report / Implementation Notes](https://github.com/stellar-experimental/henyey/issues/3394#issuecomment-4734321886)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build -p henyey-invariant` (under workspace `-Dwarnings`)
- [x] `cargo build --all` (under workspace `-Dwarnings`)
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-invariant` — 16 passed

## Build-verify outcome (the #3384 discipline)

The narrowing builds clean under the global `-Dwarnings` both crate-scoped and workspace-wide. It does **not** trip `private_interfaces` (the struct is only a private field's type, not part of any `pub` signature), nor `unreachable_pub` / `dead_code` (it remains live within the crate). `pub(crate)` is the correct landing — a plain delete would have been wrong.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)