### PR TITLE
Build genesis from USE_CONFIG_FOR_GENESIS / TESTING_UPGRADE_* for byte-parity

### DIFF
--- a/crates/app/src/app/bootstrap.rs
+++ b/crates/app/src/app/bootstrap.rs
@@ -12,6 +12,52 @@ use super::App;
 /// Total coins in the genesis ledger (100 billion XLM in stroops).
 const GENESIS_TOTAL_COINS: i64 = 1_000_000_000_000_000_000;
 
+/// Genesis-ledger construction parameters derived from `[testing]` config.
+///
+/// Mirrors stellar-core's `USE_CONFIG_FOR_GENESIS` + `TESTING_UPGRADE_*`
+/// handling in `LedgerManagerImpl::startNewLedger()`
+/// (LedgerManagerImpl.cpp:489-503). When `use_config_for_genesis` is false
+/// (the default), genesis is built exactly as before: `ledger_version = 0`,
+/// `base_fee = 100`, `base_reserve = 100_000_000`, `max_tx_set_size = 100`,
+/// and NO Soroban `ConfigSetting` entries.
+///
+/// When `use_config_for_genesis` is true, the genesis header is built at
+/// `protocol_version` with the `base_fee`/`base_reserve`/`max_tx_set_size`
+/// overrides, and (for protocol >= 20) the full Soroban config-settings set
+/// is injected into the genesis bucket list — matching SSC mixed-image
+/// missions running BUILD_TESTS-enabled stellar-core.
+#[derive(Debug, Clone, Copy)]
+pub struct GenesisConfig {
+    /// Whether to honor the `TESTING_UPGRADE_*` overrides and inject the
+    /// Soroban config-settings set into genesis.
+    pub use_config_for_genesis: bool,
+    /// Protocol version for the genesis header when `use_config_for_genesis`.
+    pub protocol_version: u32,
+    /// `base_fee` override for the genesis header.
+    pub base_fee: u32,
+    /// `base_reserve` override for the genesis header.
+    pub base_reserve: u32,
+    /// `max_tx_set_size` override for the genesis header.
+    pub max_tx_set_size: u32,
+}
+
+impl Default for GenesisConfig {
+    fn default() -> Self {
+        // Matches stellar-core Config.cpp defaults (false / 26 / 100 /
+        // 100_000_000 / 50). With `use_config_for_genesis = false` these
+        // overrides are inert and genesis is byte-identical to the pre-change
+        // behavior (the genesis header still uses the hardcoded 0 / 100 /
+        // 100_000_000 / 100 values below).
+        Self {
+            use_config_for_genesis: false,
+            protocol_version: 26,
+            base_fee: 100,
+            base_reserve: 100_000_000,
+            max_tx_set_size: 50,
+        }
+    }
+}
+
 /// Initialize a fresh genesis ledger in an empty database.
 ///
 /// This is the shared genesis initialization used by all code paths that need
@@ -45,6 +91,7 @@ pub fn initialize_genesis(
     bucket_dir: Option<&std::path::Path>,
     network_passphrase: &str,
     genesis_test_account_count: u32,
+    genesis_config: &GenesisConfig,
 ) -> anyhow::Result<()> {
     use henyey_db::schema::state_keys;
     use henyey_history::build_history_archive_state;
@@ -55,6 +102,13 @@ pub fn initialize_genesis(
         TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
         TransactionSet, VecM, WriteXdr,
     };
+
+    // SKELETON (commit 1, failing test): genesis is still built at the
+    // hardcoded defaults regardless of `genesis_config` — the regression test
+    // must FAIL here. The real config handling lands in commit 2.
+    let _ = genesis_config;
+    let (ledger_version, base_fee, base_reserve, max_tx_set_size) =
+        (0u32, 100u32, 100_000_000u32, 100u32);
 
     // Build genesis account entries (root + optional test accounts).
     let genesis_entries = build_genesis_entries(
@@ -77,7 +131,7 @@ pub fn initialize_genesis(
     // Build genesis header.
     let bucket_list_hash = bucket_list.hash();
     let mut header = LedgerHeader {
-        ledger_version: 0,
+        ledger_version,
         previous_ledger_hash: Hash([0u8; 32]),
         scp_value: StellarValue {
             tx_set_hash: Hash([0u8; 32]),
@@ -92,9 +146,9 @@ pub fn initialize_genesis(
         fee_pool: 0,
         inflation_seq: 0,
         id_pool: 0,
-        base_fee: 100,
-        base_reserve: 100_000_000, // 10 XLM
-        max_tx_set_size: 100,
+        base_fee,
+        base_reserve,
+        max_tx_set_size,
         skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
         ext: LedgerHeaderExt::V0,
     };
@@ -355,7 +409,7 @@ mod tests {
     #[test]
     fn test_initialize_genesis_writes_complete_state() {
         let db = henyey_db::Database::open_in_memory().unwrap();
-        initialize_genesis(&db, None, PASSPHRASE, 0).unwrap();
+        initialize_genesis(&db, None, PASSPHRASE, 0, &GenesisConfig::default()).unwrap();
 
         db.with_connection(|conn| {
             // LCL = 1
@@ -387,9 +441,9 @@ mod tests {
     fn test_initialize_genesis_rejects_nonempty_db_with_lcl() {
         let db = henyey_db::Database::open_in_memory().unwrap();
         // First init succeeds
-        initialize_genesis(&db, None, PASSPHRASE, 0).unwrap();
+        initialize_genesis(&db, None, PASSPHRASE, 0, &GenesisConfig::default()).unwrap();
         // Second init should fail (DB has LCL)
-        let result = initialize_genesis(&db, None, PASSPHRASE, 0);
+        let result = initialize_genesis(&db, None, PASSPHRASE, 0, &GenesisConfig::default());
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -433,7 +487,7 @@ mod tests {
         db.with_connection(|conn| conn.store_ledger_header(&header, &header_xdr))
             .unwrap();
 
-        let result = initialize_genesis(&db, None, PASSPHRASE, 0);
+        let result = initialize_genesis(&db, None, PASSPHRASE, 0, &GenesisConfig::default());
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -445,7 +499,7 @@ mod tests {
     #[test]
     fn test_initialize_genesis_with_test_accounts() {
         let db = henyey_db::Database::open_in_memory().unwrap();
-        initialize_genesis(&db, None, PASSPHRASE, 3).unwrap();
+        initialize_genesis(&db, None, PASSPHRASE, 3, &GenesisConfig::default()).unwrap();
 
         db.with_connection(|conn| {
             let lcl = conn.get_last_closed_ledger()?;
@@ -461,7 +515,14 @@ mod tests {
         let bucket_dir = dir.path().join("buckets");
         let db = henyey_db::Database::open_in_memory().unwrap();
 
-        initialize_genesis(&db, Some(&bucket_dir), PASSPHRASE, 0).unwrap();
+        initialize_genesis(
+            &db,
+            Some(&bucket_dir),
+            PASSPHRASE,
+            0,
+            &GenesisConfig::default(),
+        )
+        .unwrap();
 
         // At least one bucket file should exist.
         let entries: Vec<_> = std::fs::read_dir(&bucket_dir)
@@ -472,5 +533,144 @@ mod tests {
             !entries.is_empty(),
             "bucket files should be persisted to disk"
         );
+    }
+
+    /// Helper: build a `GenesisConfig` with `use_config_for_genesis = true` at a
+    /// fixed protocol, using stellar-core's TESTING_UPGRADE_* defaults.
+    fn config_for_genesis(protocol: u32) -> GenesisConfig {
+        GenesisConfig {
+            use_config_for_genesis: true,
+            protocol_version: protocol,
+            base_fee: 100,
+            base_reserve: 100_000_000,
+            max_tx_set_size: 50,
+        }
+    }
+
+    /// Collect the `ConfigSettingId`s present in the genesis Soroban config set
+    /// for the given protocol.
+    fn genesis_config_setting_ids(protocol: u32) -> Vec<stellar_xdr::curr::ConfigSettingId> {
+        use stellar_xdr::curr::LedgerEntryData;
+        let network_id = NetworkId::from_passphrase(PASSPHRASE);
+        let entries =
+            henyey_ledger::build_genesis_soroban_config_entries(protocol, &network_id).unwrap();
+        let mut ids: Vec<_> = entries
+            .iter()
+            .filter_map(|e| match &e.data {
+                LedgerEntryData::ConfigSetting(cs) => Some(cs.discriminant()),
+                _ => None,
+            })
+            .collect();
+        ids.sort_by_key(|id| *id as i32);
+        ids
+    }
+
+    /// Regression test for #3492: with USE_CONFIG_FOR_GENESIS=true the genesis
+    /// header carries the configured protocol + fee overrides, and the genesis
+    /// bucket list contains the FULL Soroban ConfigSetting entry set.
+    ///
+    /// Fails on `origin/main` (genesis hardcodes ledger_version=0 and emits
+    /// zero ConfigSetting entries — bootstrap.rs:80).
+    #[test]
+    fn test_genesis_config_for_genesis_matches_core_3492() {
+        use stellar_xdr::curr::ConfigSettingId;
+
+        let db = henyey_db::Database::open_in_memory().unwrap();
+        let protocol = 25;
+        initialize_genesis(&db, None, PASSPHRASE, 0, &config_for_genesis(protocol)).unwrap();
+
+        // (a) Header carries the configured protocol + TESTING_UPGRADE_* fees.
+        db.with_connection(|conn| {
+            let header = conn.load_ledger_header(1)?.unwrap();
+            assert_eq!(
+                header.ledger_version, protocol,
+                "genesis header must use the configured protocol version"
+            );
+            assert_eq!(
+                header.base_fee, 100,
+                "base_fee from TESTING_UPGRADE_DESIRED_FEE"
+            );
+            assert_eq!(
+                header.base_reserve, 100_000_000,
+                "base_reserve from TESTING_UPGRADE_RESERVE"
+            );
+            assert_eq!(
+                header.max_tx_set_size, 50,
+                "max_tx_set_size from TESTING_UPGRADE_MAX_TX_SET_SIZE (50, not 100)"
+            );
+            Ok(())
+        })
+        .unwrap();
+
+        // (b) The genesis Soroban config set is present, with the EXACT expected
+        // per-ID membership at protocol 25 (V20's 14 + V23's 3 = 17 entries; no
+        // V26 frozen-key entries yet). Per-ID presence, not just "non-empty".
+        let ids = genesis_config_setting_ids(protocol);
+        let expected: Vec<ConfigSettingId> = {
+            let mut v = vec![
+                ConfigSettingId::ContractMaxSizeBytes,
+                ConfigSettingId::ContractComputeV0,
+                ConfigSettingId::ContractLedgerCostV0,
+                ConfigSettingId::ContractHistoricalDataV0,
+                ConfigSettingId::ContractEventsV0,
+                ConfigSettingId::ContractBandwidthV0,
+                ConfigSettingId::ContractCostParamsCpuInstructions,
+                ConfigSettingId::ContractCostParamsMemoryBytes,
+                ConfigSettingId::ContractDataKeySizeBytes,
+                ConfigSettingId::ContractDataEntrySizeBytes,
+                ConfigSettingId::StateArchival,
+                ConfigSettingId::ContractExecutionLanes,
+                ConfigSettingId::LiveSorobanStateSizeWindow,
+                ConfigSettingId::EvictionIterator,
+                // V23 additions:
+                ConfigSettingId::ContractParallelComputeV0,
+                ConfigSettingId::ContractLedgerCostExtV0,
+                ConfigSettingId::ScpTiming,
+            ];
+            v.sort_by_key(|id| *id as i32);
+            v
+        };
+        assert_eq!(
+            ids, expected,
+            "genesis config-setting ID set at p25 must match core exactly"
+        );
+        assert_eq!(ids.len(), 17, "p25 genesis config-setting count");
+    }
+
+    /// Backward-compat guard: with USE_CONFIG_FOR_GENESIS absent/false the
+    /// genesis is BYTE-IDENTICAL to the legacy behavior — ledger_version 0, no
+    /// config entries, and a pinned header/bucket-list hash. Would FAIL if the
+    /// fix regressed the default path.
+    #[test]
+    fn test_genesis_no_config_for_genesis_unchanged() {
+        use henyey_ledger::compute_header_hash;
+
+        let db = henyey_db::Database::open_in_memory().unwrap();
+        initialize_genesis(&db, None, PASSPHRASE, 0, &GenesisConfig::default()).unwrap();
+
+        db.with_connection(|conn| {
+            let header = conn.load_ledger_header(1)?.unwrap();
+            // Legacy genesis header constants.
+            assert_eq!(header.ledger_version, 0);
+            assert_eq!(header.base_fee, 100);
+            assert_eq!(header.base_reserve, 100_000_000);
+            assert_eq!(header.max_tx_set_size, 100);
+
+            // Pin the genesis hashes for the testnet passphrase. These are the
+            // pre-change values; any drift means the default path regressed.
+            let header_hash = compute_header_hash(&header).unwrap();
+            assert_eq!(
+                header_hash.to_hex(),
+                "63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99",
+                "genesis header hash regressed for the no-config path"
+            );
+            assert_eq!(
+                hex::encode(header.bucket_list_hash.0),
+                "572a2e32ff248a07b0e70fd1f6d318c1facd20b6cc08c33d5775259868125a16",
+                "genesis bucket-list hash regressed for the no-config path"
+            );
+            Ok(())
+        })
+        .unwrap();
     }
 }

--- a/crates/app/src/app/bootstrap.rs
+++ b/crates/app/src/app/bootstrap.rs
@@ -103,19 +103,46 @@ pub fn initialize_genesis(
         TransactionSet, VecM, WriteXdr,
     };
 
-    // SKELETON (commit 1, failing test): genesis is still built at the
-    // hardcoded defaults regardless of `genesis_config` — the regression test
-    // must FAIL here. The real config handling lands in commit 2.
-    let _ = genesis_config;
+    // Header field values. When USE_CONFIG_FOR_GENESIS is set, stellar-core
+    // overrides ledger_version/baseFee/baseReserve/maxTxSetSize from the
+    // TESTING_UPGRADE_* config (LedgerManagerImpl.cpp:489-503). Otherwise the
+    // genesis defaults (0 / 100 / 100_000_000 / 100) are used, byte-identical
+    // to the pre-change behavior.
     let (ledger_version, base_fee, base_reserve, max_tx_set_size) =
-        (0u32, 100u32, 100_000_000u32, 100u32);
+        if genesis_config.use_config_for_genesis {
+            (
+                genesis_config.protocol_version,
+                genesis_config.base_fee,
+                genesis_config.base_reserve,
+                genesis_config.max_tx_set_size,
+            )
+        } else {
+            (0u32, 100u32, 100_000_000u32, 100u32)
+        };
 
     // Build genesis account entries (root + optional test accounts).
-    let genesis_entries = build_genesis_entries(
+    let mut genesis_entries = build_genesis_entries(
         network_passphrase,
         genesis_test_account_count,
         GENESIS_TOTAL_COINS,
     );
+
+    // When USE_CONFIG_FOR_GENESIS is set and the genesis protocol is >= 20,
+    // inject the full Soroban ConfigSetting entry set. Mirrors
+    // SorobanNetworkConfig::initializeGenesisLedgerForTesting
+    // (NetworkConfig.cpp:1708), which stellar-core's startNewLedger(genesis)
+    // invokes (LedgerManagerImpl.cpp:421). Entry ordering is irrelevant —
+    // add_batch sorts the batch by LedgerKey, matching core's canonical bucket
+    // assembly.
+    if genesis_config.use_config_for_genesis && ledger_version >= 20 {
+        let network_id = NetworkId::from_passphrase(network_passphrase);
+        let config_entries =
+            henyey_ledger::build_genesis_soroban_config_entries(ledger_version, &network_id)
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to build genesis Soroban config entries: {}", e)
+                })?;
+        genesis_entries.extend(config_entries);
+    }
 
     // Create bucket list and add all genesis entries.
     let mut bucket_list = BucketList::new();

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -1220,6 +1220,7 @@ impl App {
                 Some(&config.buckets.directory),
                 &config.network.passphrase,
                 config.testing.genesis_test_account_count,
+                &config.testing.genesis_config(),
             )?;
         }
 

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -77,6 +77,11 @@ const SUPPORTED_KEYS: &[&str] = &[
     "PUBLISH_TO_ARCHIVE_DELAY",
     "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
     "GENESIS_TEST_ACCOUNT_COUNT",
+    "USE_CONFIG_FOR_GENESIS",
+    "TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION",
+    "TESTING_UPGRADE_DESIRED_FEE",
+    "TESTING_UPGRADE_RESERVE",
+    "TESTING_UPGRADE_MAX_TX_SET_SIZE",
     "RUN_STANDALONE",
     // Sub-tables (handled structurally)
     "HISTORY",
@@ -634,6 +639,25 @@ pub fn translate_stellar_core_config(raw: &toml::Value) -> anyhow::Result<AppCon
     }
     if let Some(v) = get_u32(table, "GENESIS_TEST_ACCOUNT_COUNT") {
         config.testing.genesis_test_account_count = v;
+    }
+    // Genesis-construction overrides. Mirrors stellar-core's
+    // USE_CONFIG_FOR_GENESIS / TESTING_UPGRADE_* keys (Config.cpp:198/231-234).
+    // Absent keys leave the stellar-core-matching defaults in place, so a
+    // config without these is byte-identical to the legacy genesis.
+    if let Some(v) = get_bool(table, "USE_CONFIG_FOR_GENESIS") {
+        config.testing.use_config_for_genesis = v;
+    }
+    if let Some(v) = get_u32(table, "TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION") {
+        config.testing.testing_upgrade_ledger_protocol_version = v;
+    }
+    if let Some(v) = get_u32(table, "TESTING_UPGRADE_DESIRED_FEE") {
+        config.testing.testing_upgrade_desired_fee = v;
+    }
+    if let Some(v) = get_u32(table, "TESTING_UPGRADE_RESERVE") {
+        config.testing.testing_upgrade_reserve = v;
+    }
+    if let Some(v) = get_u32(table, "TESTING_UPGRADE_MAX_TX_SET_SIZE") {
+        config.testing.testing_upgrade_max_tx_set_size = v;
     }
     if let Some(v) = get_bool(table, "RUN_STANDALONE") {
         config.testing.run_standalone = v;
@@ -2131,6 +2155,51 @@ mod tests {
         .unwrap();
         let config = translate_stellar_core_config(&core_toml).unwrap();
         assert_eq!(config.testing.genesis_test_account_count, 0);
+    }
+
+    #[test]
+    fn test_use_config_for_genesis_parsed() {
+        let core_toml: toml::Value = toml::from_str(
+            r#"
+            NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+            USE_CONFIG_FOR_GENESIS = true
+            TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = 25
+            TESTING_UPGRADE_DESIRED_FEE = 200
+            TESTING_UPGRADE_RESERVE = 5000000
+            TESTING_UPGRADE_MAX_TX_SET_SIZE = 500
+            "#,
+        )
+        .unwrap();
+        let config = translate_stellar_core_config(&core_toml).unwrap();
+        assert!(config.testing.use_config_for_genesis);
+        assert_eq!(config.testing.testing_upgrade_ledger_protocol_version, 25);
+        assert_eq!(config.testing.testing_upgrade_desired_fee, 200);
+        assert_eq!(config.testing.testing_upgrade_reserve, 5_000_000);
+        assert_eq!(config.testing.testing_upgrade_max_tx_set_size, 500);
+
+        let gc = config.testing.genesis_config();
+        assert!(gc.use_config_for_genesis);
+        assert_eq!(gc.protocol_version, 25);
+        assert_eq!(gc.base_fee, 200);
+        assert_eq!(gc.base_reserve, 5_000_000);
+        assert_eq!(gc.max_tx_set_size, 500);
+    }
+
+    #[test]
+    fn test_use_config_for_genesis_defaults() {
+        // Absent keys ⇒ stellar-core defaults (false / 26 / 100 / 100_000_000 / 50).
+        let core_toml: toml::Value = toml::from_str(
+            r#"
+            NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
+            "#,
+        )
+        .unwrap();
+        let config = translate_stellar_core_config(&core_toml).unwrap();
+        assert!(!config.testing.use_config_for_genesis);
+        assert_eq!(config.testing.testing_upgrade_ledger_protocol_version, 26);
+        assert_eq!(config.testing.testing_upgrade_desired_fee, 100);
+        assert_eq!(config.testing.testing_upgrade_reserve, 100_000_000);
+        assert_eq!(config.testing.testing_upgrade_max_tx_set_size, 50);
     }
 
     #[test]

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -622,7 +622,27 @@ impl Default for DiagnosticsConfig {
 /// [testing]
 /// accelerate_time = true  # 1s ledger close, checkpoint frequency 8
 /// ```
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+fn default_testing_upgrade_protocol_version() -> u32 {
+    // stellar-core CURRENT_LEDGER_PROTOCOL_VERSION (Config.cpp:36).
+    26
+}
+
+fn default_testing_upgrade_desired_fee() -> u32 {
+    // stellar-core GENESIS_LEDGER_BASE_FEE (LedgerManagerImpl.cpp:111).
+    100
+}
+
+fn default_testing_upgrade_reserve() -> u32 {
+    // stellar-core GENESIS_LEDGER_BASE_RESERVE (LedgerManagerImpl.cpp:112).
+    100_000_000
+}
+
+fn default_testing_upgrade_max_tx_set_size() -> u32 {
+    // stellar-core Config.cpp:234 (note: 50, not the genesis-header 100).
+    50
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TestingConfig {
     /// When true, accelerate time for testing: 1-second ledger close and
@@ -653,6 +673,45 @@ pub struct TestingConfig {
     #[serde(default)]
     pub genesis_test_account_count: u32,
 
+    /// When true, build the genesis ledger from the `TESTING_UPGRADE_*`
+    /// settings (configured protocol version, base fee/reserve/maxTxSetSize)
+    /// and inject the full Soroban `ConfigSetting` entry set, instead of the
+    /// default `ledger_version = 0` empty-config genesis.
+    ///
+    /// Maps to stellar-core's `USE_CONFIG_FOR_GENESIS`. All SSC mixed-image
+    /// missions set this true so the genesis bucket-list hash matches
+    /// stellar-core. Default `false` preserves the legacy genesis exactly.
+    #[serde(default)]
+    pub use_config_for_genesis: bool,
+
+    /// Protocol version of the genesis ledger when `use_config_for_genesis`.
+    ///
+    /// Maps to stellar-core's `TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION`
+    /// (default `CURRENT_LEDGER_PROTOCOL_VERSION` = 26).
+    #[serde(default = "default_testing_upgrade_protocol_version")]
+    pub testing_upgrade_ledger_protocol_version: u32,
+
+    /// `base_fee` of the genesis ledger when `use_config_for_genesis`.
+    ///
+    /// Maps to stellar-core's `TESTING_UPGRADE_DESIRED_FEE`
+    /// (default `GENESIS_LEDGER_BASE_FEE` = 100).
+    #[serde(default = "default_testing_upgrade_desired_fee")]
+    pub testing_upgrade_desired_fee: u32,
+
+    /// `base_reserve` of the genesis ledger when `use_config_for_genesis`.
+    ///
+    /// Maps to stellar-core's `TESTING_UPGRADE_RESERVE`
+    /// (default `GENESIS_LEDGER_BASE_RESERVE` = 100_000_000).
+    #[serde(default = "default_testing_upgrade_reserve")]
+    pub testing_upgrade_reserve: u32,
+
+    /// `max_tx_set_size` of the genesis ledger when `use_config_for_genesis`.
+    ///
+    /// Maps to stellar-core's `TESTING_UPGRADE_MAX_TX_SET_SIZE` (default 50 —
+    /// note this differs from the genesis-header default of 100).
+    #[serde(default = "default_testing_upgrade_max_tx_set_size")]
+    pub testing_upgrade_max_tx_set_size: u32,
+
     /// When true, the node operates as a standalone validator not connected
     /// to a real network. Standalone validators are exempt from certain
     /// config restrictions that protect networked validators (diagnostic
@@ -661,6 +720,37 @@ pub struct TestingConfig {
     /// Maps to stellar-core's `RUN_STANDALONE`.
     #[serde(default)]
     pub run_standalone: bool,
+}
+
+impl TestingConfig {
+    /// Build the [`GenesisConfig`](crate::app::bootstrap::GenesisConfig) used
+    /// by genesis initialization from these testing settings.
+    pub fn genesis_config(&self) -> crate::app::bootstrap::GenesisConfig {
+        crate::app::bootstrap::GenesisConfig {
+            use_config_for_genesis: self.use_config_for_genesis,
+            protocol_version: self.testing_upgrade_ledger_protocol_version,
+            base_fee: self.testing_upgrade_desired_fee,
+            base_reserve: self.testing_upgrade_reserve,
+            max_tx_set_size: self.testing_upgrade_max_tx_set_size,
+        }
+    }
+}
+
+impl Default for TestingConfig {
+    fn default() -> Self {
+        Self {
+            accelerate_time: false,
+            ledger_close_time: None,
+            generate_load_for_testing: false,
+            genesis_test_account_count: 0,
+            use_config_for_genesis: false,
+            testing_upgrade_ledger_protocol_version: default_testing_upgrade_protocol_version(),
+            testing_upgrade_desired_fee: default_testing_upgrade_desired_fee(),
+            testing_upgrade_reserve: default_testing_upgrade_reserve(),
+            testing_upgrade_max_tx_set_size: default_testing_upgrade_max_tx_set_size(),
+            run_standalone: false,
+        }
+    }
 }
 
 /// Catchup behavior configuration.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -68,7 +68,7 @@ pub mod metrics;
 pub mod run_cmd;
 pub mod survey;
 
-pub use app::bootstrap::initialize_genesis;
+pub use app::bootstrap::{initialize_genesis, GenesisConfig};
 pub use app::{App, AppState, FallbackCatchup, LedgerSummary, RestoreResult, SimulationDebugStats};
 pub use catchup_cmd::{run_catchup, CatchupMode, CatchupOptions};
 pub use config::{AppConfig, BuildMetadata, MaintenanceAppConfig};

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -1788,6 +1788,7 @@ fn local_config() -> AppConfig {
             generate_load_for_testing: true,
             genesis_test_account_count: 0,
             run_standalone: true,
+            ..Default::default()
         },
         compat_http: CompatHttpConfig {
             enabled: true,
@@ -1925,6 +1926,7 @@ async fn cmd_run(
                 Some(&config.buckets.directory),
                 &config.network.passphrase,
                 config.testing.genesis_test_account_count,
+                &config.testing.genesis_config(),
             )?;
             tracing::info!("Local mode: genesis ledger initialized");
 
@@ -2049,6 +2051,7 @@ async fn cmd_new_db(
         Some(bucket_dir),
         passphrase,
         config.testing.genesis_test_account_count,
+        &config.testing.genesis_config(),
     )?;
 
     println!("Database created successfully at: {}", db_path.display());
@@ -2063,12 +2066,14 @@ fn initialize_genesis_ledger(
     bucket_dir: Option<&std::path::Path>,
     network_passphrase: &str,
     genesis_test_account_count: u32,
+    genesis_config: &henyey_app::GenesisConfig,
 ) -> anyhow::Result<()> {
     henyey_app::initialize_genesis(
         db,
         bucket_dir,
         network_passphrase,
         genesis_test_account_count,
+        genesis_config,
     )
 }
 
@@ -3928,7 +3933,14 @@ mod tests {
         let db = henyey_db::Database::open_in_memory().unwrap();
         let passphrase = "Standalone Network ; February 2017";
 
-        initialize_genesis_ledger(&db, None, passphrase, 0).unwrap();
+        initialize_genesis_ledger(
+            &db,
+            None,
+            passphrase,
+            0,
+            &henyey_app::GenesisConfig::default(),
+        )
+        .unwrap();
 
         // Verify LCL is set to 1
         db.with_connection(|conn| {
@@ -3998,7 +4010,14 @@ mod tests {
         let passphrase = "Standalone Network ; February 2017";
         let count = 10;
 
-        initialize_genesis_ledger(&db, None, passphrase, count).unwrap();
+        initialize_genesis_ledger(
+            &db,
+            None,
+            passphrase,
+            count,
+            &henyey_app::GenesisConfig::default(),
+        )
+        .unwrap();
 
         // Verify LCL is set and header is stored
         db.with_connection(|conn| {
@@ -4012,7 +4031,14 @@ mod tests {
             // Verify bucket_list_hash differs from the 0-account case
             // (it should include 11 accounts instead of 1)
             let db2 = henyey_db::Database::open_in_memory().unwrap();
-            initialize_genesis_ledger(&db2, None, passphrase, 0).unwrap();
+            initialize_genesis_ledger(
+                &db2,
+                None,
+                passphrase,
+                0,
+                &henyey_app::GenesisConfig::default(),
+            )
+            .unwrap();
             let header0 = db2
                 .with_connection(|c| c.load_ledger_header(1))
                 .unwrap()
@@ -4090,7 +4116,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let bucket_dir = tmp.path().join("buckets");
 
-        initialize_genesis_ledger(&db, Some(&bucket_dir), passphrase, 0).unwrap();
+        initialize_genesis_ledger(
+            &db,
+            Some(&bucket_dir),
+            passphrase,
+            0,
+            &henyey_app::GenesisConfig::default(),
+        )
+        .unwrap();
 
         // The bucket directory should have been created
         assert!(bucket_dir.exists(), "bucket directory should be created");
@@ -4145,7 +4178,14 @@ mod tests {
         let passphrase = "Standalone Network ; February 2017";
 
         // Should succeed without error even with no bucket_dir
-        initialize_genesis_ledger(&db, None, passphrase, 0).unwrap();
+        initialize_genesis_ledger(
+            &db,
+            None,
+            passphrase,
+            0,
+            &henyey_app::GenesisConfig::default(),
+        )
+        .unwrap();
 
         // Verify genesis ledger was still created correctly
         db.with_connection(|conn| {

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -105,6 +105,7 @@ pub use header::{
     is_before_protocol_version, protocol_version, verify_header_chain, SKIP_1, SKIP_2, SKIP_3,
     SKIP_4, SKIP_LIST_SIZE,
 };
+pub use manager::build_genesis_soroban_config_entries;
 pub use manager::new_bucket_list_with_soroban_config;
 pub use manager::{
     prepend_fee_event, scan_level_pairs_for_caches, CacheInitResult, HeaderSnapshot, LedgerManager,

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -10515,4 +10515,228 @@ mod tests {
             "hot archive bucket list must not be installed"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Genesis Soroban config-entry builder (#3492)
+    // -----------------------------------------------------------------------
+
+    fn genesis_config_entry(protocol: u32, id: ConfigSettingId) -> ConfigSettingEntry {
+        let network_id = NetworkId::from_passphrase("Test SDF Network ; September 2015");
+        let entries = build_genesis_soroban_config_entries(protocol, &network_id).unwrap();
+        entries
+            .into_iter()
+            .find_map(|e| match e.data {
+                LedgerEntryData::ConfigSetting(cs) if cs.discriminant() == id => Some(cs),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("config setting {id:?} not present at protocol {protocol}"))
+    }
+
+    fn genesis_cpu_params(protocol: u32) -> Vec<stellar_xdr::curr::ContractCostParamEntry> {
+        match genesis_config_entry(protocol, ConfigSettingId::ContractCostParamsCpuInstructions) {
+            ConfigSettingEntry::ContractCostParamsCpuInstructions(p) => p.0.to_vec(),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    fn genesis_mem_params(protocol: u32) -> Vec<stellar_xdr::curr::ContractCostParamEntry> {
+        match genesis_config_entry(protocol, ConfigSettingId::ContractCostParamsMemoryBytes) {
+            ConfigSettingEntry::ContractCostParamsMemoryBytes(p) => p.0.to_vec(),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_genesis_soroban_config_entries_counts() {
+        let network_id = NetworkId::from_passphrase("Test SDF Network ; September 2015");
+        // p24: V20's 14 entries + V23's 3 entries (protocol 24 includes the
+        // full upgrade cascade through 24, which includes V23). V21/V22 only
+        // resize the cost-param entries — they add no new config-setting keys.
+        let p24 = build_genesis_soroban_config_entries(24, &network_id).unwrap();
+        assert_eq!(p24.len(), 17, "p24 genesis config-setting count");
+        // p25: same set as p24 (V25 only resizes cost params, adds no keys).
+        let p25 = build_genesis_soroban_config_entries(25, &network_id).unwrap();
+        assert_eq!(p25.len(), 17, "p25 genesis config-setting count");
+        // p26: + 2 V26 frozen-key entries.
+        let p26 = build_genesis_soroban_config_entries(26, &network_id).unwrap();
+        assert_eq!(p26.len(), 19, "p26 genesis config-setting count");
+        // Pre-Soroban: empty.
+        let p19 = build_genesis_soroban_config_entries(19, &network_id).unwrap();
+        assert!(p19.is_empty(), "pre-Soroban genesis has no config entries");
+    }
+
+    #[test]
+    fn test_build_genesis_soroban_config_entries_no_duplicate_keys() {
+        let network_id = NetworkId::from_passphrase("Test SDF Network ; September 2015");
+        for protocol in [24u32, 25, 26] {
+            let entries = build_genesis_soroban_config_entries(protocol, &network_id).unwrap();
+            let mut ids: Vec<i32> = entries
+                .iter()
+                .filter_map(|e| match &e.data {
+                    LedgerEntryData::ConfigSetting(cs) => Some(cs.discriminant() as i32),
+                    _ => None,
+                })
+                .collect();
+            let total = ids.len();
+            ids.sort_unstable();
+            ids.dedup();
+            assert_eq!(
+                ids.len(),
+                total,
+                "no duplicate config-setting keys at protocol {protocol}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_genesis_recalibrated_cpu_params_match_core() {
+        // Spot-check the recalibrated V20 CPU params (NetworkConfig.cpp:2620).
+        // Index comments per the ContractCostType enum.
+        let cpu = genesis_cpu_params(24);
+        assert_eq!(cpu[4].const_term, 295, "DispatchHostFunction const");
+        assert_eq!(cpu[4].linear_term, 0, "DispatchHostFunction linear");
+        assert_eq!(cpu[7].const_term, 331, "ValDeser const");
+        assert_eq!(cpu[7].linear_term, 4369, "ValDeser linear");
+        assert_eq!(cpu[11].const_term, 417482, "VmInstantiation const");
+        assert_eq!(cpu[11].linear_term, 45712, "VmInstantiation linear");
+        assert_eq!(
+            cpu[16].const_term, 2314804,
+            "RecoverEcdsaSecp256k1Key const"
+        );
+        assert_eq!(cpu[22].const_term, 1059, "ChaCha20DrawBytes const");
+        assert_eq!(cpu[22].linear_term, 502, "ChaCha20DrawBytes linear");
+    }
+
+    /// Run V20 + recalibration in isolation and return the (cpu, mem) cost
+    /// param tables, BEFORE the V21+ cascade overwrites any indices.
+    fn recalibrated_v20_params_isolated() -> (
+        Vec<stellar_xdr::curr::ContractCostParamEntry>,
+        Vec<stellar_xdr::curr::ContractCostParamEntry>,
+    ) {
+        use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
+        let snapshot = SnapshotHandle::new(LedgerSnapshot::empty(1));
+        let header = create_genesis_header();
+        let mut ltx = CloseLedgerState::begin(snapshot, header, Hash256::ZERO, 1);
+        create_ledger_entries_for_v20(&mut ltx, 1, 0).unwrap();
+        update_recalibrated_cost_types_for_v20(&mut ltx, 1).unwrap();
+        let entries = ltx.current_delta().current_entries();
+        let mut cpu = None;
+        let mut mem = None;
+        for e in entries {
+            if let LedgerEntryData::ConfigSetting(cs) = e.data {
+                match cs {
+                    ConfigSettingEntry::ContractCostParamsCpuInstructions(p) => {
+                        cpu = Some(p.0.to_vec())
+                    }
+                    ConfigSettingEntry::ContractCostParamsMemoryBytes(p) => {
+                        mem = Some(p.0.to_vec())
+                    }
+                    _ => {}
+                }
+            }
+        }
+        (cpu.unwrap(), mem.unwrap())
+    }
+
+    #[test]
+    fn test_genesis_recalibrated_mem_params_match_core() {
+        // The recalibration rewrites mem indices 11 and 12 to 132773/4903
+        // (NetworkConfig.cpp:2706). Index 12 (VmCachedInstantiation) is later
+        // overwritten by createCostTypesForV21 (69472/1217), matching core's
+        // ordering, so we verify the recalibrated values in ISOLATION here and
+        // verify the V21 overwrite of index 12 separately below.
+        let (_cpu, mem) = recalibrated_v20_params_isolated();
+        assert_eq!(mem[11].const_term, 132773, "VmInstantiation mem const");
+        assert_eq!(mem[11].linear_term, 4903, "VmInstantiation mem linear");
+        assert_eq!(
+            mem[12].const_term, 132773,
+            "VmCachedInstantiation mem const"
+        );
+        assert_eq!(
+            mem[12].linear_term, 4903,
+            "VmCachedInstantiation mem linear"
+        );
+    }
+
+    #[test]
+    fn test_genesis_v21_overwrites_recalibrated_mem_index_12() {
+        // After the full p24 cascade, index 12 mem carries the V21 value
+        // (69472/1217), and index 11 retains the recalibrated value
+        // (132773/4903) since V21 mem does not touch index 11.
+        let mem = genesis_mem_params(24);
+        assert_eq!(
+            mem[12].const_term, 69472,
+            "V21 overwrites VmCachedInstantiation mem"
+        );
+        assert_eq!(mem[12].linear_term, 1217);
+        assert_eq!(
+            mem[11].const_term, 132773,
+            "VmInstantiation mem retained from recalibration"
+        );
+        assert_eq!(mem[11].linear_term, 4903);
+    }
+
+    #[test]
+    fn test_update_recalibrated_cost_types_for_v20_overwrites_v20_values() {
+        // The recalibration must REPLACE the initial V20 values. Verify a few
+        // indices changed from the initial table to the recalibrated table.
+        let initial_cpu = initial_cpu_cost_params_for_v20();
+        // Initial DispatchHostFunction const is 310; recalibrated is 295.
+        assert_eq!(initial_cpu[4].const_term, 310);
+        let cpu = genesis_cpu_params(24);
+        assert_eq!(cpu[4].const_term, 295);
+        // Initial VmInstantiation is (451626, 45405); recalibrated (417482, 45712).
+        assert_eq!(initial_cpu[11].const_term, 451626);
+        assert_eq!(cpu[11].const_term, 417482);
+    }
+
+    #[test]
+    fn test_genesis_v23_rent_params_override_v20_ledger_cost() {
+        // V23's updateRentCostParamsForV23 read-modify-writes the V20-created
+        // ContractLedgerCostV0 entry; harvesting via current_entries() must
+        // carry the V23 value (3 GB), not the V20 value (30 GB).
+        match genesis_config_entry(25, ConfigSettingId::ContractLedgerCostV0) {
+            ConfigSettingEntry::ContractLedgerCostV0(s) => {
+                assert_eq!(
+                    s.soroban_state_target_size_bytes, 3_000_000_000,
+                    "V23 rent override must be reflected in genesis"
+                );
+                assert_eq!(s.rent_fee1_kb_soroban_state_size_low, -17_000);
+                assert_eq!(s.rent_fee1_kb_soroban_state_size_high, 10_000);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+        // The V20 initial value (30 GB) is checked in isolation below
+        // (test_genesis_v20_ledger_cost_initial_value_before_v23), since every
+        // supported genesis protocol (24+) runs the V23 override.
+    }
+
+    #[test]
+    fn test_genesis_v20_ledger_cost_initial_value_before_v23() {
+        // Confirm the V20-created ContractLedgerCostV0 carries 30 GB BEFORE the
+        // V23 override, by running only V20 + recalibration in isolation. This
+        // guards that the V23 override (3 GB) is a genuine read-modify-write of
+        // the V20 value rather than a coincidence.
+        use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
+        let snapshot = SnapshotHandle::new(LedgerSnapshot::empty(1));
+        let header = create_genesis_header();
+        let mut ltx = CloseLedgerState::begin(snapshot, header, Hash256::ZERO, 1);
+        create_ledger_entries_for_v20(&mut ltx, 1, 0).unwrap();
+        update_recalibrated_cost_types_for_v20(&mut ltx, 1).unwrap();
+        let entries = ltx.current_delta().current_entries();
+        let cost = entries
+            .into_iter()
+            .find_map(|e| match e.data {
+                LedgerEntryData::ConfigSetting(ConfigSettingEntry::ContractLedgerCostV0(s)) => {
+                    Some(s)
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(
+            cost.soroban_state_target_size_bytes,
+            30 * 1024 * 1024 * 1024_i64,
+            "V20 initial ledger-cost target size is 30 GB before V23"
+        );
+    }
 }

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -3953,6 +3953,169 @@ fn create_ledger_entries_for_v26(ltx: &mut CloseLedgerState, ledger_seq: u32) ->
     Ok(())
 }
 
+/// Re-calibrate the V20 CPU/memory cost-param entries to the post-release
+/// corrected values.
+///
+/// Parity: `SorobanNetworkConfig::updateRecalibratedCostTypesForV20`
+/// (NetworkConfig.cpp:2606-2720), which stellar-core runs under `#ifdef
+/// BUILD_TESTS` inside `initializeGenesisLedgerForTesting` immediately after
+/// `createLedgerEntriesForV20` (NetworkConfig.cpp:1724). Protocol 20 shipped
+/// with somewhat incorrect costs that were re-calibrated shortly after
+/// release; the genesis path catches up to the corrected values.
+///
+/// This is GENESIS-ONLY and MUST NOT be wired into the live
+/// `apply_version_upgrade_side_effects` upgrade path — a node upgrading a
+/// running network from <20 to >=20 follows the on-network sequence, which
+/// reaches the recalibrated values via the normal per-protocol config
+/// upgrades, not this BUILD_TESTS shortcut.
+///
+/// Indices match the `ContractCostType` enum (see `initial_cpu_cost_params_for_v20`):
+/// DispatchHostFunction=4, VisitObject=5, ValSer=6, ValDeser=7,
+/// ComputeSha256Hash=8, ComputeEd25519PubKey=9, VerifyEd25519Sig=10,
+/// VmInstantiation=11, VmCachedInstantiation=12, InvokeVmFunction=13,
+/// ComputeKeccak256Hash=14, DecodeEcdsaCurve256Sig=15,
+/// RecoverEcdsaSecp256k1Key=16, Int256AddSub=17, Int256Mul=18, Int256Div=19,
+/// Int256Pow=20, Int256Shift=21, ChaCha20DrawBytes=22.
+fn update_recalibrated_cost_types_for_v20(
+    ltx: &mut CloseLedgerState,
+    ledger_seq: u32,
+) -> Result<()> {
+    // CPU param recalibration (NetworkConfig.cpp:2620-2693). `resize` keeps the
+    // existing V20 size (23 entries); we pass the current count via the helper,
+    // which resizes to NEW_SIZE then overwrites the listed indices.
+    const V20_COST_PARAM_SIZE: usize = 23;
+
+    // (index, const_term, linear_term)
+    let cpu_updates: &[(usize, i64, i64)] = &[
+        (4, 295, 0),         // DispatchHostFunction
+        (5, 60, 0),          // VisitObject
+        (6, 221, 26),        // ValSer
+        (7, 331, 4369),      // ValDeser
+        (8, 3636, 7013),     // ComputeSha256Hash
+        (9, 40256, 0),       // ComputeEd25519PubKey
+        (10, 377551, 4059),  // VerifyEd25519Sig
+        (11, 417482, 45712), // VmInstantiation
+        (12, 417482, 45712), // VmCachedInstantiation
+        (13, 1945, 0),       // InvokeVmFunction
+        (14, 6481, 5943),    // ComputeKeccak256Hash
+        (15, 711, 0),        // DecodeEcdsaCurve256Sig
+        (16, 2314804, 0),    // RecoverEcdsaSecp256k1Key
+        (17, 4176, 0),       // Int256AddSub
+        (18, 4716, 0),       // Int256Mul
+        (19, 4680, 0),       // Int256Div
+        (20, 4256, 0),       // Int256Pow
+        (21, 884, 0),        // Int256Shift
+        (22, 1059, 502),     // ChaCha20DrawBytes
+    ];
+
+    // Memory param recalibration (NetworkConfig.cpp:2702-2717): only
+    // VmInstantiation and VmCachedInstantiation are rewritten.
+    let mem_updates: &[(usize, i64, i64)] = &[
+        (11, 132773, 4903), // VmInstantiation
+        (12, 132773, 4903), // VmCachedInstantiation
+    ];
+
+    resize_and_update_cost_params(
+        ltx,
+        ledger_seq,
+        V20_COST_PARAM_SIZE,
+        cpu_updates,
+        mem_updates,
+    )?;
+
+    tracing::info!(
+        ledger_seq = ledger_seq,
+        "Applied updateRecalibratedCostTypesForV20 (genesis-only BUILD_TESTS recalibration)"
+    );
+
+    Ok(())
+}
+
+/// Build the full Soroban `ConfigSetting` ledger-entry set for a genesis ledger
+/// at `protocol`, for `USE_CONFIG_FOR_GENESIS` networks.
+///
+/// Parity: `SorobanNetworkConfig::initializeGenesisLedgerForTesting`
+/// (NetworkConfig.cpp:1708-1751). Reuses the SAME per-protocol cascade that
+/// the live upgrade path drives in `apply_version_upgrade_side_effects`
+/// (manager.rs:3081), gated by the identical `protocolVersionStartsFrom`
+/// thresholds (here `prev_version = 0`). The genesis-only BUILD_TESTS V20 cost
+/// recalibration (`update_recalibrated_cost_types_for_v20`) is layered between
+/// V20 and V21, matching NetworkConfig.cpp:1724.
+///
+/// The returned entries carry their FINAL post-cascade values: create-then-
+/// update collapses to "created (final value)" in the delta, and the V23
+/// rent-param update read-modify-writes the V20-created `ContractLedgerCostV0`
+/// / `StateArchival` entries in the same delta. Entries are harvested via the
+/// delta's current entries so any in-delta update is reflected.
+///
+/// Entry ORDER is irrelevant to the bucket-list hash: `BucketList::add_batch`
+/// sorts the batch by `LedgerKey` (bucket_list.rs) and the bucket re-sorts.
+///
+/// Henyey supports protocol 24+ only; `protocol` is expected to be >= 24. The
+/// cascade is correct for any `protocol >= 20`, but values < 24 are not a
+/// supported genesis target.
+pub fn build_genesis_soroban_config_entries(
+    protocol: u32,
+    _network_id: &NetworkId,
+) -> Result<Vec<LedgerEntry>> {
+    use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
+
+    // Genesis ledger sequence is 1; the live bucket list is empty at the point
+    // stellar-core runs initializeGenesisLedgerForTesting (LedgerManagerImpl.cpp
+    // :421, before root-account creation and bucket sealing), so the V20
+    // LiveSorobanStateSizeWindow is seeded with size 0.
+    const GENESIS_LEDGER_SEQ: u32 = 1;
+    const GENESIS_INITIAL_BUCKET_LIST_SIZE: u64 = 0;
+
+    if protocol < 20 {
+        // Pre-Soroban: no config entries (matches core's
+        // protocolVersionStartsFrom(SOROBAN_PROTOCOL_VERSION) guard).
+        return Ok(Vec::new());
+    }
+
+    // Build an empty-snapshot close state at genesis. The cascade functions
+    // read-modify-write entries they themselves created in this same delta, so
+    // an empty base snapshot is sufficient.
+    let snapshot = SnapshotHandle::new(LedgerSnapshot::empty(GENESIS_LEDGER_SEQ));
+    let header = create_genesis_header();
+    let mut ltx = CloseLedgerState::begin(snapshot, header, Hash256::ZERO, GENESIS_LEDGER_SEQ);
+
+    // V20: create the 14 base config entries.
+    create_ledger_entries_for_v20(
+        &mut ltx,
+        GENESIS_LEDGER_SEQ,
+        GENESIS_INITIAL_BUCKET_LIST_SIZE,
+    )?;
+    // V20 BUILD_TESTS recalibration (genesis-only) — NetworkConfig.cpp:1724.
+    update_recalibrated_cost_types_for_v20(&mut ltx, GENESIS_LEDGER_SEQ)?;
+
+    if protocol >= 21 {
+        create_cost_types_for_v21(&mut ltx, GENESIS_LEDGER_SEQ)?;
+    }
+    if protocol >= 22 {
+        create_cost_types_for_v22(&mut ltx, GENESIS_LEDGER_SEQ)?;
+    }
+    if protocol >= 23 {
+        create_and_update_ledger_entries_for_v23(&mut ltx, GENESIS_LEDGER_SEQ)?;
+    }
+    if protocol >= 25 {
+        create_cost_types_for_v25(&mut ltx, GENESIS_LEDGER_SEQ)?;
+    }
+    if protocol >= 26 {
+        update_cost_types_for_v26(&mut ltx, GENESIS_LEDGER_SEQ)?;
+        create_ledger_entries_for_v26(&mut ltx, GENESIS_LEDGER_SEQ)?;
+    }
+
+    // Harvest the final entry values. `current_entries()` returns the current
+    // value of every create AND update in the delta — so cost params that V20
+    // created and V21/V22/V25/V26 updated, and the V23 rent-param updates to
+    // the V20-created ledger-cost / state-archival entries, all carry their
+    // final values. Because every entry the cascade touches originates from a
+    // `record_create` earlier in the same delta, create-then-update collapses
+    // to a single "created (final value)" change and no entry is duplicated.
+    Ok(ltx.current_delta().current_entries())
+}
+
 impl LedgerCloseContext<'_> {
     /// Load StateArchivalSettings through the CloseLedgerState read path.
     ///

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -1933,6 +1933,7 @@ pub fn initialize_genesis_ledger(
         None,
         network_passphrase,
         config.testing.genesis_test_account_count,
+        &config.testing.genesis_config(),
     )
 }
 


### PR DESCRIPTION
Closes #3492

## Summary

Henyey's genesis was always built at `ledger_version=0` with zero Soroban `ConfigSetting` entries, regardless of config. stellar-core v26.0.1 under `USE_CONFIG_FOR_GENESIS=true` (which all SSC mixed-image missions set) builds genesis at the configured protocol WITH the full Soroban config-settings set, so the genesis `bucketListHash` diverged and ledger-1 hashes mismatched (`c93881` core vs `4884d0` henyey).

This plumbs `USE_CONFIG_FOR_GENESIS` and `TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION` / `_DESIRED_FEE` / `_RESERVE` / `_MAX_TX_SET_SIZE` end-to-end so Henyey's genesis matches stellar-core byte-for-byte when the mission config sets them, while leaving the default (no-config) genesis byte-identical to before.

- **`compat_config.rs` + `config.rs`** — parse the 5 keys into `TestingConfig` (defaults `false / 26 / 100 / 100_000_000 / 50`, verified against `Config.cpp:198/231-234` and `LedgerManagerImpl.cpp:111-112`; note `max_tx_set_size` default is 50, not the genesis-header 100), with a `genesis_config()` accessor. Absent keys ⇒ legacy genesis.
- **`bootstrap.rs`** — `initialize_genesis` takes a `GenesisConfig`; when `use_config_for_genesis`, the header uses the configured version/fee/reserve/maxTxSetSize and (protocol ≥ 20) the full Soroban config set is injected. Mirrors `LedgerManagerImpl::startNewLedger` (LedgerManagerImpl.cpp:489-503) → `initializeGenesisLedgerForTesting` (NetworkConfig.cpp:1708).
- **`manager.rs`** — `build_genesis_soroban_config_entries` REUSES the existing V20→V21→V22→V23→V25→V26 cascade (no duplicated cost tables), harvesting final values via `current_entries()`. Adds a genesis-only `update_recalibrated_cost_types_for_v20` mirroring `NetworkConfig.cpp:2606` (BUILD_TESTS) — explicitly NOT wired into the live `apply_version_upgrade_side_effects` upgrade path.
- **4 call sites** (`app/mod.rs`, `henyey/main.rs`, `simulation/lib.rs` + wrappers) thread `GenesisConfig` through, default-constructed where config is unavailable.

### `create_genesis_header` resolution (Critic C)

`manager.rs::create_genesis_header` is the in-memory `LedgerManager::new` / `reset()` placeholder header — always paired with `initialized=false` and overwritten by `initialize()` / `bootstrap_from_db()`. It never builds a persisted bucket list and has no `USE_CONFIG_FOR_GENESIS` reachability. The SSC node reaches genesis exclusively through the DB-backed `bootstrap.rs::initialize_genesis`. **Scoped OUT** — no second divergent path.

### V20 recalibration (Critic B)

stellar-core runs `updateRecalibratedCostTypesForV20` (NetworkConfig.cpp:2606, under `#ifdef BUILD_TESTS`) inside the genesis path, rewriting 19 CPU + 2 mem cost entries. Since `USE_CONFIG_FOR_GENESIS` / `GENESIS_TEST_ACCOUNT_COUNT` are themselves BUILD_TESTS-only, SSC core always applies it. Reproduced verbatim from the submodule, applied ONLY in the genesis config path. Note: V21 later overwrites recalibrated mem index 12 (VmCachedInstantiation), matching core's ordering — covered by `test_genesis_v21_overwrites_recalibrated_mem_index_12`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3492#issuecomment-4747522244)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build --all`
- [x] `cargo test -p henyey-app` (1077 + 13 pass)
- [x] `cargo test -p henyey-ledger` (494 + new genesis tests pass)
- [x] `cargo test -p henyey-simulation` genesis tests pass

## Regression test (kind: bug-fix)

- **Test:** `crates/app/src/app/bootstrap.rs::test_genesis_config_for_genesis_matches_core_3492`
- **Pre-fix:** committed as `893672a8` — verified FAILED with: `assertion left == right failed: genesis header must use the configured protocol version — left: 0, right: 25`
- **Post-fix:** verified PASSES after `4405cc63`
- **Backward-compat guard:** `test_genesis_no_config_for_genesis_unchanged` pins the legacy genesis header hash (`63d98f53…`) and bucket-list hash (`572a2e32…`); fails if the default path regresses.

New ledger coverage: `build_genesis_soroban_config_entries` counts at p24/25/26 (17/17/19), no-duplicate-keys, recalibrated CPU/mem spot-checks (DispatchHostFunction=295, ValDeser=331/4369, VmInstantiation mem=132773/4903), V23 rent-param override of the V20 ledger-cost entry, and the V21 overwrite of mem index 12.

## Deviations from plan

- The plan's example asserted p24 = 14 config entries; the correct count is **17** (protocol 24 includes the full upgrade cascade through V24, which runs V23's 3 new entries). p25 = 17, p26 = 19. Test expectations adjusted accordingly; the bootstrap p25 structural assertion (17, per-ID) matches the plan.
- The recalibration mem spot-check is verified in isolation (V20 + recalibration only) because V21 legitimately overwrites mem index 12 afterward — this is correct parity, captured by a dedicated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)