### PR TITLE
Make crate:herder clippy-clean under -Dwarnings and narrow PendingQuorumSet

### DIFF
--- a/crates/herder/src/externalize_lag.rs
+++ b/crates/herder/src/externalize_lag.rs
@@ -225,7 +225,7 @@ mod tests {
 
         tracker.record_event(100, &self_node, true, t0);
 
-        let qset = make_qset(&[self_node.clone()]);
+        let qset = make_qset(std::slice::from_ref(&self_node));
         assert_eq!(tracker.get_lag_info_summary(&qset), None);
     }
 

--- a/crates/herder/src/parallel_tx_set_builder.rs
+++ b/crates/herder/src/parallel_tx_set_builder.rs
@@ -2985,9 +2985,12 @@ mod stellar_core_parity_tests {
     fn assert_no_intra_stage_conflicts(stages: &[Vec<Vec<HashedTx>>], context: &str) {
         use std::collections::HashSet;
 
+        // (RO key set, RW key set) for a single cluster.
+        type ClusterKeySets = (HashSet<Vec<u8>>, HashSet<Vec<u8>>);
+
         for (si, stage) in stages.iter().enumerate() {
             // Collect per-cluster RW and RO key sets.
-            let cluster_keys: Vec<(HashSet<Vec<u8>>, HashSet<Vec<u8>>)> = stage
+            let cluster_keys: Vec<ClusterKeySets> = stage
                 .iter()
                 .map(|cluster| {
                     let mut ro_set = HashSet::new();
@@ -3199,12 +3202,12 @@ mod stellar_core_parity_tests {
                 let phase = stages_to_xdr_phase(stages, Some(base_fee));
                 let xdr_bytes = phase
                     .to_xdr(Limits::none())
-                    .expect(&format!("{ctx}: XDR serialization failed"));
+                    .unwrap_or_else(|_| panic!("{ctx}: XDR serialization failed"));
                 let decoded = TransactionPhase::from_xdr(&xdr_bytes, Limits::none())
-                    .expect(&format!("{ctx}: XDR deserialization failed"));
+                    .unwrap_or_else(|_| panic!("{ctx}: XDR deserialization failed"));
                 let re_encoded = decoded
                     .to_xdr(Limits::none())
-                    .expect(&format!("{ctx}: XDR re-serialization failed"));
+                    .unwrap_or_else(|_| panic!("{ctx}: XDR re-serialization failed"));
                 assert_eq!(
                     xdr_bytes, re_encoded,
                     "{ctx}: XDR roundtrip produced different bytes"

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -421,7 +421,7 @@ pub struct PendingTxSet {
 
 /// Pending quorum set request.
 #[derive(Debug, Clone)]
-pub struct PendingQuorumSet {
+pub(crate) struct PendingQuorumSet {
     /// Number of times we've requested this.
     pub request_count: u32,
     /// Node IDs that use this quorum set (envelope senders).
@@ -8949,13 +8949,13 @@ mod compare_tx_sets_tests {
 
         // Two StellarValues with the same tx_set_hash but different close_times
         let sv_a = StellarValue {
-            tx_set_hash: Hash(tx_set_hash.as_bytes().clone()),
+            tx_set_hash: Hash(*tx_set_hash.as_bytes()),
             close_time: TimePoint(1000),
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Basic,
         };
         let sv_b = StellarValue {
-            tx_set_hash: Hash(tx_set_hash.as_bytes().clone()),
+            tx_set_hash: Hash(*tx_set_hash.as_bytes()),
             close_time: TimePoint(1001),
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Basic,

--- a/crates/herder/src/tx_queue/flood_queue.rs
+++ b/crates/herder/src/tx_queue/flood_queue.rs
@@ -265,7 +265,7 @@ mod tests {
         fq.visit_top_txs(|_| VisitTxResult::Processed, &mut remaining, 25, &limits);
 
         // Reset and repopulate
-        let txs = vec![tx1.clone(), tx2.clone()];
+        let txs = [tx1.clone(), tx2.clone()];
         fq.reset_and_repopulate(txs.iter(), 25);
 
         // Should be able to drain again

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -9054,6 +9054,7 @@ mod resource_limit_parity_tests {
 
     /// Run a resource-limit scenario: create 32 TXs, add to queue, build tx set,
     /// validate shape and base fee.
+    #[allow(clippy::too_many_arguments)]
     fn run_resource_limit_scenario(
         soroban_limit: Resource,
         min_stage: u32,
@@ -9967,7 +9968,6 @@ mod eviction_queue_tests {
     }
 }
 
-#[cfg(test)]
 #[cfg(test)]
 mod fee_rate_tests {
     use super::*;

--- a/crates/herder/src/tx_set_tracker.rs
+++ b/crates/herder/src/tx_set_tracker.rs
@@ -472,7 +472,7 @@ impl TxSetTracker {
     /// Return all hashes currently in the cache. Test-only.
     #[cfg(test)]
     pub fn cached_hashes(&self) -> Vec<Hash256> {
-        self.cache.iter().map(|entry| entry.key().clone()).collect()
+        self.cache.iter().map(|entry| *entry.key()).collect()
     }
 
     pub fn pending_count(&self) -> usize {


### PR DESCRIPTION
Closes #3439

## Summary

Make `cargo clippy -p henyey-herder --all-targets -- -D warnings` GREEN by fixing all 10 herder clippy lint sites (every one is in `#[cfg(test)]` code) plus removing one duplicated `#[cfg(test)]` attribute, and narrow the crate-internal data-only `PendingQuorumSet` struct from `pub` to `pub(crate)`. Net behavioral diff = 0 — only test-target lint hygiene and a Rust-only visibility annotation; no live quorum/SCP/consensus logic touched.

Triage enumerated 5 findings; a clean `-Dwarnings` run on current `origin/main` reports 10 clippy errors. All 10 are fixed here so the herder `-Dwarnings` gate is green (the issue's acceptance criterion). All three plan critics concurred the 5→10 fold-in is correct scoping, not creep.

Fixes applied (all `#[cfg(test)]` unless noted):
- `tx_queue/mod.rs`: remove duplicate `#[cfg(test)]` before `mod fee_rate_tests`; `#[allow(clippy::too_many_arguments)]` on test helper `run_resource_limit_scenario`.
- `scp_driver.rs`: `[u8;32]` clone_on_copy ×2 → deref; **narrow `pub struct PendingQuorumSet` → `pub(crate)`** (data-only struct, in-crate callers only, absent from `lib.rs` re-export, no external integration-test caller — build-verified no E0624).
- `tx_set_tracker.rs`: `Hash256` clone_on_copy → deref.
- `parallel_tx_set_builder.rs`: `type_complexity` → local `type` alias; `expect_fun_call` ×3 → `unwrap_or_else(|_| panic!(...))`.
- `externalize_lag.rs`: `std::slice::from_ref`.
- `tx_queue/flood_queue.rs`: `useless_vec` → array.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3439#issuecomment-4747178356)

## Test plan

- [x] cargo fmt --check
- [x] `cargo clippy -p henyey-herder --all-targets -- -D warnings` (acceptance gate) — clean (was 10 errors → 0)
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-herder --all-targets` — clean
- [x] cargo build --all — clean
- [x] cargo test -p henyey-herder — 1185+ passed, 0 failed
- [x] cargo clippy --all -- -D warnings — clean

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)