### PR TITLE
Fix broken main: compat /metrics tests expect 9 but ad7385ab emits 13

### DIFF
--- a/crates/app/src/compat_http/handlers/metrics.rs
+++ b/crates/app/src/compat_http/handlers/metrics.rs
@@ -257,12 +257,16 @@ mod tests {
                 "herder.pending.transactions": { "type": "counter", "count": 0 },
                 "ledger.ledger.version": { "type": "counter", "count": 0 },
                 "scp.value.valid": { "type": "meter", "count": 0 },
-                "scp.value.invalid": { "type": "meter", "count": 0 }
+                "scp.value.invalid": { "type": "meter", "count": 0 },
+                "scp.envelope.invalidsig": { "type": "counter", "count": 0 },
+                "history.publish.failure": { "type": "counter", "count": 0 },
+                "ledger.invariant.failure": { "type": "counter", "count": 0 },
+                "ledger.transaction.internal-error": { "type": "counter", "count": 0 }
             }
         });
 
         let metrics = value["metrics"].as_object().unwrap();
-        assert_eq!(metrics.len(), 9, "should have 9 metrics");
+        assert_eq!(metrics.len(), 13, "should have 13 metrics");
         for (name, metric) in metrics {
             assert!(
                 metric.get("type").is_some(),
@@ -388,8 +392,8 @@ mod tests {
         assert_eq!(invalid["event_type"], "value");
         assert_eq!(invalid["count"], 7, "scp.value.invalid count is real total");
 
-        // --- Shape preserved: all 9 metrics with type+count ---
-        assert_eq!(m.len(), 9, "should still emit 9 metrics");
+        // --- Shape preserved: all 13 metrics with type+count ---
+        assert_eq!(m.len(), 13, "should still emit 13 metrics");
         for (name, metric) in m {
             assert!(metric.get("type").is_some(), "{name} has type");
             assert!(metric.get("count").is_some(), "{name} has count");
@@ -443,8 +447,8 @@ mod tests {
             );
         }
 
-        // Shape contract: 9 metrics, all with type+count.
-        assert_eq!(m.len(), 9);
+        // Shape contract: 13 metrics, all with type+count.
+        assert_eq!(m.len(), 13);
         for (name, metric) in m {
             assert!(metric.get("type").is_some(), "{name} has type");
             assert!(metric.get("count").is_some(), "{name} has count");


### PR DESCRIPTION
## Problem
`CI / Test` fails deterministically on `origin/main`: `compat_http::handlers::metrics::tests::{test_metrics_zero_at_startup, test_metrics_real_values_after_observations}` panic `left: 13, right: 9`. Commit `ad7385ab` ("Add zero-value error metrics … for SSC CheckNoErrorMetrics") added 4 metrics (now 13 emitted) but left the test assertions at 9. This reds every PR's Test check.

## Fix
Test-only: update the three `len()` assertions 9 → 13 and add the 4 new counter metrics to the `test_all_metrics_have_type_field` sample literal so it stays accurate. The added metrics are legitimate (zero-value error counters required by SSC) — the assertions simply lagged the handler.

## Verification
- `cargo test -p henyey-app --lib compat_http::handlers::metrics::` → 5 passed, 0 failed (incl. the 2 previously-red tests)
- `cargo fmt --check` clean

Closes #3480

🤖 Generated with [Claude Code](https://claude.com/claude-code)