### PR TITLE
Consolidate duplicated SQLite PRAGMA init into a shared helper

### DIFF
--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -22,6 +22,24 @@ const BUSY_TIMEOUT_MS: u32 = 30_000;
 /// SQLite cache size in kibibytes (negative value = KiB for PRAGMA cache_size).
 const CACHE_SIZE_KIB: i32 = -64_000;
 
+/// Applies the per-connection SQLite PRAGMAs shared by the file-backed and
+/// in-memory open paths.
+///
+/// These are set via the pool's `with_init` callback so every pooled
+/// connection gets the same configuration. Note that `journal_mode` is
+/// database-level (persistent) and is therefore set once in [`Database::initialize`]
+/// rather than here.
+fn init_connection_pragmas(conn: &mut rusqlite::Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(&format!(
+        "PRAGMA busy_timeout = {};\
+         PRAGMA synchronous = FULL;\
+         PRAGMA foreign_keys = ON;\
+         PRAGMA cache_size = {};\
+         PRAGMA temp_store = MEMORY;",
+        BUSY_TIMEOUT_MS, CACHE_SIZE_KIB
+    ))
+}
+
 impl Database {
     /// Opens a database at the given path, creating it if necessary.
     ///
@@ -46,17 +64,8 @@ impl Database {
             }
         }
 
-        let manager = r2d2_sqlite::SqliteConnectionManager::file(path).with_init(|conn| {
-            conn.execute_batch(&format!(
-                "PRAGMA busy_timeout = {};\
-                 PRAGMA synchronous = FULL;\
-                 PRAGMA foreign_keys = ON;\
-                 PRAGMA cache_size = {};\
-                 PRAGMA temp_store = MEMORY;",
-                BUSY_TIMEOUT_MS, CACHE_SIZE_KIB
-            ))?;
-            Ok(())
-        });
+        let manager =
+            r2d2_sqlite::SqliteConnectionManager::file(path).with_init(init_connection_pragmas);
         let pool = r2d2::Pool::builder()
             .max_size(POOL_MAX_SIZE)
             .connection_timeout(std::time::Duration::from_secs(CONNECTION_TIMEOUT_SECS))
@@ -74,17 +83,8 @@ impl Database {
     /// persisted across restarts. The connection pool size is limited to 1
     /// since in-memory databases are connection-specific.
     pub fn open_in_memory() -> Result<Self> {
-        let manager = r2d2_sqlite::SqliteConnectionManager::memory().with_init(|conn| {
-            conn.execute_batch(&format!(
-                "PRAGMA busy_timeout = {};\
-                 PRAGMA synchronous = FULL;\
-                 PRAGMA foreign_keys = ON;\
-                 PRAGMA cache_size = {};\
-                 PRAGMA temp_store = MEMORY;",
-                BUSY_TIMEOUT_MS, CACHE_SIZE_KIB
-            ))?;
-            Ok(())
-        });
+        let manager =
+            r2d2_sqlite::SqliteConnectionManager::memory().with_init(init_connection_pragmas);
         let pool = r2d2::Pool::builder().max_size(1).build(manager)?;
 
         let db = Self { pool };


### PR DESCRIPTION
Closes #3437

## Summary

The per-connection SQLite PRAGMA setup closure was duplicated verbatim across `Database::open` (file-backed) and `Database::open_in_memory` in `crates/db/src/database/mod.rs`. Both passed the same `with_init` closure running an identical `PRAGMA busy_timeout / synchronous / foreign_keys / cache_size / temp_store` batch. This extracts that closure into a single `init_connection_pragmas` helper used by both pool managers, so the two open paths cannot drift. Behavior-neutral: the same PRAGMAs in the same order run for each path; the emitted SQL is byte-identical to before.

## Re-confirmation before consolidating

Verified on current `origin/main` (b458c88e) that the two PRAGMA sequences are IDENTICAL (same five PRAGMAs, same order, same const interpolation). The only difference between the paths is the manager constructor (`file(path)` vs `memory()`) and pool size, which are preserved unchanged. Nothing path-specific was folded into the shared helper.

## Plan reference

[Triage Report (trivial-refactor short-circuit)](https://github.com/stellar-experimental/henyey/issues/3437#issuecomment-4745156479)

## Test plan

- [x] cargo build --all
- [x] cargo test -p henyey-db (110 passed; 0 failed — includes `test_open_in_memory_applies_pragmas`, proving PRAGMA init still works for both open paths)
- [x] cargo clippy --all -- -D warnings (clean)
- [x] cargo fmt --check (clean)

## Deviations from plan

The helper takes `&mut rusqlite::Connection` (not `&Connection`) because `r2d2_sqlite::SqliteConnectionManager::with_init` requires `Fn(&mut Connection) -> rusqlite::Result<()>`. This lets the helper be passed directly as a function reference to `with_init` on both paths. No behavioral effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)