### PR TITLE
Stack-allocate XDR record-mark padding and simplify test-only match blocks

### DIFF
--- a/crates/common/src/fs_utils.rs
+++ b/crates/common/src/fs_utils.rs
@@ -305,9 +305,13 @@ where
     let marked_len = len | 0x8000_0000;
     writer.write_all(&marked_len.to_be_bytes())?;
     writer.write_all(&bytes)?;
+    // `pad` is at most 3 (it is `(4 - len % 4) % 4`), so a fixed 3-byte stack
+    // array sliced to `..pad` avoids a per-write heap allocation and is
+    // byte-identical to `vec![0u8; pad]`: both yield exactly `pad` zero bytes,
+    // and the slice index `..pad` is always in-bounds for `pad in 0..=3`.
     let pad = (4 - (len % 4)) % 4;
     if pad > 0 {
-        writer.write_all(&vec![0u8; pad as usize])?;
+        writer.write_all(&[0u8; 3][..pad as usize])?;
     }
     Ok(())
 }
@@ -672,6 +676,46 @@ mod tests {
         let parsed: Vec<Hash> = parse_gz_record_marked_xdr_stream(&raw);
         assert_eq!(parsed, items);
         assert_eq!(count_temp_files(dir.path()), 0);
+    }
+
+    #[test]
+    fn test_write_record_marked_xdr_padding_bytes_pinned() {
+        use stellar_xdr::curr::Hash;
+
+        // (a) Pin the exact on-disk byte layout produced by the production
+        // path for a representative `WriteXdr` item. A `Hash` encodes to 32
+        // bytes (a 4-multiple), so `pad == 0` and the decoded record is
+        // exactly 4 (mark) + 32 (payload) bytes with no trailing pad. This is
+        // the only case real XDR types produce, and it is what the
+        // `&[0u8; 3][..pad]` change must keep byte-identical.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("out.xdr.gz");
+        let items = [Hash([7u8; 32])];
+        atomic_gzip_xdr_write_slice(&path, &items).unwrap();
+
+        let raw = fs::read(&path).unwrap();
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+        let mut decoded = Vec::new();
+        GzDecoder::new(&raw[..]).read_to_end(&mut decoded).unwrap();
+
+        // Marked length: 32 | 0x8000_0000 == 0x8000_0020, big-endian.
+        assert_eq!(&decoded[0..4], &0x8000_0020u32.to_be_bytes());
+        // Payload: the 32 Hash bytes.
+        assert_eq!(&decoded[4..36], &[7u8; 32]);
+        // No trailing pad — the record is exactly 4 + 32 bytes.
+        assert_eq!(decoded.len(), 4 + 32);
+
+        // Also confirm the decoded item round-trips.
+        let parsed: Vec<Hash> = parse_gz_record_marked_xdr_stream(&raw);
+        assert_eq!(parsed, items);
+
+        // (b) Document the defensive-branch equivalence under test: for the
+        // unreachable `pad in 1..=3` cases, the stack slice `&[0u8; 3][..n]`
+        // emits the identical bytes as the previous `vec![0u8; n]`.
+        for n in 0..=3usize {
+            assert_eq!(&[0u8; 3][..n], &vec![0u8; n][..]);
+        }
     }
 
     #[test]

--- a/crates/common/src/spawn.rs
+++ b/crates/common/src/spawn.rs
@@ -161,9 +161,8 @@ mod tests {
 
     impl Visit for CapturedEvent {
         fn record_str(&mut self, field: &Field, value: &str) {
-            match field.name() {
-                "task" => self.task = Some(value.to_string()),
-                _ => {}
+            if field.name() == "task" {
+                self.task = Some(value.to_string());
             }
         }
         fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {

--- a/crates/common/src/tracking.rs
+++ b/crates/common/src/tracking.rs
@@ -217,16 +217,15 @@ mod tests {
 
     impl Visit for CapturedEvent {
         fn record_str(&mut self, field: &Field, value: &str) {
-            match field.name() {
-                "call" => self.call = Some(value.to_string()),
-                _ => {}
+            if field.name() == "call" {
+                self.call = Some(value.to_string());
             }
         }
         fn record_u64(&mut self, field: &Field, value: u64) {
-            match field.name() {
-                "elapsed_ms" => self.elapsed_ms = Some(value),
-                "total_ms" => self.total_ms = Some(value),
-                _ => {}
+            if field.name() == "elapsed_ms" {
+                self.elapsed_ms = Some(value);
+            } else if field.name() == "total_ms" {
+                self.total_ms = Some(value);
             }
         }
         fn record_i64(&mut self, field: &Field, value: i64) {


### PR DESCRIPTION
Closes #3388

## Summary

Two behavior-neutral `henyey-common` cleanups, net behavioral diff = 0:

- **Finding 1 (production XDR byte-output path):** in `write_record_marked_xdr_to` (`crates/common/src/fs_utils.rs`), replace the per-write heap `vec![0u8; pad]` with the fixed stack slice `&[0u8; 3][..pad]`. `pad` is provably `0..=3`, so the slice index is always in-bounds. The change is **byte-identical**: both expressions yield exactly `pad` zero bytes and `write_all` is buffer-source-agnostic. Cross-checked against stellar-core `XDROutputFileStream` — XDR sizes are 4-aligned so `pad == 0` in production; the pad branch is defensive and unreached for real `WriteXdr` types.
- **Finding 2 (test-only, `#[cfg(test)]`):** convert single-arm-with-wildcard `match field.name()` blocks in the capturing tracing subscribers to `if`/`if-else` form — `spawn.rs` `record_str` (`"task"`), `tracking.rs` `record_str` (`"call"`) and `record_u64` (`"elapsed_ms"`/`"total_ms"`).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3388#issuecomment-4734584440)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (clean)
- [x] cargo build --all (clean)
- [x] cargo test -p henyey-common — 220 unit + 38 doctests pass
- [x] New guard test `test_write_record_marked_xdr_padding_bytes_pinned` passes

## New coverage

Added `fs_utils::tests::test_write_record_marked_xdr_padding_bytes_pinned`: pins the exact on-disk layout for a `Hash` item (marked length `0x80000020` + 32 payload bytes + zero trailing pad, decoded record exactly `4 + 32` bytes) and asserts `&[0u8; 3][..n] == &vec![0u8; n][..]` for `n in 0..=3`, documenting the defensive-branch byte equivalence.

## Parity considerations

XDR output bytes are byte-identical before and after — `&[0u8; 3][..pad]` and `vec![0u8; pad]` produce the same byte sequence for all `pad in 0..=3`. The `henyey_history` twin is intentionally untouched (separate crate). Finding 2 is `#[cfg(test)]`-only — no parity surface.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)