### PR TITLE
Derive Copy on HistoryWorkStage

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -1022,7 +1022,7 @@ impl App {
                     _ = interval.tick() => {
                         let progress = get_progress(&state_monitor).await;
                         if progress.stage != last_stage || progress.message != last_message {
-                            last_stage = progress.stage.clone();
+                            last_stage = progress.stage;
                             last_message = progress.message.clone();
                             if let Some(stage) = progress.stage {
                                 tracing::info!(stage = ?stage, message = %progress.message, "Historywork progress");

--- a/crates/historywork/src/lib.rs
+++ b/crates/historywork/src/lib.rs
@@ -185,7 +185,7 @@ pub type SharedHistoryState = Arc<Mutex<HistoryWorkState>>;
 ///
 /// This enum is used for progress reporting and monitoring. Each variant
 /// corresponds to a specific work item in the download or publish pipeline.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HistoryWorkStage {
     /// Fetching the History Archive State (HAS) JSON file.
     FetchHas,


### PR DESCRIPTION
Closes #3441

## Summary

`HistoryWorkStage` is a plain unit-variant enum (six payload-free variants) and is therefore trivially `Copy`, but it only derived `Clone`. This adds `Copy` to its derive list — a purely additive, behavior-neutral change (existing `.clone()`/move uses keep compiling). The catchup progress reporter's now-redundant `progress.stage.clone()` (flagged by `clippy::clone_on_copy`) is simplified to a move.

## Plan reference

Trivial short-circuit — [Triage Report / Implementation Notes comment](https://github.com/stellar-experimental/henyey/issues/3441#issuecomment-4745190496).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-historywork` passes (2 unit + 1 integration; doctests ignored)

## Deviations from plan

None. The optional consumer-site `.clone()` removal was applied because `clippy --all -- -D warnings` flagged it (`clone_on_copy`) once `Copy` was derived — exactly the condition the plan gated it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)