### PR TITLE
Fix stale node_seed assertion blocking CI Test on main

### DIFF
--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -1463,7 +1463,7 @@ mod tests {
         assert_eq!(config.buckets.directory, PathBuf::from("/tmp/buckets"));
         assert_eq!(
             config.node.node_seed.as_deref(),
-            Some("SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH")
+            Some("SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2")
         );
         assert!(!config.node.is_validator);
         assert!(!config.node.force_scp);


### PR DESCRIPTION
## Problem
`CI / Test` fails deterministically on `origin/main`: `compat_config::tests::test_translate_basic_config` panics — the test input `NODE_SEED` was changed to the `"<seed> self"` self-entry form (commit `45a97265`) but the assertion still expected the old seed. This reds every PR's Test check.

## Fix
One-line assertion update: expect the parsed seed `SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2` (the parser correctly strips the ` self` label). Matches the sibling tests at the new-seed form. Behavior-neutral test fix; no production code touched.

## Verification
- `cargo test -p henyey-app --lib compat_config::tests::test_translate_basic_config` → ok
- full `compat_config::tests` module → all pass
- `cargo fmt --check` clean

Closes #3406

🤖 Generated with [Claude Code](https://claude.com/claude-code)