### PR TITLE
Clean up stale comments and drop scaffolding in overlay shutdown test

### DIFF
--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -3461,12 +3461,12 @@ mod tests {
             for _ in 0..5 {
                 let cancelled = Arc::clone(&cancelled);
                 handles.push(tokio::spawn(async move {
-                    // Would only complete here if not aborted.
+                    // Hold the Arc clone for the task's lifetime so the
+                    // post-abort strong_count assertion is meaningful. The
+                    // sleep never resolves (paused time, no advance), so the
+                    // task only ends via abort.
+                    let _cancelled = cancelled;
                     tokio::time::sleep(Duration::from_secs(3600)).await;
-                    // If the task completes normally (not aborted), this
-                    // wouldn't run because sleep(3600) in paused-time
-                    // only resolves via time advance. Abort cancels it.
-                    drop(cancelled); // prevent "unused" warning
                 }));
             }
         }


### PR DESCRIPTION
Closes #3395

## Summary

Finding 3 (the only still-live finding) from #3395: cleans up a misleading
comment and the `drop(cancelled)` scaffolding inside the overlay test
`test_shutdown_timeout_aborts_slow_handles`. The spawned task previously
slept `3600s` under paused time, then ran `drop(cancelled); // prevent
"unused" warning`, with comments claiming the task "would only complete here
if not aborted" — both unreachable/misleading, since paused time never
advances the sleep and the test aborts the task. Replaced with a
`let _cancelled = cancelled;` binding that holds the Arc clone for the task's
lifetime, which is exactly what makes the post-abort `Arc::strong_count == 1`
assertion meaningful. Behavior is identical; test-only.

Findings 1 (`match_single_binding`) and 2 (`std::Mutex` in
`message_handlers.rs`) from the issue were verified ALREADY RESOLVED on
current `origin/main` by prior waves (#3363 / #3372 — the latter deleted
`message_handlers.rs` entirely), so they are intentionally untouched.

## Plan reference

Per the `## Triage Report` Implementation Notes on #3395 (trivial
short-circuit — reduced to the single live finding 3).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build --all`
- [x] `cargo clippy --all -- -D warnings` (clean; the `--all-targets`
  `nonminimal_bool`/`identity_op` lints in `henyey-tx` and `codec.rs` are
  PRE-EXISTING on clean `origin/main` @ 53955612 and unrelated to this change)
- [x] `cargo test -p henyey-overlay` — 471 unit + integration + doc tests pass,
  including `test_shutdown_timeout_aborts_slow_handles`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)