### PR TITLE
Remove residual dead public API in henyey-history and reconcile docs

### DIFF
--- a/crates/history/README.md
+++ b/crates/history/README.md
@@ -11,7 +11,6 @@ History archive access, catchup, replay, and checkpoint publishing for Henyey.
 ```mermaid
 flowchart LR
     A[HistoryArchive]
-    B[HistoryManager]
     C[HistoryArchiveState]
     D[CatchupRange]
     E[CatchupManager]
@@ -24,7 +23,6 @@ flowchart LR
     L[RemoteArchive]
     M[CdpDataLake]
 
-    B --> A
     A --> C
     E --> D
     E --> A
@@ -43,7 +41,6 @@ flowchart LR
 | Type | Description |
 |------|-------------|
 | `HistoryArchive` | Reqwest-based client for one readable history archive. |
-| `HistoryManager` | Read-side failover wrapper across multiple `HistoryArchive`s. |
 | `HistoryArchiveManager` | Mixed read/write archive manager mirroring stellar-core archive configuration logic. |
 | `HistoryArchiveState` | Parsed HAS document with bucket hash helpers and FutureBucket state. |
 | `CatchupManager` | End-to-end catchup orchestrator: download, verify, apply buckets, replay. |
@@ -148,7 +145,6 @@ See `publish_queue.rs` module docs for the full semantic mapping to stellar-core
 
 | Rust | stellar-core |
 |------|--------------|
-| `lib.rs` (`HistoryManager`) | `src/history/HistoryManagerImpl.cpp` |
 | `lib.rs` (`HistoryArchiveManager`, `ArchiveEntry`) | `src/history/HistoryArchiveManager.cpp` |
 | `archive.rs` | `src/history/HistoryArchive.cpp` |
 | `archive_state.rs` | `src/history/HistoryArchive.cpp` (HAS serialization and bucket-state logic) |

--- a/crates/history/SPEC_ADHERENCE.md
+++ b/crates/history/SPEC_ADHERENCE.md
@@ -178,7 +178,7 @@ All constants present with correct values:
 | INV-C1 (Chain monotonic) | Full | `verify.rs:312-332` (forward link within group), `verify.rs:515-530` (`verify_ledger_header_history_entry` hashes header). |
 | INV-C2 (Checkpoint alignment) | Full | `verify.rs:282-292` (group partition by checkpoint); checkpoint ledger range enforced via `verify_tx_result_ordering` (`verify.rs:808-842`). |
 | INV-C3 (HAS integrity) | Full | `verify.rs:709-761` + `archive_state.rs:404-473`. |
-| INV-C4 (BucketList hash agreement) | Full | `verify.rs:480-494` (`verify_ledger_hash`) + `archive_state.rs:600-654` (`compute_bucket_list_hash`). |
+| INV-C4 (BucketList hash agreement) | Full | `replay/execution.rs:140-200` (`verify_bucket_list_hash`, called under `config.verify_bucket_list`) + `archive_state.rs:600-654` (`compute_bucket_list_hash`). Verified at checkpoint ledgers (and ≥V23 only when eviction ran), matching stellar-core's checkpoint-boundary assertion in `CatchupWork.cpp:259-260`. |
 | INV-C5 (Trust anchor authentication) | Full | Verification function supports `TrustSource::Scp` (`verify.rs:355-384`) and online catchup now plumbs the SCP-derived anchor from `App::resolve_scp_trust_anchor()` → `CatchupManager::set_trusted_scp_anchor()` → `catchup/replay.rs`. LCL disagreement is fatal when trusted hash exists. |
 | INV-C6 (Tx result hash check) | Partial | `verify_tx_result_set` correct (`verify.rs:542-563`) but no `OFFLINE_COMPLETE`-mode caller that loops over every replay-range ledger. See §12. |
 | INV-C7 (Knit-to-LCL exclusivity) | Full | `catchup/replay.rs:58-117` — five mutually-exclusive cases; case 5 returns `KnitOvershot` error (fatal). |

--- a/crates/history/src/cdp.rs
+++ b/crates/history/src/cdp.rs
@@ -334,12 +334,6 @@ impl CachedCdpDataLake {
         })
     }
 
-    /// Set the number of ledgers to prefetch.
-    pub fn with_prefetch_count(mut self, count: usize) -> Self {
-        self.prefetch_count = count;
-        self
-    }
-
     /// Get the cache file path for a ledger.
     fn cache_path(&self, ledger_seq: u32) -> std::path::PathBuf {
         self.cache_dir.join(format!("{}.xdr.zst", ledger_seq))
@@ -348,34 +342,6 @@ impl CachedCdpDataLake {
     /// Check if a ledger is cached.
     pub fn is_cached(&self, ledger_seq: u32) -> bool {
         self.cache_path(ledger_seq).exists()
-    }
-
-    /// Delete a cached ledger file to free up disk space.
-    ///
-    /// This is useful for streaming access patterns where ledgers are processed
-    /// sequentially and don't need to be retained after processing.
-    ///
-    /// Returns `true` if the file was deleted, `false` if it didn't exist.
-    pub fn delete_cached(&self, ledger_seq: u32) -> bool {
-        let path = self.cache_path(ledger_seq);
-        if path.exists() {
-            if let Err(e) = std::fs::remove_file(&path) {
-                tracing::warn!(ledger_seq, error = %e, "Failed to delete cached CDP file");
-                false
-            } else {
-                tracing::trace!(ledger_seq, "Deleted cached CDP file");
-                true
-            }
-        } else {
-            false
-        }
-    }
-
-    /// Delete all cached ledgers in a range.
-    ///
-    /// Returns the number of files successfully deleted.
-    pub fn delete_cached_range(&self, start: u32, end: u32) -> usize {
-        (start..=end).filter(|&seq| self.delete_cached(seq)).count()
     }
 
     /// Get count of cached ledgers in a range.

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -330,10 +330,8 @@ pub enum HistoryError {
     ///
     /// Replaces string-based [`VerificationFailed`](HistoryError::VerificationFailed)
     /// for hash comparison errors in [`crate::verify::verify_bucket_hash`],
-    /// [`crate::verify::verify_ledger_hash`],
     /// [`crate::verify::verify_ledger_header_history_entry`],
     /// [`crate::verify::verify_tx_result_set`],
-    /// [`crate::verify::verify_header_matches_trusted`],
     /// [`crate::verify::verify_chain_anchors`], and
     /// [`crate::replay::execution::verify_bucket_list_hash`].
     #[error("verification hash mismatch: {0}")]

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -75,7 +75,6 @@
 //! # Key Types
 //!
 //! - [`HistoryArchive`]: Client for accessing a single history archive
-//! - [`HistoryManager`]: Manages multiple archives with failover support
 //! - [`HistoryArchiveState`]: Parsed checkpoint metadata (HAS file)
 //! - [`CatchupManager`]: Orchestrates the full catchup process
 //! - [`ReplayConfig`]: Configuration for ledger replay and verification
@@ -204,160 +203,6 @@ pub struct ArchiveConfig {
     pub get_enabled: bool,
     /// Whether this archive can be used for publishing history data.
     pub put_enabled: bool,
-}
-
-/// Manager for multiple history archives with failover support.
-///
-/// The `HistoryManager` wraps multiple [`HistoryArchive`] instances and provides
-/// automatic failover: if one archive fails to respond, the manager tries the next
-/// archive in the list until one succeeds or all archives have been exhausted.
-///
-/// This is essential for reliable catchup since individual archives may be temporarily
-/// unavailable or have incomplete data.
-///
-/// # Example
-///
-/// ```no_run
-/// use henyey_history::{HistoryManager, archive::testnet};
-///
-/// # async fn example() -> Result<(), henyey_history::HistoryError> {
-/// let manager = HistoryManager::from_urls(testnet::ARCHIVE_URLS)?;
-///
-/// // Automatically tries each archive until one succeeds
-/// let has = manager.fetch_root_has().await?;
-/// println!("Network at ledger {}", has.current_ledger());
-/// # Ok(())
-/// # }
-/// ```
-pub struct HistoryManager {
-    archives: Vec<HistoryArchive>,
-}
-
-impl HistoryManager {
-    /// Create a new history manager with the given archives.
-    pub fn new(archives: Vec<HistoryArchive>) -> Self {
-        Self { archives }
-    }
-
-    /// Create a history manager from a list of URLs.
-    pub fn from_urls(urls: &[&str]) -> Result<Self> {
-        let archives: Result<Vec<_>> = urls.iter().map(|url| HistoryArchive::new(url)).collect();
-        Ok(Self::new(archives?))
-    }
-
-    /// Add an archive to the manager.
-    pub fn add_archive(&mut self, archive: HistoryArchive) {
-        self.archives.push(archive);
-    }
-
-    /// Get the number of archives.
-    pub fn archive_count(&self) -> usize {
-        self.archives.len()
-    }
-
-    /// Try an operation against each archive until one succeeds.
-    ///
-    /// On failure, logs a warning with the archive URL and the error,
-    /// then moves on to the next archive. Returns `fallback_err` if all
-    /// archives fail.
-    async fn try_archives<'a, F, T>(
-        &'a self,
-        op: F,
-        context: &str,
-        fallback_err: HistoryError,
-    ) -> Result<T>
-    where
-        F: Fn(
-            &'a HistoryArchive,
-        )
-            -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<T>> + Send + 'a>>,
-    {
-        for archive in &self.archives {
-            match op(archive).await {
-                Ok(value) => return Ok(value),
-                Err(e) => {
-                    tracing::warn!(
-                        url = %archive.base_url(),
-                        error = %e,
-                        "Failed to {} from archive", context,
-                    );
-                }
-            }
-        }
-        Err(fallback_err)
-    }
-
-    /// Get the root HAS from any available archive.
-    ///
-    /// Tries each archive in sequence until one succeeds.
-    pub async fn fetch_root_has(&self) -> Result<HistoryArchiveState> {
-        self.try_archives(
-            |a| Box::pin(a.fetch_root_has()),
-            "get HAS",
-            HistoryError::NoArchiveAvailable,
-        )
-        .await
-    }
-
-    /// Get the checkpoint HAS from any available archive.
-    pub async fn fetch_checkpoint_has(&self, ledger: u32) -> Result<HistoryArchiveState> {
-        self.try_archives(
-            |a| Box::pin(a.fetch_checkpoint_has(ledger)),
-            "get checkpoint HAS",
-            HistoryError::CheckpointNotFound(ledger),
-        )
-        .await
-    }
-
-    /// Download a bucket from any available archive.
-    pub async fn fetch_bucket(&self, hash: &henyey_common::Hash256) -> Result<Vec<u8>> {
-        let hash = *hash;
-        self.try_archives(
-            |a| Box::pin(a.fetch_bucket(&hash)),
-            "get bucket",
-            HistoryError::BucketNotFound(hash),
-        )
-        .await
-    }
-
-    /// Get ledger headers for a checkpoint from any available archive.
-    pub async fn fetch_ledger_headers(
-        &self,
-        checkpoint: u32,
-    ) -> Result<Vec<stellar_xdr::curr::LedgerHeaderHistoryEntry>> {
-        self.try_archives(
-            |a| Box::pin(a.fetch_ledger_headers(checkpoint)),
-            "get ledger headers",
-            HistoryError::CheckpointNotFound(checkpoint),
-        )
-        .await
-    }
-
-    /// Get transactions for a checkpoint from any available archive.
-    pub async fn fetch_transactions(
-        &self,
-        checkpoint: u32,
-    ) -> Result<Vec<stellar_xdr::curr::TransactionHistoryEntry>> {
-        self.try_archives(
-            |a| Box::pin(a.fetch_transactions(checkpoint)),
-            "get transactions",
-            HistoryError::CheckpointNotFound(checkpoint),
-        )
-        .await
-    }
-
-    /// Get transaction results for a checkpoint from any available archive.
-    pub async fn fetch_results(
-        &self,
-        checkpoint: u32,
-    ) -> Result<Vec<stellar_xdr::curr::TransactionHistoryResultEntry>> {
-        self.try_archives(
-            |a| Box::pin(a.fetch_results(checkpoint)),
-            "get transaction results",
-            HistoryError::CheckpointNotFound(checkpoint),
-        )
-        .await
-    }
 }
 
 /// Summary result of a successful catchup operation.
@@ -543,14 +388,6 @@ impl HistoryArchiveManager {
     pub fn get_archive(&self, name: &str) -> Result<&ArchiveEntry> {
         self.archives
             .iter()
-            .find(|a| a.name == name)
-            .ok_or_else(|| HistoryError::ArchiveNotFound(name.to_string()))
-    }
-
-    /// Get a mutable reference to an archive entry by name.
-    pub fn get_archive_mut(&mut self, name: &str) -> Result<&mut ArchiveEntry> {
-        self.archives
-            .iter_mut()
             .find(|a| a.name == name)
             .ok_or_else(|| HistoryError::ArchiveNotFound(name.to_string()))
     }

--- a/crates/history/src/paths.rs
+++ b/crates/history/src/paths.rs
@@ -98,16 +98,6 @@ pub fn root_has_path() -> &'static str {
     ".well-known/stellar-history.json"
 }
 
-/// Generate the directory path for ledger-related files at a checkpoint.
-///
-/// Returns: `ledger/{xx}/{yy}/{zz}`
-pub fn ledger_dir(ledger: u32) -> String {
-    let checkpoint = checkpoint_ledger(ledger);
-    let hex = format!("{:08x}", checkpoint);
-
-    format!("ledger/{}/{}/{}", &hex[0..2], &hex[2..4], &hex[4..6])
-}
-
 /// Generate the path for a checkpoint file without extension.
 ///
 /// Returns: `{category}/{xx}/{yy}/{zz}/{category}-{hex}`

--- a/crates/history/src/publish.rs
+++ b/crates/history/src/publish.rs
@@ -634,44 +634,6 @@ impl PublishManager {
         let has_path = self.has_path(checkpoint_ledger);
         has_path.exists()
     }
-
-    /// Get the latest published checkpoint.
-    pub fn latest_published_checkpoint(&self) -> Option<u32> {
-        // Scan the history directory for published checkpoints
-        let base = &self.config.local_path;
-        let has_dir = base.join("history");
-
-        if !has_dir.exists() {
-            return None;
-        }
-
-        fn scan_dir(path: &Path, latest: &mut Option<u32>) {
-            let Ok(entries) = std::fs::read_dir(path) else {
-                return;
-            };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    scan_dir(&path, latest);
-                } else if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if let Some(hex) = name
-                        .strip_prefix("history-")
-                        .and_then(|n| n.strip_suffix(".json"))
-                    {
-                        if let Ok(seq) = u32::from_str_radix(hex, 16) {
-                            if is_checkpoint_ledger(seq) {
-                                *latest = Some(latest.map_or(seq, |l| l.max(seq)));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let mut latest: Option<u32> = None;
-        scan_dir(&has_dir, &mut latest);
-        latest
-    }
 }
 
 #[cfg(test)]

--- a/crates/history/src/verify.rs
+++ b/crates/history/src/verify.rs
@@ -476,35 +476,6 @@ pub fn verify_bucket_hash(data: &[u8], expected_hash: &Hash256) -> Result<()> {
     Ok(())
 }
 
-/// Verify that a ledger header's bucket list hash matches the expected value.
-///
-/// This verifies that the ledger state (represented by the BucketList) matches
-/// what the header claims.
-///
-/// # Arguments
-///
-/// * `header` - The ledger header to verify
-/// * `bucket_list_hash` - The computed hash of the BucketList
-///
-/// # Returns
-///
-/// Ok(()) if the hashes match, or an error if they don't.
-pub fn verify_ledger_hash(header: &LedgerHeader, bucket_list_hash: &Hash256) -> Result<()> {
-    let header_bucket_hash = Hash256::from(header.bucket_list_hash.clone());
-
-    if header_bucket_hash != *bucket_list_hash {
-        return Err(crate::error::VerifyHashMismatchInfo::log_and_new(
-            crate::error::VerifyHashKind::BucketList,
-            Some(header.ledger_seq),
-            header_bucket_hash,
-            *bucket_list_hash,
-        )
-        .into());
-    }
-
-    Ok(())
-}
-
 /// Compute the SHA-256 hash of a ledger header.
 ///
 /// This is the hash that gets stored in the next ledger's `previous_ledger_hash`.
@@ -640,55 +611,6 @@ pub fn verify_tx_set(header: &LedgerHeader, tx_set: &TransactionSetVariant) -> R
     }
 
     Ok(())
-}
-
-/// Verify that a header links correctly to a known trusted header.
-///
-/// This is used to verify headers downloaded from history against
-/// a header we received via SCP (which we trust).
-///
-/// # Arguments
-///
-/// * `downloaded_header` - Header downloaded from history archive
-/// * `trusted_header` - Header received via SCP consensus
-pub fn verify_header_matches_trusted(
-    downloaded_header: &LedgerHeader,
-    trusted_header: &LedgerHeader,
-) -> Result<()> {
-    if downloaded_header.ledger_seq != trusted_header.ledger_seq {
-        return Err(HistoryError::InvalidSequence {
-            expected: trusted_header.ledger_seq,
-            got: downloaded_header.ledger_seq,
-        });
-    }
-
-    let downloaded_hash = compute_header_hash(downloaded_header)?;
-    let trusted_hash = compute_header_hash(trusted_header)?;
-
-    if downloaded_hash != trusted_hash {
-        return Err(crate::error::VerifyHashMismatchInfo::log_and_new(
-            crate::error::VerifyHashKind::TrustedHeader,
-            Some(downloaded_header.ledger_seq),
-            trusted_hash,
-            downloaded_hash,
-        )
-        .into());
-    }
-
-    Ok(())
-}
-
-/// Result of verifying a complete catchup dataset.
-#[derive(Debug, Clone)]
-pub struct VerificationResult {
-    /// Number of headers verified.
-    pub headers_verified: u32,
-    /// Number of buckets verified.
-    pub buckets_verified: u32,
-    /// Number of ledgers verified.
-    pub ledgers_verified: u32,
-    /// The final ledger hash.
-    pub final_ledger_hash: Hash256,
 }
 
 /// Verify the HAS network passphrase matches the expected passphrase.
@@ -1559,26 +1481,6 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_ledger_hash_mismatch_typed() {
-        let mut header = make_test_header(42, Hash256::ZERO);
-        // Set a bucket_list_hash that won't match the computed one.
-        header.bucket_list_hash = Hash([0xAA; 32]);
-        let computed_bucket_list_hash = Hash256::ZERO;
-
-        let err = verify_ledger_hash(&header, &computed_bucket_list_hash).unwrap_err();
-
-        match err {
-            HistoryError::VerificationHashMismatch(info) => {
-                assert_eq!(info.kind(), crate::error::VerifyHashKind::BucketList);
-                assert_eq!(info.ledger(), Some(42));
-                assert_eq!(info.expected(), Hash256::from(header.bucket_list_hash));
-                assert_eq!(info.actual(), computed_bucket_list_hash);
-            }
-            other => panic!("expected VerificationHashMismatch, got: {other}"),
-        }
-    }
-
-    #[test]
     fn test_verify_ledger_header_history_entry_mismatch_typed() {
         let header = make_test_header(100, Hash256::ZERO);
         let entry = LedgerHeaderHistoryEntry {
@@ -1626,34 +1528,6 @@ mod tests {
         let header = make_test_header(GENESIS_LEDGER_SEQ, Hash256::ZERO);
         // Empty result set at genesis should succeed regardless of hash.
         assert!(verify_tx_result_set(&header, &[]).is_ok());
-    }
-
-    #[test]
-    fn test_verify_header_matches_trusted_mismatch_typed() {
-        let downloaded = make_test_header(77, Hash256::ZERO);
-        // Trusted header with same seq but different content.
-        let mut trusted = make_test_header(77, Hash256::ZERO);
-        trusted.total_coins = 999; // Different content → different hash
-
-        let err = verify_header_matches_trusted(&downloaded, &trusted).unwrap_err();
-
-        match err {
-            HistoryError::VerificationHashMismatch(info) => {
-                assert_eq!(info.kind(), crate::error::VerifyHashKind::TrustedHeader);
-                assert_eq!(info.ledger(), Some(77));
-                let trusted_hash = compute_header_hash(&trusted).unwrap();
-                let downloaded_hash = compute_header_hash(&downloaded).unwrap();
-                assert_eq!(info.expected(), trusted_hash);
-                assert_eq!(info.actual(), downloaded_hash);
-            }
-            other => panic!("expected VerificationHashMismatch, got: {other}"),
-        }
-    }
-
-    #[test]
-    fn test_verify_header_matches_trusted_ok() {
-        let header = make_test_header(77, Hash256::ZERO);
-        assert!(verify_header_matches_trusted(&header, &header).is_ok());
     }
 
     // --- Precedence regression tests for verify_tx_result_ordering ---


### PR DESCRIPTION
Closes #3426

## Summary

Deletes eight dead/near-dead public symbols in `crate:history` (all re-confirmed live on current `origin/main`), removes their `#[cfg(test)]` tests, `no_run` doctest, and doc anchors, and re-points INV-C4 in `SPEC_ADHERENCE.md` from the dead `verify_ledger_hash` to the live enforcer `replay::execution::verify_bucket_list_hash`. Behavior-preserving — net diff is 378 deletions, 1 insertion (the remapped INV-C4 citation).

Per-finding:
- **F1** `HistoryManager` struct + impl + its `no_run` doctest + the Key-Types bullet + README mermaid node/edge + component-table row + file-mapping row.
- **F2** `VerificationResult`.
- **F3** `verify_ledger_hash` + its test; **INV-C4 re-mapped** to `verify_bucket_list_hash` + `compute_bucket_list_hash` (status stays **Full** — that is the real enforcer, parity-confirmed against stellar-core `CatchupWork.cpp:259-260`).
- **F4** `verify_header_matches_trusted` + its two tests + the `error.rs` doc anchor.
- **F5** cdp `with_prefetch_count` / `delete_cached` / `delete_cached_range` — **KEEP** the live `prefetch_count` field (used at `cdp.rs:454`,`:499`).
- **F6** `latest_published_checkpoint` (self-contained dir scan; no backing field).
- **F7** `HistoryArchiveManager::get_archive_mut`.
- **F8** `ledger_dir`.

PARITY_STATUS.md was left untouched: its rows cite the C++ `HistoryManager.h`/`HistoryManagerImpl.h` headers and `lib.rs`'s surviving `HistoryArchiveManager`/static helpers, not the deleted Rust struct.

Per Critic A's minor item (lost `VerifyHashKind::BucketList` typed-error assertion from F3's deleted test): this shape is already covered by the live enforcer's test at `replay/execution.rs:1293-1300` (asserts `kind` = `BucketList`, `ledger`, `expected != actual`), so no re-home was needed.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3426#issuecomment-4744409654)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-history`
- [x] `cargo test -p henyey-history --lib` (555 passed) + `--tests` (13 passed)
- [x] `cargo test -p henyey-history --doc` (29 passed — required for F1's doctest deletion; no dangling intra-doc link)
- [x] `cargo build --all`

## Deviations from plan

- The plan's `cargo test -p henyey-history --tests --doc` was run as two invocations (`--tests` then `--doc`) because the installed cargo rejects mixing `--doc` with other target selectors. Both passed; the mandatory `--doc` coverage is preserved.
- The plan referenced "PARITY_STATUS:158" for an F1 fix, but that line (and lines 29/43) cite C++ headers / `lib.rs`'s surviving `HistoryArchiveManager`, not the deleted Rust struct — so PARITY_STATUS needed no edit. The only stale Rust-struct citation was README's file-mapping row, which was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)