### PR TITLE
Narrow WorkScheduler::cancel_all to pub(crate)

### DIFF
--- a/crates/work/src/lib.rs
+++ b/crates/work/src/lib.rs
@@ -88,7 +88,8 @@
 //! The scheduler supports cooperative cancellation. Work items should periodically
 //! check [`WorkContext::is_cancelled()`] and return [`WorkOutcome::Cancelled`] if
 //! cancellation is requested. The scheduler propagates cancellation to all
-//! registered work items when [`WorkScheduler::cancel_all()`] is called.
+//! registered work items when the `CancellationToken` passed to
+//! `run_until_done_with_cancel` fires.
 //!
 //! # Thread Safety
 //!

--- a/crates/work/src/scheduler.rs
+++ b/crates/work/src/scheduler.rs
@@ -370,7 +370,7 @@ impl WorkScheduler {
     ///
     /// Each work item that is pending or running will be cancelled, and their
     /// dependents will be blocked.
-    pub fn cancel_all(&mut self) {
+    pub(crate) fn cancel_all(&mut self) {
         let ids: Vec<WorkId> = self.entries.keys().copied().collect();
         for id in ids {
             let _ = self.cancel(id);


### PR DESCRIPTION
Closes #3449

## Summary

Narrows `WorkScheduler::cancel_all` from `pub` to `pub(crate)` in `crates/work/src/scheduler.rs`. Its only callers are in-crate (the run loop at `scheduler.rs:443` and `:478`); it has no external or integration-test consumer. The crate module-doc intra-doc link `[`WorkScheduler::cancel_all()`]` at `lib.rs:91` would dangle once the target is `pub(crate)`, so it is de-linked and replaced with prose pointing at the public `run_until_done_with_cancel` cancellation entry point.

Per the converged plan's #3384 delete-or-keep-pub discipline, the other two flagged symbols are **kept pub** because they are live API of the EXTERNAL `crates/work/tests/scheduler.rs` integration crate, and narrowing them fails the project's `-Dwarnings` build gates:
- `cancel` (scheduler.rs:351) — external caller `tests/scheduler.rs:438`; narrowing → `error[E0624]: method 'cancel' is private`.
- `WorkSchedulerMetrics` (scheduler.rs:197) + `metrics()` (scheduler.rs:383) — re-exported at `lib.rs:103`, sole reader `tests/scheduler.rs:216`; narrowing → `dead_code` ("never constructed"/"never used"), lib won't compile. **No production consumer of the metrics surface was found** — it is kept pub solely for that live integration-test coverage, so a future audit should not re-flag it as dead.

Visibility-only; net behavioral diff = 0.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3449#issuecomment-4746834091)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `RUSTFLAGS="-Dwarnings" cargo build --all`
- [x] `cargo build -p henyey-work --tests` (integration-test crate compiles — the gate)
- [x] `cargo test -p henyey-work` (12 tests + doctests pass, incl. `tests/scheduler.rs` integration crate)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)