### PR TITLE
Simplify signed-payload hint fill and drop dead Sha256Hasher Default

### DIFF
--- a/crates/crypto/src/hash.rs
+++ b/crates/crypto/src/hash.rs
@@ -131,12 +131,6 @@ impl Sha256Hasher {
     }
 }
 
-impl Default for Sha256Hasher {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Type alias for BLAKE2b with 32-byte output (256 bits).
 pub(crate) type Blake2b256 = Blake2b<blake2::digest::consts::U32>;
 

--- a/crates/crypto/src/signature.rs
+++ b/crates/crypto/src/signature.rs
@@ -189,9 +189,7 @@ pub fn verify_ed25519_signed_payload(
     } else {
         // For shorter payloads, copy bytes left-aligned, remainder zero.
         let mut hint = [0u8; 4];
-        for (i, &byte) in signed_payload.payload.iter().enumerate() {
-            hint[i] = byte;
-        }
+        hint[..signed_payload.payload.len()].copy_from_slice(&signed_payload.payload);
         hint
     };
     let expected_hint = [
@@ -370,9 +368,7 @@ mod tests {
             ]
         } else {
             let mut hint = [0u8; 4];
-            for (i, &byte) in payload.iter().enumerate() {
-                hint[i] = byte;
-            }
+            hint[..payload.len()].copy_from_slice(&payload);
             hint
         };
         let xor_hint = [


### PR DESCRIPTION
Closes #3389

## Summary

Two behavior-preserving `henyey-crypto` cleanups (net behavioral diff = 0):

1. Replace the index-by-index fixed-array fill loop in `verify_ed25519_signed_payload` (the `else` branch reached when `payload.len() < 4`) with `copy_from_slice`. The `hint` array stays zero-initialized and the payload bytes are copied left-aligned into the head, leaving the tail zero — byte- and semantics-identical to the loop. Destination `hint[..payload.len()]` and source `&payload` are both `payload.len()` bytes, so `copy_from_slice` cannot panic. The same rewrite is applied to the `#[cfg(test)]` signing helper for in-file consistency (test-only).
2. Delete the unused `impl Default for Sha256Hasher`. Zero in-tree callers (all 7 use sites are `Sha256Hasher::new()`); a trait impl cannot be visibility-narrowed, so delete is the correct action. Build-verified under `-D warnings` to confirm no hidden dependent.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3389#issuecomment-4734583996)

## Parity

PARITY-CRITICAL path. `verify_ed25519_signed_payload` mirrors stellar-core `SignatureUtils::getSignedPayloadHint` → `getHint(ByteSlice)`. For `payload.len() < 4` (incl. empty), stellar-core zero-inits a `SignatureHint` and `memcpy`s payload bytes left-aligned into the head, tail zero. The `copy_from_slice` rewrite reproduces this exactly; only the copy mechanism changes, not the bytes, alignment, zero-init, or the subsequent XOR-with-pubkey-hint / hint-compare.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build --all` warning-free under `-D warnings` (confirms no dependent on the deleted `Default`)
- [x] `cargo clippy -p henyey-crypto --all-targets -- -D warnings` clean
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo test -p henyey-crypto` passes (incl. `test_verify_ed25519_signed_payload_short_payload` / `_empty_payload` / `_valid` / `_hint_mismatch` / `_invalid_signature`)

## Deviations from plan

None. The optional `#[cfg(test)]` helper rewrite was applied (plan left it to `/do`'s discretion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)