### PR TITLE
Refs #3419: add inbound-peer drop diagnostics to overlay

### DIFF
--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -627,6 +627,11 @@ metric_catalog! {
             => "Total inbound peer disconnections (run_peer_loop returned)";
         OVERLAY_INBOUND_REJECT_TOTAL = "stellar_overlay_inbound_reject_total"
             => "Total inbound connections rejected before establishment";
+        // #3419 diagnostic: monotonic count of inbound peers that reached
+        // authenticated state. Climbing while the `inbound_authenticated` gauge
+        // stays near 0 means "authenticated then churned", not "never authenticated".
+        OVERLAY_INBOUND_AUTHENTICATED_TOTAL = "stellar_overlay_inbound_authenticated_total"
+            => "Total inbound peers that transitioned to authenticated (monotonic)";
         OVERLAY_OUTBOUND_ATTEMPT_TOTAL = "stellar_overlay_outbound_attempt_total"
             => "Total outbound connection attempts (dial initiated)";
         OVERLAY_OUTBOUND_ESTABLISH_TOTAL = "stellar_overlay_outbound_establish_total"
@@ -1067,6 +1072,7 @@ pub(crate) async fn refresh_gauges(state: &ServerState) {
         OVERLAY_INBOUND_ESTABLISH_TOTAL.absolute(ov.inbound_establish);
         OVERLAY_INBOUND_DROP_TOTAL.absolute(ov.inbound_drop);
         OVERLAY_INBOUND_REJECT_TOTAL.absolute(ov.inbound_reject);
+        OVERLAY_INBOUND_AUTHENTICATED_TOTAL.absolute(ov.inbound_authenticated_total);
         OVERLAY_OUTBOUND_ATTEMPT_TOTAL.absolute(ov.outbound_attempt);
         OVERLAY_OUTBOUND_ESTABLISH_TOTAL.absolute(ov.outbound_establish);
         OVERLAY_OUTBOUND_DROP_TOTAL.absolute(ov.outbound_drop);

--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -481,6 +481,19 @@ impl OverlayManager {
             shared.pending_connections.release_peer_id(&peer_id);
         }
         shared.metrics.inbound_establish.inc();
+        // #3419 diagnostic (observability-only): an inbound peer transitioned to
+        // authenticated. The monotonic counter lets an operator distinguish
+        // "never authenticated" (stays 0) from "authenticated then churned"
+        // (climbs while the instantaneous gauge stays near 0). The warn event
+        // gives a timestamped, per-direction authenticated-transition signal.
+        shared.metrics.inbound_authenticated_total.inc();
+        warn!(
+            target: "overlay_inbound_diag",
+            peer_id = %peer_id,
+            direction = "inbound",
+            event = "authenticated",
+            "inbound peer transitioned to authenticated"
+        );
 
         let generation = register_result.generation;
         Self::run_peer_loop(

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -909,6 +909,40 @@ impl OverlayManager {
         }
     }
 
+    /// #3419 diagnostic (observability-only): emit a `warn!` describing how an
+    /// inbound peer connection dropped/reset, capturing the last message henyey
+    /// sent on that connection before the drop. This does NOT alter any control
+    /// flow, handshake, auth, codec, or dispatch behavior — it only reads
+    /// already-tracked per-peer state and logs it.
+    ///
+    /// Gated to inbound connections only: the mainnet symptom in #3419 is
+    /// `stellar_overlay_inbound_authenticated` sustained near 0 while inbound
+    /// peers establish then get reset by the remote post-auth. Outbound drops
+    /// are not the subject of this investigation, so we don't spam them here.
+    ///
+    /// `reason` is a short, low-cardinality classification of the drop site
+    /// (e.g. "recv_error", "remote_closed", "send_error"); `detail` carries the
+    /// errno / error string when available (empty otherwise).
+    fn log_inbound_drop_diag(peer: &Peer, peer_id: &PeerId, reason: &str, detail: &str) {
+        if peer.direction() != ConnectionDirection::Inbound {
+            return;
+        }
+        let stats = peer.stats();
+        warn!(
+            target: "overlay_inbound_diag",
+            peer_id = %peer_id,
+            addr = %peer.remote_addr(),
+            direction = "inbound",
+            authenticated = peer.is_ready(),
+            last_sent_msg_type = peer.last_sent_msg_type(),
+            messages_sent = stats.messages_sent.load(Ordering::Relaxed),
+            messages_received = stats.messages_received.load(Ordering::Relaxed),
+            drop_reason = reason,
+            drop_detail = detail,
+            "inbound peer connection dropped; last message henyey sent before reset recorded"
+        );
+    }
+
     pub(super) async fn run_peer_loop(
         peer_id: PeerId,
         mut peer: Peer,
@@ -965,6 +999,7 @@ impl OverlayManager {
                             if let Err(e) = peer.send(m).await {
                                 debug!("Failed to send to {}: {}", peer_id, e);
                                 state.metrics.errors_write.inc();
+                                Self::log_inbound_drop_diag(&peer, &peer_id, "send_error", &e.to_string());
                                 break;
                             }
                             state.metrics.messages_written.inc();
@@ -982,6 +1017,7 @@ impl OverlayManager {
                                 }
                                 Err(e) => {
                                     debug!("Failed to send batch to {}: {}", peer_id, e);
+                                    Self::log_inbound_drop_diag(&peer, &peer_id, "flood_send_error", &e.to_string());
                                     break;
                                 }
                             }
@@ -1065,11 +1101,13 @@ impl OverlayManager {
                         }
                         Ok(None) => {
                             info!("Peer {} loop exiting: connection closed by remote (total_msgs={}, scp_msgs={})", peer_id, total_messages, scp_messages);
+                            Self::log_inbound_drop_diag(&peer, &peer_id, "remote_closed", "");
                             break;
                         }
                         Err(e) => {
                             state.metrics.errors_read.inc();
                             info!("Peer {} loop exiting: recv error: {} (total_msgs={}, scp_msgs={})", peer_id, e, total_messages, scp_messages);
+                            Self::log_inbound_drop_diag(&peer, &peer_id, "recv_error", &e.to_string());
                             break;
                         }
                     }

--- a/crates/overlay/src/metrics.rs
+++ b/crates/overlay/src/metrics.rs
@@ -448,6 +448,13 @@ pub struct OverlayMetrics {
     /// Inbound connections rejected at any point after accept but before establish
     /// (handshake failure, banned, duplicate, slots full, register race).
     pub inbound_reject: Counter,
+    /// Monotonic count of inbound peers that transitioned to authenticated
+    /// (handshake completed + registered). Diagnostic for #3419: lets an
+    /// operator distinguish "never authenticated" (stays 0) from "authenticated
+    /// then churned" (climbs while the instantaneous
+    /// `stellar_overlay_inbound_authenticated` gauge stays near 0). Mirrors the
+    /// increment point of `inbound_establish`; observability-only.
+    pub inbound_authenticated_total: Counter,
     /// Outbound connection attempts: a dial was actually initiated (after the
     /// address reservation succeeded inside `connect_to_discovered_peer` /
     /// `connect_to_explicit_peer`). Does NOT include caller-side skips (e.g.,
@@ -572,6 +579,7 @@ impl OverlayMetrics {
             inbound_establish: self.inbound_establish.get(),
             inbound_drop: self.inbound_drop.get(),
             inbound_reject: self.inbound_reject.get(),
+            inbound_authenticated_total: self.inbound_authenticated_total.get(),
             outbound_attempt: self.outbound_attempt.get(),
             outbound_establish: self.outbound_establish.get(),
             outbound_drop: self.outbound_drop.get(),
@@ -647,6 +655,7 @@ impl OverlayMetrics {
             &self.inbound_establish,
             &self.inbound_drop,
             &self.inbound_reject,
+            &self.inbound_authenticated_total,
             &self.outbound_attempt,
             &self.outbound_establish,
             &self.outbound_drop,
@@ -711,6 +720,8 @@ pub struct OverlayMetricsSnapshot {
     pub inbound_establish: u64,
     pub inbound_drop: u64,
     pub inbound_reject: u64,
+    /// Monotonic count of inbound peers that reached authenticated state (#3419).
+    pub inbound_authenticated_total: u64,
     pub outbound_attempt: u64,
     pub outbound_establish: u64,
     pub outbound_drop: u64,

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -213,6 +213,12 @@ pub struct Peer {
     /// Used to conditionally release the reservation on cleanup; inbound
     /// peers that bypassed reservation (mutual-dial) must not release it.
     holds_pending_peer_id: bool,
+    /// Diagnostic (#3419, observability-only): the wire name of the most-recent
+    /// `StellarMessage` we sent on this connection (handshake or post-auth).
+    /// Updated on every send path; read by the peer loop on drop to surface the
+    /// "last message henyey sent before the connection reset" pattern. `"none"`
+    /// until the first send. Purely additive state — does NOT gate any logic.
+    last_sent_msg_type: &'static str,
 }
 
 impl Peer {
@@ -253,6 +259,7 @@ impl Peer {
             stats: Arc::new(PeerStats::default()),
             metrics,
             holds_pending_peer_id: false,
+            last_sent_msg_type: "none",
         };
 
         peer.handshake(
@@ -305,6 +312,7 @@ impl Peer {
             stats: Arc::new(PeerStats::default()),
             metrics,
             holds_pending_peer_id: false,
+            last_sent_msg_type: "none",
         };
 
         // Perform handshake (with ban + pending-dedup checks after HELLO for inbound)
@@ -763,6 +771,8 @@ impl Peer {
     /// Send a raw message (before authentication, e.g., Hello).
     async fn send_raw(&mut self, message: StellarMessage) -> Result<()> {
         let kind = OverlayMessageKind::from_stellar_message(&message);
+        // #3419 diagnostic: record the last-sent wire type (observability-only).
+        self.last_sent_msg_type = helpers::message_type_name(&message);
         let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_unauthenticated(message);
         // `Connection::send` returns the on-the-wire frame size, so we don't
@@ -783,6 +793,8 @@ impl Peer {
     /// Send an Auth message (with MAC but sequence 0).
     async fn send_auth(&mut self, message: StellarMessage) -> Result<()> {
         let kind = OverlayMessageKind::from_stellar_message(&message);
+        // #3419 diagnostic: record the last-sent wire type (observability-only).
+        self.last_sent_msg_type = helpers::message_type_name(&message);
         let body_size = msg_body_size(&message);
         let auth_msg = self.auth.wrap_auth_message(message)?;
         let wire_size = self.connection.send(auth_msg).await?;
@@ -806,6 +818,8 @@ impl Peer {
 
         let kind = OverlayMessageKind::from_stellar_message(&message);
         let msg_type = helpers::message_type_name(&message);
+        // #3419 diagnostic: record the last-sent wire type (observability-only).
+        self.last_sent_msg_type = msg_type;
         trace!("SEND {} to {}", msg_type, self.info.peer_id);
 
         let body_size = msg_body_size(&message);
@@ -959,6 +973,14 @@ impl Peer {
         self.info.direction
     }
 
+    /// Diagnostic (#3419, observability-only): the wire name of the most-recent
+    /// `StellarMessage` sent on this connection, or `"none"` if nothing has been
+    /// sent yet. Read by the peer loop on drop to surface the last message
+    /// henyey sent before a remote reset.
+    pub fn last_sent_msg_type(&self) -> &'static str {
+        self.last_sent_msg_type
+    }
+
     /// Whether this peer owns a pending_peer_id reservation.
     /// Used by the manager to decide whether to call `release_peer_id`
     /// during cleanup — peers that bypassed the reservation in a
@@ -1032,6 +1054,7 @@ impl Peer {
             stats: Arc::new(PeerStats::default()),
             metrics,
             holds_pending_peer_id,
+            last_sent_msg_type: "none",
         }
     }
 }
@@ -1107,6 +1130,7 @@ mod tests {
             stats: Arc::new(PeerStats::default()),
             metrics: metrics_a,
             holds_pending_peer_id: false,
+            last_sent_msg_type: "none",
         };
         let peer_b = Peer {
             info: PeerInfo {
@@ -1125,6 +1149,7 @@ mod tests {
             stats: Arc::new(PeerStats::default()),
             metrics: metrics_b,
             holds_pending_peer_id: false,
+            last_sent_msg_type: "none",
         };
         (peer_a, peer_b)
     }
@@ -1183,6 +1208,7 @@ mod tests {
             stats: Arc::new(PeerStats::default()),
             metrics: Arc::new(OverlayMetrics::new()),
             holds_pending_peer_id: false,
+            last_sent_msg_type: "none",
         };
         (peer, hello)
     }
@@ -1431,6 +1457,7 @@ mod tests {
             stats: Arc::new(PeerStats::default()),
             metrics: Arc::new(OverlayMetrics::new()),
             holds_pending_peer_id: false,
+            last_sent_msg_type: "none",
         };
 
         (responder, client_conn, client_auth)
@@ -1630,6 +1657,7 @@ mod tests {
             stats: Arc::new(PeerStats::default()),
             metrics: Arc::new(OverlayMetrics::new()),
             holds_pending_peer_id: false,
+            last_sent_msg_type: "none",
         };
 
         // The remote side: a raw responder AuthContext that replies to the


### PR DESCRIPTION
Refs #3419

**Diagnostic instrumentation only — not a fix.** Per the operator's decision on #3419, this adds observability to the live mainnet validator to capture the real inbound-auth failure mode. The prior investigation (see issue comments) **exonerated the suspect commit `45a97265`**: henyey's inbound auth path provably works (471 overlay lib tests pass; `inbound_establish` increments; the gauge climbs slowly over hours), and the symptom is that non-tier1 remotes reset henyey-as-acceptor shortly after a successful handshake. This PR adds the instrumentation that investigation recommended to see *why*.

## Observability-only — zero behavior change

No change to handshake/auth sequencing, MAC/codec semantics, message framing, dispatch, or any control flow. All additions are:
- A cheap additive per-connection field (last-sent message wire-type) and a read-only accessor.
- `tracing` events (warn-level) at existing drop sites.
- One new monotonic counter.

The existing 471 overlay lib tests pass unchanged precisely because no behavior changed.

## What was instrumented

1. **Last message before reset.** `Peer` now tracks `last_sent_msg_type` (the wire name of the most-recent `StellarMessage` sent), updated on every send path (handshake `send_raw`/`send_auth` and post-auth `send`). On an **inbound** peer drop/reset in the peer loop — recv error (e.g. "Connection reset by peer" / errno 104), remote close, or send error — we emit `warn!(target: "overlay_inbound_diag", ...)` capturing: peer id, addr, direction (inbound), authenticated state at drop, **last-sent message type**, messages sent/received, and the drop reason + errno/detail. Gated to inbound only (the #3419 symptom) so it does not spam outbound churn.

2. **Per-direction authenticated-over-time signal.**
   - A `warn!(target: "overlay_inbound_diag", event="authenticated")` fires when an inbound peer transitions to authenticated (timestamped transition signal).
   - New monotonic counter `stellar_overlay_inbound_authenticated_total`, incremented at the inbound establish/register point. The existing `stellar_overlay_inbound_authenticated` is an instantaneous gauge; this counter lets an operator distinguish **"never authenticated"** (stays 0) from **"authenticated then churned"** (climbs while the gauge stays near 0).

## What to look for after redeploy

The operator will redeploy this build to mainnet to capture data. In the logs/metrics, look for:
- `overlay_inbound_diag` warn lines with `drop_reason=recv_error` / `remote_closed` and the `last_sent_msg_type` field — **this is the last message henyey sent the acceptor before the remote reset it**. The prior investigation flagged the post-auth `SEND_MORE_EXTENDED` grant / first flood/SCP reply as a candidate; this confirms (or refutes) it directly.
- `stellar_overlay_inbound_authenticated_total` climbing while `stellar_overlay_inbound_authenticated` (gauge) stays near 0 → confirms "authenticated then churned" rather than "never authenticated".
- Compare `messages_sent`/`messages_received` at drop to see how far into the session the reset happens (prior investigation saw ~15-17 msgs post-auth).

## Test plan

- [x] `cargo build -p henyey-overlay`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-overlay` — all pass (471 lib + integration + doctests; behavior unchanged)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Deviations from plan

None. This issue stays **open** — it is diagnostic instrumentation, not a fix, so the PR intentionally does not `Closes` it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)