### PR TITLE
Trim unused rpc re-exports and use slice params in get_events

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -13,6 +13,5 @@ mod simulate;
 mod types;
 mod util;
 
-pub use context::{RpcAppHandle, RpcContext};
-pub use fee_window::FeeWindows;
+pub use context::RpcAppHandle;
 pub use server::{RpcServer, RpcServerRunning};

--- a/crates/rpc/src/methods/get_events.rs
+++ b/crates/rpc/src/methods/get_events.rs
@@ -189,7 +189,7 @@ type EventFilters = (EventTypeFilter, ContractIdFilters, TopicFilters);
 /// or an error if the value is present but not an array.
 fn validate_filters_field(
     val: Option<&serde_json::Value>,
-) -> Result<Option<&Vec<serde_json::Value>>, JsonRpcError> {
+) -> Result<Option<&[serde_json::Value]>, JsonRpcError> {
     match val {
         None => Ok(None),
         Some(v) if v.is_null() => Ok(None),
@@ -203,7 +203,7 @@ fn validate_filters_field(
 ///
 /// Returns `(event_type, contract_ids, topic_filters)`.
 fn parse_event_filters(
-    filters: Option<&Vec<serde_json::Value>>,
+    filters: Option<&[serde_json::Value]>,
 ) -> Result<EventFilters, JsonRpcError> {
     let mut event_type: Option<&'static str> = None;
     let mut contract_ids = Vec::new();


### PR DESCRIPTION
Closes #3445

## Summary

Two behavior-neutral `henyey-rpc` cleanups, re-confirmed on current `origin/main` (`28b2b261`):
- **F1:** Drop `FeeWindows` and `RpcContext` from the crate's public `pub use` in `crates/rpc/src/lib.rs` — both have zero external `henyey_rpc::` consumers. `RpcAppHandle` is retained (used by `RpcServer::new` in `crates/henyey/src/main.rs` and `crates/rpc/tests/`). The struct definitions stay `pub` inside their private modules, so no `dead_code` churn.
- **F2:** Switch `validate_filters_field` return type and `parse_event_filters` parameter from `&Vec<serde_json::Value>` to `&[serde_json::Value]` in `crates/rpc/src/methods/get_events.rs` (clippy::ptr_arg). All call sites and tests compile unedited via deref coercion.

Net diff = 0 behavior; no JSON-RPC response-shape change (both changes are below the wire boundary).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3445#issuecomment-4746853579)

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-rpc --tests` — clean (proves F1 items have zero external/dead-code consumers)
- [x] `cargo build --all` — clean, including the `henyey` binary
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo test -p henyey-rpc` — 233 + 28 + 37 + 1 + 0 pass, 0 failures (identical to pre-change)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)