### PR TITLE
Simplify Account-arm sub-entry extraction in invariant

### DIFF
--- a/crates/invariant/src/sub_entries.rs
+++ b/crates/invariant/src/sub_entries.rs
@@ -12,8 +12,8 @@
 use std::collections::HashMap;
 
 use stellar_xdr::curr::{
-    AccountId, ContractEvent, LedgerEntry, LedgerEntryData, Operation, OperationResult,
-    TrustLineAsset,
+    AccountEntry, AccountId, ContractEvent, LedgerEntry, LedgerEntryData, Operation,
+    OperationResult, TrustLineAsset,
 };
 
 use crate::{Invariant, OperationDelta};
@@ -69,6 +69,24 @@ fn get_sub_entry_account(entry: &LedgerEntry) -> Option<&AccountId> {
     }
 }
 
+/// Extract the `AccountEntry` from an optional ledger entry.
+///
+/// Returns `None` for an absent entry and — defensively — for any non-account
+/// variant. In `update_changed_sub_entries` the outer `match` already proves the
+/// present side is an `Account` (same calling convention as stellar-core's
+/// `current->data.account()` direct access), so the non-account case is dead;
+/// returning `None` keeps that path contributing 0 (matching the prior
+/// `else { 0 }`) rather than panicking.
+fn account_of(entry: Option<&LedgerEntry>) -> Option<&AccountEntry> {
+    match entry {
+        Some(LedgerEntry {
+            data: LedgerEntryData::Account(a),
+            ..
+        }) => Some(a),
+        _ => None,
+    }
+}
+
 /// Update the sub-entries change map for a single entry delta.
 fn update_changed_sub_entries(
     changes: &mut HashMap<AccountId, SubEntriesChange>,
@@ -81,43 +99,13 @@ fn update_changed_sub_entries(
         LedgerEntryData::Account(acc) => {
             let account_id = acc.account_id.clone();
             let change = changes.entry(account_id).or_default();
-            change.num_sub_entries += current
-                .map(|e| {
-                    if let LedgerEntryData::Account(a) = &e.data {
-                        a.num_sub_entries as i32
-                    } else {
-                        0
-                    }
-                })
-                .unwrap_or(0)
-                - previous
-                    .map(|e| {
-                        if let LedgerEntryData::Account(a) = &e.data {
-                            a.num_sub_entries as i32
-                        } else {
-                            0
-                        }
-                    })
-                    .unwrap_or(0);
+            let cur = account_of(current);
+            let prev = account_of(previous);
+            change.num_sub_entries += cur.map_or(0, |a| a.num_sub_entries as i32)
+                - prev.map_or(0, |a| a.num_sub_entries as i32);
 
-            let cur_signers = current
-                .map(|e| {
-                    if let LedgerEntryData::Account(a) = &e.data {
-                        a.signers.len() as i32
-                    } else {
-                        0
-                    }
-                })
-                .unwrap_or(0);
-            let prev_signers = previous
-                .map(|e| {
-                    if let LedgerEntryData::Account(a) = &e.data {
-                        a.signers.len() as i32
-                    } else {
-                        0
-                    }
-                })
-                .unwrap_or(0);
+            let cur_signers = cur.map_or(0, |a| a.signers.len() as i32);
+            let prev_signers = prev.map_or(0, |a| a.signers.len() as i32);
             change.signers += cur_signers - prev_signers;
             change.calculated_sub_entries += cur_signers - prev_signers;
         }


### PR DESCRIPTION
Closes #3442

## Summary

Behavior-neutral cleanup of the `LedgerEntryData::Account` arm of `update_changed_sub_entries` in `crates/invariant/src/sub_entries.rs`. The four `if let LedgerEntryData::Account(a) = &e.data { .. } else { 0 }` closures plus `.map(..).unwrap_or(0)` are replaced with a small local `account_of(Option<&LedgerEntry>) -> Option<&AccountEntry>` helper and `map_or(0, ..)`. The outer `match` already proves the present side is an `Account`, so the inner `else { 0 }` is dead code; `account_of` returns `None` (not panic) on that dead path, preserving the prior 0-contribution and no-panic semantics. Net 12 fewer lines in the file.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3442#issuecomment-4748145671)

## Test plan

- [x] `cargo fmt -p henyey-invariant --check`
- [x] `cargo build -p henyey-invariant --all-targets` under `-Dwarnings`
- [x] `cargo test -p henyey-invariant` passes (27 tests)
- [x] `cargo build --all`
- [x] `cargo clippy --all -- -D warnings`

## Parity

PARITY-CRITICAL crate. Parity-mapped to stellar-core `AccountSubEntriesCountIsValid.cpp::updateChangedSubEntriesCount` (case ACCOUNT, lines 61-75), which accesses `current->data.account()` directly with no inner type re-check — so the removed `else { 0 }` has no upstream analogue and removing it cannot diverge. The `+=` accumulation, operand order, and `as i32` casts are preserved verbatim (the pre-existing `+=` vs core's `=` divergence is intentionally left out of scope), so the computed deltas are bit-identical (`map_or(0,f) == map(f).unwrap_or(0)`) and the invariant fires on identical conditions.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)