### PR TITLE
Narrow visibility and remove dead code in henyey-history

### DIFF
--- a/crates/history/src/archive_state.rs
+++ b/crates/history/src/archive_state.rs
@@ -154,6 +154,7 @@ fn parse_next_states(
 }
 
 /// Parse bucket hashes at a specific level, returning (curr, snap) as Options.
+#[cfg(test)]
 fn parse_level_hashes(level: &HASBucketLevel) -> (Option<Hash256>, Option<Hash256>) {
     (
         parse_nonzero_hash(&level.curr),
@@ -543,6 +544,7 @@ impl HistoryArchiveState {
     ///
     /// Returns `Some` for version >= 2 HAS with populated hot archive,
     /// `None` for version < 2 or missing hot archive data.
+    #[cfg(test)]
     pub fn hot_archive_levels_mut(&mut self) -> Option<&mut Vec<HASBucketLevel>> {
         self.hot_archive_buckets.as_mut()
     }
@@ -659,6 +661,7 @@ impl HistoryArchiveState {
     }
 
     /// Get the number of bucket levels.
+    #[cfg(test)]
     pub fn bucket_level_count(&self) -> usize {
         self.current_buckets.len()
     }
@@ -672,6 +675,7 @@ impl HistoryArchiveState {
     /// # Returns
     ///
     /// A tuple of (current_hash, snapshot_hash) if the level exists.
+    #[cfg(test)]
     pub fn bucket_hashes_at_level(
         &self,
         level: usize,
@@ -679,33 +683,11 @@ impl HistoryArchiveState {
         self.current_buckets.get(level).map(parse_level_hashes)
     }
 
-    /// Get hot archive bucket hashes for a specific level.
-    ///
-    /// # Arguments
-    ///
-    /// * `level` - The bucket level index (0 = most frequently updated)
-    ///
-    /// # Returns
-    ///
-    /// A tuple of (current_hash, snapshot_hash) if the level exists.
-    pub fn hot_archive_bucket_hashes_at_level(
-        &self,
-        level: usize,
-    ) -> Option<(Option<Hash256>, Option<Hash256>)> {
-        let hot_buckets = self.hot_archive_buckets.as_ref()?;
-        hot_buckets.get(level).map(parse_level_hashes)
-    }
-
     /// Check if this HAS contains hot archive buckets.
     pub fn has_hot_archive_buckets(&self) -> bool {
         self.hot_archive_buckets
             .as_ref()
             .is_some_and(|v| !v.is_empty())
-    }
-
-    /// Get the number of hot archive bucket levels.
-    pub fn hot_archive_bucket_level_count(&self) -> usize {
-        self.hot_archive_buckets.as_ref().map_or(0, |v| v.len())
     }
 
     /// Get bucket hashes as (curr, snap) tuples for all levels.
@@ -859,6 +841,7 @@ impl HistoryArchiveState {
     }
 
     /// Clear all futures, resetting every level's next to default (state 0).
+    #[cfg(test)]
     pub fn clear_all_futures(&mut self) {
         for level in &mut self.current_buckets {
             level.next = HASBucketNext::default();

--- a/crates/history/src/catchup/mod.rs
+++ b/crates/history/src/catchup/mod.rs
@@ -169,7 +169,7 @@ impl Default for CatchupProgress {
 ///
 /// This struct holds all the data needed for catchup when it has been
 /// pre-fetched (e.g., for testing or when using an alternative data source).
-/// Pass this to [`CatchupManager::catchup_to_ledger_with_checkpoint_data`]
+/// Pass this to [`CatchupManager::catchup_to_ledger_with_checkpoint_data_config`]
 /// to skip the download phase.
 #[derive(Debug, Clone)]
 pub struct CheckpointData {
@@ -976,27 +976,6 @@ impl CatchupManager {
             &header,
             hash,
             self.progress.buckets_total,
-            ledger_manager,
-        )
-        .await
-    }
-
-    /// Catch up to a target ledger using pre-downloaded checkpoint data.
-    ///
-    /// This is the backwards-compatible 3-argument entry point that defaults to
-    /// `CatchupRunMode::OfflineBasic`. Use
-    /// [`catchup_to_ledger_with_checkpoint_data_config`] when you need to
-    /// specify a different run mode.
-    pub async fn catchup_to_ledger_with_checkpoint_data(
-        &mut self,
-        target: u32,
-        data: CheckpointData,
-        ledger_manager: &LedgerManager,
-    ) -> Result<CatchupResult> {
-        self.catchup_to_ledger_with_checkpoint_data_config(
-            target,
-            data,
-            CatchupConfiguration::offline_basic(CatchupMode::Minimal),
             ledger_manager,
         )
         .await

--- a/crates/history/src/checkpoint_builder.rs
+++ b/crates/history/src/checkpoint_builder.rs
@@ -331,11 +331,13 @@ impl CheckpointBuilder {
     }
 
     /// Get the current checkpoint being built, if any.
+    #[cfg(test)]
     pub fn current_checkpoint(&self) -> Option<u32> {
         self.current_checkpoint
     }
 
     /// Check if a checkpoint is currently being built.
+    #[cfg(test)]
     pub fn is_open(&self) -> bool {
         self.current_checkpoint.is_some()
     }
@@ -634,6 +636,7 @@ impl CheckpointBuilder {
     }
 
     /// Check if startup validation has been performed.
+    #[cfg(test)]
     pub fn is_validated(&self) -> bool {
         self.startup_validated
     }

--- a/crates/history/src/remote_archive.rs
+++ b/crates/history/src/remote_archive.rs
@@ -217,7 +217,7 @@ impl RemoteArchive {
     /// Ensure a remote directory exists, creating it if necessary.
     ///
     /// This is a no-op if no mkdir command is configured.
-    pub async fn ensure_dir(&self, remote_dir: &str) -> Result<()> {
+    async fn ensure_dir(&self, remote_dir: &str) -> Result<()> {
         if self.config.mkdir_cmd.is_some() {
             // Ignore errors from mkdir as the directory may already exist
             let _ = self.mkdir(remote_dir).await;


### PR DESCRIPTION
Closes #3440

## Summary

Behavior-neutral visibility/dead-code cleanup of the 5 valid audit findings in `henyey-history` (the 2 stale findings — `ledger_range`, `is_writable`/`is_readable` — were DROPPED in planning because they have live production callers). Deletes two zero-caller hot-archive accessors, `#[cfg(test)]`-gates seven items whose only callers are `#[cfg(test)]` (including the second-order `parse_level_hashes` free fn, which becomes test-only once its production callers are gated/deleted), narrows `ensure_dir` to module-private (live internal caller), and deletes the zero-caller 3-arg `catchup_to_ledger_with_checkpoint_data` wrapper (retargeting its intra-doc-link to the surviving `_config` variant). Net behavioral diff = 0.

Per the #3384 lesson, the cfg(test)-only-caller items are gated with `#[cfg(test)]` rather than `pub(crate)`: `--all-targets` compiles the lib *without* cfg(test), so a `pub(crate)` method with only test callers is dead in the lib build and fails under `-Dwarnings`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3440#issuecomment-4748231891)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-history --all-targets (under -Dwarnings — the lib-build-without-cfg(test) gate that catches the parse_level_hashes second-order dead-code; clean)
- [x] cargo test -p henyey-history passes (555 unit + integration suites, 0 failed)
- [x] cargo build --all

## Deviations from plan

None. Build-verified diffstat matches the plan exactly: 4 files, +10/−45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)