### PR TITLE
Remove dead herder cleanup: stale doc bullet, time_call re-export, spawn shim

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2862,7 +2862,7 @@ impl App {
         });
 
         self.set_phase_sub(phase::PHASE_6_6_TX_QUEUE_JOIN);
-        match henyey_herder::await_blocking_logged("tx-queue close-update", join).await {
+        match henyey_common::await_blocking_logged("tx-queue close-update", join).await {
             Ok((shift_result, invalid_banned)) => {
                 if shift_result.unbanned_count > 0 || shift_result.evicted_due_to_age > 0 {
                     tracing::debug!(

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -4130,7 +4130,7 @@ impl Herder {
         // near-free re-schedule that improves fairness when the drain returns
         // instantly (e.g., empty ready queue). (#2716)
         tokio::task::yield_now().await;
-        crate::spawn::await_blocking_logged(&ctx, handle)
+        henyey_common::spawn::await_blocking_logged(&ctx, handle)
             .await
             .ok()
             .unwrap_or(0)
@@ -4146,7 +4146,7 @@ impl Herder {
         slot: SlotIndex,
     ) -> TimeoutOutcome {
         let herder = Arc::clone(self);
-        match crate::spawn::spawn_blocking_logged("handle_nomination_timeout", move || {
+        match henyey_common::spawn::spawn_blocking_logged("handle_nomination_timeout", move || {
             herder.handle_nomination_timeout(slot)
         })
         .await

--- a/crates/herder/src/lib.rs
+++ b/crates/herder/src/lib.rs
@@ -101,7 +101,6 @@
 //! - `herder_utils`: Utility functions (value extraction, node ID formatting)
 //! - `timer_manager`: SCP nomination/ballot timeout scheduling (tokio)
 //! - `sync_recovery`: Out-of-sync detection and recovery
-//! - `tx_broadcast`: Periodic transaction flooding to peers
 //! - `drift_tracker`: Close time drift monitoring
 //! - `dead_node_tracker`: Missing/dead validator detection
 //! - `flow_control`: Flow control constants (transaction size limits)
@@ -127,7 +126,6 @@ mod quorum_set_tracker;
 mod quorum_tracker;
 mod scp_driver;
 pub mod scp_verify;
-mod spawn;
 mod state;
 mod surge_pricing;
 pub mod sync_recovery;
@@ -215,9 +213,6 @@ pub use sync_recovery::{
 
 // Dead node detection
 pub use dead_node_tracker::{DeadNodeTracker, CHECK_FOR_DEAD_NODES_MINUTES};
-
-// Spawn-blocking helpers
-pub use spawn::{await_blocking_logged, spawn_blocking_logged};
 
 /// Result type for Herder operations.
 pub type Result<T> = std::result::Result<T, HerderError>;

--- a/crates/herder/src/spawn.rs
+++ b/crates/herder/src/spawn.rs
@@ -1,7 +1,0 @@
-//! Spawn-blocking helpers with structured error logging.
-//!
-//! Re-exports [`henyey_common::spawn`] helpers for backward compatibility.
-//! New callers should use `henyey_common::{spawn_blocking_logged, await_blocking_logged}`
-//! directly.
-
-pub use henyey_common::spawn::{await_blocking_logged, spawn_blocking_logged};

--- a/crates/herder/src/tracked_lock.rs
+++ b/crates/herder/src/tracked_lock.rs
@@ -63,14 +63,13 @@ use std::time::Instant;
 
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-// Re-export the shared timing primitives so in-crate call sites keep
-// using the familiar `tracked_lock::time_call(...)` path without
+// Re-export the shared timing primitives so in-crate call sites can use
+// `tracked_lock::PhaseTimer` / `tracked_lock::LOCK_SLOW_THRESHOLD` without
 // reaching into `henyey_common::tracking` directly. `LOCK_SLOW_THRESHOLD`
 // is defined once in `henyey-common` and consumed by both this crate
 // and the app-crate tokio companion, so both instrumentation families
 // speak the same language in the validator log.
-#[allow(unused_imports)]
-pub(crate) use henyey_common::tracking::{time_call, PhaseTimer, LOCK_SLOW_THRESHOLD};
+pub(crate) use henyey_common::tracking::{PhaseTimer, LOCK_SLOW_THRESHOLD};
 
 /// RAII wrapper around a `parking_lot` RwLock guard that emits
 /// a single `WARN lock=<label> kind="hold"` on drop iff the


### PR DESCRIPTION
Closes #3392

## Summary

Behavior-preserving `crate:herder` low-cleanup — pure subtraction (6 insertions / 19 deletions), zero observable behavior change. Three findings:

- **F1 (docs):** Delete the stale `tx_broadcast` bullet from the `# Modules` docstring in `lib.rs`. The module was already removed (removal note lives a few lines below) and no `tx_broadcast*` file exists.
- **F2 (dead code):** Drop the genuinely-dead `time_call` re-export from `tracked_lock.rs` (zero references in lib or `--tests`) and remove the now-unnecessary `#[allow(unused_imports)]`. `PhaseTimer` (consumed at `herder.rs`) and `LOCK_SLOW_THRESHOLD` (11 in-module consumers) are **kept** — the audit's literal "reduce to just PhaseTimer" would not compile. All lock-timing / `WARN lock=…` instrumentation is byte-identical.
- **F3 (vestigial shim, cross-crate):** Delete the `spawn.rs` re-export shim and its `mod`/`pub use` in `lib.rs`, repointing all 3 callers — `herder.rs` ×2 (in-crate) and `crates/app/src/app/ledger_close.rs` ×1 (app crate) — directly at the identical `henyey_common` functions. The app edit also aligns the lone outlier with the prevailing `henyey_common::*` style.

Instrumentation / plumbing / doc only — no consensus behavior change vs stellar-core v26.0.1. `LOCK_SLOW_THRESHOLD` and every `WARN lock=…` emission site are untouched, so consensus timing/logging is byte-identical.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3392#issuecomment-4735614568)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` — clean across the whole workspace (proves the shim deletion + repoints are complete)
- [x] `cargo build --all` under `-Dwarnings` — clean
- [x] `cargo test -p henyey-herder` — 1185 lib tests pass (incl. `tracked_lock` unit tests that would fail to compile if `LOCK_SLOW_THRESHOLD` were dropped) + integration/doc tests pass

## Deviations from plan

None. (Net diff is 6/-19 vs the plan's stated 10/-23 — the `tracked_lock.rs` comment rewrite is slightly tighter; functionally identical.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)