### PR TITLE
Remove dead HerderError::QueueFull variant

### DIFF
--- a/crates/herder/src/error.rs
+++ b/crates/herder/src/error.rs
@@ -11,13 +11,6 @@ use thiserror::Error;
 /// capacity limits, SCP consensus problems, or internal state errors.
 #[derive(Debug, Error)]
 pub enum HerderError {
-    /// Transaction queue is at capacity.
-    ///
-    /// The queue has reached its maximum size and cannot accept additional
-    /// transactions without evicting lower-fee transactions.
-    #[error("transaction queue full")]
-    QueueFull,
-
     /// An error occurred in the SCP consensus layer.
     ///
     /// This wraps errors from the underlying SCP implementation, such as


### PR DESCRIPTION
Closes #3425

## Summary

Removes the dead `HerderError::QueueFull` enum variant from `crates/herder/src/error.rs`. The variant was never constructed or matched anywhere in the workspace — a residual the first dead-variant sweep (#3334) missed when it removed two sibling variants (`TransactionValidationFailed`, `LedgerClose`). Re-confirmed zero `HerderError::QueueFull` references workspace-wide before deletion. The unrelated `TxQueueResult::QueueFull` is untouched. No external crate matches `HerderError` exhaustively, so removal cannot break a downstream match.

Pure error-variant removal: no consensus/quorum/SCP behavior change. Parity with stellar-core is unaffected.

## Plan reference

Trivial short-circuit (XS) — see the `## Implementation Notes` section of the triage report on #3425.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all (RUSTFLAGS="-Dwarnings") — clean
- [x] cargo test -p henyey-herder — 1185 + integration tests pass, 0 failures

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)