### PR TITLE
Remove four dead-code chains in crate:ledger

### DIFF
--- a/crates/ledger/src/delta.rs
+++ b/crates/ledger/src/delta.rs
@@ -708,11 +708,6 @@ impl LedgerDelta {
             .collect()
     }
 
-    /// Result of categorizing delta entries for bucket list update.
-    pub fn categorize_for_bucket_update(&self) -> DeltaCategorization {
-        categorize_changes(self.changes().cloned(), false, self.ledger_seq)
-    }
-
     /// Drains entries from the delta, categorizing them for bucket list update.
     /// Moves entries instead of cloning, saving ~50K clone operations.
     /// Metadata (fee_pool_delta, total_coins_delta) is preserved.

--- a/crates/ledger/src/error.rs
+++ b/crates/ledger/src/error.rs
@@ -14,20 +14,12 @@ use thiserror::Error;
 ///
 /// # Error Categories
 ///
-/// - **State errors**: `NotInitialized`, `AlreadyInitialized`, `EntryNotFound`
+/// - **State errors**: `NotInitialized`, `AlreadyInitialized`
 /// - **Validation errors**: `InvalidSequence`, `HashMismatch`, `InvalidHeaderChain`
-/// - **Close errors**: `InvalidLedgerClose`, `DuplicateEntry`, `MissingEntry`
-/// - **External errors**: `Database`, `Bucket`, `Xdr`
+/// - **External errors**: `Bucket`, `Xdr`
 /// - **Internal errors**: `Serialization`, `Snapshot`, `Internal`
 #[derive(Debug, Error)]
 pub enum LedgerError {
-    /// A requested ledger entry was not found.
-    ///
-    /// This can occur when loading entries that don't exist in the
-    /// bucket list or snapshot cache.
-    #[error("entry not found")]
-    EntryNotFound,
-
     /// Ledger sequence number doesn't match expected value.
     ///
     /// This typically indicates an attempt to close a ledger out of order,
@@ -85,25 +77,9 @@ pub enum LedgerError {
     #[error("ledger already initialized")]
     AlreadyInitialized,
 
-    /// Invalid ledger close operation.
-    #[error("invalid ledger close: {0}")]
-    InvalidLedgerClose(String),
-
-    /// Attempted to create an entry that already exists.
-    #[error("duplicate entry: {0}")]
-    DuplicateEntry(String),
-
-    /// Attempted to update or delete an entry that doesn't exist.
-    #[error("missing entry for update/delete: {0}")]
-    MissingEntry(String),
-
     /// Snapshot-related error.
     #[error("snapshot error: {0}")]
     Snapshot(String),
-
-    /// Checked arithmetic error (balance overflow, underflow, etc.).
-    #[error("balance error: {0}")]
-    Balance(#[from] henyey_common::checked_types::BalanceError),
 
     /// Internal error (indicates a bug).
     ///

--- a/crates/ledger/src/header.rs
+++ b/crates/ledger/src/header.rs
@@ -124,46 +124,6 @@ pub fn calculate_skip_values(header: &LedgerHeader) -> [stellar_xdr::curr::Hash;
     skip_list
 }
 
-/// Calculate the target ledger sequence for a skip list entry.
-///
-/// Given a ledger sequence and skip list index, computes which historical
-/// ledger that skip list entry points to.
-///
-/// # Arguments
-///
-/// * `current_seq` - The ledger sequence containing the skip list
-/// * `skip_index` - Which skip list entry (0-3)
-///
-/// # Returns
-///
-/// The target ledger sequence, or `None` if:
-/// - The index is out of range (>= 4)
-/// - The target would be before genesis (sequence 0)
-pub fn skip_list_target_seq(current_seq: u32, skip_index: usize) -> Option<u32> {
-    if skip_index >= SKIP_LIST_SIZE {
-        return None;
-    }
-
-    fn round_back(current_seq: u32, interval: u32) -> u32 {
-        let rem = current_seq % interval;
-        if rem == 0 {
-            interval
-        } else {
-            rem
-        }
-    }
-
-    let delta = match skip_index {
-        0 => 1,
-        1 => round_back(current_seq, 4),
-        2 => round_back(current_seq, 16),
-        3 => round_back(current_seq, 64),
-        _ => return None,
-    };
-
-    current_seq.checked_sub(delta)
-}
-
 /// Verify that a ledger header correctly chains to its predecessor.
 ///
 /// This validates the cryptographic chain integrity by checking:
@@ -202,50 +162,6 @@ pub fn verify_header_chain(
             expected: prev_header_hash.to_hex(),
             actual: current_prev_hash.to_hex(),
         });
-    }
-
-    Ok(())
-}
-
-/// Verify the skip list entries against historical headers.
-///
-/// This validates that each non-zero skip list entry correctly points
-/// to the expected historical header hash.
-///
-/// # Arguments
-///
-/// * `header` - The header whose skip list to verify
-/// * `get_header_at_seq` - Function to look up historical header hashes
-///
-/// # Verification
-///
-/// For each skip list entry, if the target sequence exists and can be
-/// looked up, the stored hash must match the actual header hash at that
-/// sequence. Zero hashes are skipped (valid for genesis/early ledgers).
-pub fn verify_skip_list(
-    header: &LedgerHeader,
-    get_header_at_seq: impl Fn(u32) -> Option<Hash256>,
-) -> Result<()> {
-    for (i, skip_hash) in header.skip_list.iter().enumerate() {
-        let skip_hash256 = Hash256::from(skip_hash.0);
-
-        if skip_hash256.is_zero() {
-            continue;
-        }
-
-        if let Some(target_seq) = skip_list_target_seq(header.ledger_seq, i) {
-            if let Some(expected_hash) = get_header_at_seq(target_seq) {
-                if skip_hash256 != expected_hash {
-                    return Err(LedgerError::InvalidHeaderChain(format!(
-                        "skip list entry {} mismatch at seq {}: expected {}, got {}",
-                        i,
-                        target_seq,
-                        expected_hash.to_hex(),
-                        skip_hash256.to_hex()
-                    )));
-                }
-            }
-        }
     }
 
     Ok(())
@@ -413,15 +329,6 @@ mod tests {
         header.skip_list = calculate_skip_values(&header);
         assert_eq!(header.skip_list[0], Hash([4u8; 32]));
         assert_eq!(header.skip_list[1], Hash([3u8; 32]));
-    }
-
-    #[test]
-    fn test_skip_list_target_seq() {
-        assert_eq!(skip_list_target_seq(10, 0), Some(9));
-        assert_eq!(skip_list_target_seq(1, 0), Some(0));
-        assert_eq!(skip_list_target_seq(8, 1), Some(4));
-        assert_eq!(skip_list_target_seq(10, 1), Some(8));
-        assert_eq!(skip_list_target_seq(0, 0), None);
     }
 
     #[test]

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -102,8 +102,8 @@ pub use execution::{
 };
 pub use header::{
     calculate_skip_values, close_time, compute_header_hash, create_next_header,
-    is_before_protocol_version, protocol_version, skip_list_target_seq, verify_header_chain,
-    verify_skip_list, SKIP_1, SKIP_2, SKIP_3, SKIP_4, SKIP_LIST_SIZE,
+    is_before_protocol_version, protocol_version, verify_header_chain, SKIP_1, SKIP_2, SKIP_3,
+    SKIP_4, SKIP_LIST_SIZE,
 };
 pub use manager::new_bucket_list_with_soroban_config;
 pub use manager::{

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -2525,15 +2525,6 @@ impl LedgerManager {
             Ok(store.all_ledger_entries())
         });
 
-        // Create index-based lookup for offers by (account, asset).
-        let offer_store_idx = self.offer_store.clone();
-        let offers_by_account_asset_fn: crate::snapshot::OffersByAccountAssetFn = Arc::new(
-            move |account_id: &AccountId, asset: &stellar_xdr::curr::Asset| {
-                let store = offer_store_idx.lock();
-                Ok(store.offers_by_account_and_asset_as_entries(account_id, asset))
-            },
-        );
-
         // Create index-based lookup for pool share trustlines by account.
         // This mirrors stellar-core's `getPoolShareTrustLine(accountID, asset)` which
         // queries SQL for all pool share trustlines owned by an account.  Without this
@@ -2551,7 +2542,6 @@ impl LedgerManager {
 
         let mut handle = SnapshotHandle::with_lookups_and_entries(snapshot, lookup_fn, entries_fn);
         handle.set_batch_lookup(batch_lookup_fn);
-        handle.set_offers_by_account_asset(offers_by_account_asset_fn);
         handle.set_pool_share_tls_by_account(pool_share_tls_by_account_fn);
         let closure_build_elapsed = t3.elapsed();
 
@@ -5973,7 +5963,7 @@ impl LedgerCloseContext<'_> {
             }
         }
 
-        // Record stats (counts were already computed during categorize_for_bucket_update)
+        // Record stats (counts were already computed during drain_categorization_for_bucket_update)
         self.stats.record_entry_changes(
             bucket_created_count,
             bucket_updated_count,

--- a/crates/ledger/src/snapshot.rs
+++ b/crates/ledger/src/snapshot.rs
@@ -278,12 +278,6 @@ pub type EntriesLookupFn = Arc<dyn Fn() -> Result<Vec<LedgerEntry>> + Send + Syn
 /// Batch entry lookup function for loading multiple entries in a single bucket list pass.
 pub type BatchEntryLookupFn = Arc<dyn Fn(&[LedgerKey]) -> Result<Vec<LedgerEntry>> + Send + Sync>;
 
-/// Lookup function for offers by (account, asset) pair.
-///
-/// Returns all offers owned by the given account that buy or sell the given asset.
-pub type OffersByAccountAssetFn =
-    Arc<dyn Fn(&AccountId, &stellar_xdr::curr::Asset) -> Result<Vec<LedgerEntry>> + Send + Sync>;
-
 /// Lookup function for pool share trustlines by account.
 ///
 /// Returns the pool IDs for all pool share trustlines owned by the given account.
@@ -322,8 +316,6 @@ pub struct SnapshotHandle {
     entries_fn: Option<EntriesLookupFn>,
     /// Optional batch lookup for multiple entries in a single pass.
     batch_lookup_fn: Option<BatchEntryLookupFn>,
-    /// Optional index-based lookup for offers by (account, asset).
-    offers_by_account_asset_fn: Option<OffersByAccountAssetFn>,
     /// Optional index-based lookup for pool share trustline pool IDs by account.
     pool_share_tls_by_account_fn: Option<PoolShareTrustlinesByAccountFn>,
     /// Cache populated by prefetch, checked before falling through to lookup_fn.
@@ -345,7 +337,6 @@ impl SnapshotHandle {
             lookup_fn: None,
             entries_fn: None,
             batch_lookup_fn: None,
-            offers_by_account_asset_fn: None,
             pool_share_tls_by_account_fn: None,
             prefetch_cache: Arc::new(parking_lot::RwLock::new(HashMap::new())),
             stats: Arc::new(SnapshotLookupStats::default()),
@@ -387,11 +378,6 @@ impl SnapshotHandle {
         self.batch_lookup_fn = Some(batch_fn);
     }
 
-    /// Set the offers-by-(account, asset) lookup function.
-    pub fn set_offers_by_account_asset(&mut self, f: OffersByAccountAssetFn) {
-        self.offers_by_account_asset_fn = Some(f);
-    }
-
     /// Set the pool-share-trustlines-by-account lookup function.
     pub fn set_pool_share_tls_by_account(&mut self, f: PoolShareTrustlinesByAccountFn) {
         self.pool_share_tls_by_account_fn = Some(f);
@@ -420,33 +406,6 @@ impl SnapshotHandle {
             return f(account_id);
         }
         Ok(Vec::new())
-    }
-
-    /// Look up all offers owned by `account_id` that buy or sell `asset`.
-    ///
-    /// Uses the index-based lookup if available, otherwise falls back to
-    /// `all_entries()` with a linear scan.
-    pub fn offers_by_account_and_asset(
-        &self,
-        account_id: &AccountId,
-        asset: &stellar_xdr::curr::Asset,
-    ) -> Result<Vec<LedgerEntry>> {
-        if let Some(ref f) = self.offers_by_account_asset_fn {
-            return f(account_id, asset);
-        }
-        // Fallback: linear scan over all entries
-        let entries = self.all_entries()?;
-        Ok(entries
-            .into_iter()
-            .filter(|entry| {
-                if let LedgerEntryData::Offer(ref offer) = entry.data {
-                    offer.seller_id == *account_id
-                        && (offer.buying == *asset || offer.selling == *asset)
-                } else {
-                    false
-                }
-            })
-            .collect())
     }
 
     /// Load multiple entries by their keys.


### PR DESCRIPTION
Closes #3427

## Summary

Behavior-neutral dead-code removal of four triage- and parity-confirmed chains in `crate:ledger`, all call-less on `origin/main`. Net behavioral diff = 0 (deletion-only; the few net insertions are a trimmed doc-comment category list, a rewrapped `pub use`, and a corrected stale comment).

1. **error.rs** — delete 5 unused `LedgerError` variants (`EntryNotFound`, `InvalidLedgerClose`, `DuplicateEntry`, `MissingEntry`, `Balance`) and trim the `# Error Categories` doc list. `Balance(#[from] BalanceError)` is never `?`-propagated (all `sub_account_balance` sites use `.expect`). `Xdr` and `InvalidHeaderChain` (live) retained.
2. **header.rs + lib.rs** — delete the orphaned `verify_skip_list` + `skip_list_target_seq` pair (def + `test_skip_list_target_seq` + both `pub use` names). Full deletion rather than `pub(crate)` narrowing, which fails `-Dwarnings` (cfg(test)-only caller). The LIVE `calculate_skip_values` (the real skip-list parity surface) is untouched.
3. **delta.rs + manager.rs** — delete the non-drain `categorize_for_bucket_update` and fix the stale comment naming it. The LIVE `drain_categorization_for_bucket_update` is untouched.
4. **snapshot.rs + manager.rs** — delete the unread `SnapshotHandle` offers-by-account-asset lookup chain (type alias, field + init, setter, reader, manager closure + wiring). The LIVE tx-crate offers family is untouched; the orphaned `OfferStore::offers_by_account_and_asset_as_entries` is intentionally left `pub` (no warning) to avoid cross-crate scope creep.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3427#issuecomment-4746249529)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (exit 0 — the previously-noted pre-existing overlay `codec.rs:549` error no longer reproduces on current main; no new clippy errors introduced)
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-ledger`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-ledger` (486 lib tests + integration tests pass)

## Parity

`crate:ledger` is parity-critical. Per the converged plan's parity rulings (stellar-core v26.0.1): none of the four deleted chains mirror a stellar-core function — the skip-list verify pair has no upstream counterpart (the compute side `calculate_skip_values` is the parity surface and is kept), the non-drain categorize is a non-sealing henyey-only duplicate (the sealing `drain_*` mirrors `getAllEntries`), and the snapshot offers closure is an unread internal optimization (parity carried by the live tx-crate chain). No `PARITY_STATUS.md` / README parity-column row references any of these symbols.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)