### PR TITLE
Make publish-queue first-write-wins explicit, drop dead 'pending' SQL

### DIFF
--- a/crates/db/PARITY_STATUS.md
+++ b/crates/db/PARITY_STATUS.md
@@ -242,7 +242,6 @@ Features not yet implemented. These ARE counted against parity %.
 - No Rust test covers the upstream SQLite MVCC scenario from `DatabaseTests.cpp`.
 - No direct unit test covers the missing `getNodeQuorumSet()` parity gap.
 - `ban.rs` has no dedicated unit tests (functionality exercised through integration tests).
-- `delete_old_tx_set_data()` remains effectively untested because it is currently a no-op.
 
 ## Parity Calculation
 

--- a/crates/db/src/queries/publish_queue.rs
+++ b/crates/db/src/queries/publish_queue.rs
@@ -19,7 +19,8 @@ use crate::error::DbError;
 pub trait PublishQueueQueries {
     /// Adds a checkpoint ledger to the publish queue.
     ///
-    /// This is a no-op if the ledger is already in the queue.
+    /// First-write-wins: this is a no-op if the ledger is already in the
+    /// queue, leaving the existing row (and its stored HAS JSON) untouched.
     /// The `has_json` parameter stores the History Archive State JSON
     /// captured at checkpoint time, ensuring the publish path uses the
     /// exact HAS (including hot archive bucket hashes) from the
@@ -74,10 +75,13 @@ pub trait PublishQueueQueries {
 
 impl PublishQueueQueries for Connection {
     fn enqueue_publish(&self, ledger_seq: u32, has_json: &str) -> Result<(), DbError> {
+        // `INSERT OR IGNORE` makes the first-write-wins contract explicit: on a
+        // `ledgerseq` primary-key conflict the new row is ignored, leaving the
+        // existing entry intact. This intentionally swallows the PK conflict for
+        // idempotency. All callers always pass a non-null `has_json`, so the
+        // `state NOT NULL` constraint is never at risk.
         self.execute(
-            "INSERT INTO publishqueue (ledgerseq, state) VALUES (?1, ?2) \
-             ON CONFLICT(ledgerseq) DO UPDATE SET state = excluded.state \
-             WHERE publishqueue.state = 'pending'",
+            "INSERT OR IGNORE INTO publishqueue (ledgerseq, state) VALUES (?1, ?2)",
             params![ledger_seq as i64, has_json],
         )?;
         Ok(())
@@ -128,9 +132,7 @@ impl PublishQueueQueries for Connection {
     }
 
     fn load_all_publish_has(&self) -> Result<Vec<String>, DbError> {
-        let mut stmt = self.prepare(
-            "SELECT state FROM publishqueue WHERE state != 'pending' ORDER BY ledgerseq ASC",
-        )?;
+        let mut stmt = self.prepare("SELECT state FROM publishqueue ORDER BY ledgerseq ASC")?;
         let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(DbError::from)
@@ -159,7 +161,14 @@ mod tests {
     }
 
     #[test]
-    fn test_enqueue_publish_overwrites_existing_legacy_state() {
+    fn test_enqueue_publish_does_not_overwrite_existing_row() {
+        // First-write-wins: an existing row for a `ledgerseq` is never
+        // overwritten by a subsequent enqueue, even if the pre-existing row
+        // holds a legacy value (e.g. the old `'pending'` sentinel that this
+        // crate no longer writes). The `INSERT OR IGNORE` ignores the PK
+        // conflict and leaves the existing row intact. This pins the removal
+        // of the old `WHERE state = 'pending'` UPDATE branch — under that
+        // branch this row WOULD have been overwritten.
         let conn = setup_db();
 
         conn.execute(
@@ -172,7 +181,7 @@ mod tests {
         conn.enqueue_publish(63, has_json).unwrap();
 
         let stored = conn.load_publish_has(63).unwrap().unwrap();
-        assert_eq!(stored, has_json);
+        assert_eq!(stored, "pending");
     }
 
     #[test]
@@ -187,6 +196,23 @@ mod tests {
 
         let stored = conn.load_publish_has(63).unwrap().unwrap();
         assert_eq!(stored, first_has);
+    }
+
+    #[test]
+    fn test_load_all_publish_has_returns_all_rows() {
+        // Pins the removal of the dead `WHERE state != 'pending'` filter:
+        // every enqueued HAS row is returned, in ascending ledgerseq order.
+        let conn = setup_db();
+
+        let has_63 = r#"{"version":2,"currentLedger":63}"#;
+        let has_127 = r#"{"version":2,"currentLedger":127}"#;
+
+        // Insert out of order to confirm the ORDER BY is honored.
+        conn.enqueue_publish(127, has_127).unwrap();
+        conn.enqueue_publish(63, has_63).unwrap();
+
+        let all = conn.load_all_publish_has().unwrap();
+        assert_eq!(all, vec![has_63.to_string(), has_127.to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #3390

## Summary

Behavior-neutral cleanup of `henyey-db`'s `publish_queue.rs`. The `publishqueue` `state` column only ever stores HAS JSON — the `'pending'` sentinel is a dead artifact of an older enum-string schema and is never written. This PR makes the existing **first-write-wins** semantics explicit and removes the dead SQL:

- `enqueue_publish`: the always-skipped `ON CONFLICT(ledgerseq) DO UPDATE SET state = excluded.state WHERE publishqueue.state = 'pending'` UPDATE branch is replaced with `INSERT OR IGNORE INTO publishqueue (ledgerseq, state) VALUES (?1, ?2)` — identical first-write-wins on a primary-key conflict.
- `load_all_publish_has`: drops the no-op `WHERE state != 'pending'` filter.
- Trait doc on `enqueue_publish` updated to state first-write-wins precisely.
- `crates/db/PARITY_STATUS.md`: deletes the stale `delete_old_tx_set_data()` bullet (the function exists nowhere in the codebase).

No schema / migration / stored-format change. Net observable behavior is unchanged.

## Parity

stellar-core v26.0.1 uses last-write-wins for publish-queue entries (file rename), while henyey-db is first-write-wins. This is **unobservable on the production path**: each checkpoint seq is enqueued exactly once inside the ledger-close commit, and `restore_checkpoint` deletes rows with `ledgerseq > lcl` (strict `>`) before replay, so the same committed seq is never re-enqueued with a differing HAS. This PR preserves first-write-wins and introduces no new semantics. The db-vs-stellar-core reconciliation is tracked separately as **#3412** (out of scope here).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3390#issuecomment-4735165674)

## Test plan

- [x] `cargo build --all`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-db` — 110 passed, 0 failed

### Guard tests (per plan)

- **Transformed** `test_enqueue_publish_overwrites_existing_legacy_state` → `test_enqueue_publish_does_not_overwrite_existing_row`: seeds a legacy `'pending'` row and asserts a subsequent `enqueue_publish` does NOT overwrite it (pins first-write-wins; this test would fail under the removed UPDATE branch).
- **Added** `test_load_all_publish_has_returns_all_rows`: inserts two HAS rows out of order, asserts `load_all_publish_has()` returns both in `ledgerseq` order (pins the filter removal as a no-op).
- **Unchanged** `test_enqueue_publish_keeps_existing_has_json`: pins first-write-wins on duplicate enqueue — guards against an accidental flip to `INSERT OR REPLACE`/last-write-wins.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)