### PR TITLE
Classify ENOSPC bucket-IO as recoverable, not corruption (#3478)

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -211,7 +211,13 @@ impl App {
                 // Must resolve async merges first — structure-based restart_merges
                 // creates PendingMerge::Async handles, and BucketLevel::clone()
                 // drops unresolved async merges.
-                self.ledger_manager.resolve_pending_bucket_merges();
+                //
+                // Propagate a resolution failure via `?` so only THIS catchup
+                // attempt aborts (self-healable on retry) rather than the
+                // process. A transient-IO (ENOSPC) failure is recoverable and
+                // the level is reset internally to re-merge; corruption stays
+                // fatal upstream. (#3478)
+                self.ledger_manager.try_resolve_pending_bucket_merges()?;
                 let bucket_list = self.ledger_manager.bucket_list().clone();
                 let hot_archive = self
                     .ledger_manager
@@ -591,11 +597,16 @@ impl App {
         if let Some(persist_data) = catchup_persist_data {
             match finalize.0 {
                 super::persist::CatchupFinalizerInner::Inline { db, ledger_manager } => {
-                    super::persist::CatchupPersistReady::new(persist_data, db, ledger_manager)
-                        .spawn()
-                        .handle
-                        .await
-                        .expect("inline catchup persist panicked");
+                    super::persist::CatchupPersistReady::new(
+                        persist_data,
+                        db,
+                        ledger_manager,
+                        self.recoverable_shutdown_handle(),
+                    )
+                    .spawn()
+                    .handle
+                    .await
+                    .expect("inline catchup persist panicked");
                     tracing::info!(
                         ledger_seq = catchup_result.ledger_seq,
                         "Catchup persist completed (inline)"
@@ -623,8 +634,12 @@ impl App {
                             "Failed to set catchup persist sentinel"
                         );
                     }
-                    let ready =
-                        super::persist::CatchupPersistReady::new(persist_data, db, ledger_manager);
+                    let ready = super::persist::CatchupPersistReady::new(
+                        persist_data,
+                        db,
+                        ledger_manager,
+                        self.recoverable_shutdown_handle(),
+                    );
                     // Send-failure tolerance: if the receiver was dropped
                     // (caller cancellation), `ready` drops here — no persist
                     // task spawned, no untracked work.

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -3003,6 +3003,7 @@ impl App {
                 db: self.db.clone(),
                 ledger_manager: self.ledger_manager.clone(),
                 bucket_dir: self.bucket_manager.bucket_dir().to_path_buf(),
+                shutdown: self.recoverable_shutdown_handle(),
             },
             pending.ledger_seq,
         );

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -1923,6 +1923,43 @@ impl App {
         self.shutdown();
     }
 
+    /// Trigger a clean, recoverable shutdown due to a transient environmental
+    /// failure (e.g. ENOSPC/EDQUOT during bucket persist — #3478).
+    ///
+    /// Unlike [`trigger_fatal_shutdown`](Self::trigger_fatal_shutdown), this:
+    /// - does **NOT** emit `fatal_wipe_required = true` (see [`FATAL_WIPE_FIELD`]) —
+    ///   the on-disk state is intact (no partial state was committed), so a
+    ///   wipe would be both wasteful and wrong; the operator just needs to free
+    ///   space and restart; and
+    /// - does **NOT** set `fatal_state_failure` — the condition is recoverable,
+    ///   so a restart after disk recovery may proceed normally.
+    ///
+    /// # Parity (stellar-core v26.0.1)
+    ///
+    /// A bucket merge/flush IO failure in core throws a plain `runtime_error`
+    /// tagged `POSSIBLY_CORRUPTED_LOCAL_FS` ("ensure enough space") that
+    /// propagates uncaught out of `closeLedger` → **clean process exit**. Core
+    /// auto-wipes on NEITHER ENOSPC nor corruption (wipe is operator-driven),
+    /// and there is no `std::abort`/`terminate` on the bucket path. This method
+    /// is the parity-faithful henyey equivalent: a clean shutdown with the
+    /// free-space operator guidance and no wipe — distinct from corruption,
+    /// which retains the abort + wipe path.
+    pub fn trigger_recoverable_shutdown(&self, reason: &str) {
+        tracing::error!(
+            "RECOVERABLE: transient local IO failure — {}. \
+             Node will shut down cleanly. Free disk space and restart; \
+             no state wipe required (on-disk state is intact).",
+            reason
+        );
+        self.shutdown();
+    }
+
+    /// A handle that lets a detached persist task request a clean recoverable
+    /// shutdown (no state wipe) on a transient-IO persist failure (#3478).
+    pub(crate) fn recoverable_shutdown_handle(&self) -> super::persist::RecoverableShutdownHandle {
+        super::persist::RecoverableShutdownHandle::new(self.shutdown_tx.clone())
+    }
+
     /// Subscribe to shutdown notifications.
     pub fn subscribe_shutdown(&self) -> tokio::sync::broadcast::Receiver<()> {
         self.shutdown_tx.subscribe()
@@ -3297,6 +3334,81 @@ mod fatal_wipe_field_tests {
         assert!(
             app.fatal_state_failure.load(Ordering::SeqCst),
             "fatal_state_failure must be set"
+        );
+    }
+
+    /// #3478: `trigger_recoverable_shutdown()` must NOT emit
+    /// `fatal_wipe_required` and must NOT set `fatal_state_failure` — a
+    /// transient ENOSPC is environmental, the on-disk state is intact, and a
+    /// wipe would be wrong. The inverse of the fatal-shutdown contract above.
+    #[tokio::test]
+    async fn test_recoverable_shutdown_does_not_emit_wipe_field_3478() {
+        use std::sync::atomic::Ordering;
+        use tracing::{
+            field::{Field, Visit},
+            subscriber::with_default,
+            Event, Metadata, Subscriber,
+        };
+
+        #[derive(Default)]
+        struct CapturedBool {
+            value: Option<bool>,
+        }
+        impl Visit for CapturedBool {
+            fn record_bool(&mut self, field: &Field, value: bool) {
+                if field.name() == FATAL_WIPE_FIELD {
+                    self.value = Some(value);
+                }
+            }
+            fn record_debug(&mut self, _: &Field, _: &dyn std::fmt::Debug) {}
+        }
+
+        #[derive(Default, Clone)]
+        struct WipeFieldSubscriber {
+            captured: Arc<Mutex<Option<bool>>>,
+        }
+        impl Subscriber for WipeFieldSubscriber {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
+                true
+            }
+            fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+                tracing::span::Id::from_u64(1)
+            }
+            fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+            fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+            fn event(&self, event: &Event<'_>) {
+                let mut cap = CapturedBool::default();
+                event.record(&mut cap);
+                if let Some(v) = cap.value {
+                    *self.captured.lock().unwrap() = Some(v);
+                }
+            }
+            fn enter(&self, _: &tracing::span::Id) {}
+            fn exit(&self, _: &tracing::span::Id) {}
+        }
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = super::super::App::new(config).await.unwrap();
+
+        let sub = WipeFieldSubscriber::default();
+        let captured = sub.captured.clone();
+
+        with_default(sub, || {
+            app.trigger_recoverable_shutdown("disk full (test)");
+        });
+
+        assert_eq!(
+            *captured.lock().unwrap(),
+            None,
+            "trigger_recoverable_shutdown must NOT emit {FATAL_WIPE_FIELD}"
+        );
+        assert!(
+            !app.fatal_state_failure.load(Ordering::SeqCst),
+            "trigger_recoverable_shutdown must NOT set fatal_state_failure (recoverable)"
         );
     }
 

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -881,7 +881,7 @@ pub struct App {
     ///
     /// Stale-bucket GC now runs on every ledger close (matching stellar-core's
     /// unconditional `forgetUnreferencedBuckets`), rather than every 100 ledgers.
-    /// At ~5s cadence a GC run that blocks in `resolve_pending_bucket_merges()`
+    /// At ~5s cadence a GC run that blocks in `try_resolve_pending_bucket_merges()`
     /// during a merge backlog could still be running when the next close fires.
     /// This flag makes per-ledger GC self-coalescing: at most one background GC
     /// at a time. If a run falls behind, subsequent ledgers skip GC (deferring
@@ -1085,12 +1085,56 @@ fn collect_db_referenced_bucket_hashes(db: &henyey_db::Database) -> anyhow::Resu
 /// See `retain_buckets()` doc comment for the full GC safety contract and
 /// `PARITY_STATUS.md` §6 for the divergence rationale vs stellar-core's
 /// refcount-based approach.
+/// What the best-effort GC path should do when resolving pending bucket merges
+/// fails (#3478).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GcMergeOutcome {
+    /// Transient-IO (ENOSPC/EDQUOT): skip GC this tick (recoverable, retries
+    /// next ledger). Mirrors the existing best-effort DB-error skip.
+    SkipThisTick,
+    /// Corruption / other: the bucket list cannot be trusted — stay fatal.
+    Fatal,
+}
+
+/// Decide the GC path's response to a merge-resolution error. Extracted so the
+/// transient-vs-fatal decision is unit-testable without a live `LedgerManager`.
+fn gc_merge_resolution_outcome(err: &henyey_bucket::BucketError) -> GcMergeOutcome {
+    if err.is_transient_io() {
+        GcMergeOutcome::SkipThisTick
+    } else {
+        GcMergeOutcome::Fatal
+    }
+}
+
 fn collect_gc_roots(
     lm: &henyey_ledger::LedgerManager,
     sm: &BucketSnapshotManager,
     db: &henyey_db::Database,
 ) -> Option<Vec<Hash256>> {
-    lm.resolve_pending_bucket_merges();
+    // GC is best-effort and self-coalescing (re-runs every ledger). On a
+    // transient-IO (ENOSPC/EDQUOT) merge-resolution failure (#3478) we skip GC
+    // this tick — exactly like the DB-error case below — instead of crashing;
+    // the failed level is reset internally so the merge re-issues next close.
+    // Genuine corruption stays fatal (the bucket list cannot be trusted).
+    if let Err(e) = lm.try_resolve_pending_bucket_merges() {
+        match gc_merge_resolution_outcome(&e) {
+            GcMergeOutcome::SkipThisTick => {
+                tracing::warn!(
+                    error = %e,
+                    "Skipping bucket cleanup: transient IO resolving pending merges \
+                     (recoverable — will retry next ledger)"
+                );
+                return None;
+            }
+            GcMergeOutcome::Fatal => {
+                // Corruption / other: the bucket list cannot be trusted to
+                // continue. Preserve the pre-#3478 fatal behavior.
+                panic!(
+                    "bucket merge failure is fatal — cannot continue with corrupt bucket list: {e}"
+                );
+            }
+        }
+    }
 
     let mut hashes = lm.all_referenced_bucket_hashes();
     hashes.extend(sm.all_referenced_hashes());
@@ -2846,7 +2890,7 @@ impl App {
     ///
     /// # Safety
     ///
-    /// `resolve_pending_bucket_merges()` must run first: background merge threads
+    /// `try_resolve_pending_bucket_merges()` must run first: background merge threads
     /// may have written output files to disk whose hashes haven't been polled yet.
     /// Without resolution, those outputs would not appear in `all_referenced_hashes()`
     /// and could be prematurely deleted while a `DiskBucket` still references the path.
@@ -2857,7 +2901,7 @@ impl App {
     /// # Re-entrancy guard (#3028)
     ///
     /// Because this now runs on every ledger close (~5s) rather than every 100th,
-    /// a slow run (blocked in `resolve_pending_bucket_merges()` during a merge
+    /// a slow run (blocked in `try_resolve_pending_bucket_merges()` during a merge
     /// backlog) could still be in flight when the next close fires. The
     /// `bucket_gc_in_flight` flag coalesces overlapping invocations: at most one
     /// background GC runs at a time, and a ledger whose GC would overlap an
@@ -3945,6 +3989,43 @@ mod tests {
     use super::*;
     use stellar_xdr::curr::StellarValueExt;
     use tempfile;
+
+    /// #3478: the best-effort GC path must SKIP (not crash) on a transient-IO
+    /// (ENOSPC/EDQUOT) merge-resolution failure, and stay FATAL on corruption
+    /// or non-free-space IO. This guards the transient-vs-fatal decision the
+    /// `collect_gc_roots` caller makes.
+    #[test]
+    fn test_gc_skips_on_transient_io_stays_fatal_on_corruption_3478() {
+        use henyey_bucket::BucketError;
+
+        // ENOSPC (28) and EDQUOT (122): skip this tick (recoverable).
+        let enospc = BucketError::Io(std::io::Error::from_raw_os_error(28));
+        assert_eq!(
+            gc_merge_resolution_outcome(&enospc),
+            GcMergeOutcome::SkipThisTick,
+            "ENOSPC must cause GC to skip this tick, not crash"
+        );
+        let edquot = BucketError::Io(std::io::Error::from_raw_os_error(122));
+        assert_eq!(
+            gc_merge_resolution_outcome(&edquot),
+            GcMergeOutcome::SkipThisTick,
+            "EDQUOT must cause GC to skip this tick"
+        );
+
+        // Corruption and EIO: stay fatal (bucket list cannot be trusted).
+        let corruption = BucketError::Corruption("unsorted".to_string());
+        assert_eq!(
+            gc_merge_resolution_outcome(&corruption),
+            GcMergeOutcome::Fatal,
+            "corruption must stay fatal"
+        );
+        let eio = BucketError::Io(std::io::Error::from_raw_os_error(5));
+        assert_eq!(
+            gc_merge_resolution_outcome(&eio),
+            GcMergeOutcome::Fatal,
+            "EIO must stay fatal (could be hardware corruption)"
+        );
+    }
 
     /// Panic-safety of the bucket-GC re-entrancy guard (#3028): `ResetGuard`
     /// MUST clear the in-flight flag on drop even when the surrounding scope

--- a/crates/app/src/app/persist.rs
+++ b/crates/app/src/app/persist.rs
@@ -20,12 +20,47 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use henyey_bucket::HotArchiveBucket;
+use henyey_bucket::{BucketError, HotArchiveBucket};
 use henyey_db::Database;
 use henyey_history::{checkpoint_ledger, is_checkpoint_ledger, GENESIS_LEDGER_SEQ};
 use henyey_ledger::LedgerManager;
 
 use super::types::PendingPersist;
+
+/// Handle that lets a detached persist task request a **clean, recoverable**
+/// process shutdown on a transient environmental IO failure (ENOSPC/EDQUOT),
+/// instead of `std::process::abort()` (#3478).
+///
+/// Persist work runs on a detached blocking thread with no `App` reference, so
+/// the shutdown signal is threaded in via this thin `Clone` handle (wrapping
+/// the app's broadcast shutdown sender). The semantics mirror
+/// [`App::trigger_recoverable_shutdown`](crate::App::trigger_recoverable_shutdown):
+/// a clean shutdown WITHOUT `fatal_wipe_required` and WITHOUT setting
+/// `fatal_state_failure` — the on-disk state is intact and the operator just
+/// frees space and restarts.
+#[derive(Clone)]
+pub(crate) struct RecoverableShutdownHandle {
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
+}
+
+impl RecoverableShutdownHandle {
+    pub(crate) fn new(shutdown_tx: tokio::sync::broadcast::Sender<()>) -> Self {
+        Self { shutdown_tx }
+    }
+
+    /// Emit the recoverable-shutdown log (no `fatal_wipe_required`) and signal
+    /// the main loop to exit cleanly.
+    fn trigger(&self, context: &str, error: &dyn std::fmt::Display) {
+        tracing::error!(
+            context,
+            error = %error,
+            "RECOVERABLE: transient local IO failure during persist. \
+             Node will shut down cleanly. Free disk space and restart; \
+             no state wipe required (on-disk state is intact)."
+        );
+        let _ = self.shutdown_tx.send(());
+    }
+}
 
 /// Data needed to persist catchup state to SQLite after catchup completes.
 ///
@@ -169,8 +204,9 @@ impl CatchupPersistReady {
         data: CatchupPersistData,
         db: Database,
         ledger_manager: Arc<LedgerManager>,
+        shutdown: RecoverableShutdownHandle,
     ) -> Self {
-        let (job, ledger_seq) = PersistJob::catchup(data, db, ledger_manager);
+        let (job, ledger_seq) = PersistJob::catchup(data, db, ledger_manager, shutdown);
         Self { job, ledger_seq }
     }
 
@@ -236,6 +272,8 @@ pub(super) enum PersistJob {
         data: Box<CatchupPersistData>,
         db: Database,
         ledger_manager: Arc<LedgerManager>,
+        /// Clean recoverable shutdown on transient-IO persist failure (#3478).
+        shutdown: RecoverableShutdownHandle,
     },
     /// Post-close: flush hot archive + buckets + write full ledger data to DB,
     /// then optionally store LedgerCloseMeta for RPC.
@@ -247,6 +285,8 @@ pub(super) enum PersistJob {
         db: Database,
         ledger_manager: Arc<LedgerManager>,
         bucket_dir: std::path::PathBuf,
+        /// Clean recoverable shutdown on transient-IO persist failure (#3478).
+        shutdown: RecoverableShutdownHandle,
     },
 }
 
@@ -259,6 +299,7 @@ impl PersistJob {
         data: CatchupPersistData,
         db: Database,
         ledger_manager: Arc<LedgerManager>,
+        shutdown: RecoverableShutdownHandle,
     ) -> (Self, u32) {
         let seq = data.header.ledger_seq;
         (
@@ -266,6 +307,7 @@ impl PersistJob {
                 data: Box::new(data),
                 db,
                 ledger_manager,
+                shutdown,
             },
             seq,
         )
@@ -284,8 +326,9 @@ impl PersistJob {
                 data,
                 db,
                 ledger_manager,
+                shutdown,
             } => {
-                flush_bucket_persist_sync(&ledger_manager);
+                flush_bucket_persist_sync(&ledger_manager, &shutdown);
 
                 if let Err(e) = data.write_to_db(&db) {
                     fatal_persist_error("catchup DB write", &e);
@@ -299,6 +342,7 @@ impl PersistJob {
                 db,
                 ledger_manager,
                 bucket_dir,
+                shutdown,
             } => {
                 let persist_start = std::time::Instant::now();
 
@@ -309,7 +353,7 @@ impl PersistJob {
                 // durable on disk first. (The publish-queue enqueue itself, the
                 // §4.11 Step 1 "queue checkpoint", is co-transactional inside
                 // `write_fn` — see `LedgerPersistInputs::serialize_and_write_to_db`.)
-                flush_hot_archive_and_buckets_sync(&ledger_manager, &bucket_dir);
+                flush_hot_archive_and_buckets_sync(&ledger_manager, &bucket_dir, &shutdown);
 
                 // LEDGER_SPEC §4.11 Step 2 (#3066): "commit LedgerTxn". This is
                 // the single atomic SQLite transaction that co-writes header,
@@ -366,15 +410,15 @@ pub(super) fn spawn_persist_task(job: PersistJob, ledger_seq: u32) -> PendingPer
 /// Takes the pending persist handle from the bucket list (brief write lock),
 /// then joins the background thread WITHOUT holding the lock. This prevents
 /// blocking concurrent `bucket_list()` reads on the event loop.
-fn flush_bucket_persist_sync(ledger_manager: &LedgerManager) {
+fn flush_bucket_persist_sync(ledger_manager: &LedgerManager, shutdown: &RecoverableShutdownHandle) {
     let pending_handle = ledger_manager.bucket_list_mut().take_pending_persist();
     if let Some(handle) = pending_handle {
-        if let Err(e) = handle
-            .join()
-            .expect("bucket persist thread panicked")
-            .map_err(|e| format!("flush_pending_persist: {e}"))
-        {
-            fatal_persist_error("bucket flush", &e);
+        if let Err(e) = handle.join().expect("bucket persist thread panicked") {
+            // `e` is a classified `MergeError` (errno preserved through the
+            // persist thread), re-materialized to a classified `BucketError`
+            // so a transient ENOSPC routes to a clean recoverable shutdown
+            // rather than `abort()` (#3478).
+            handle_persist_error("bucket flush", &e.to_bucket_error(), shutdown);
         }
     }
 }
@@ -383,18 +427,22 @@ fn flush_bucket_persist_sync(ledger_manager: &LedgerManager) {
 ///
 /// Used by the post-close path where hot archive persist and bucket flush
 /// both run on the calling blocking thread.
-fn flush_hot_archive_and_buckets_sync(ledger_manager: &LedgerManager, bucket_dir: &Path) {
+fn flush_hot_archive_and_buckets_sync(
+    ledger_manager: &LedgerManager,
+    bucket_dir: &Path,
+    shutdown: &RecoverableShutdownHandle,
+) {
     // Persist hot archive buckets to disk.
     let habl_guard = ledger_manager.hot_archive_bucket_list();
     if let Some(habl) = habl_guard.as_ref() {
         if let Err(e) = persist_hot_archive_to_dir(habl.levels(), bucket_dir) {
-            fatal_persist_error("hot archive persist", &e);
+            handle_persist_error("hot archive persist", &e, shutdown);
         }
     }
     drop(habl_guard);
 
     // Flush pending bucket persist (take-then-join without holding the lock).
-    flush_bucket_persist_sync(ledger_manager);
+    flush_bucket_persist_sync(ledger_manager, shutdown);
 }
 
 /// Write hot archive bucket files to the bucket directory.
@@ -403,10 +451,13 @@ fn flush_hot_archive_and_buckets_sync(ledger_manager: &LedgerManager, bucket_dir
 /// already have a backing file on disk. Returns an error if any bucket
 /// file fails to write — the caller must not proceed to write HAS or
 /// publish state that references missing bucket files.
+///
+/// Returns the structured [`BucketError`] (preserving the `errno`) so the
+/// caller can distinguish a transient ENOSPC from genuine corruption (#3478).
 fn persist_hot_archive_to_dir(
     levels: &[henyey_bucket::HotArchiveBucketLevel],
     bucket_dir: &Path,
-) -> Result<(), String> {
+) -> Result<(), BucketError> {
     for level in levels {
         let mut buckets: Vec<&HotArchiveBucket> = vec![level.curr(), level.snap_bucket()];
         if let Some(next) = level.next() {
@@ -417,13 +468,7 @@ fn persist_hot_archive_to_dir(
                 let path =
                     bucket_dir.join(henyey_bucket::canonical_bucket_filename(&bucket.hash()));
                 if !path.exists() {
-                    bucket.save_to_xdr_file(&path).map_err(|e| {
-                        format!(
-                            "Failed to persist hot archive bucket {} to disk: {}",
-                            bucket.hash().to_hex(),
-                            e
-                        )
-                    })?;
+                    bucket.save_to_xdr_file(&path)?;
                 }
             }
         }
@@ -431,10 +476,31 @@ fn persist_hot_archive_to_dir(
     Ok(())
 }
 
+/// Route a persist failure to the correct shutdown path based on its
+/// classification (#3478).
+///
+/// - **Transient IO** (ENOSPC/EDQUOT): environmental, no partial state
+///   committed → a clean recoverable shutdown WITHOUT a state wipe. Matches
+///   stellar-core, which throws `POSSIBLY_CORRUPTED_LOCAL_FS` ("ensure enough
+///   space") → clean exit; operator frees space + restarts; no wipe.
+/// - **Anything else** (corruption / non-free-space IO): keeps the existing
+///   `abort()` behavior — the node's on-disk state may diverge from in-memory
+///   state, violating determinism guarantees.
+fn handle_persist_error(context: &str, error: &BucketError, shutdown: &RecoverableShutdownHandle) {
+    if error.is_transient_io() {
+        shutdown.trigger(context, error);
+    } else {
+        fatal_persist_error(context, error);
+    }
+}
+
 /// Log a fatal persist error and abort the process.
 ///
-/// All persist failures are unrecoverable — the node's on-disk state would
-/// diverge from in-memory state, violating determinism guarantees.
+/// Used for persist failures that are NOT a recoverable transient-IO condition
+/// (corruption, non-free-space IO): the node's on-disk state would diverge
+/// from in-memory state, violating determinism guarantees. (A transient
+/// ENOSPC/EDQUOT routes to a clean recoverable shutdown instead — see
+/// [`handle_persist_error`].)
 pub(super) fn fatal_persist_error(context: &str, error: &dyn std::fmt::Display) -> ! {
     tracing::error!(context, error = %error, "Fatal persist failure, aborting");
     std::process::abort();
@@ -445,6 +511,69 @@ mod tests {
     use super::*;
     use henyey_db::queries::StateQueries;
     use stellar_xdr::curr::{Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt};
+
+    /// A detached `RecoverableShutdownHandle` for tests (no live App).
+    fn test_recoverable_shutdown() -> RecoverableShutdownHandle {
+        let (tx, _rx) = tokio::sync::broadcast::channel(1);
+        RecoverableShutdownHandle::new(tx)
+    }
+
+    /// #3478: the persist-error classifier must route a transient ENOSPC
+    /// (errno 28) to a clean recoverable shutdown (broadcast a shutdown
+    /// signal), NOT to `std::process::abort()` — the on-disk state is intact.
+    #[test]
+    fn transient_io_persist_error_routes_to_recoverable_shutdown_3478() {
+        let (tx, mut rx) = tokio::sync::broadcast::channel(1);
+        let shutdown = RecoverableShutdownHandle::new(tx);
+
+        let enospc = BucketError::Io(std::io::Error::from_raw_os_error(28));
+        assert!(enospc.is_transient_io(), "errno 28 must be transient IO");
+
+        // handle_persist_error must NOT abort for a transient-IO error; it must
+        // signal a clean shutdown. (If it aborted, the test process would die.)
+        handle_persist_error("test transient flush", &enospc, &shutdown);
+
+        // The recoverable shutdown signal was sent (no wipe, no abort).
+        assert!(
+            rx.try_recv().is_ok(),
+            "transient-IO persist error must trigger a clean recoverable shutdown signal"
+        );
+    }
+
+    /// #3478: EDQUOT (errno 122) is also a transient free-space class and must
+    /// route to recoverable shutdown.
+    #[test]
+    fn edquot_persist_error_is_transient_3478() {
+        let edquot = BucketError::Io(std::io::Error::from_raw_os_error(122));
+        assert!(
+            edquot.is_transient_io(),
+            "errno 122 (EDQUOT) must be transient IO"
+        );
+    }
+
+    /// #3478: a corruption (or non-free-space IO) persist error must NOT be
+    /// classified transient — it stays on the fatal `abort()` path. We assert
+    /// the classifier branch (the `abort()` itself is not unit-testable).
+    #[test]
+    fn corruption_persist_error_stays_fatal_3478() {
+        let corruption = BucketError::Corruption("bucket entries unsorted".to_string());
+        assert!(
+            !corruption.is_transient_io(),
+            "corruption must NOT be classified transient (stays fatal/abort)"
+        );
+
+        // EIO (errno 5) is conservatively fatal (could be hardware corruption).
+        let eio = BucketError::Io(std::io::Error::from_raw_os_error(5));
+        assert!(
+            !eio.is_transient_io(),
+            "EIO must NOT be classified transient (stays fatal/abort)"
+        );
+
+        // A transient handle that is never triggered for these classes: assert
+        // no shutdown signal is produced by the classifier when we DON'T call
+        // handle_persist_error (the fatal path would abort, which we can't run
+        // here — so we only verify classification above).
+    }
 
     fn make_header(seq: u32) -> (LedgerHeader, Vec<u8>) {
         use stellar_xdr::curr::{LedgerHeaderExtensionV1, Limits, WriteXdr};
@@ -564,7 +693,7 @@ mod tests {
             has_json: "{}".to_string(),
             publish_enabled: false,
         };
-        let ready = CatchupPersistReady::new(data, db, lm);
+        let ready = CatchupPersistReady::new(data, db, lm, test_recoverable_shutdown());
         assert_eq!(ready.ledger_seq(), 99);
         let pending = ready.spawn();
         assert_eq!(pending.ledger_seq, 99);
@@ -608,7 +737,7 @@ mod tests {
             has_json: "{}".to_string(),
             publish_enabled: false,
         };
-        let ready = CatchupPersistReady::new(data, db, lm);
+        let ready = CatchupPersistReady::new(data, db, lm, test_recoverable_shutdown());
         let result_ok = Ok(crate::app::types::CatchupResult {
             ledger_seq: 50,
             ledger_hash: henyey_common::Hash256::default(),
@@ -757,6 +886,7 @@ mod tests {
                 db: db_for_write,
                 ledger_manager: lm,
                 bucket_dir: bucket_dir.path().to_path_buf(),
+                shutdown: test_recoverable_shutdown(),
             };
 
             let pending = spawn_persist_task(job, test_seq);

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -6768,4 +6768,143 @@ mod tests {
         // Cleanup test bucket directory
         let _ = std::fs::remove_dir_all(&bucket_dir);
     }
+
+    // ========================================================================
+    // Regression tests for #3478 — ENOSPC during bucket merge is recoverable,
+    // not corruption. The validator must NOT panic/abort on a transient disk-
+    // full (no partial state committed), but MUST stay fatal on genuine
+    // corruption (HashMismatch / Corruption). Classification keys on the raw
+    // errno (ENOSPC=28, EDQUOT=122), NOT on string-matching.
+    // ========================================================================
+
+    /// The exact production ENOSPC error observed on mainnet (session
+    /// 74535976): `IO error: No space left on device (os error 28)`.
+    /// ENOSPC is errno 28 on Linux.
+    fn make_enospc_bucket_error() -> BucketError {
+        BucketError::Io(std::io::Error::from_raw_os_error(28))
+    }
+
+    /// A transient-IO merge whose result is the production ENOSPC error must
+    /// surface `Err` AND classify as `is_transient_io() == true` — proving the
+    /// errno survives the merge error chain (it was stringified away on main).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_enospc_merge_failure_is_recoverable_not_corruption_3478() {
+        let mut level = BucketLevel::new(1);
+
+        // Inject a level-1 async merge whose result is the exact production
+        // ENOSPC error, via the test-only structured-errno ctor.
+        let merge_err =
+            crate::merge_map::MergeError::from_bucket_error(&make_enospc_bucket_error());
+        let handle = AsyncMergeHandle::new_failed_for_test(1, merge_err);
+        level.next = Some(PendingMerge::Async(handle));
+
+        let mut bl = BucketList::new();
+        bl.levels[1] = level;
+
+        let err = bl
+            .resolve_all_pending_merges()
+            .expect_err("ENOSPC merge failure must surface an error");
+
+        assert!(
+            err.is_transient_io(),
+            "ENOSPC (errno 28) must classify as transient IO (recoverable), got: {err:?}"
+        );
+    }
+
+    /// Genuine corruption (HashMismatch / Corruption) must STAY fatal — it must
+    /// NOT be classified as transient IO, so it is never masked/recovered.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_corruption_merge_failure_stays_fatal_3478() {
+        // HashMismatch
+        let hash_mismatch = BucketError::HashMismatch {
+            expected: "aa".to_string(),
+            actual: "bb".to_string(),
+        };
+        assert!(
+            !hash_mismatch.is_transient_io(),
+            "HashMismatch must NOT be transient IO (stays fatal)"
+        );
+
+        // Corruption
+        let corruption = BucketError::Corruption("entries not sorted".to_string());
+        assert!(
+            !corruption.is_transient_io(),
+            "Corruption must NOT be transient IO (stays fatal)"
+        );
+
+        // EIO (errno 5) is conservatively NOT transient (could be hardware
+        // corruption).
+        let eio = BucketError::Io(std::io::Error::from_raw_os_error(5));
+        assert!(
+            !eio.is_transient_io(),
+            "EIO must NOT be transient IO (conservative — could be corruption)"
+        );
+
+        // And the round-trip through MergeError preserves corruption class.
+        let merge_err = crate::merge_map::MergeError::from_bucket_error(&corruption);
+        let mut level = BucketLevel::new(1);
+        let handle = AsyncMergeHandle::new_failed_for_test(1, merge_err);
+        level.next = Some(PendingMerge::Async(handle));
+        let mut bl = BucketList::new();
+        bl.levels[1] = level;
+        let err = bl
+            .resolve_all_pending_merges()
+            .expect_err("corruption merge failure must surface an error");
+        assert!(
+            !err.is_transient_io(),
+            "corruption round-tripped through MergeError must stay fatal, got: {err:?}"
+        );
+    }
+
+    /// A transient-IO-failed level must NOT poison its cache: once "disk
+    /// recovers", a subsequent real re-prepare at a later ledger must re-issue
+    /// the merge and complete cleanly. On main the failed merge caches
+    /// `Ready(Err)` permanently and the level would wedge forever.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_failed_level_remerges_after_recovery_3478() {
+        let mut bl = BucketList::new();
+
+        // Inject a transient-IO (ENOSPC) failed async merge into level 1.
+        let merge_err =
+            crate::merge_map::MergeError::from_bucket_error(&make_enospc_bucket_error());
+        let handle = AsyncMergeHandle::new_failed_for_test(1, merge_err);
+        bl.levels[1].next = Some(PendingMerge::Async(handle));
+
+        // Resolving surfaces the transient-IO error.
+        let err = bl
+            .resolve_all_pending_merges()
+            .expect_err("ENOSPC merge failure must surface an error");
+        assert!(err.is_transient_io(), "expected transient IO, got {err:?}");
+
+        // After a transient-IO failure the level must be reset so the NEXT
+        // close can re-issue a fresh merge — NOT left holding a poisoned
+        // `Ready(Err)`. Drive a REAL re-prepare and assert it succeeds.
+        assert!(
+            bl.levels[1].next.is_none(),
+            "transient-IO-failed level must reset its pending merge so the next close re-issues it"
+        );
+
+        // "Disk recovers": drive a real re-prepare on level 1 (in-memory merge,
+        // no bucket_dir) and assert it completes cleanly.
+        let incoming = Arc::new(Bucket::empty());
+        bl.levels[1]
+            .prepare_with_normalization(
+                TEST_PROTOCOL,
+                incoming,
+                &[],
+                MergeContext {
+                    keep_dead_entries: DeadEntryPolicy::Keep,
+                    normalize_init: InitEntryPolicy::Preserve,
+                    use_empty_curr: false,
+                    bucket_dir: None,
+                    merge_map: None,
+                    merge_counters: None,
+                    bucket_list_db: BucketListDbConfig::default(),
+                },
+            )
+            .expect("re-prepare after recovery must start a fresh merge");
+
+        bl.resolve_all_pending_merges()
+            .expect("re-issued merge must resolve cleanly after disk recovery");
+    }
 }

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -317,8 +317,13 @@ enum MergeRecvState {
     /// Merge in progress; receiver delivers the result.
     Pending(oneshot::Receiver<Result<Bucket>>),
     /// Terminal state — merge completed or failed; result is cached.
-    /// Errors stored as strings since BucketError is not Clone.
-    Ready(std::result::Result<Arc<Bucket>, String>),
+    ///
+    /// Errors are stored as a structured [`MergeError`] (not a bare string)
+    /// since `BucketError` is not `Clone`. The `MergeError` carries the coarse
+    /// class / raw `errno`, so `resolve()` can re-materialize a *classified*
+    /// `BucketError` and a transient ENOSPC stays distinguishable from
+    /// corruption (#3478).
+    Ready(std::result::Result<Arc<Bucket>, crate::merge_map::MergeError>),
 }
 
 /// Handle to an asynchronous bucket merge running in a background thread.
@@ -518,16 +523,20 @@ impl AsyncMergeHandle {
     /// - No runtime: `blocking_recv` directly
     pub fn resolve(&mut self) -> Result<Arc<Bucket>> {
         if let MergeRecvState::Ready(ref result) = self.state {
-            return result.clone().map_err(|msg| BucketError::Merge(msg));
+            // Re-materialize a *classified* BucketError from the cached
+            // structured MergeError so the errno survives repeated resolves.
+            return result.clone().map_err(|e| e.to_bucket_error());
         }
 
         let start = std::time::Instant::now();
 
         // Take the Pending receiver, replacing with a temporary Ready(Err) in case
-        // the recv panics (belt-and-suspenders).
+        // the recv panics (belt-and-suspenders). Classified `Other` (fatal).
         let MergeRecvState::Pending(rx) = std::mem::replace(
             &mut self.state,
-            MergeRecvState::Ready(Err("merge resolve interrupted".to_string())),
+            MergeRecvState::Ready(Err(crate::merge_map::MergeError::from_message(
+                "merge resolve interrupted",
+            ))),
         ) else {
             unreachable!("already checked for Ready above");
         };
@@ -550,16 +559,42 @@ impl AsyncMergeHandle {
                     Ok(bucket)
                 }
                 Err(e) => {
-                    let msg = e.to_string();
-                    self.state = MergeRecvState::Ready(Err(msg.clone()));
-                    Err(BucketError::Merge(msg))
+                    // Preserve the structured class/errno from the original
+                    // BucketError (#3478) instead of stringifying it away.
+                    let merge_err = crate::merge_map::MergeError::from_bucket_error(&e);
+                    self.state = MergeRecvState::Ready(Err(merge_err.clone()));
+                    Err(merge_err.to_bucket_error())
                 }
             },
             Err(e) => {
-                let msg = e.to_string();
-                self.state = MergeRecvState::Ready(Err(msg.clone()));
-                Err(BucketError::Merge(msg))
+                // Channel/cancellation error — no originating BucketError class.
+                let merge_err = crate::merge_map::MergeError::from_bucket_error(&e);
+                self.state = MergeRecvState::Ready(Err(merge_err.clone()));
+                Err(merge_err.to_bucket_error())
             }
+        }
+    }
+
+    /// Test-only constructor: build a handle already resolved to a failure
+    /// carrying a structured [`MergeError`] (with its real `errno`).
+    ///
+    /// Used by the #3478 regression tests to inject the exact production
+    /// ENOSPC failure so the classification path (`is_transient_io`) is
+    /// exercised on a real structured errno, not a hard-coded boolean.
+    #[cfg(test)]
+    pub(crate) fn new_failed_for_test(level: usize, error: crate::merge_map::MergeError) -> Self {
+        let merge_key = MergeKey::new(
+            DeadEntryPolicy::Keep,
+            Hash256::default(),
+            Hash256::default(),
+        );
+        Self {
+            state: MergeRecvState::Ready(Err(error)),
+            level,
+            input_file_paths: Vec::new(),
+            input_curr_hash: Hash256::default(),
+            input_snap_hash: Hash256::default(),
+            merge_key,
         }
     }
 }
@@ -642,14 +677,14 @@ impl SharedMergeHandle {
     /// Uses the same runtime-aware blocking strategy as AsyncMergeHandle::resolve().
     pub fn resolve(&mut self) -> Result<Arc<Bucket>> {
         if let Some(ref result) = self.cached_result {
-            return result
-                .clone()
-                .map_err(|e| BucketError::Merge(e.to_string()));
+            // Re-materialize a classified BucketError from the structured
+            // MergeError so the errno survives (#3478).
+            return result.clone().map_err(|e| e.to_bucket_error());
         }
 
         let result = blocking_recv_watch(&mut self.receiver)?;
         self.cached_result = Some(result.clone());
-        result.map_err(|e| BucketError::Merge(e.to_string()))
+        result.map_err(|e| e.to_bucket_error())
     }
 }
 
@@ -928,23 +963,45 @@ impl BucketLevel {
     /// before cloning the bucket list, as unresolved merges would be
     /// lost during cloning.
     ///
-    /// Merge failures are propagated as errors (matching stellar-core's
-    /// fatal behavior for merge failures).
+    /// Merge failures are propagated as errors. A transient-IO (ENOSPC/EDQUOT)
+    /// failure is recoverable and re-classified by the caller; genuine
+    /// corruption stays fatal (#3478). The error is re-materialized as a
+    /// *classified* `BucketError` (via the cached structured `MergeError`), so
+    /// repeated calls keep surfacing the same classified error rather than
+    /// silently returning `Ok` once cached.
     pub fn resolve_pending_merge(&mut self) -> Result<()> {
         match &mut self.next {
             Some(PendingMerge::Async(ref mut handle)) => {
-                if matches!(handle.state, MergeRecvState::Pending(_)) {
-                    handle.resolve()?;
-                }
+                // Always call resolve(): if Pending it blocks and caches; if
+                // already Ready(Err) it re-surfaces the cached classified
+                // error (so a poisoned level is never silently treated as Ok).
+                handle.resolve()?;
             }
             Some(PendingMerge::Shared(ref mut handle)) => {
-                if handle.cached_result.is_none() {
-                    handle.resolve()?;
-                }
+                handle.resolve()?;
             }
             _ => {}
         }
         Ok(())
+    }
+
+    /// The `MergeKey` of this level's pending merge, if any. Used to clear the
+    /// shared merge map when resetting a transient-IO-failed level (#3478).
+    fn pending_merge_key(&self) -> Option<MergeKey> {
+        match &self.next {
+            Some(PendingMerge::Async(handle)) => Some(handle.merge_key.clone()),
+            Some(PendingMerge::Shared(handle)) => Some(handle.metadata.merge_key.clone()),
+            _ => None,
+        }
+    }
+
+    /// Reset a level whose pending merge failed transiently, so the next close
+    /// re-issues a fresh merge instead of being served a poisoned `Ready(Err)`
+    /// (#3478, §3). Clears the pending merge and drops the in-flight guard
+    /// (signalling any reattached consumers via the guard's `Drop`).
+    fn reset_failed_merge(&mut self) {
+        self.next = None;
+        self.in_flight_guard = None;
     }
 
     /// Get a reference to the next bucket if any (pending merge result).
@@ -1400,7 +1457,12 @@ pub struct BucketList {
     eviction_counters: Arc<EvictionCounters>,
     /// Background thread handle for async bucket persistence.
     /// Bounded to one concurrent write; the next add_batch waits for completion.
-    pending_persist: Option<std::thread::JoinHandle<std::result::Result<(), String>>>,
+    ///
+    /// The error payload is a structured [`MergeError`] (not a bare `String`)
+    /// so a transient ENOSPC during persist stays distinguishable from genuine
+    /// corruption at the flush site (#3478).
+    pending_persist:
+        Option<std::thread::JoinHandle<std::result::Result<(), crate::merge_map::MergeError>>>,
 }
 
 /// Deduplicate ledger entries by key, keeping only the last occurrence.
@@ -1555,6 +1617,55 @@ where
     load_and_verify_shared(hash, load_bucket)
 }
 
+/// Persist a batch of buckets to disk, returning a structured [`MergeError`]
+/// that preserves the IO error classification (#3478).
+///
+/// Runs on the background persist thread. If multiple buckets fail, the
+/// returned error preserves the most-severe class so corruption is never
+/// masked by a co-occurring transient failure: `Corruption` wins over
+/// `TransientIo`, which wins over `Other`. The message aggregates all failures.
+fn persist_buckets_collecting_error(
+    buckets_to_persist: Vec<(Arc<Bucket>, std::path::PathBuf)>,
+) -> std::result::Result<(), crate::merge_map::MergeError> {
+    let mut messages = Vec::new();
+    // Track the most-severe class seen across failures.
+    let mut worst: Option<crate::error::BucketErrorClass> = None;
+    for (bucket, path) in buckets_to_persist {
+        if let Err(e) = bucket.save_to_xdr_file(&path) {
+            messages.push(format!("bucket {}: {}", bucket.hash().to_hex(), e));
+            let class = e.error_class();
+            worst = Some(match worst {
+                None => class,
+                Some(prev) => more_severe_class(prev, class),
+            });
+        }
+    }
+    if messages.is_empty() {
+        Ok(())
+    } else {
+        Err(crate::merge_map::MergeError {
+            class: worst.unwrap_or(crate::error::BucketErrorClass::Other),
+            message: std::sync::Arc::from(messages.join("; ")),
+        })
+    }
+}
+
+/// Pick the more-severe of two error classes so corruption is never masked by
+/// a co-occurring transient failure (#3478): `Corruption` > `TransientIo` >
+/// `Other`. (`Other` is fatal too, but a transient class is the more specific
+/// recoverable signal, so it ranks above `Other` for the recovery decision.)
+fn more_severe_class(
+    a: crate::error::BucketErrorClass,
+    b: crate::error::BucketErrorClass,
+) -> crate::error::BucketErrorClass {
+    use crate::error::BucketErrorClass::*;
+    match (a, b) {
+        (Corruption, _) | (_, Corruption) => Corruption,
+        (TransientIo(e), _) | (_, TransientIo(e)) => TransientIo(e),
+        _ => Other,
+    }
+}
+
 impl BucketList {
     /// Number of levels in the BucketList.
     pub const NUM_LEVELS: usize = BUCKET_LIST_LEVELS;
@@ -1590,15 +1701,14 @@ impl BucketList {
     /// Call before writing state that references bucket files (HAS, LCL, publish).
     pub fn flush_pending_persist(&mut self) -> Result<()> {
         if let Some(handle) = self.pending_persist.take() {
-            let result: std::result::Result<(), String> = handle
+            let result: std::result::Result<(), crate::merge_map::MergeError> = handle
                 .join()
                 .expect("background bucket persist thread panicked");
-            result.map_err(|e| {
-                BucketError::Io(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("background bucket persist failed: {}", e),
-                ))
-            })?;
+            // Re-materialize a classified BucketError (preserving the original
+            // ErrorKind/errno) instead of flattening to ErrorKind::Other, so
+            // the persist flush site can distinguish a transient ENOSPC from
+            // corruption (#3478).
+            result.map_err(|e| e.to_bucket_error())?;
         }
         Ok(())
     }
@@ -1610,7 +1720,8 @@ impl BucketList {
     /// thread join, preventing lock contention with concurrent readers.
     pub fn take_pending_persist(
         &mut self,
-    ) -> Option<std::thread::JoinHandle<std::result::Result<(), String>>> {
+    ) -> Option<std::thread::JoinHandle<std::result::Result<(), crate::merge_map::MergeError>>>
+    {
         self.pending_persist.take()
     }
 
@@ -1659,9 +1770,44 @@ impl BucketList {
     /// This should be called before cloning a bucket list to ensure that all
     /// async merges are resolved and their results are cached, preventing data
     /// loss during cloning.
+    ///
+    /// # Recovery semantics (#3478)
+    ///
+    /// On a **transient-IO** (ENOSPC/EDQUOT) merge failure — environmental,
+    /// no partial state committed — the failed level is RESET (its pending
+    /// merge and shared-merge-map entry are cleared) so the next close
+    /// re-issues a fresh merge once disk recovers, rather than being served a
+    /// poisoned cached `Ready(Err)`. The error is still propagated so callers
+    /// can back off (skip GC / abort a catchup attempt) without panicking.
+    ///
+    /// Genuine **corruption** (and any other class) is left terminal and
+    /// propagated unchanged — we must NOT silently retry corruption.
     pub fn resolve_all_pending_merges(&mut self) -> Result<()> {
-        for level in &mut self.levels {
-            level.resolve_pending_merge()?;
+        for idx in 0..self.levels.len() {
+            let result = self.levels[idx].resolve_pending_merge();
+            if let Err(ref err) = result {
+                if err.is_transient_io() {
+                    // Recoverable: reset this level so the next close re-issues
+                    // the merge, and clear the shared merge-map entry for its
+                    // key so the re-issue starts fresh (not a stale in-flight /
+                    // completed lookup).
+                    let key = self.levels[idx].pending_merge_key();
+                    self.levels[idx].reset_failed_merge();
+                    if let (Some(key), Some(merge_map)) = (key, self.merge_map.as_ref()) {
+                        if let Ok(mut map) = merge_map.write() {
+                            map.in_flight.remove(&key);
+                            map.remove_merge(&key);
+                        }
+                    }
+                    tracing::warn!(
+                        level = idx,
+                        error = %err,
+                        "Transient IO failure resolving bucket merge; level reset to re-merge \
+                         on next close (recoverable — not corruption)"
+                    );
+                }
+                return result;
+            }
         }
         Ok(())
     }
@@ -2406,15 +2552,11 @@ impl BucketList {
         if let Some(ref dir) = self.bucket_dir {
             // Wait for any previous background persist to complete
             if let Some(handle) = self.pending_persist.take() {
-                let result: std::result::Result<(), String> = handle
+                let result: std::result::Result<(), crate::merge_map::MergeError> = handle
                     .join()
                     .expect("background bucket persist thread panicked");
-                result.map_err(|e| {
-                    BucketError::Io(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("background bucket persist failed: {}", e),
-                    ))
-                })?;
+                // Preserve the structured class/errno (#3478).
+                result.map_err(|e| e.to_bucket_error())?;
             }
 
             let mut buckets_to_persist: Vec<(Arc<Bucket>, std::path::PathBuf)> = Vec::new();
@@ -2430,17 +2572,7 @@ impl BucketList {
             }
             if !buckets_to_persist.is_empty() {
                 self.pending_persist = Some(std::thread::spawn(move || {
-                    let mut errors = Vec::new();
-                    for (bucket, path) in buckets_to_persist {
-                        if let Err(e) = bucket.save_to_xdr_file(&path) {
-                            errors.push(format!("bucket {}: {}", bucket.hash().to_hex(), e));
-                        }
-                    }
-                    if errors.is_empty() {
-                        Ok(())
-                    } else {
-                        Err(errors.join("; "))
-                    }
+                    persist_buckets_collecting_error(buckets_to_persist)
                 }));
             }
         }
@@ -3553,7 +3685,8 @@ impl Drop for BucketList {
     fn drop(&mut self) {
         // Wait for any pending background persist to complete
         if let Some(handle) = self.pending_persist.take() {
-            let result: std::result::Result<(), String> = match handle.join() {
+            let result: std::result::Result<(), crate::merge_map::MergeError> = match handle.join()
+            {
                 Ok(r) => r,
                 Err(_) => return,
             };

--- a/crates/bucket/src/error.rs
+++ b/crates/bucket/src/error.rs
@@ -5,6 +5,52 @@
 
 use thiserror::Error;
 
+/// Raw `errno` for `ENOSPC` ("No space left on device") on Linux.
+pub const ENOSPC: i32 = 28;
+/// Raw `errno` for `EDQUOT` ("Disk quota exceeded") on Linux.
+pub const EDQUOT: i32 = 122;
+
+/// Coarse classification of a bucket error for recovery decisions.
+///
+/// This is the `Clone`able classification threaded through the merge error
+/// chain (`MergeResult` / `MergeRecvState`) so that recovery decisions key on
+/// the structured class / raw `errno` rather than on string-matching the
+/// rendered error message (#3478).
+///
+/// # Parity (stellar-core v26.0.1)
+///
+/// stellar-core does NOT inspect `errno`: a bucket merge/flush IO failure
+/// throws a plain `runtime_error` tagged `POSSIBLY_CORRUPTED_LOCAL_FS`
+/// ("ensure enough space") which propagates uncaught out of `closeLedger` →
+/// **clean process exit** (see `FutureBucket.cpp:446-452`,
+/// `BucketManager.cpp:79,89,95`). There is no `std::abort`/`terminate` on the
+/// bucket path, and core auto-wipes on NEITHER ENOSPC nor corruption (wipe is
+/// operator-driven). Corruption is the DISTINCT path
+/// (`LedgerManagerImpl.cpp:1752`, `POSSIBLY_CORRUPTED_LOCAL_DATA`, "reset this
+/// instance"). henyey narrows "transient" to the free-space class
+/// (ENOSPC/EDQUOT) and keeps everything else (incl. EIO/EROFS) fatal — a
+/// conservative SUPERSET of core's fatality that never masks corruption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BucketErrorClass {
+    /// Transient, environmental free-space IO failure (ENOSPC / EDQUOT).
+    /// Recoverable: no partial state is committed; the operation can be
+    /// retried after disk recovers. Carries the raw `errno`.
+    TransientIo(i32),
+    /// Genuine data corruption (hash mismatch / structural corruption).
+    /// Fatal: must NOT be masked or silently retried.
+    Corruption,
+    /// Any other failure (non-free-space IO, serialization, merge logic, …).
+    /// Treated as fatal (conservative).
+    Other,
+}
+
+impl BucketErrorClass {
+    /// True only for the transient free-space IO class.
+    pub fn is_transient_io(self) -> bool {
+        matches!(self, BucketErrorClass::TransientIo(_))
+    }
+}
+
 /// Errors that can occur during bucket operations.
 ///
 /// This enum covers all failure modes in the bucket subsystem, from I/O
@@ -72,4 +118,33 @@ pub enum BucketError {
     /// time failures) — this variant covers load-time validation only.
     #[error("bucket corruption: {0}")]
     Corruption(String),
+}
+
+impl BucketError {
+    /// Classify this error for recovery decisions (#3478).
+    ///
+    /// Keys on the structured `io::Error` raw `errno` for the `Io` arm — NOT on
+    /// string-matching the rendered message. Only `ENOSPC`(28)/`EDQUOT`(122)
+    /// are transient (free-space class). `HashMismatch`/`Corruption` are
+    /// `Corruption`; everything else is `Other` (fatal, conservative).
+    pub fn error_class(&self) -> BucketErrorClass {
+        match self {
+            BucketError::Io(e) => match e.raw_os_error() {
+                Some(errno @ (ENOSPC | EDQUOT)) => BucketErrorClass::TransientIo(errno),
+                _ => BucketErrorClass::Other,
+            },
+            BucketError::HashMismatch { .. } | BucketError::Corruption(_) => {
+                BucketErrorClass::Corruption
+            }
+            _ => BucketErrorClass::Other,
+        }
+    }
+
+    /// True only for a transient, environmental free-space IO failure
+    /// (`ENOSPC`/`EDQUOT`). Such failures commit no partial state and are
+    /// recoverable once disk recovers — distinct from genuine corruption,
+    /// which stays fatal. See [`BucketErrorClass`] for the parity rationale.
+    pub fn is_transient_io(&self) -> bool {
+        self.error_class().is_transient_io()
+    }
 }

--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -159,7 +159,7 @@ pub use henyey_common::{
 // Error handling
 // ============================================================================
 
-pub use error::BucketError;
+pub use error::{BucketError, BucketErrorClass};
 
 // ============================================================================
 // Eviction (Soroban state archival)
@@ -237,7 +237,9 @@ pub use cache::{BucketEntryCache, CacheStats};
 // Merge deduplication
 // ============================================================================
 
-pub use merge_map::{BucketMergeMap, InFlightGuard, MergeResult, MergeSlot, SharedMergeMetadata};
+pub use merge_map::{
+    BucketMergeMap, InFlightGuard, MergeError, MergeResult, MergeSlot, SharedMergeMetadata,
+};
 
 // ============================================================================
 // Bucket applicator (catchup)

--- a/crates/bucket/src/merge_map.rs
+++ b/crates/bucket/src/merge_map.rs
@@ -41,15 +41,82 @@ use henyey_common::Hash256;
 use tokio::sync::watch;
 
 use crate::bucket::Bucket;
+use crate::error::{BucketError, BucketErrorClass};
 use crate::future_bucket::MergeKey;
 
 // ============================================================================
 // In-Flight Merge Types
 // ============================================================================
 
+/// A `Clone`able merge failure that preserves the structured error
+/// classification (and raw `errno` for transient IO) across the merge error
+/// chain (#3478).
+///
+/// `BucketError` is not `Clone` (it wraps `std::io::Error`), so historically
+/// the merge channel carried a bare `Arc<str>` and the `errno` was lost — a
+/// transient ENOSPC was indistinguishable from genuine corruption by the time
+/// it reached the resolve sites. This thin wrapper carries the coarse
+/// [`BucketErrorClass`] (cheap, `Copy`) alongside the rendered message so
+/// recovery decisions key on the class, not on string-matching.
+#[derive(Debug, Clone)]
+pub struct MergeError {
+    /// Coarse classification, carrying the raw `errno` for transient IO.
+    pub class: BucketErrorClass,
+    /// Rendered message (for logging / re-materialized non-IO errors).
+    pub message: Arc<str>,
+}
+
+impl MergeError {
+    /// Build a `MergeError` from a `BucketError`, capturing its class.
+    pub fn from_bucket_error(err: &BucketError) -> Self {
+        Self {
+            class: err.error_class(),
+            message: Arc::from(err.to_string()),
+        }
+    }
+
+    /// Build a `MergeError` from a plain message with an explicit class.
+    /// Used for channel/cancellation errors that have no originating
+    /// `BucketError` (classified `Other` — fatal/conservative).
+    pub fn from_message(message: impl Into<Arc<str>>) -> Self {
+        Self {
+            class: BucketErrorClass::Other,
+            message: message.into(),
+        }
+    }
+
+    /// True only for the transient free-space IO class (ENOSPC/EDQUOT).
+    pub fn is_transient_io(&self) -> bool {
+        self.class.is_transient_io()
+    }
+
+    /// Re-materialize a classified [`BucketError`] from this wrapper.
+    ///
+    /// `TransientIo(errno)` round-trips to `BucketError::Io` carrying the same
+    /// raw `errno` (so `is_transient_io()` stays true); `Corruption` to
+    /// `BucketError::Corruption`; `Other` to `BucketError::Merge`.
+    pub fn to_bucket_error(&self) -> BucketError {
+        match self.class {
+            BucketErrorClass::TransientIo(errno) => {
+                BucketError::Io(std::io::Error::from_raw_os_error(errno))
+            }
+            BucketErrorClass::Corruption => BucketError::Corruption(self.message.to_string()),
+            BucketErrorClass::Other => BucketError::Merge(self.message.to_string()),
+        }
+    }
+}
+
+impl std::fmt::Display for MergeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 /// Result of an in-flight merge — either success or error.
-/// Must be cloneable so multiple receivers can access it.
-pub type MergeResult = std::result::Result<Arc<Bucket>, Arc<str>>;
+/// Must be cloneable so multiple receivers can access it. The error payload is
+/// a structured [`MergeError`] (not a bare string) so the `errno` survives for
+/// recovery classification (#3478).
+pub type MergeResult = std::result::Result<Arc<Bucket>, Arc<MergeError>>;
 
 /// Outcome of requesting a merge slot via [`BucketMergeMap::get_or_start`].
 pub enum MergeSlot {
@@ -114,10 +181,12 @@ impl InFlightGuard {
         // Drop will remove from in_flight
     }
 
-    /// Signal failure. Sends error to all reattached receivers.
-    pub fn fail(mut self, error: &str) {
+    /// Signal failure. Sends a structured error to all reattached receivers,
+    /// preserving the error classification (so a transient ENOSPC stays
+    /// distinguishable from corruption — #3478).
+    pub fn fail(mut self, error: MergeError) {
         self.signaled = true;
-        let _ = self.sender.send(Some(Err(Arc::from(error))));
+        let _ = self.sender.send(Some(Err(Arc::new(error))));
         // Drop will remove from in_flight
     }
 }
@@ -125,10 +194,12 @@ impl InFlightGuard {
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
         if !self.signaled {
-            // Panic/early-return path: signal stable terminal error
-            let _ = self
-                .sender
-                .send(Some(Err(Arc::from("merge abandoned (guard dropped)"))));
+            // Panic/early-return path: signal stable terminal error. Classified
+            // `Other` (fatal/conservative) — an abandoned guard is not a known
+            // transient condition.
+            let _ = self.sender.send(Some(Err(Arc::new(MergeError::from_message(
+                "merge abandoned (guard dropped)",
+            )))));
         }
         // Always remove from in_flight (exactly once)
         if let Ok(mut map) = self.map.write() {

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -42,8 +42,8 @@ use crate::{
     LedgerError, Result,
 };
 use henyey_bucket::{
-    BucketEntry, BucketEntryExt, BucketList, BucketListSnapshot, BucketMergeMap, EvictionIterator,
-    EvictionResult, HotArchiveBucketList, PendingMergeState,
+    BucketEntry, BucketEntryExt, BucketError, BucketList, BucketListSnapshot, BucketMergeMap,
+    EvictionIterator, EvictionResult, HotArchiveBucketList, PendingMergeState,
 };
 use henyey_common::protocol::{
     hot_archive_supported, needs_upgrade_to_version, protocol_version_starts_from, ProtocolVersion,
@@ -1729,11 +1729,19 @@ impl LedgerManager {
     /// This must be called before cloning the bucket list, because
     /// `BucketLevel::clone()` drops unresolved async merges. After calling
     /// this, all pending merges are `PendingMerge::InMemory` and safe to clone.
-    pub fn resolve_pending_bucket_merges(&self) {
-        self.bucket_list
-            .write()
-            .resolve_all_pending_merges()
-            .expect("bucket merge failure is fatal — cannot continue with corrupt bucket list");
+    ///
+    /// Returns `Err` on a merge failure. The error is classified (#3478): a
+    /// transient-IO (ENOSPC/EDQUOT) failure is environmental and recoverable —
+    /// callers should back off (skip the best-effort GC tick, or abort that
+    /// catchup attempt) rather than terminate the process; the failed level is
+    /// reset internally so the next close re-issues the merge. Genuine
+    /// corruption stays fatal and callers should treat it as such.
+    ///
+    /// Mirrors stellar-core: a bucket merge IO failure throws (recoverable
+    /// clean exit on ENOSPC; node corruption is the distinct fatal path) — it
+    /// never `std::abort`s on the bucket path.
+    pub fn try_resolve_pending_bucket_merges(&self) -> std::result::Result<(), BucketError> {
+        self.bucket_list.write().resolve_all_pending_merges()
     }
 
     /// Get a lock on the unified offer store for direct access.


### PR DESCRIPTION
Closes #3478

## Summary

The validator FATALLY panicked/aborted on a transient ENOSPC during bucket ops even though no corruption occurred (the node restarted cleanly afterward). stellar-core treats bucket-IO failure as RECOVERABLE — it throws `POSSIBLY_CORRUPTED_LOCAL_FS` ("ensure enough space") → clean process exit, never `std::abort`, never auto-wipe — distinct from corruption (`POSSIBLY_CORRUPTED_LOCAL_DATA`, "reset this instance"). Henyey's `.expect()`/`std::process::abort()` were strictly more aggressive than core.

This PR classifies bucket merge/flush IO failures as transient free-space (ENOSPC=28 / EDQUOT=122) vs corruption by threading a structured errno through the previously lossy error chain, and matches core's split: transient-IO recovers (skip GC tick / abort one catchup attempt / clean no-wipe shutdown), corruption stays fatal.

## What changed, by site

**§1 — Classification (errno, not string-matching).** `crates/bucket/src/error.rs`: `BucketError::is_transient_io()` / `error_class()` keyed on the raw `io::Error` errno (28/122 → `TransientIo`; `HashMismatch`/`Corruption` → `Corruption`; everything else incl. EIO/EROFS → `Other`, fatal/conservative). The errno is carried through the chain via a `Clone`able `merge_map::MergeError { class, message }` replacing the bare `Arc<str>` in `MergeResult`, `MergeRecvState::Ready`, and the pending-persist `JoinHandle`. `resolve()` re-materializes a *classified* `BucketError`; `flush_pending_persist` no longer flattens to `ErrorKind::Other`.

**§2 — Site 1 (merge/GC), the recurrence.** `LedgerManager::resolve_pending_bucket_merges` → fallible `try_resolve_pending_bucket_merges(-> Result)`. The best-effort GC caller (`collect_gc_roots`) skips the tick (`warn!` + `None`) on transient-IO, exactly like the existing DB-error case; corruption stays fatal (panic). The catchup-clone caller propagates via `?` to abort only that catchup attempt (self-healable), not the process.

**§3 — Re-merge after recovery (no poisoned cache).** A transient-IO-failed level is RESET (pending merge + shared `merge_map` in-flight/completed entry for its key cleared) so the next close re-issues a fresh merge instead of being wedged on a permanent `Ready(Err)`. Corruption stays terminal.

**§4 — Site 2 (persist), the original report.** New `App::trigger_recoverable_shutdown` + `persist::RecoverableShutdownHandle` — a clean shutdown that does NOT set `fatal_wipe_required` and does NOT set `fatal_state_failure` (required new work: `trigger_fatal_shutdown` unconditionally set wipe). Transient-IO persist failures route there instead of `std::process::abort()`; corruption / non-free-space IO keep the abort+wipe path.

Determinism preserved (§5): never promotes a half-written output, never marks a failed merge resolved-successful, resolve-before-cleanup ordering kept.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3478#issuecomment-4748225924)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy` on touched crates (`bucket`, `ledger`, `app`) `--all-targets -- -D warnings` — clean
- [x] `cargo build --all` — clean
- [x] `cargo test -p henyey-bucket` (508 + integration), `-p henyey-ledger` (494 + integration), `-p henyey-app` (1082 + integration) — all pass

> Note: `cargo clippy --all --all-targets` trips a **pre-existing, unrelated** `clippy::identity_op` in `crates/overlay/src/codec.rs:549` (`0 | 0x80000000`) on clippy 1.95 — present on `origin/main`, untouched by this PR.

## Regression test (kind: bug-fix)

- **Tests:** `crates/bucket/src/bucket_list.rs::test_enospc_merge_failure_is_recoverable_not_corruption_3478`, `test_corruption_merge_failure_stays_fatal_3478`, `test_failed_level_remerges_after_recovery_3478` (+ a test-only `AsyncMergeHandle::new_failed_for_test` injecting the real structured errno). New coverage: `app::mod` GC-skip-vs-fatal classifier, `app::persist` transient→recoverable-shutdown / corruption→fatal routing, `app::lifecycle` no-wipe assertion (inverse of the existing `fatal_wipe_required` test).
- **Pre-fix:** committed as `0d97e69e` — verified FAILED on `origin/main`: `is_transient_io()`, `merge_map::MergeError`, and `new_failed_for_test` do not exist and the errno is stringified away (does not compile).
- **Post-fix:** verified PASS after `fa44f78e`.

## Deviations from plan

None. In-process retry-with-backoff/pause-and-resume on ENOSPC is deliberately NOT implemented here (beyond-core, operator-gated) and filed as follow-up #3498. The disk-exhaustion guard/quota (hardening angle #2) remains a separate operator/infra track. #3422 (overlay diag) is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)