### PR TITLE
Remove dead SCP accessors and narrow ballot re-exports

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -63,8 +63,8 @@ mod envelope;
 mod state_machine;
 mod statements;
 
-pub use statements::get_companion_quorum_set_hash;
-pub use statements::get_working_ballot;
+pub(crate) use statements::get_companion_quorum_set_hash;
+pub(crate) use statements::get_working_ballot;
 use statements::{are_ballots_less_and_compatible, are_ballots_less_and_incompatible};
 pub(crate) use statements::{ballot_compare, ballot_compatible, cmp_opt_ballot};
 
@@ -374,11 +374,6 @@ impl BallotProtocol {
     /// Get the high ballot (highest confirmable).
     pub fn high_ballot(&self) -> Option<&ScpBallot> {
         self.high_ballot.as_ref()
-    }
-
-    /// Get the current consensus value.
-    pub fn value(&self) -> Option<&Value> {
-        self.current_ballot.as_ref().map(|b| &b.value)
     }
 
     /// Check protocol invariants for debugging.

--- a/crates/scp/src/compare.rs
+++ b/crates/scp/src/compare.rs
@@ -32,7 +32,7 @@ pub(crate) fn ballot_summary_of(pledges: &ScpStatementPledges) -> Option<(Ballot
 /// check in stellar-core:
 /// 1. Identity: node_id + slot_index must match (SCP.cpp:420-423)
 /// 2. Phase: nomination ↔ ballot never replaces (Slot.cpp:118-121)
-/// 3. Ballot ordering: delegates to [`is_newer_ballot_st`] (BallotProtocol.cpp:55-90)
+/// 3. Ballot ordering: delegates to `is_newer_ballot_st` (BallotProtocol.cpp:55-90)
 ///
 /// Note: stellar-core's slot-existence check (`getSlot`) depends on runtime
 /// state and is not replicated in this free function.

--- a/crates/scp/src/scp.rs
+++ b/crates/scp/src/scp.rs
@@ -43,7 +43,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
 
 use parking_lot::RwLock;
 use stellar_xdr::curr::{
@@ -355,24 +354,6 @@ impl<D: SCPDriver> SCP<D> {
         self.slots.read().contains_key(&slot_index)
     }
 
-    /// Get the current value for a slot.
-    ///
-    /// For externalized slots, returns the externalized value.
-    /// For non-externalized slots, returns the ballot's committed value,
-    /// or the nomination composite value if the ballot hasn't committed yet.
-    /// Returns `None` if the slot has no value at all.
-    pub fn get_slot_current_value(&self, slot_index: u64) -> Option<Value> {
-        let slots = self.slots.read();
-        let slot = slots.get(&slot_index)?;
-        if let Some(value) = slot.get_externalized_value() {
-            return Some(value.clone());
-        }
-        if let Some(commit_ballot) = slot.ballot().commit() {
-            return Some(commit_ballot.value.clone());
-        }
-        slot.nomination().latest_composite().cloned()
-    }
-
     /// Restore `fully_validated` for a slot and emit any deferred
     /// ballot/nomination envelopes that were suppressed while the
     /// value was pending full validation.
@@ -471,16 +452,6 @@ impl<D: SCPDriver> SCP<D> {
             .filter(|(_, slot)| slot.is_externalized())
             .map(|(&index, _)| index)
             .max()
-    }
-
-    /// Get the timeout duration for a nomination round.
-    pub fn get_nomination_timeout(&self, round: u32) -> Duration {
-        self.driver.compute_timeout(round, true)
-    }
-
-    /// Get the timeout duration for a ballot round.
-    pub fn get_ballot_timeout(&self, round: u32) -> Duration {
-        self.driver.compute_timeout(round, false)
     }
 
     /// Check if we've heard from a v-blocking set for a slot.


### PR DESCRIPTION
Closes #3446

## Summary

Four behavior-neutral `henyey-scp` cleanups (net diff -37/+3, no behavior change, parity-neutral):

- **F1** — delete the zero-caller `BallotProtocol::value()` (`ballot/mod.rs`). `BallotProtocol` lives in the private `mod ballot;` and is not re-exported in `lib.rs`, so the accessor is dead-in-lib; deletion is clean under `-Dwarnings`.
- **F2** — delete the zero-caller `SCP::get_slot_current_value`, `get_nomination_timeout`, `get_ballot_timeout` (`scp.rs`). `SCP` IS re-exported (lib.rs:84), so a `pub(crate)` narrow would make them dead-in-lib; delete is the correct #3384 disposition. Also removes the now-orphaned file-level `use std::time::Duration;` (the test module keeps its own).
- **F3** — narrow the `get_companion_quorum_set_hash` / `get_working_ballot` re-exports from `pub` to `pub(crate)` (`ballot/mod.rs:66-67`). They are `pub use` from the private `mod ballot;`, surfaced nowhere in `lib.rs`, with zero external `henyey_scp::` callers. (Corrects the triage's "F3 stale" note: `lib.rs:62` is `pub use ballot::BallotPhase;` only — the cited 3-symbol re-export does not exist on current main 491b43d2.)
- **F4** — replace the private-intra-doc-link `[`is_newer_ballot_st`]` (`compare.rs:35`) with a backtick code span so `RUSTDOCFLAGS=-Dwarnings cargo doc` is warning-free.

No nomination/ballot state machine, quorum checks, v-blocking, or message validation is touched.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3446#issuecomment-4748661928)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build -p henyey-scp --all-targets` under `-Dwarnings` (clean)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc -p henyey-scp --no-deps` (warning-free)
- [x] `cargo test -p henyey-scp` — 384 + 50 + 7 + 124 unit tests pass, 5 doc-tests (ignored), integration tests compile
- [x] `cargo build --all` (clean — confirms no cross-crate consumers)

## Parity

Parity-neutral. F1/F2 symbols have no stellar-core mapping (absent from `PARITY_STATUS.md`). F3 symbols are parity-mapped (`getWorkingBallot`, `getCompanionQuorumSetHashFromStatement`) and stay "Full"; the `pub(crate)` narrow moves encapsulation closer to upstream's module-internal statics. No `PARITY_STATUS.md` edit.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)