### PR TITLE
Remove five dead overlay accessors and correct survey parity rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ henyey/
 |-------|---------|--------|
 | [`henyey-scp`](crates/scp/README.md) | Stellar Consensus Protocol: nomination, balloting, quorum logic | [96%](crates/scp/PARITY_STATUS.md) |
 | [`henyey-herder`](crates/herder/README.md) | Consensus coordination, transaction queue, ledger close triggers | [79%](crates/herder/PARITY_STATUS.md) |
-| [`henyey-overlay`](crates/overlay/README.md) | P2P overlay network, peer management, message flooding | [91%](crates/overlay/PARITY_STATUS.md) |
+| [`henyey-overlay`](crates/overlay/README.md) | P2P overlay network, peer management, message flooding | [90%](crates/overlay/PARITY_STATUS.md) |
 
 ### Execution Layer
 

--- a/crates/overlay/PARITY_STATUS.md
+++ b/crates/overlay/PARITY_STATUS.md
@@ -2,8 +2,8 @@
 
 **Crate**: `henyey-overlay`
 **Upstream**: `stellar-core/src/overlay/`
-**Overall Parity**: 91%
-**Last Updated**: 2026-05-28
+**Overall Parity**: 90%
+**Last Updated**: 2026-06-19
 
 ## Summary
 
@@ -402,7 +402,7 @@ Corresponds to: `SurveyManager.h`, `SurveyDataManager.h`, `SurveyMessageLimiter.
 | `relayStopSurveyCollecting()` | `survey_impl::handle_survey_stop_collecting()` | Full |
 | `modifyNodeData()` | `modify_node_data()` | Full |
 | `modifyPeerData()` | `modify_peer_data()` | Full |
-| `recordDroppedPeer()` | `record_dropped_peer()` | Full |
+| `recordDroppedPeer()` | `record_dropped_peer()` | None |
 | `updateSurveyPhase()` | `update_phase()` | Full |
 | `sendTopologyRequest()` | `survey_impl::handle_survey_request()` | Full |
 | `processTimeSlicedTopologyResponse()` | `survey_impl::handle_survey_response()` | Full |
@@ -416,7 +416,7 @@ Corresponds to: `SurveyManager.h`, `SurveyDataManager.h`, `SurveyMessageLimiter.
 | `SurveyDataManager::stopSurveyCollecting()` | `stop_collecting()` | Full |
 | `SurveyDataManager::modifyNodeData()` | `modify_node_data()` | Full |
 | `SurveyDataManager::modifyPeerData()` | `modify_peer_data()` | Full |
-| `SurveyDataManager::recordDroppedPeer()` | `record_dropped_peer()` | Full |
+| `SurveyDataManager::recordDroppedPeer()` | `record_dropped_peer()` | None |
 | `SurveyDataManager::getNonce()` | `nonce()` | Full |
 | `SurveyDataManager::nonceIsReporting()` | (via phase check) | Full |
 | `SurveyDataManager::fillSurveyData()` | `survey_impl::handle_survey_request()` | Full |
@@ -488,6 +488,7 @@ Features not yet implemented. These ARE counted against parity %.
 | `OverlayManagerImpl::updateSizeCounters()` | Low | Metrics for pending/auth sizes |
 | `OverlayManagerImpl::availableOutboundAuthenticatedSlots()` | Low | Slot availability check |
 | `SurveyManager::getMsgSummary()` | Low | Survey message logging |
+| `SurveyDataManager::recordDroppedPeer()` | Medium | `record_dropped_peer()` exists with correct internal semantics but has **zero production callers** — it is never invoked from the peer-drop path, so henyey survey responses always report `dropped_peers: 0`. The symmetric add/node-data counters (`record_added_peer` / `modify_node_data`) are likewise production-unwired. Wiring these into the peer lifecycle is a behavior-changing parity task tracked in #3500. |
 
 ## Architectural Differences
 
@@ -548,7 +549,7 @@ Features not yet implemented. These ARE counted against parity %.
 
 | Category | Count |
 |----------|-------|
-| Implemented (Full) | 257 |
-| Gaps (None + Partial) | 26 |
+| Implemented (Full) | 255 |
+| Gaps (None + Partial) | 28 |
 | Intentional Omissions | 10 |
-| **Parity** | **257 / (257 + 26) = 91%** |
+| **Parity** | **255 / (255 + 28) = 90%** |

--- a/crates/overlay/src/error.rs
+++ b/crates/overlay/src/error.rs
@@ -146,31 +146,6 @@ pub enum OverlayError {
     Internal(String),
 }
 
-impl OverlayError {
-    /// Returns true if this error is transient and the operation could succeed on retry.
-    ///
-    /// Connection failures, timeouts, and I/O errors are typically retriable.
-    pub fn is_retriable(&self) -> bool {
-        matches!(
-            self,
-            OverlayError::ConnectionFailed(_)
-                | OverlayError::ConnectionTimeout(_)
-                | OverlayError::Io(_)
-        )
-    }
-
-    /// Returns true if this error indicates a fundamental incompatibility.
-    ///
-    /// Network mismatches and version incompatibilities are fatal - retrying
-    /// will not help and the peer should not be contacted again.
-    pub fn is_fatal(&self) -> bool {
-        matches!(
-            self,
-            OverlayError::NetworkMismatch | OverlayError::VersionMismatch(_)
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/overlay/src/item_fetcher.rs
+++ b/crates/overlay/src/item_fetcher.rs
@@ -400,11 +400,6 @@ impl ItemFetcher {
         *self.available_peers.lock().unwrap() = peers;
     }
 
-    /// Get the current list of available peers.
-    pub fn get_available_peers(&self) -> Vec<PeerId> {
-        self.available_peers.lock().unwrap().clone()
-    }
-
     /// Wrapper around `Tracker::try_next_peer` that increments the
     /// `item_fetcher_next_peer` counter on `AskPeer` results. All call sites
     /// should use this instead of calling `tracker.try_next_peer()` directly

--- a/crates/overlay/src/lib.rs
+++ b/crates/overlay/src/lib.rs
@@ -481,27 +481,11 @@ impl PeerAddress {
         }
     }
 
-    /// Returns a canonical dedup key for this peer address.
-    ///
-    /// For IP-address hosts, normalizes the string representation via a parse
-    /// round-trip (e.g. stripping leading zeros). For hostname hosts (config
-    /// entries before DNS resolution), falls back to the raw `host:port`.
-    ///
-    /// This is a synchronous, allocation-only operation — no DNS lookup.
-    #[deprecated(note = "Use dial_key() or ResolvedPeerAddr::try_from_peer_address() instead")]
-    pub fn canonical_key(&self) -> String {
-        if let Ok(ip) = self.host.parse::<std::net::IpAddr>() {
-            format!("{}:{}", ip, self.port)
-        } else {
-            format!("{}:{}", self.host, self.port)
-        }
-    }
-
     /// Compute the dial key for this address.
     ///
     /// IPs produce a normalized `DialKey::Resolved`; hostnames and IPv6 literals
-    /// produce `DialKey::Hostname`. This replaces `canonical_key()` with a
-    /// type-safe equivalent that makes hostname/IP aliasing impossible.
+    /// produce `DialKey::Hostname`. This is a type-safe dedup key that makes
+    /// hostname/IP aliasing impossible.
     pub fn dial_key(&self) -> DialKey {
         match ResolvedPeerAddr::try_from_peer_address(self) {
             Some(resolved) => DialKey::Resolved(resolved),
@@ -931,13 +915,6 @@ impl LocalNode {
     /// Uses the testnet network passphrase and current protocol versions.
     pub fn new_testnet(secret_key: henyey_crypto::SecretKey) -> Self {
         Self::with_network(secret_key, henyey_common::NetworkId::testnet())
-    }
-
-    /// Creates a new local node configured for the Stellar mainnet.
-    ///
-    /// Uses the mainnet network passphrase and current protocol versions.
-    pub fn new_mainnet(secret_key: henyey_crypto::SecretKey) -> Self {
-        Self::with_network(secret_key, henyey_common::NetworkId::mainnet())
     }
 
     /// Creates a new local node with a custom network passphrase.

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -3716,7 +3716,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_known_peer_canonical_key_dedup() {
+    fn test_add_known_peer_dial_key_dedup() {
         let local_node = {
             let secret = henyey_crypto::SecretKey::generate();
             crate::LocalNode::new_testnet(secret)
@@ -3726,7 +3726,7 @@ mod tests {
             ..Default::default()
         };
         let manager = OverlayManager::new(config, local_node).unwrap();
-        // Same IP, should be rejected as duplicate via canonical key
+        // Same IP, should be rejected as duplicate via dial key
         assert!(!manager.add_known_peer(PeerAddress::new("10.0.0.1", 11625)));
         // Different port, should be accepted
         assert!(manager.add_known_peer(PeerAddress::new("10.0.0.1", 11626)));

--- a/crates/overlay/src/peer_manager.rs
+++ b/crates/overlay/src/peer_manager.rs
@@ -206,20 +206,6 @@ impl PeerManager {
         })
     }
 
-    /// Create a peer manager using an existing database connection.
-    pub fn from_connection(conn: Connection) -> Result<Self> {
-        Self::init_db(&conn)?;
-
-        let cache = Self::load_all_from_db(&conn)?;
-
-        let db = Arc::new(Mutex::new(conn));
-
-        Ok(Self {
-            cache: RwLock::new(cache),
-            db: Some(db),
-        })
-    }
-
     /// Initialize the database schema.
     fn init_db(conn: &Connection) -> Result<()> {
         conn.execute(
@@ -948,9 +934,9 @@ mod tests {
     }
 
     #[test]
-    fn test_get_peers_to_send_canonical_key_exclusion() {
-        // Exclusion must compare via canonical_key, not raw field equality.
-        // PeerManager records store IP strings; canonical_key normalizes
+    fn test_get_peers_to_send_dial_key_exclusion() {
+        // Exclusion must compare via dial_key, not raw field equality.
+        // PeerManager records store IP strings; dial_key normalizes
         // them (e.g. IPv6 shortening, future IPv4-mapped IPv6 handling).
         let manager = PeerManager::new_in_memory();
 
@@ -964,7 +950,7 @@ mod tests {
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].host, "5.6.7.8");
 
-        // Verify canonical_key is used by constructing a fresh PeerAddress
+        // Verify dial_key is used by constructing a fresh PeerAddress
         // with the same IP — it should still be excluded
         let exclude_fresh = PeerAddress::new("1.2.3.4".to_string(), 11625);
         let peers = manager.get_peers_to_send(10, &exclude_fresh);


### PR DESCRIPTION
Closes #3444

## Summary

Deletes five `pub` methods in `henyey-overlay` that have zero call sites workspace-wide, and corrects two false `Full` survey parity rows (O6, honesty route — no behavior change). All deletions are unused accessors/constructors/error-classifiers with no wire, auth, flooding, framing, or peer-selection footprint, so the net observable behavior diff is zero.

Per-finding:
- **O1** — delete `LocalNode::new_mainnet` (`lib.rs`); keep `new_testnet` (real callers).
- **O2** — delete `PeerAddress::canonical_key` (`lib.rs`), superseded by `dial_key()`. Two tests embedded the old symbol name in their `fn` name + comments (they call `dial_key()`, not the deleted symbol) → renamed to `*_dial_key_*`.
- **O3** — delete `PeerManager::from_connection` (`peer_manager.rs`).
- **O4** — delete `OverlayError::is_retriable` / `is_fatal` (`error.rs`).
- **O5** — delete the unused `ItemFetcher::get_available_peers` getter (`item_fetcher.rs`); keep the `available_peers` field + `set_available_peers` (used by herder).
- **O6** — correct `recordDroppedPeer` rows in `PARITY_STATUS.md` from `Full` → `None` (the method is production-unwired, so henyey surveys always report `dropped_peers:0`), add a Gaps entry, and adjust the parity count (257→255 Full, 26→28 gaps, 91%→90%) + README crate-overview row. Behavior-changing wiring deferred to **#3500**.

`record_dropped_peer` wiring (O6 follow-up / triage-flagged O6 option-a) is SCOPED OUT of this PR — tracked in #3500.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3444#issuecomment-4748654338)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build -p henyey-overlay --all-targets` under `-Dwarnings` (the #3384 dead-code disposition proof) — clean
- [x] `cargo build --all` — clean
- [x] `cargo test -p henyey-overlay` — all pass, incl. the two renamed tests (`test_get_peers_to_send_dial_key_exclusion`, `test_add_known_peer_dial_key_dedup`)

## Deviations from plan

None. O6 PARITY_STATUS edit kept scoped to the two named `recordDroppedPeer` rows + one Gaps entry (the optional `modifyNodeData` rows were left untouched per the plan's default). The parity-count summary, header percent, and README crate row were updated to stay consistent with the two Full→None changes (required by CLAUDE.md when parity changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)