### PR TITLE
Narrow await_join_logged to pub(crate) in crate:common

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -80,7 +80,7 @@ pub use meta::*;
 pub use network::NetworkId;
 pub use protocol::*;
 pub use resource::*;
-pub use spawn::{await_blocking_logged, await_join_logged, spawn_blocking_logged, spawn_observed};
+pub use spawn::{await_blocking_logged, spawn_blocking_logged, spawn_observed};
 pub use types::{deterministic_seed, *};
 pub use xdr_stream::{xdr_encoded_len, xdr_encoded_len_u32, xdr_to_bytes};
 

--- a/crates/common/src/spawn.rs
+++ b/crates/common/src/spawn.rs
@@ -99,7 +99,7 @@ where
 /// In release builds with `panic = "abort"`, task panics abort the process
 /// before this function can observe them. This helper is most useful in
 /// dev/test builds and as documentation of intent.
-pub async fn await_join_logged<T>(
+pub(crate) async fn await_join_logged<T>(
     context: &str,
     handle: JoinHandle<T>,
 ) -> Result<T, tokio::task::JoinError> {


### PR DESCRIPTION
Closes #3435

## Summary

Narrows `await_join_logged` (crates/common/src/spawn.rs) from `pub` to `pub(crate)` and drops it from the `henyey-common` re-export in lib.rs. The function has zero external callers — its only live references are the in-crate non-test caller `spawn_observed` and same-module unit tests, all satisfied by `pub(crate)`. Net behavioral diff = 0.

This addresses **F1 only**. **F2 (`try_add_account_balance` bool→Result) was scoped out as a parity-faithful decision**: the `bool` return mirrors stellar-core `addBalance` (TransactionUtils.cpp:592, decl TransactionUtils.h:164) exactly. The proposed Result conversion would deviate from the upstream bool contract, and the alternative of routing the 6 callers through `checked_types::add_account_balance` is not behavior-neutral (that function rejects negative `delta` with `Underflow`, whereas `addBalance`/`try_add_account_balance` accept negative deltas). `try_add_account_balance` is kept unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3435#issuecomment-4747168558)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-common` — clean
- [x] `cargo build --workspace` — clean (crate:common is workspace-wide-depended; no downstream breakage)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo test -p henyey-common` — all pass (38 tests + 7 spawn-module tests incl. `test_await_join_logged_panic`, `test_await_join_logged_cancel`, `test_spawn_observed_panic`)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)