### PR TITLE
Flip enqueue_publish to last-write-wins for stellar-core parity

### DIFF
--- a/crates/db/src/queries/publish_queue.rs
+++ b/crates/db/src/queries/publish_queue.rs
@@ -161,14 +161,29 @@ mod tests {
     }
 
     #[test]
-    fn test_enqueue_publish_does_not_overwrite_existing_row() {
-        // First-write-wins: an existing row for a `ledgerseq` is never
-        // overwritten by a subsequent enqueue, even if the pre-existing row
-        // holds a legacy value (e.g. the old `'pending'` sentinel that this
-        // crate no longer writes). The `INSERT OR IGNORE` ignores the PK
-        // conflict and leaves the existing row intact. This pins the removal
-        // of the old `WHERE state = 'pending'` UPDATE branch — under that
-        // branch this row WOULD have been overwritten.
+    fn test_enqueue_publish_last_write_wins() {
+        // Last-write-wins: re-enqueuing the same `ledgerseq` with a differing
+        // HAS overwrites the stored row. This mirrors stellar-core v26.0.1's
+        // `writeCheckpointFile` durable-rename onto a fixed per-seq path (an
+        // unconditional overwrite) and henyey-history's `INSERT OR REPLACE`.
+        let conn = setup_db();
+
+        let has_a = r#"{"version":2,"currentLedger":63,"marker":"A"}"#;
+        let has_b = r#"{"version":2,"currentLedger":63,"marker":"B"}"#;
+
+        conn.enqueue_publish(63, has_a).unwrap();
+        conn.enqueue_publish(63, has_b).unwrap();
+
+        let stored = conn.load_publish_has(63).unwrap().unwrap();
+        assert_eq!(stored, has_b);
+    }
+
+    #[test]
+    fn test_enqueue_publish_overwrites_legacy_pending_row() {
+        // Last-write-wins repairs legacy rows: a pre-existing `'pending'`
+        // sentinel row (which this crate no longer writes) is overwritten by a
+        // real HAS on re-enqueue. This matches the pre-#3390 `WHERE state =
+        // 'pending'` UPDATE branch and stellar-core's unconditional rename.
         let conn = setup_db();
 
         conn.execute(
@@ -181,21 +196,7 @@ mod tests {
         conn.enqueue_publish(63, has_json).unwrap();
 
         let stored = conn.load_publish_has(63).unwrap().unwrap();
-        assert_eq!(stored, "pending");
-    }
-
-    #[test]
-    fn test_enqueue_publish_keeps_existing_has_json() {
-        let conn = setup_db();
-
-        let first_has = r#"{"version":2,"currentLedger":63,"marker":"first"}"#;
-        let second_has = r#"{"version":2,"currentLedger":63,"marker":"second"}"#;
-
-        conn.enqueue_publish(63, first_has).unwrap();
-        conn.enqueue_publish(63, second_has).unwrap();
-
-        let stored = conn.load_publish_has(63).unwrap().unwrap();
-        assert_eq!(stored, first_has);
+        assert_eq!(stored, has_json);
     }
 
     #[test]

--- a/crates/db/src/queries/publish_queue.rs
+++ b/crates/db/src/queries/publish_queue.rs
@@ -19,8 +19,11 @@ use crate::error::DbError;
 pub trait PublishQueueQueries {
     /// Adds a checkpoint ledger to the publish queue.
     ///
-    /// First-write-wins: this is a no-op if the ledger is already in the
-    /// queue, leaving the existing row (and its stored HAS JSON) untouched.
+    /// Last-write-wins: re-enqueuing an existing `ledgerseq` overwrites the
+    /// stored row with the new HAS JSON. This matches stellar-core v26.0.1's
+    /// `writeCheckpointFile`, which `durableRename`s the HAS onto a fixed
+    /// per-seq path (an unconditional overwrite), and henyey-history's
+    /// `PublishQueue::enqueue`, which already uses `INSERT OR REPLACE`.
     /// The `has_json` parameter stores the History Archive State JSON
     /// captured at checkpoint time, ensuring the publish path uses the
     /// exact HAS (including hot archive bucket hashes) from the
@@ -75,13 +78,16 @@ pub trait PublishQueueQueries {
 
 impl PublishQueueQueries for Connection {
     fn enqueue_publish(&self, ledger_seq: u32, has_json: &str) -> Result<(), DbError> {
-        // `INSERT OR IGNORE` makes the first-write-wins contract explicit: on a
-        // `ledgerseq` primary-key conflict the new row is ignored, leaving the
-        // existing entry intact. This intentionally swallows the PK conflict for
-        // idempotency. All callers always pass a non-null `has_json`, so the
-        // `state NOT NULL` constraint is never at risk.
+        // `INSERT OR REPLACE` makes the last-write-wins contract explicit: on a
+        // `ledgerseq` primary-key conflict the existing row is deleted and the
+        // new row inserted, overwriting `state` with the new `has_json`. This
+        // matches stellar-core's durable-rename overwrite and henyey-history's
+        // `INSERT OR REPLACE`. The table has only `(ledgerseq PK, state)` with
+        // no other columns, FKs, or triggers, so the replace cannot drop a
+        // column or orphan data. All callers always pass a non-null `has_json`,
+        // so the `state NOT NULL` constraint is never at risk.
         self.execute(
-            "INSERT OR IGNORE INTO publishqueue (ledgerseq, state) VALUES (?1, ?2)",
+            "INSERT OR REPLACE INTO publishqueue (ledgerseq, state) VALUES (?1, ?2)",
             params![ledger_seq as i64, has_json],
         )?;
         Ok(())


### PR DESCRIPTION
Closes #3412

## Summary

henyey-db's `enqueue_publish` was first-write-wins (`INSERT OR IGNORE`, made explicit in #3390 and mutation-tested in #3414), but stellar-core v26.0.1's `writeCheckpointFile` writes the HAS via `fs::durableRename` onto a fixed per-seq path — an unconditional overwrite, i.e. **last-write-wins** — and henyey-history's `PublishQueue::enqueue` already uses `INSERT OR REPLACE`. This PR flips the one SQL keyword (`INSERT OR IGNORE` → `INSERT OR REPLACE`) so all three implementations agree, and updates the doc comments to describe the last-write-wins contract and parity rationale. No schema, migration, or stored-format change.

## Deliberate, parity-justified semantic flip (NOT a regression)

This intentionally **reverses** the first-write-wins guards made explicit in #3390/#3414. First-write-wins was never an intentional design choice — it was a cleanup artifact. The project rule is "do not introduce new semantics; align with stellar-core," and last-write-wins matches both upstream (`durableRename` overwrite) and henyey-history's existing `INSERT OR REPLACE`.

The flip is **behavior-neutral on the production path**:
- The only steady-state caller (`ledger_close.rs:156`) enqueues inside the close commit, gated on a checkpoint ledger; ledgers close monotonically so each checkpoint seq is enqueued exactly once — `IGNORE` vs `REPLACE` is indistinguishable.
- On startup, `restore_checkpoint(lcl)` deletes every row with `ledgerseq > lcl` *before* replay, so any checkpoint re-closed during catchup hits an empty slot — again indistinguishable.

The sole behavior delta vs main is the legacy `'pending'`-sentinel repair case, where a stale row is now overwritten by a real HAS — strictly more correct, matching the pre-#3390 `WHERE state='pending'` UPDATE branch and stellar-core's unconditional rename.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3412#issuecomment-4737084696)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-db` — 110 passed

## Regression tests (bug-fix)

- **NEW** `crates/db/src/queries/publish_queue.rs::test_enqueue_publish_last_write_wins` — enqueue seq 63 with HAS-A, re-enqueue with HAS-B, assert stored == HAS-B.
- **TRANSFORMED** `test_enqueue_publish_keeps_existing_has_json` → `test_enqueue_publish_last_write_wins` (replaced; old test asserted first-write-wins).
- **TRANSFORMED** `test_enqueue_publish_does_not_overwrite_existing_row` → `test_enqueue_publish_overwrites_legacy_pending_row` — asserts a real HAS overwrites a legacy `'pending'` row.
- **Pre-fix:** committed as `f4730370` — verified FAILED (kept HAS-A / kept `pending` under `INSERT OR IGNORE`).
- **Post-fix:** verified PASSES after `010dd1eb`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)