### PR TITLE
Simplify needless Ok(...?) wrap in force_scp tests

### DIFF
--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -4403,7 +4403,7 @@ url = "https://history.stellar.org/prd/core-testnet/core_testnet_001"
             .with_connection(|conn| {
                 use henyey_db::queries::StateQueries;
                 use henyey_db::schema::state_keys;
-                Ok(conn.get_state(state_keys::FORCE_SCP)?)
+                conn.get_state(state_keys::FORCE_SCP)
             })
             .unwrap();
         assert!(
@@ -4444,7 +4444,7 @@ url = "https://history.stellar.org/prd/core-testnet/core_testnet_001"
             .with_connection(|conn| {
                 use henyey_db::queries::StateQueries;
                 use henyey_db::schema::state_keys;
-                Ok(conn.get_state(state_keys::FORCE_SCP)?)
+                conn.get_state(state_keys::FORCE_SCP)
             })
             .unwrap();
         assert_eq!(


### PR DESCRIPTION
Closes #3391

## Summary

Drops the redundant `Ok(...?)` wrapper around `conn.get_state(state_keys::FORCE_SCP)` in the two `with_connection` closures inside `crates/henyey/src/main.rs`'s `#[cfg(test)] mod tests` (finding 2 of #3391). The closure returns `Result<Option<String>, DbError>` and `get_state` returns the same type, so the tail expression `conn.get_state(...)` already yields the correct value/type — the wrapper is the `needless_question_mark` pattern clippy flags under `--all-targets`. No `From`-conversion crosses the `?` (same error type), so the change is purely syntactic and behavior-preserving (net diff = 0).

This lint only fires under `cargo clippy --all-targets` (the inline `#[cfg(test)]` module is compiled there); it does NOT fire under CI's `cargo clippy --all` (which does not compile inline test cfg), so it was local-dev-quality, not CI-blocking. Both states are now clean.

## Finding 1 — closed as superseded (no code change)

The original issue had two findings. **Finding 1** (drop the redundant `meta_matches` term in offline verify-execution) was intentionally NOT actioned and is closed as resolved-by-#3357/#3383. On current origin/main the audit's premise is stale: the "Full meta comparison would be more complex" stub comment is gone; `meta_matches = meta_is_none || tx_result_matches` and its use in `all_match` are documented as a deliberate henyey-local choice (`crates/henyey/src/verify_execution/run.rs:111-116, 320-322`) and pinned by 7 regression tests. `meta_matches` is also load-bearing — it gates the printed public `meta_mismatches` stat counter. The only true residue (the logically-inert `meta_matches` term inside the `all_match` conjunction, via boolean absorption) is harmless and already self-documented. Removing it would change observable stats output and break 7 passing tests for zero benefit. #3391 therefore reduces to finding 2 only.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3391#issuecomment-4735194769)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey --all-targets -- -D warnings` (acceptance gate — lint cleared)
- [x] `cargo clippy --all -- -D warnings` (CI form — clean)
- [x] `cargo build --all`
- [x] `cargo test -p henyey` (62 unit + integration tests pass, incl. `test_cmd_force_scp_rejects_non_validator` and `test_cmd_force_scp_accepts_validator` which exercise the edited closures)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)