### PR TITLE
Dedup archived-entry key builder, drop dead loadgen locals, fold RepairReport accumulation

### DIFF
--- a/crates/simulation/src/applyload.rs
+++ b/crates/simulation/src/applyload.rs
@@ -25,9 +25,12 @@ use henyey_tx::envelope_utils::envelope_soroban_data;
 use stellar_xdr::curr::{
     ConfigSettingEntry, ContractDataDurability, ContractId, ContractIdPreimage,
     ContractIdPreimageFromAddress, ExtensionPoint, Hash, LedgerEntry, LedgerEntryData,
-    LedgerEntryExt, LedgerKey, LedgerKeyContractData, LedgerUpgrade, Limits, OperationBody,
-    ScAddress, ScVal, TransactionEnvelope, Uint256, WriteXdr,
+    LedgerEntryExt, LedgerKey, LedgerUpgrade, Limits, OperationBody, ScAddress, ScVal,
+    TransactionEnvelope, Uint256, WriteXdr,
 };
+// `LedgerKeyContractData` is only constructed in test fixtures below.
+#[cfg(test)]
+use stellar_xdr::curr::LedgerKeyContractData;
 use tracing::{debug, info, warn};
 
 use crate::loadgen::{ContractInstance, TxGenerator};
@@ -622,21 +625,6 @@ impl ApplyLoad {
         &self.write_entry_utilization
     }
 
-    /// Returns a `LedgerKey` for a pre-populated archived state entry at the
-    /// given index.
-    ///
-    /// Matches stellar-core `ApplyLoad::getKeyForArchivedEntry()`.
-    pub fn key_for_archived_entry(index: u64) -> LedgerKey {
-        let contract_id_bytes = Hash256::hash(b"archived-entry");
-        let contract_addr = ScAddress::Contract(ContractId(Hash(contract_id_bytes.0)));
-
-        LedgerKey::ContractData(LedgerKeyContractData {
-            contract: contract_addr,
-            key: ScVal::U64(index),
-            durability: ContractDataDurability::Persistent,
-        })
-    }
-
     /// Calculate the required number of hot archive entries based on config.
     ///
     /// Matches stellar-core `ApplyLoad::calculateRequiredHotArchiveEntries()`.
@@ -897,14 +885,8 @@ impl ApplyLoad {
 
         // For each cluster, deploy a batch_transfer contract and fund it.
         for i in 0..num_clusters {
-            let success_before = self.apply_soroban_success;
-            let salt = Hash256::hash(i.to_string().as_bytes());
-
-            // In a full implementation, we would:
-            // 1. Upload batch_transfer wasm (once)
-            // 2. Deploy contract instance
-            // 3. Fund contract with XLM via SAC payment
-            // For now, create a placeholder instance.
+            // TODO: deploy real batch_transfer instance (upload wasm, deploy,
+            // fund via SAC). For now, create a placeholder instance.
             let contract_id = Hash256::hash(format!("batch-transfer-{}", i).as_bytes());
             let instance_key = crate::loadgen_soroban::contract_instance_key(&contract_id);
 
@@ -915,8 +897,6 @@ impl ApplyLoad {
             };
 
             self.batch_transfer_instances.push(instance);
-            let _ = salt; // suppress unused warning
-            let _ = success_before;
         }
 
         ensure!(
@@ -1684,7 +1664,7 @@ fn generate_archived_entries(
 ) -> Vec<LedgerEntry> {
     let mut entries = Vec::new();
     for _ in 0..count {
-        let lk = ApplyLoad::key_for_archived_entry(*current_key);
+        let lk = crate::loadgen_soroban::get_key_for_archived_entry(*current_key);
         let LedgerKey::ContractData(cd) = &lk else {
             unreachable!()
         };
@@ -1823,29 +1803,6 @@ mod tests {
         assert_eq!(h.count(), 3);
         assert_eq!(h.mean(), 200.0);
         assert_eq!(h.values(), &[100, 200, 300]);
-    }
-
-    #[test]
-    fn test_key_for_archived_entry() {
-        let key0 = ApplyLoad::key_for_archived_entry(0);
-        let key1 = ApplyLoad::key_for_archived_entry(1);
-        let key0_again = ApplyLoad::key_for_archived_entry(0);
-
-        // Same index produces same key.
-        assert_eq!(
-            key0.to_xdr(Limits::none()).unwrap(),
-            key0_again.to_xdr(Limits::none()).unwrap()
-        );
-
-        // Different indices produce different keys.
-        assert_ne!(
-            key0.to_xdr(Limits::none()).unwrap(),
-            key1.to_xdr(Limits::none()).unwrap()
-        );
-
-        // Both are ContractData keys.
-        assert!(matches!(key0, LedgerKey::ContractData(_)));
-        assert!(matches!(key1, LedgerKey::ContractData(_)));
     }
 
     #[test]

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -119,6 +119,18 @@ struct RepairReport {
     errors: usize,
 }
 
+impl RepairReport {
+    /// Folds the counters from `other` into `self` field-wise. Used to
+    /// accumulate per-iteration repair stats across stabilize-loop rounds.
+    fn accumulate(&mut self, other: &RepairReport) {
+        self.initiated += other.initiated;
+        self.already_connected += other.already_connected;
+        self.pool_full += other.pool_full;
+        self.overlay_not_ready += other.overlay_not_ready;
+        self.errors += other.errors;
+    }
+}
+
 impl std::fmt::Display for RepairReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -835,11 +847,7 @@ impl Simulation {
             self.bail_if_any_node_exited().await?;
 
             let report = self.repair_app_connectivity().await;
-            cumulative_report.initiated += report.initiated;
-            cumulative_report.already_connected += report.already_connected;
-            cumulative_report.pool_full += report.pool_full;
-            cumulative_report.overlay_not_ready += report.overlay_not_ready;
-            cumulative_report.errors += report.errors;
+            cumulative_report.accumulate(&report);
 
             let remaining = deadline
                 .checked_duration_since(tokio::time::Instant::now())
@@ -1013,11 +1021,7 @@ impl Simulation {
             self.bail_if_any_node_exited().await?;
 
             let report = self.repair_app_connectivity().await;
-            cumulative_report.initiated += report.initiated;
-            cumulative_report.already_connected += report.already_connected;
-            cumulative_report.pool_full += report.pool_full;
-            cumulative_report.overlay_not_ready += report.overlay_not_ready;
-            cumulative_report.errors += report.errors;
+            cumulative_report.accumulate(&report);
 
             let remaining = deadline
                 .checked_duration_since(tokio::time::Instant::now())
@@ -2024,6 +2028,34 @@ mod crank_tests {
         sim.add_node("B", SecretKey::from_seed(&[2u8; 32]));
         sim.add_pending_connection("A", "B");
         sim
+    }
+
+    #[test]
+    fn test_repair_report_accumulate() {
+        // Distinct per-field values so a copy-paste field mismatch in
+        // `accumulate` is caught by the assertions below.
+        let mut acc = RepairReport {
+            initiated: 1,
+            already_connected: 2,
+            pool_full: 4,
+            overlay_not_ready: 8,
+            errors: 16,
+        };
+        let other = RepairReport {
+            initiated: 32,
+            already_connected: 64,
+            pool_full: 128,
+            overlay_not_ready: 256,
+            errors: 512,
+        };
+
+        acc.accumulate(&other);
+
+        assert_eq!(acc.initiated, 1 + 32);
+        assert_eq!(acc.already_connected, 2 + 64);
+        assert_eq!(acc.pool_full, 4 + 128);
+        assert_eq!(acc.overlay_not_ready, 8 + 256);
+        assert_eq!(acc.errors, 16 + 512);
     }
 
     // ==================================================================


### PR DESCRIPTION
Closes #3447

## Summary

Three behavior-neutral cleanups in `henyey-simulation` (a loadgen/benchmark/test-topology harness). Net behavioral diff = 0.

- **F1 (dedup):** Deleted the byte-equivalent `ApplyLoad::key_for_archived_entry` and repointed its caller in `generate_archived_entries` to `crate::loadgen_soroban::get_key_for_archived_entry`. Removed the now-redundant applyload-side `test_key_for_archived_entry` — `loadgen_soroban::test_get_key_for_archived_entry` covers the same builder. `LedgerKeyContractData` is now only used in test fixtures, so its import is `#[cfg(test)]`-gated.
- **F2 (dead locals):** Deleted the `success_before`/`salt` locals (computed then `let _ =`-suppressed) in `setup_batch_transfer_contracts`, leaving a `// TODO` for the real deploy. Kept the live placeholder `ContractInstance` (pushed into `batch_transfer_instances`, length-asserted, indexed) — out of cleanup scope to implement the real deploy.
- **F3 (dedup accumulation):** Added `RepairReport::accumulate(&mut self, &RepairReport)` and replaced the two identical 5-line accumulation blocks. Added `test_repair_report_accumulate` guarding the field mapping.

**F1 re-validated as actionable:** The triage note flagged F1 as STALE (claiming the dedup partner `get_key_for_archived_entry` did not exist). That was a false negative — the partner exists on current main at `loadgen_soroban.rs:1014`, re-exported from `lib.rs:64`, and is byte-equivalent to the deleted method. F1 was implemented as planned.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3447#issuecomment-4747158622)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-simulation` — 54 tests pass, incl. new `test_repair_report_accumulate` and surviving `test_get_key_for_archived_entry`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)