### PR TITLE
Narrow dispatch-only rpc handlers and tidy two crate:rpc outliers

### DIFF
--- a/crates/rpc/src/methods/fee_stats.rs
+++ b/crates/rpc/src/methods/fee_stats.rs
@@ -11,7 +11,7 @@ use crate::context::RpcContext;
 use crate::error::JsonRpcError;
 use crate::fee_window::FeeDistribution;
 
-pub async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
+pub(crate) async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
     let ledger = ctx.app.ledger_summary();
 
     let classic = ctx.fee_windows.get_classic_distribution();

--- a/crates/rpc/src/methods/get_events.rs
+++ b/crates/rpc/src/methods/get_events.rs
@@ -19,7 +19,7 @@ const DEFAULT_EVENTS_LIMIT: u64 = 100;
 const MAX_EVENTS_LIMIT: u64 = 10_000;
 
 // SECURITY: request body bounded by HTTP framework body size limit; serde rejects invalid types
-pub async fn handle(
+pub(crate) async fn handle(
     ctx: &Arc<RpcContext>,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, JsonRpcError> {

--- a/crates/rpc/src/methods/get_ledger_entries.rs
+++ b/crates/rpc/src/methods/get_ledger_entries.rs
@@ -16,7 +16,7 @@ use henyey_bucket::SearchableBucketListSnapshot;
 const MAX_KEYS: usize = 200;
 
 // SECURITY: request body bounded by HTTP framework body size limit; serde rejects invalid types
-pub async fn handle(
+pub(crate) async fn handle(
     ctx: &Arc<RpcContext>,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, JsonRpcError> {

--- a/crates/rpc/src/methods/get_ledgers.rs
+++ b/crates/rpc/src/methods/get_ledgers.rs
@@ -16,7 +16,7 @@ const DEFAULT_LEDGER_LIMIT: u32 = 5;
 /// Maximum number of ledgers that can be requested in a single query.
 const MAX_LEDGER_LIMIT: u32 = 200;
 
-pub async fn handle(
+pub(crate) async fn handle(
     ctx: &Arc<RpcContext>,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, JsonRpcError> {

--- a/crates/rpc/src/methods/get_transaction.rs
+++ b/crates/rpc/src/methods/get_transaction.rs
@@ -8,7 +8,7 @@ use crate::context::RpcContext;
 use crate::error::JsonRpcError;
 use crate::util;
 
-pub async fn handle(
+pub(crate) async fn handle(
     ctx: &Arc<RpcContext>,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, JsonRpcError> {

--- a/crates/rpc/src/methods/get_transactions.rs
+++ b/crates/rpc/src/methods/get_transactions.rs
@@ -17,7 +17,7 @@ const DEFAULT_TX_LIMIT: u32 = 10;
 const MAX_TX_LIMIT: u32 = 200;
 
 // SECURITY: request body bounded by HTTP framework body size limit; serde rejects invalid types
-pub async fn handle(
+pub(crate) async fn handle(
     ctx: &Arc<RpcContext>,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, JsonRpcError> {

--- a/crates/rpc/src/methods/health.rs
+++ b/crates/rpc/src/methods/health.rs
@@ -7,7 +7,7 @@ use crate::context::RpcContext;
 use crate::error::JsonRpcError;
 use crate::util;
 
-pub async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
+pub(crate) async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
     let ledger = ctx.app.ledger_summary();
     let rpc_config = &ctx.app.config().rpc;
 

--- a/crates/rpc/src/methods/latest_ledger.rs
+++ b/crates/rpc/src/methods/latest_ledger.rs
@@ -22,7 +22,7 @@ use crate::util;
 /// `LedgerCloseMeta` yet, so the field may be an empty string. When present,
 /// the blob is validated against the expected sequence number via
 /// [`parse_ledger_close_meta_checked`](util::parse_ledger_close_meta_checked).
-pub async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
+pub(crate) async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
     // Read all in-memory fields from a single atomic snapshot so they cannot
     // straddle a ledger close boundary.
     let snap = ctx.app.ledger_snapshot();

--- a/crates/rpc/src/methods/network.rs
+++ b/crates/rpc/src/methods/network.rs
@@ -8,7 +8,7 @@ use crate::error::JsonRpcError;
 const TESTNET_PASSPHRASE: &str = "Test SDF Network ; September 2015";
 const TESTNET_FRIENDBOT_URL: &str = "https://friendbot.stellar.org/";
 
-pub async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
+pub(crate) async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
     let info = ctx.app.info();
 
     // Provide the friendbot URL for testnet

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -10,7 +10,7 @@ use crate::context::RpcContext;
 use crate::error::JsonRpcError;
 use crate::util::{self, XdrFormat};
 
-pub async fn handle(
+pub(crate) async fn handle(
     ctx: &Arc<RpcContext>,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, JsonRpcError> {

--- a/crates/rpc/src/methods/version_info.rs
+++ b/crates/rpc/src/methods/version_info.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use crate::context::RpcContext;
 use crate::error::JsonRpcError;
 
-pub async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
+pub(crate) async fn handle(ctx: &Arc<RpcContext>) -> Result<serde_json::Value, JsonRpcError> {
     let info = ctx.app.info();
     let ledger = ctx.app.ledger_summary();
 

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -608,7 +608,7 @@ mod tests {
     /// directly, complementing the behavioral test below.
     #[test]
     fn test_send_transaction_classified_as_write_method() {
-        // Mirror the classification logic from rpc_handler (line 377).
+        // Mirror the is_write_method classification logic in rpc_handler.
         let is_write = |method: &str| method == "sendTransaction";
 
         assert!(

--- a/crates/rpc/src/simulate/mod.rs
+++ b/crates/rpc/src/simulate/mod.rs
@@ -64,7 +64,7 @@ struct InvokeRequest {
 }
 
 /// Represents a single ledger entry state change from simulation.
-pub(self) struct LedgerEntryDiff {
+struct LedgerEntryDiff {
     key: LedgerKey,
     state_before: Option<stellar_xdr::curr::LedgerEntry>,
     state_after: Option<stellar_xdr::curr::LedgerEntry>,
@@ -336,7 +336,7 @@ where
 // SECURITY: simulation input bounded by HTTP body size limit and serde type validation.
 // SECURITY: concurrent simulations bounded by try_bounded_blocking with simulation_semaphore.
 // Pre-blocking work (XDR parsing, validation) is bounded by request_semaphore at the server level.
-pub async fn handle(
+pub(crate) async fn handle(
     ctx: &Arc<RpcContext>,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, JsonRpcError> {


### PR DESCRIPTION
Closes #3396

## Summary

Behavior-preserving crate:rpc cleanup (refactor + docs, net diff = 0):

- **Finding 1:** drop the redundant `pub(self)` on `struct LedgerEntryDiff` (`simulate/mod.rs`) — `pub(self)` is exactly equivalent to private, and it was the only `pub(self)` in the workspace.
- **Finding 2:** narrow all 12 dispatch-only `handle` functions (11 in `methods/` + 1 in `simulate/mod.rs`) from `pub` to `pub(crate)`. Each is reached only from the sibling private `dispatch.rs`; none is re-exported (`lib.rs` exports only `RpcContext`/`RpcAppHandle`/`FeeWindows`/`RpcServer`/`RpcServerRunning`). All 12 classify as category (a) — live in-crate non-test caller — confirmed by a clean `clippy --all-targets -Dwarnings` (no `unreachable_pub`/`dead_code`).
- **Finding 3:** replace the stale `(line 377)` reference in a `server.rs` test comment with a drift-proof symbol reference.

No handler body, serializer, dispatch mapping, or public re-export changes — every JSON-RPC response shape is identical.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3396#issuecomment-4735233962)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build -p henyey-rpc` under `RUSTFLAGS=-Dwarnings` — clean
- [x] `cargo clippy -p henyey-rpc --all-targets -- -D warnings` — clean (no `unreachable_pub`/`dead_code`)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo build --all` — clean
- [x] `cargo test -p henyey-rpc` — all pass (incl. 37-test `server` unit suite + `http_dispatch::rpc_http_dispatch_covers_core_methods`)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)