### PR TITLE
Clean up crate:bucket visibility, unused deps, and duplicate type name

### DIFF
--- a/crates/bucket/Cargo.toml
+++ b/crates/bucket/Cargo.toml
@@ -16,8 +16,6 @@ flate2.workspace = true
 
 # Async runtime
 tokio.workspace = true
-futures.workspace = true
-async-trait.workspace = true
 
 # Serialization
 serde.workspace = true
@@ -28,8 +26,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 # Utilities
-bytes.workspace = true
-hex.workspace = true
 tempfile.workspace = true
 sha2.workspace = true
 

--- a/crates/bucket/PARITY_STATUS.md
+++ b/crates/bucket/PARITY_STATUS.md
@@ -235,7 +235,7 @@ Corresponds to: `LiveBucketIndex.h`, `DiskIndex.h`, `InMemoryIndex.h`, `BucketIn
 | `EvictionResultCandidates::isValid()` (BUCKETLISTDB §12.5/§12.6 scan-validity check) | `EvictionResult::is_valid()` (V23-crossing + ledger_seq + 3 archival-settings fields), enforced on the background-scan reuse path in `henyey-ledger` `manager.rs` | Full |
 | `EvictionMetrics` / `EvictionStatistics::recordEvictedEntry()` | `EvictionCounters` / eviction stats | Full |
 | `EvictionStatistics::submitMetricsAndRestartCycle()` | Simplified eviction statistics only | Partial |
-| Binary fuse filter and random-eviction cache | `BucketBloomFilter` / `RandomEvictionCache` | Full |
+| Binary fuse filter and random-eviction cache | `BucketBloomFilter` / `BucketEntryCache` | Full |
 | `updateTypeBoundaries()` / `buildTypeRangesMap()` | Type range tracking in index construction | Full |
 
 ## Intentional Omissions

--- a/crates/bucket/SPEC_ADHERENCE.md
+++ b/crates/bucket/SPEC_ADHERENCE.md
@@ -59,7 +59,7 @@
 | §9.3 | DiskIndex | Full | index.rs:523-740; bloom_filter.rs:68-130 |
 | §9.4 | Type range map | Full | index.rs (TypeRange) |
 | §9.5 | AssetPoolIDMap | Full | index.rs:207-280, 469, 698 |
-| §9.6 | Entry cache | Full | cache.rs (RandomEvictionCache); bucket_list.rs:1716-1733 |
+| §9.6 | Entry cache | Full | cache.rs (BucketEntryCache); bucket_list.rs:1716-1733 |
 | §9.7 | Persistence + version invalidation | Full | index_persistence.rs:53, 427-456 (`BUCKET_INDEX_VERSION = 5`) |
 | §10.1 | BucketSnapshotManager | Full | snapshot.rs:1152-1276 |
 | §10.2 | Point lookup | Full | snapshot.rs:372-406 |

--- a/crates/bucket/src/cache.rs
+++ b/crates/bucket/src/cache.rs
@@ -118,7 +118,7 @@ impl CacheEntry {
 ///
 /// The cache tracks both entry count and estimated memory usage. Eviction
 /// is triggered when either limit is exceeded.
-pub struct RandomEvictionCache {
+pub struct BucketEntryCache {
     /// The cache storage, protected by a mutex.
     inner: Mutex<CacheInner>,
     /// Maximum cache size in bytes.
@@ -161,7 +161,7 @@ impl CacheInner {
     }
 }
 
-impl RandomEvictionCache {
+impl BucketEntryCache {
     /// Creates a new cache with the given limits.
     pub fn with_limits(max_bytes: usize, max_entries: usize) -> Self {
         Self {
@@ -395,10 +395,10 @@ impl RandomEvictionCache {
     }
 }
 
-impl std::fmt::Debug for RandomEvictionCache {
+impl std::fmt::Debug for BucketEntryCache {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let stats = self.stats();
-        f.debug_struct("RandomEvictionCache")
+        f.debug_struct("BucketEntryCache")
             .field("entry_count", &stats.entry_count)
             .field("size_bytes", &stats.size_bytes)
             .field("max_bytes", &stats.max_bytes)
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_cache_basic_operations() {
-        let cache = RandomEvictionCache::with_limits(1_000_000, 1_000);
+        let cache = BucketEntryCache::with_limits(1_000_000, 1_000);
         cache.activate();
 
         let key = make_account_key(1);
@@ -518,7 +518,7 @@ mod tests {
 
     #[test]
     fn test_cache_not_active() {
-        let cache = RandomEvictionCache::with_limits(1_000_000, 1_000);
+        let cache = BucketEntryCache::with_limits(1_000_000, 1_000);
         // Don't activate the cache
 
         let key = make_account_key(1);
@@ -532,44 +532,44 @@ mod tests {
     #[test]
     fn test_is_cached_type_account_only() {
         // Account key should be cached
-        assert!(RandomEvictionCache::is_cached_type(&make_account_key(1)));
+        assert!(BucketEntryCache::is_cached_type(&make_account_key(1)));
 
         // Trustline key should NOT be cached (matching stellar-core)
         let trustline_key = make_trustline_key(1, b"USD\0");
-        assert!(!RandomEvictionCache::is_cached_type(&trustline_key));
+        assert!(!BucketEntryCache::is_cached_type(&trustline_key));
 
         // ClaimableBalance key should NOT be cached
         let cb_key = LedgerKey::ClaimableBalance(LedgerKeyClaimableBalance {
             balance_id: ClaimableBalanceId::ClaimableBalanceIdTypeV0(Hash([0; 32])),
         });
-        assert!(!RandomEvictionCache::is_cached_type(&cb_key));
+        assert!(!BucketEntryCache::is_cached_type(&cb_key));
 
         // LiquidityPool key should NOT be cached
         let lp_key = LedgerKey::LiquidityPool(LedgerKeyLiquidityPool {
             liquidity_pool_id: PoolId(Hash([0; 32])),
         });
-        assert!(!RandomEvictionCache::is_cached_type(&lp_key));
+        assert!(!BucketEntryCache::is_cached_type(&lp_key));
 
         // Offer key should NOT be cached
         let offer_key = LedgerKey::Offer(LedgerKeyOffer {
             seller_id: make_account_id(1),
             offer_id: 1,
         });
-        assert!(!RandomEvictionCache::is_cached_type(&offer_key));
+        assert!(!BucketEntryCache::is_cached_type(&offer_key));
 
         // Data key should NOT be cached
         let data_key = LedgerKey::Data(LedgerKeyData {
             account_id: make_account_id(1),
             data_name: String64::from(stellar_xdr::curr::StringM::default()),
         });
-        assert!(!RandomEvictionCache::is_cached_type(&data_key));
+        assert!(!BucketEntryCache::is_cached_type(&data_key));
     }
 
     #[test]
     fn test_cache_eviction() {
         // Create cache with small entry limit — power-of-2 evicts one per insert
         // when at capacity, so after 10 inserts with max=5 we should have exactly 5.
-        let cache = RandomEvictionCache::with_limits(1_000_000, 5);
+        let cache = BucketEntryCache::with_limits(1_000_000, 5);
         cache.activate();
 
         for i in 0..10u8 {
@@ -584,7 +584,7 @@ mod tests {
         // Power-of-2-choices should preferentially evict less-recently-used entries.
         // Use a large enough cache that self-eviction (both random picks landing on
         // the same index) is negligible.
-        let cache = RandomEvictionCache::with_limits(1_000_000, 100);
+        let cache = BucketEntryCache::with_limits(1_000_000, 100);
         cache.activate();
 
         let hot_key = make_account_key(0);
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn test_eviction_by_byte_limit() {
         // Each account entry is ~200+ bytes. A 500-byte cache should only hold 1-2.
-        let cache = RandomEvictionCache::with_limits(500, 1_000_000);
+        let cache = BucketEntryCache::with_limits(500, 1_000_000);
         cache.activate();
 
         for i in 0..10u8 {
@@ -619,7 +619,7 @@ mod tests {
     #[test]
     fn test_keys_vec_consistency_after_removes() {
         // Verify the keys vec stays consistent after interleaved inserts and removes.
-        let cache = RandomEvictionCache::with_limits(1_000_000, 100);
+        let cache = BucketEntryCache::with_limits(1_000_000, 100);
         cache.activate();
 
         // Insert 20 entries
@@ -657,7 +657,7 @@ mod tests {
 
     #[test]
     fn test_cache_stats() {
-        let cache = RandomEvictionCache::with_limits(1_000_000, 1_000);
+        let cache = BucketEntryCache::with_limits(1_000_000, 1_000);
         cache.activate();
 
         let key = make_account_key(1);
@@ -681,7 +681,7 @@ mod tests {
 
     #[test]
     fn test_cache_clear() {
-        let cache = RandomEvictionCache::with_limits(1_000_000, 1_000);
+        let cache = BucketEntryCache::with_limits(1_000_000, 1_000);
         cache.activate();
 
         for i in 0..5u8 {
@@ -697,7 +697,7 @@ mod tests {
 
     #[test]
     fn test_cache_update_existing() {
-        let cache = RandomEvictionCache::with_limits(1_000_000, 1_000);
+        let cache = BucketEntryCache::with_limits(1_000_000, 1_000);
         cache.activate();
 
         let key = make_account_key(1);
@@ -717,7 +717,7 @@ mod tests {
 
     #[test]
     fn test_cache_rejects_non_account_types() {
-        let cache = RandomEvictionCache::with_limits(1_000_000, 1_000);
+        let cache = BucketEntryCache::with_limits(1_000_000, 1_000);
         cache.activate();
 
         // Trustline should not be cached

--- a/crates/bucket/src/disk_bucket.rs
+++ b/crates/bucket/src/disk_bucket.rs
@@ -47,7 +47,7 @@ use stellar_xdr::curr::{
 use henyey_common::{BucketListDbConfig, Hash256};
 
 use crate::bloom_filter::HashSeed;
-use crate::cache::RandomEvictionCache;
+use crate::cache::BucketEntryCache;
 use crate::entry::{BucketEntry, BucketEntryExt};
 use crate::index::LiveBucketIndex;
 use crate::{BucketError, Result};
@@ -108,7 +108,7 @@ pub struct DiskBucket {
     /// Per-bucket entry cache for DiskIndex buckets.
     /// Initialized lazily via `maybe_initialize_cache()`.
     /// Only caches ACCOUNT entries (matching stellar-core).
-    cache: OnceLock<Arc<RandomEvictionCache>>,
+    cache: OnceLock<Arc<BucketEntryCache>>,
     /// Cached protocol version read from the leading metaentry.
     ///
     /// `Some(Some(v))` — bucket has a metaentry with `ledger_version = v`.
@@ -605,7 +605,7 @@ impl DiskBucket {
     }
 
     /// Returns the per-bucket cache, if initialized.
-    pub fn cache(&self) -> Option<&Arc<RandomEvictionCache>> {
+    pub fn cache(&self) -> Option<&Arc<BucketEntryCache>> {
         self.cache.get()
     }
 
@@ -665,7 +665,7 @@ impl DiskBucket {
             return;
         }
 
-        let cache = RandomEvictionCache::with_limits(usize::MAX, cache_entries);
+        let cache = BucketEntryCache::with_limits(usize::MAX, cache_entries);
         cache.activate();
         let _ = self.cache.set(Arc::new(cache));
     }

--- a/crates/bucket/src/eviction.rs
+++ b/crates/bucket/src/eviction.rs
@@ -543,7 +543,7 @@ pub fn default_state_archival_settings() -> StateArchivalSettings {
 /// - Level 2: 64
 /// - Level 3: 256
 /// - ...
-pub fn level_size(level: u32) -> u64 {
+pub(crate) fn level_size(level: u32) -> u64 {
     1u64 << (2 * (level + 1))
 }
 
@@ -563,7 +563,7 @@ fn round_down(value: u64, modulo: u64) -> u64 {
 ///
 /// A level spills when the ledger number is at a levelHalf or levelSize boundary.
 /// The top level (level 10) never spills.
-pub fn level_should_spill(ledger: u32, level: u32) -> bool {
+pub(crate) fn level_should_spill(ledger: u32, level: u32) -> bool {
     if level >= BUCKET_LIST_LEVELS as u32 - 1 {
         return false; // Top level never spills
     }
@@ -582,7 +582,7 @@ pub fn level_should_spill(ledger: u32, level: u32) -> bool {
 /// - Level 1 curr: 2 ledgers
 /// - Level 1 snap: 8 ledgers
 /// - Level N curr: 2^(2*N - 1) ledgers
-pub fn bucket_update_period(level: u32, is_curr: bool) -> u32 {
+pub(crate) fn bucket_update_period(level: u32, is_curr: bool) -> u32 {
     if !is_curr {
         // Snap bucket updates when the level below spills
         return bucket_update_period(level + 1, true);

--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -166,9 +166,8 @@ pub use error::BucketError;
 // ============================================================================
 
 pub use eviction::{
-    bucket_update_period, default_state_archival_settings, level_half, level_should_spill,
-    level_size, update_starting_eviction_iterator, EvictionCandidate, EvictionIterator,
-    EvictionIteratorExt, EvictionResult, ResolvedEviction,
+    default_state_archival_settings, level_half, update_starting_eviction_iterator,
+    EvictionCandidate, EvictionIterator, EvictionIteratorExt, EvictionResult, ResolvedEviction,
 };
 
 // ============================================================================

--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -231,7 +231,7 @@ pub use index_persistence::{
 // Caching
 // ============================================================================
 
-pub use cache::{CacheStats, RandomEvictionCache};
+pub use cache::{BucketEntryCache, CacheStats};
 
 // ============================================================================
 // Merge deduplication


### PR DESCRIPTION
Closes #3434

## Summary

Behavior-preserving crate:bucket hygiene cleanup addressing the three findings in the converged plan (net diff = 0):

- **F1 (visibility):** Narrow `level_size`, `level_should_spill`, `bucket_update_period` from `pub` to `pub(crate)` (no caller outside `eviction.rs` + same-module unit tests) and drop them from the lib.rs eviction re-export. `level_half` and `update_starting_eviction_iterator` stay `pub` (consumed by the `bucket_list_integration` external test crate); `default_state_archival_settings` stays `pub` (re-export/README consumer — narrowing trips `-Dwarnings` dead-code, the #3384 trap).
- **F2 (unused deps):** Remove `bytes`, `hex`, `futures`, `async-trait` from `crates/bucket/Cargo.toml` (zero usage anywhere in the crate).
- **F3 (duplicate type name):** Rename the bucket-local `RandomEvictionCache` → `BucketEntryCache`, ending the name collision with the generic `henyey_crypto::RandomEvictionCache<K,V>`. The bucket type has zero external consumers (only `disk_bucket.rs`). Kept as the separable last commit (`497476bf`) per the Lane-D advisory so it can be dropped cleanly if a reviewer prefers deferring. C++ parity references to stellar-core's `RandomEvictionCache` are intentionally unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3434#issuecomment-4746844284)

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-bucket --all-targets` (the load-bearing gate — compiles the integration-test crate consuming the kept-pub helpers) → clean
- [x] `cargo build --all` → clean (confirms no transitive consumer of the renamed symbol)
- [x] `cargo test -p henyey-bucket` → 505 + 32 + 5 + 6 = 548 tests pass
- [x] `cargo clippy --all -- -D warnings` → clean
- [x] `cargo fmt --check` → clean

## Deviations from plan

- README.md line 162 (`cache.rs` → `src/util/RandomEvictionCache.h`) was left unchanged: that cell is the stellar-core C++ source-file path mapping, not the bucket-local Rust type. The plan's "update only doc-row text, not mappings" directive applies — only the SPEC_ADHERENCE.md (§9.6) and PARITY_STATUS.md Rust-symbol rows were renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)