### PR TITLE
Collapse RandomEvictionCache::get double lookup; document Curve25519 parity surface

### DIFF
--- a/crates/crypto/src/curve25519.rs
+++ b/crates/crypto/src/curve25519.rs
@@ -16,6 +16,23 @@
 //! During P2P handshake, peers generate random Curve25519 keys and sign them
 //! with their long-lived Ed25519 keys.
 //!
+//! # Retained parity surface (do not narrow or delete)
+//!
+//! The `pub` wrapper API in this module — [`Curve25519Secret`],
+//! [`Curve25519Public`], [`KeyOrdering`], their methods, and the `From` impls —
+//! is a deliberately-retained, parity-mapped surface that mirrors stellar-core's
+//! `src/crypto/Curve25519.h` (`curve25519RandomSecret` / `curve25519DerivePublic`
+//! / `curve25519DeriveSharedKey`, all tracked as Full parity in
+//! `PARITY_STATUS.md`). It is kept `pub` despite having only test-internal
+//! callers today (the overlay currently reimplements ECDH inline on raw
+//! `x25519_dalek` rather than going through these wrappers), so that a future
+//! dead-code audit does not re-flag it. It must **not** be narrowed to
+//! `pub(crate)` (that fails `-D warnings` with dead-code errors) and must
+//! **not** be deleted: [`Curve25519Secret::derive_shared_key`] is the sole live
+//! caller of the HMAC/HKDF helper chain in `hash.rs` (`hkdf_extract` →
+//! `hmac_sha256` → ...), so deleting this module would orphan and cascade-delete
+//! that Full-parity surface.
+//!
 //! # Example
 //!
 //! ```

--- a/crates/crypto/src/random_eviction_cache.rs
+++ b/crates/crypto/src/random_eviction_cache.rs
@@ -61,13 +61,11 @@ impl<K: Eq + Hash + Clone, V> RandomEvictionCache<K, V> {
     /// Matches stellar-core's `maybeGet()` which increments the generation
     /// counter and records it on the accessed entry.
     pub fn get(&mut self, key: &K) -> Option<&V> {
-        // We need to do a two-step lookup to satisfy the borrow checker:
-        // first check existence, then mutate.
-        if !self.map.contains_key(key) {
-            return None;
-        }
+        // `map` and `generation` are disjoint fields, so a single `get_mut`
+        // split-borrow suffices: `?` returns `None` on a miss before any
+        // generation bump, and on a hit we bump once and stamp the entry.
+        let entry = self.map.get_mut(key)?;
         self.generation += 1;
-        let entry = self.map.get_mut(key).unwrap();
         entry.last_access = self.generation;
         Some(&entry.value)
     }


### PR DESCRIPTION
Closes #3436

## Summary

Two findings in `crate:crypto`, both behavior-preserving (net runtime diff = 0).

- **F1** — In `RandomEvictionCache::get`, replace the two-step `contains_key` guard + `get_mut(key).unwrap()` with a single `get_mut(key)?` split-borrow on the disjoint `map`/`generation` fields (one HashMap probe per hit instead of two), and drop the stale "two-step lookup to satisfy the borrow checker" comment. Behavior-identical: a miss returns `None` before any generation bump; a hit bumps `generation` once and stamps `last_access` with the same value.
- **F2** — Resolved as **keep `pub` + document** (NOT narrow, NOT delete; net visibility/code diff = 0). The Curve25519 wrappers must stay `pub`: narrowing to `pub(crate)` fails `-D warnings` with dead-code errors, and deleting them cascades dead-code errors into `hash.rs` because `derive_shared_key` is the sole live caller of the `hkdf_extract` → HMAC chain (a Full-parity surface). Added an in-source module doc note recording the deliberate retention and the cascade rationale so a future dead-code audit does not re-flag it. No code or visibility change.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3436#issuecomment-4747172610)

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-crypto`
- [x] `cargo clippy -p henyey-crypto --all-targets -- -D warnings`
- [x] `cargo test -p henyey-crypto` (82 lib tests pass; doctests pass)
- [x] `cargo build --all`
- [x] `cargo clippy --all -- -D warnings`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)