### PR TITLE
Fix Survey aggregate-drop double-count in PeerRateLimiter

### DIFF
--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -2040,6 +2040,33 @@ mod tests {
         assert!(limiter.allow(TrafficClass::ControlFetch));
     }
 
+    /// Regression test for #3428: a Survey message dropped at the aggregate
+    /// cap must increment `dropped_aggregate` by exactly 1, matching the other
+    /// traffic classes. Previously the aggregate-exhausted match arm did
+    /// `Survey => self.dropped_aggregate += 1` AND then the unconditional
+    /// `self.dropped_aggregate += 1` ran, so each dropped Survey added +2.
+    #[test]
+    fn test_peer_rate_limiter_survey_drop_single_aggregate_count() {
+        let mut limiter = PeerRateLimiter::new();
+
+        // Fill the aggregate window with Survey messages (all allowed).
+        for _ in 0..DEFAULT_PEER_RATE_LIMIT {
+            assert!(limiter.allow(TrafficClass::Survey));
+        }
+
+        // Drop N more Survey messages past the aggregate cap (all rejected).
+        const N: u64 = 5;
+        for _ in 0..N {
+            assert!(!limiter.allow(TrafficClass::Survey));
+        }
+
+        // Each aggregate-cap drop must count exactly once, not twice.
+        assert_eq!(
+            limiter.dropped_aggregate, N,
+            "each dropped Survey must add +1 to dropped_aggregate (not +2)"
+        );
+    }
+
     #[test]
     fn test_peer_rate_limiter_telemetry_counters() {
         let mut limiter = PeerRateLimiter::new();

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -221,7 +221,10 @@ impl PeerRateLimiter {
                 TrafficClass::TxAndDemand => self.dropped_tx_demand += 1,
                 TrafficClass::Advert => self.dropped_advert += 1,
                 TrafficClass::ControlFetch => self.dropped_control_fetch += 1,
-                TrafficClass::Survey => self.dropped_aggregate += 1,
+                // Survey has no per-class drop counter (aggregate-only by
+                // design); the unconditional increment below records the
+                // single aggregate-cap drop, matching the other classes.
+                TrafficClass::Survey => {}
             }
             self.dropped_aggregate += 1;
             return false;


### PR DESCRIPTION
Closes #3428

## Summary

In `PeerRateLimiter::allow()` (`crates/overlay/src/manager/peer_loop.rs`), the aggregate-exhausted branch matched `TrafficClass::Survey => self.dropped_aggregate += 1` and then ran the unconditional `self.dropped_aggregate += 1`, so each dropped Survey message added **+2** to `dropped_aggregate` while every other traffic class adds +1 (its per-class counter) and +1 (aggregate). This is an observable telemetry-correctness bug: Survey was double-counted in the aggregate-drop counter. The fix makes the Survey match arm a no-op (`Survey => {}`), so the single unconditional increment records the one aggregate-cap drop, matching the other three classes. Survey is aggregate-only by design (no `dropped_survey` per-class field, no consumer), so none is added.

This is a metric-correctness fix — it changes an observable telemetry value (1 instead of 2 per dropped Survey). It touches **only** the `dropped_aggregate` counter; `allow()`'s return value (the actual drop decision) is unchanged, so live message-dispatch/flooding is untouched.

**Finding 1 was stale/refuted.** The issue's Finding 1 (clippy `identity_op` at `codec.rs:549`, `let len: u32 = 0 | 0x80000000;`) does not exist on current `origin/main` — the codec was rewritten since the cleanup audit captured it; `grep` finds no such line and `clippy --all-targets` reports no `identity_op` at codec.rs. No edit to `codec.rs` was made.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3428#issuecomment-4744090557)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (clean)
- [x] cargo build --all
- [x] cargo test -p henyey-overlay — 472 lib tests pass (471 prior + new regression test), all integration tests green

## Regression test (kind: bug-fix)

- **Test:** `crates/overlay/src/manager/peer_loop.rs::test_peer_rate_limiter_survey_drop_single_aggregate_count`
- **Pre-fix:** committed as `6252645ba106308d6adba5c216611a65b1e2c7a7` — verified FAILED with `assertion left == right failed: left: 10, right: 5` (dropped Survey double-counted: 2*N instead of N).
- **Post-fix:** verified PASSES after `08ee0b0c323334ce938f03a25128efd6d0420499`.

## Parity

n/a — non-parity path. `PeerRateLimiter` and its `dropped_aggregate` telemetry are henyey-specific hardening with no stellar-core analog.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)