### PR TITLE
Remove redundant unsafe impl Send for BucketListSnapshotSource

### DIFF
--- a/crates/rpc/src/simulate/snapshot.rs
+++ b/crates/rpc/src/simulate/snapshot.rs
@@ -31,11 +31,6 @@ pub(crate) struct BucketListSnapshotSource {
     current_ledger: u32,
 }
 
-// Safety: BucketListSnapshotSource contains only owned, immutable data.
-// SearchableBucketListSnapshot holds cloned data from the bucket list.
-// It is safe to send across threads.
-unsafe impl Send for BucketListSnapshotSource {}
-
 impl BucketListSnapshotSource {
     pub(crate) fn new(snapshot: SearchableBucketListSnapshot, current_ledger: u32) -> Self {
         Self {


### PR DESCRIPTION
Closes #3429

## Summary

`BucketListSnapshotSource` (in `crates/rpc/src/simulate/snapshot.rs`) holds only owned, immutable fields — `snapshot: SearchableBucketListSnapshot` and `current_ledger: u32` — so `Send` is auto-derived. The manual `unsafe impl Send for BucketListSnapshotSource {}` (plus its 3-line safety comment) was therefore redundant. This change deletes it, removing an unnecessary `unsafe` assertion. Behavior-neutral: a pure safety improvement (one fewer hand-written `unsafe`).

Verified the crate still compiles without the impl, proving the type is auto-`Send`.

## Plan reference

Trivial short-circuit — no separate /plan stage. Implementation directed by the [Triage Report](https://github.com/stellar-experimental/henyey/issues/3429#issuecomment-4744038641) (`## Implementation Notes`): delete the safety comment + `unsafe impl Send` at snapshot.rs lines 34-37.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all
- [x] cargo test -p henyey-rpc (38 tests pass)
- [x] cargo check -p henyey-rpc clean without the unsafe impl (auto-Send confirmed)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)