### PR TITLE
Delete dead code in henyey-simulation

### DIFF
--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -604,16 +604,6 @@ impl Simulation {
         Ok(())
     }
 
-    /// Get the expected Unix timestamp (seconds) of the next ledger close for a node.
-    ///
-    /// Returns `tracking_consensus_close_time + ledger_close_duration.as_secs()`.
-    /// Matches stellar-core's expected close time calculation used in
-    /// various `crankUntil` calls.
-    pub fn expected_next_ledger_close_unix_secs(&self, node_id: &str) -> Option<u64> {
-        let app = self.running_apps.get(node_id)?;
-        Some(app.app.expected_next_ledger_close_unix_secs())
-    }
-
     pub async fn app_peer_count(&self, node_id: &str) -> Option<usize> {
         let app = self.running_apps.get(node_id)?;
         Some(app.app.peer_count().await)

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -1126,8 +1126,6 @@ pub struct LoadGenerator {
     contract_overhead_bytes: u64,
     /// Per-account contract instance assignments (rebuilt each `SorobanInvoke` run).
     contract_instances: BTreeMap<u64, ContractInstance>,
-    /// Number of WASM uploads completed in current setup run.
-    wasms_uploaded: u32,
 
     // --- PayPregenerated state ---
     /// Open reader over the pre-generated transactions file (persists position
@@ -1154,7 +1152,6 @@ impl LoadGenerator {
             contract_instance_keys: HashSet::new(),
             contract_overhead_bytes: 0,
             contract_instances: BTreeMap::new(),
-            wasms_uploaded: 0,
             preloaded_reader: None,
             curr_preloaded: 0,
         }
@@ -1603,7 +1600,6 @@ impl LoadGenerator {
                         let wasm_hash = SorobanTxBuilder::loadgen_wasm_hash();
                         self.code_key = Some(contract_code_key(&wasm_hash));
                         self.contract_overhead_bytes = wasm.len() as u64 + 160;
-                        self.wasms_uploaded += 1;
                         config.n_wasms = config.n_wasms.saturating_sub(1);
                     }
                     result


### PR DESCRIPTION
Closes #3431

## Summary

Removes two confirmed-dead-code items in the `henyey-simulation` test/loadgen harness, both behavior-neutral and build-verified under `-Dwarnings`:

- **`Simulation::expected_next_ledger_close_unix_secs`** (`crates/simulation/src/lib.rs`) — a never-called `pub fn` delegation wrapper. Its only references were its own definition + body, which delegated to the *distinct, live* `App::expected_next_ledger_close_unix_secs` (`crates/app/src/app/mod.rs:2116`), left untouched. Because it is a `pub fn` on a `pub struct` in a library crate it is `dead_code`-exempt, so narrowing it to `pub(crate)` would trip `-Dwarnings`; **delete** is the correct path (the keep-pub alternative would require an API-pinning test for an API with zero consumers).
- **`LoadGenerator::wasms_uploaded`** (`crates/simulation/src/loadgen.rs`) — a write-only private `u32` counter (decl + init + a lone `+= 1` write, zero readers). The surrounding phase-1 upload branch is driven entirely by `config.n_wasms` (the `> 0` guard and `saturating_sub(1)` decrement), not by this field, so removal leaves loadgen output and sequencing identical.

Net diff: -14 lines, no behavior change. No new tests (build-proven refactor); existing simulation tests confirm loadgen behavior is unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3431#issuecomment-4744395253)

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-simulation` — clean
- [x] `cargo clippy -p henyey-simulation --all-targets -- -D warnings` — clean
- [x] `cargo build --all` — clean
- [x] `cargo test -p henyey-simulation` — 140 tests, 0 failed

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)