### PR TITLE
Delete dead soroban-upgrade gate and name startup-timeout const in simulation

### DIFF
--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -30,6 +30,7 @@ use loopback::LoopbackNetwork;
 
 const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const ROLLBACK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const STARTUP_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Wait for a task handle to complete within `timeout`, aborting it if the
 /// deadline expires.
@@ -188,11 +189,6 @@ pub struct Simulation {
     app_account_sequences: HashMap<String, i64>,
     root_sequence: i64,
     overlay_connection_factory: Option<Arc<dyn ConnectionFactory>>,
-    /// Whether Soroban upgrade setup has completed (set by `SorobanUpgradeSetup`
-    /// loadgen mode).
-    ///
-    /// Matches stellar-core `Simulation::mSetupForSorobanUpgrade`.
-    setup_for_soroban_upgrade: bool,
     /// Test-only task handles for mock nodes. `find_exited_node`,
     /// `app_task_finished`, and `app_task_status` check this map
     /// before `running_apps`, enabling crash-detection tests without
@@ -243,7 +239,6 @@ impl Simulation {
             app_account_sequences: HashMap::new(),
             root_sequence: 1,
             overlay_connection_factory: None,
-            setup_for_soroban_upgrade: false,
             #[cfg(test)]
             test_nodes: HashMap::new(),
             #[cfg(test)]
@@ -441,7 +436,7 @@ impl Simulation {
         // construction.
         for plan in plans {
             let node_id = plan.id.clone();
-            self.insert_ready_node(plan, Duration::from_secs(30))
+            self.insert_ready_node(plan, STARTUP_READINESS_TIMEOUT)
                 .await
                 .with_context(|| format!("bootstrap app node {}", node_id))?;
         }
@@ -521,7 +516,7 @@ impl Simulation {
             )
             .await?;
 
-        self.insert_ready_node(plan, Duration::from_secs(30))
+        self.insert_ready_node(plan, STARTUP_READINESS_TIMEOUT)
             .await?;
 
         Ok(())
@@ -617,20 +612,6 @@ impl Simulation {
     pub fn expected_next_ledger_close_unix_secs(&self, node_id: &str) -> Option<u64> {
         let app = self.running_apps.get(node_id)?;
         Some(app.app.expected_next_ledger_close_unix_secs())
-    }
-
-    /// Check whether Soroban upgrade setup has completed.
-    ///
-    /// Matches stellar-core `Simulation::isSetUpForSorobanUpgrade()`.
-    pub fn is_setup_for_soroban_upgrade(&self) -> bool {
-        self.setup_for_soroban_upgrade
-    }
-
-    /// Mark Soroban upgrade setup as complete.
-    ///
-    /// Matches stellar-core `Simulation::markReadyForSorobanUpgrade()`.
-    pub fn mark_ready_for_soroban_upgrade(&mut self) {
-        self.setup_for_soroban_upgrade = true;
     }
 
     pub async fn app_peer_count(&self, node_id: &str) -> Option<usize> {


### PR DESCRIPTION
Closes #3398

## Summary

Cleanup in `crates/simulation/src/lib.rs`, behavior-preserving (net runtime diff = 0):

1. **Delete the genuinely-dead `setup_for_soroban_upgrade` gate** — the field, its `false` initializer in `with_network`, and both pub fns `is_setup_for_soroban_upgrade` / `mark_ready_for_soroban_upgrade` (with doc comments). `git grep` over `crates/` finds zero callers, not even `#[cfg(test)]`; the clean `-Dwarnings` build proves the removal is complete. These mirror stellar-core `Simulation::isSetUpForSorobanUpgrade()` / `markReadyForSorobanUpgrade()` / `mSetupForSorobanUpgrade`, whose only upstream consumer (`TestUtils.cpp` `upgradeSorobanNetworkConfig`) was never ported to henyey — which is precisely why the mirror is dead. Trivially re-introducible if the helper is later ported.
2. **Extract the two `Duration::from_secs(30)` startup-readiness literals** (in `try_start_all_nodes` and `restart_node`) into a named const `STARTUP_READINESS_TIMEOUT`, beside the existing `*_SHUTDOWN_TIMEOUT` consts. Literal-for-literal swap — node-bootstrap readiness timing is unchanged. The unrelated `#[cfg(test)]` `Duration::from_secs(5)` fixtures are left untouched.

No PARITY_STATUS.md edit required: no row maps these two fns; the only soroban-upgrade row tracks the live `SorobanUpgradeSetup` loadgen enum, untouched here.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3398#issuecomment-4734751561)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-simulation (clean under -Dwarnings — proves the delete is complete)
- [x] cargo build --all
- [x] cargo test -p henyey-simulation (86 lib + 12 integration tests pass)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)