### PR TITLE
Tidy crate:scp docs and dead ScpError variants

### DIFF
--- a/crates/scp/README.md
+++ b/crates/scp/README.md
@@ -46,13 +46,12 @@ stateDiagram-v2
 | `BallotPhase` | Public enum describing ballot progression through `Prepare`, `Confirm`, and `Externalize`. |
 | `ValidationLevel` | Driver-reported validation result used to gate nomination and ballot progress. |
 | `SCPTimerType` | Identifies nomination versus ballot timers. |
-| `ScpError` | Error enum for malformed messages, invalid quorum sets, and internal SCP failures. |
+| `ScpError` | Error enum for SCP envelope signature-verification failures. |
 | `QuorumConfigError` | Error enum for parsing and validating Rust-side quorum-set configuration. |
 | `SlotInfo` | Serializable slot summary combining nomination and ballot diagnostics. |
 | `NominationInfo` | Serializable nomination-state snapshot. |
 | `BallotInfo` | Serializable ballot-state snapshot, including prepared and commit ranges. |
 | `QuorumInfo` / `NodeInfo` | Serializable quorum participation view for a slot and its peers. |
-| `SingletonQuorumSetCache` | Cache for repeatedly constructing one-node quorum sets during quorum operations. |
 
 ## Usage
 

--- a/crates/scp/src/driver.rs
+++ b/crates/scp/src/driver.rs
@@ -176,30 +176,6 @@ impl ValidationLevel {
     }
 }
 
-/// Callback interface for the SCP consensus protocol.
-///
-/// This trait is implemented by the application layer (typically the Herder)
-/// to connect SCP to the rest of the system. SCP is designed to be completely
-/// isolated from application logic, and all interactions happen through
-/// this trait.
-///
-/// # Thread Safety
-///
-/// Implementors must be `Send + Sync` as SCP may invoke callbacks from
-/// multiple contexts. Internal state should be protected appropriately.
-///
-/// # Callback Categories
-///
-/// The trait methods fall into several categories:
-///
-/// - **Validation**: [`validate_value`](Self::validate_value), [`extract_valid_value`](Self::extract_valid_value)
-/// - **Value Composition**: [`combine_candidates`](Self::combine_candidates)
-/// - **Quorum Set Lookup**: [`get_quorum_set`](Self::get_quorum_set), [`get_quorum_set_by_hash`](Self::get_quorum_set_by_hash)
-/// - **Cryptography**: [`sign_envelope`](Self::sign_envelope), [`verify_envelope`](Self::verify_envelope), [`hash_quorum_set`](Self::hash_quorum_set)
-/// - **Hash Computation**: [`compute_hash_node`](Self::compute_hash_node), [`compute_value_hash`](Self::compute_value_hash)
-/// - **Network**: [`emit_envelope`](Self::emit_envelope)
-/// - **Notifications**: [`nominating_value`](Self::nominating_value), [`value_externalized`](Self::value_externalized), etc.
-/// - **Timing**: [`compute_timeout`](Self::compute_timeout)
 /// Encode a value to its canonical XDR wire bytes.
 ///
 /// Module-private helper shared by the default [`SCPDriver::compute_hash_node`]
@@ -243,6 +219,30 @@ where
     result
 }
 
+/// Callback interface for the SCP consensus protocol.
+///
+/// This trait is implemented by the application layer (typically the Herder)
+/// to connect SCP to the rest of the system. SCP is designed to be completely
+/// isolated from application logic, and all interactions happen through
+/// this trait.
+///
+/// # Thread Safety
+///
+/// Implementors must be `Send + Sync` as SCP may invoke callbacks from
+/// multiple contexts. Internal state should be protected appropriately.
+///
+/// # Callback Categories
+///
+/// The trait methods fall into several categories:
+///
+/// - **Validation**: [`validate_value`](Self::validate_value), [`extract_valid_value`](Self::extract_valid_value)
+/// - **Value Composition**: [`combine_candidates`](Self::combine_candidates)
+/// - **Quorum Set Lookup**: [`get_quorum_set`](Self::get_quorum_set), [`get_quorum_set_by_hash`](Self::get_quorum_set_by_hash)
+/// - **Cryptography**: [`sign_envelope`](Self::sign_envelope), [`verify_envelope`](Self::verify_envelope), [`hash_quorum_set`](Self::hash_quorum_set)
+/// - **Hash Computation**: [`compute_hash_node`](Self::compute_hash_node), [`compute_value_hash`](Self::compute_value_hash)
+/// - **Network**: [`emit_envelope`](Self::emit_envelope)
+/// - **Notifications**: [`nominating_value`](Self::nominating_value), [`value_externalized`](Self::value_externalized), etc.
+/// - **Timing**: [`compute_timeout`](Self::compute_timeout)
 pub trait SCPDriver: Send + Sync {
     /// Validate a value.
     ///

--- a/crates/scp/src/error.rs
+++ b/crates/scp/src/error.rs
@@ -1,36 +1,13 @@
 //! Error types for SCP operations.
 //!
 //! This module defines the error types that can occur during SCP consensus
-//! operations, including message validation failures, quorum set issues,
-//! and internal state errors.
+//! operations, currently the envelope signature-verification failure mode.
 
 use thiserror::Error;
 
 /// Errors that can occur during SCP operations.
-///
-/// These errors represent various failure modes in the SCP consensus protocol,
-/// from invalid messages to internal state inconsistencies.
 #[derive(Debug, Error)]
 pub enum ScpError {
-    /// The SCP message is malformed or invalid.
-    ///
-    /// This can occur when:
-    /// - The message structure doesn't match the expected format
-    /// - Required fields are missing or have invalid values
-    /// - The message type is unknown or unexpected
-    #[error("invalid SCP message: {0}")]
-    InvalidMessage(String),
-
-    /// The quorum set configuration is invalid.
-    ///
-    /// This can occur when:
-    /// - Threshold exceeds the number of validators
-    /// - Nesting level exceeds the maximum allowed depth
-    /// - Duplicate validators are present
-    /// - The quorum set would not provide safety guarantees
-    #[error("invalid quorum set: {0}")]
-    InvalidQuorumSet(String),
-
     /// The envelope signature failed verification.
     ///
     /// Each SCP envelope must be signed by the sending node.
@@ -38,25 +15,4 @@ pub enum ScpError {
     /// or doesn't match the envelope content.
     #[error("signature verification failed")]
     SignatureVerificationFailed,
-
-    /// The value being proposed or voted on is invalid.
-    ///
-    /// The driver determines whether values are valid based on
-    /// application-specific rules (e.g., transaction validity).
-    #[error("value validation failed: {0}")]
-    ValueValidationFailed(String),
-
-    /// The requested slot was not found in the slot map.
-    ///
-    /// This typically means the slot hasn't been created yet
-    /// or has been purged from memory.
-    #[error("slot not found: {0}")]
-    SlotNotFound(u64),
-
-    /// An internal state error occurred.
-    ///
-    /// This indicates a bug or unexpected condition in the SCP
-    /// implementation that should not occur during normal operation.
-    #[error("internal state error: {0}")]
-    InternalError(String),
 }


### PR DESCRIPTION
Closes #3430

## Summary

Three behavior-preserving `crate:scp` cleanups from a single audit (net behavioral diff = 0):

1. **Finding 1 (docs):** `crates/scp/src/driver.rs` — the `SCPDriver` trait doc block was misattached: two module-private free fns (`scp_xdr_bytes`, `scp_hash_helper`) sat between the doc block and `pub trait SCPDriver`, so rustdoc attached the trait doc to `scp_xdr_bytes`. Fixed by relocating both free fns (with their own `///` docs) to sit *above* the trait-doc block. The function bodies are moved verbatim — byte-identical. `scp_hash_helper` is consensus-critical (mirrors stellar-core `SCPDriver::hashHelper`) and was moved only, not edited.
2. **Finding 2 (docs):** `crates/scp/README.md` — removed the stale public-types row listing `SingletonQuorumSetCache`, which #3336 (`70af6bc7`) made non-public. The cache itself is **KEPT** (deliberate `#[allow(dead_code)]` test utility mirroring `getSingletonQSet`); no `quorum.rs` change. Also updated the now-inaccurate `ScpError` row description.
3. **Finding 3 (refactor):** `crates/scp/src/error.rs` — deleted 5 never-constructed `ScpError` variants (`InvalidMessage`, `InvalidQuorumSet`, `ValueValidationFailed`, `SlotNotFound`, `InternalError`; each re-confirmed 0 construction/match sites repo-wide). Kept `SignatureVerificationFailed` (3 live herder sites). `ScpError` stays a single-variant `pub enum`, preserving herder's `#[from]`. The one match site (`scp_driver.rs:2453`) has a `_ =>` arm, so no exhaustive match breaks.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3430#issuecomment-4746187853)

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-scp`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-scp` — 384 lib + 124 scp_parity + 50 multi_node + 7 quorum_intersection, all pass; `SingletonQuorumSetCache` tests (`test_singleton_quorum_set_cache`, `..._thread_safe`) still compile and pass
- [x] `cargo clippy --all -- -D warnings` — clean (no new clippy errors introduced)

## Parity

- `scp_hash_helper` (mirrors `SCPDriver::hashHelper`) and `SingletonQuorumSetCache` (mirrors `getSingletonQSet`) preserved verbatim.
- The 5 deleted `ScpError` variants are henyey-internal scaffolding with no stellar-core SCP error-enum counterpart — parity-neutral.

## Deviations from plan

The plan scoped the README change to the `SingletonQuorumSetCache` row. The `ScpError` README row description (line 49) became factually stale as a direct consequence of Finding 3 (it listed "malformed messages, invalid quorum sets, and internal SCP failures"), so it was updated to reflect the remaining single variant. Behavior-neutral doc accuracy fix, same file, same crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)