### PR TITLE
Clean up two low clippy findings in crate:tx

### DIFF
--- a/crates/tx/src/operations/execute/invoke_host_function.rs
+++ b/crates/tx/src/operations/execute/invoke_host_function.rs
@@ -4227,7 +4227,7 @@ mod tests {
         // When limit is 0 and combined size is 0, it must be allowed.
         let combined_size_zero: u32 = 0;
         assert!(
-            !(combined_size_zero > limit),
+            combined_size_zero <= limit,
             "Zero limit with zero size must be allowed"
         );
     }
@@ -4238,7 +4238,7 @@ mod tests {
         let limit: u32 = 1000;
         let combined_size: u32 = 1000; // exactly at limit
         assert!(
-            !(combined_size > limit),
+            combined_size <= limit,
             "Combined size equal to limit must be allowed (strict > comparison)"
         );
     }

--- a/crates/tx/src/operations/execute/manage_data.rs
+++ b/crates/tx/src/operations/execute/manage_data.rs
@@ -37,8 +37,7 @@ pub(crate) fn execute_manage_data(
     if data_name.is_empty() || data_name.len() > MAX_DATA_NAME_LENGTH {
         return Ok(make_result(ManageDataResultCode::InvalidName));
     }
-    let data_name_bytes: &Vec<u8> =
-        <stellar_xdr::curr::String64 as AsRef<Vec<u8>>>::as_ref(&op.data_name);
+    let data_name_bytes: &[u8] = op.data_name.as_ref();
     if !is_string_valid(data_name_bytes) {
         return Ok(make_result(ManageDataResultCode::InvalidName));
     }


### PR DESCRIPTION
Closes #3399

## Summary

Two behavior-neutral cleanups in parity-critical `crate:tx`:

1. **`clippy::nonminimal_bool` (test-only)** — `crates/tx/src/operations/execute/invoke_host_function.rs`: rewrote two `#[cfg(test)]` asserts from `assert!(!(x > limit), …)` to `assert!(x <= limit, …)` (lines 4230, 4241), preserving the message strings verbatim. Truth-preserving for all `u32`: `!(x > limit) ≡ (x <= limit)` on a total order.
2. **Verbose UFCS `AsRef` cast** — `crates/tx/src/operations/execute/manage_data.rs`: replaced `let data_name_bytes: &Vec<u8> = <String64 as AsRef<Vec<u8>>>::as_ref(&op.data_name);` with `let data_name_bytes: &[u8] = op.data_name.as_ref();`. The `&[u8]` annotation is load-bearing (`String64` has three `AsRef` impls). Both impls reference the identical inner `Vec<u8>` buffer, so the slice into `is_string_valid` is byte-identical and the consensus-observable `ManageDataResultCode::InvalidName` decision is invariant.

Net behavioral diff = 0. No new tests (existing tests guard).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3399#issuecomment-4734590354)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p henyey-tx --all-targets -- -D warnings (both lints cleared, no new `useless_asref`)
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all
- [x] cargo test -p henyey-tx (1365 + 12 passed, 0 failed) — incl. `test_event_size_check_*` and ManageData `is_string_valid` tests

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)