### PR TITLE
Remove dead code and narrow over-broad visibility in henyey-ledger

### DIFF
--- a/crates/ledger/PARITY_STATUS.md
+++ b/crates/ledger/PARITY_STATUS.md
@@ -113,7 +113,7 @@ Corresponds to: `LedgerHeaderUtils.h`
 | Header hash computation | `compute_header_hash()` | Full |
 | Skip list computation | `calculate_skip_values()` | Full |
 | Next header creation | `create_next_header()` | Full |
-| Protocol version utilities | `protocol_version()`, `is_before_protocol_version()` | Full |
+| Protocol version utilities | `protocol_version()` | Full |
 | Close time extraction | `close_time()` | Full |
 | `LedgerHeaderUtils::storeInDatabase()` | Not applicable (no SQL) | None |
 | `LedgerHeaderUtils::loadByHash()` | Not applicable (no SQL) | None |
@@ -254,7 +254,7 @@ Corresponds to: `LedgerTxn.h` (offer comparison subset)
 
 | stellar-core | Rust | Status |
 |--------------|------|--------|
-| `isBetterOffer()` | `is_better_offer()` | Full |
+| `isBetterOffer()` | `Ord` impl on `OfferDescriptor` | Full |
 | `OfferDescriptor` | `OfferDescriptor` | Full |
 | `IsBetterOfferComparator` | `Ord` impl on `OfferDescriptor` | Full |
 | `AssetPair` | `AssetPair` | Full |
@@ -297,13 +297,9 @@ Corresponds to: Fee/reserve logic in `LedgerManager.h`
 | stellar-core | Rust | Status |
 |--------------|------|--------|
 | `getLastMinBalance()` | `reserves::minimum_balance()` | Full |
-| Fee calculation | `fees::calculate_fee()` | Full |
-| Available balance for fees | `fees::available_balance()` | Full |
 | Selling liabilities | `reserves::selling_liabilities()` | Full |
 | Buying liabilities | `reserves::buying_liabilities()` | Full |
 | Available to send | `reserves::available_to_send()` | Full |
-| Available to receive | `reserves::available_to_receive()` | Full |
-| Sub-entry affordability | `reserves::can_add_sub_entry()` | Full |
 
 ### lib.rs -- trustlines module (`lib.rs`)
 
@@ -316,7 +312,6 @@ Corresponds to: `TrustLineWrapper.h` (balance constraint subset)
 | `TrustLineWrapper::getBuyingLiabilities()` | `trustlines::buying_liabilities()` | Full |
 | `TrustLineWrapper::getSellingLiabilities()` | `trustlines::selling_liabilities()` | Full |
 | `TrustLineWrapper::getAvailableBalance()` | `trustlines::available_to_send()` | Full |
-| `TrustLineWrapper::getMaxAmountReceive()` | `trustlines::available_to_receive()` | Full |
 | `TrustLineWrapper::isAuthorized()` | Via flag checks in tx crate | Full |
 
 ## Intentional Omissions
@@ -442,12 +437,12 @@ The ledger crate has been verified against testnet for ledger close correctness.
 
 | Category | Count |
 |----------|-------|
-| Implemented (Full) | 139 |
+| Implemented (Full) | 134 |
 | Gaps (None + Partial) | 9 |
 | Intentional Omissions | 30 |
-| **Parity** | **139 / (139 + 9) = 94%** |
+| **Parity** | **134 / (134 + 9) = 94%** |
 
-The 139 implemented items cover: LedgerManager core operations (31, including `applySorobanStages`, `applySorobanStageClustersInParallel`, `applyThread`, `getModuleCache`), header utilities (8), delta/change tracking (13), close data (8), snapshots (8), execution pipeline (28, including `commonPreApply`/`preParallelApply`/`parallelApply` and all v20-v26 network-config synthesis paths), config upgrade (6), offer utilities (5), in-memory Soroban state (15), fee/reserve calculations (8), trustline utilities (7), CloseLedgerState merged reads with `EntryReader` (1), module cache rebuild (1 — partial, not counted here).
+The 134 implemented items cover: LedgerManager core operations (31, including `applySorobanStages`, `applySorobanStageClustersInParallel`, `applyThread`, `getModuleCache`), header utilities (8), delta/change tracking (13), close data (8), snapshots (8), execution pipeline (28, including `commonPreApply`/`preParallelApply`/`parallelApply` and all v20-v26 network-config synthesis paths), config upgrade (6), offer utilities (5), in-memory Soroban state (15), fee/reserve calculations (4), trustline utilities (6), CloseLedgerState merged reads with `EntryReader` (1), module cache rebuild (1 — partial, not counted here).
 
 The 8 gap items include: timing utilities (2), metrics methods (2), multi-threaded module cache compilation (1 Partial), CompleteConstLedgerState (1 Partial), prefetch (1), and meta streaming (1).
 

--- a/crates/ledger/README.md
+++ b/crates/ledger/README.md
@@ -96,20 +96,17 @@ assert!(maybe_entry.is_none());
 # Ok::<(), henyey_ledger::LedgerError>(())
 ```
 
-### Use ledger helpers for fees and reserves
+### Use ledger helpers for reserves
 
 ```rust
-use henyey_ledger::{fees, reserves};
-use stellar_xdr::curr::{AccountEntry, Transaction};
+use henyey_ledger::reserves;
+use stellar_xdr::curr::AccountEntry;
 
-let tx: Transaction = todo!();
 let account: AccountEntry = todo!();
 
-let charged_fee = fees::calculate_fee(&tx, 100);
 let min_balance = reserves::minimum_balance(&account, 5_000_000);
 let available = reserves::available_to_send(&account, 5_000_000);
 
-assert!(charged_fee as i64 <= account.balance);
 assert!(available <= account.balance - min_balance);
 ```
 
@@ -117,7 +114,7 @@ assert!(available <= account.balance - min_balance);
 
 | Module | Description |
 |--------|-------------|
-| `lib.rs` | Public exports plus lightweight fee, reserve, and trustline helpers. |
+| `lib.rs` | Public exports plus lightweight reserve and trustline helpers. |
 | `manager.rs` | `LedgerManager`, startup cache scans, bucket-list installation, and close/commit orchestration. |
 | `close.rs` | Ledger-close inputs and outputs, transaction-set preparation, upgrade context, and perf/stat structs. |
 | `delta.rs` | Change coalescing, fee deduction helpers, and bucket-update categorization. |

--- a/crates/ledger/src/execution/mod.rs
+++ b/crates/ledger/src/execution/mod.rs
@@ -116,7 +116,7 @@ use signatures::*;
 /// `VmInstantiation` (uncached) cost model, matching stellar-core behavior.
 ///
 /// No-op when `cache` is `None` (pre-Soroban protocol or cache init failure).
-pub fn warm_module_cache_from_entries(
+pub(crate) fn warm_module_cache_from_entries(
     cache: Option<&PersistentModuleCache>,
     entries: &[LedgerEntry],
     protocol_version: u32,
@@ -138,7 +138,7 @@ pub fn warm_module_cache_from_entries(
 ///
 /// This allows the ledger execution layer to look up archived entries without
 /// requiring the tx layer to depend on the bucket crate.
-pub struct HotArchiveLookupImpl {
+pub(crate) struct HotArchiveLookupImpl {
     hot_archive: std::sync::Arc<parking_lot::RwLock<Option<HotArchiveBucketList>>>,
 }
 
@@ -2632,7 +2632,7 @@ pub use henyey_common::ThresholdLevel;
 /// transaction and reused across TX-level checks, per-operation checks, and
 /// extra signer checks. After all checks, `check_all_signatures_used()` verifies
 /// that every signature in the envelope was consumed by at least one check.
-pub struct SignatureTracker<'a> {
+pub(crate) struct SignatureTracker<'a> {
     tx_hash: &'a Hash256,
     signatures: &'a [stellar_xdr::curr::DecoratedSignature],
     used: Vec<bool>,
@@ -2861,7 +2861,7 @@ pub struct SorobanContext<'a> {
 /// Bundles live entries and deleted keys together so they always travel as a
 /// pair.  Constructed once per stage from the current `LedgerDelta` and shared
 /// by all clusters in that stage.
-pub struct PriorStageState {
+pub(crate) struct PriorStageState {
     pub entries: Vec<LedgerEntry>,
     pub deleted_keys: Vec<LedgerKey>,
     /// Keys restored from hot archive by prior stages.
@@ -2898,7 +2898,7 @@ impl PriorStageState {
 }
 
 /// Parameters specific to a single cluster or stage within the parallel phase.
-pub struct ClusterParams<'a> {
+pub(crate) struct ClusterParams<'a> {
     pub id_pool: u64,
     pub prior_stage: &'a PriorStageState,
     pub pre_charged_fees: &'a [PreChargedFee],

--- a/crates/ledger/src/header.rs
+++ b/crates/ledger/src/header.rs
@@ -29,9 +29,6 @@ use crate::{LedgerError, Result};
 use henyey_common::Hash256;
 use stellar_xdr::curr::{LedgerHeader, Limits, WriteXdr};
 
-/// Number of entries in the skip list (fixed at 4 by protocol).
-pub const SKIP_LIST_SIZE: usize = 4;
-
 /// Skip list update intervals (from stellar-core).
 /// The skip list stores bucket_list_hash values at these intervals.
 pub const SKIP_1: u32 = 50;
@@ -250,21 +247,6 @@ pub fn close_time(header: &LedgerHeader) -> u64 {
 /// for transactions processed in this ledger.
 pub fn protocol_version(header: &LedgerHeader) -> u32 {
     header.ledger_version
-}
-
-/// Check if a header predates a given protocol version.
-///
-/// Useful for conditional logic based on protocol capabilities.
-///
-/// # Example
-///
-/// ```ignore
-/// if is_before_protocol_version(header, 20) {
-///     // Soroban not available
-/// }
-/// ```
-pub fn is_before_protocol_version(header: &LedgerHeader, version: u32) -> bool {
-    header.ledger_version < version
 }
 
 #[cfg(test)]

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -36,11 +36,10 @@
 //! - **Contract data**: Soroban smart contract storage (Protocol 20+)
 //! - **Contract code**: Soroban WASM bytecode (Protocol 20+)
 //!
-//! # Fee and Reserve Calculations
+//! # Reserve Calculations
 //!
-//! The [`fees`] and [`reserves`] modules provide utilities for calculating:
+//! The [`reserves`] module provides utilities for calculating:
 //!
-//! - Transaction fees based on operation count and base fee
 //! - Account minimum balances based on sub-entries and sponsorship
 //! - Available balance for spending (accounting for reserves and liabilities)
 //!
@@ -89,7 +88,7 @@ mod soroban_state;
 // Re-export main types
 pub use close::{
     CachePerfStats, LedgerCloseData, LedgerClosePerf, LedgerCloseResult, LedgerCloseStats,
-    SorobanPhaseStructure, SortState, TransactionSetVariant, TxPerf, TxWithFee, UpgradeContext,
+    SorobanPhaseStructure, TransactionSetVariant, TxPerf, UpgradeContext,
 };
 pub use close_state::CloseLedgerState;
 pub use config_upgrade::{ConfigUpgradeSetFrame, ConfigUpgradeValidity};
@@ -101,14 +100,13 @@ pub use execution::{
     SorobanNetworkInfo,
 };
 pub use header::{
-    calculate_skip_values, close_time, compute_header_hash, create_next_header,
-    is_before_protocol_version, protocol_version, verify_header_chain, SKIP_1, SKIP_2, SKIP_3,
-    SKIP_4, SKIP_LIST_SIZE,
+    calculate_skip_values, close_time, compute_header_hash, create_next_header, protocol_version,
+    verify_header_chain,
 };
 pub use manager::build_genesis_soroban_config_entries;
 pub use manager::new_bucket_list_with_soroban_config;
 pub use manager::{
-    prepend_fee_event, scan_level_pairs_for_caches, CacheInitResult, HeaderSnapshot, LedgerManager,
+    prepend_fee_event, scan_level_pairs_for_caches, HeaderSnapshot, LedgerManager,
     LedgerManagerConfig,
 };
 pub use memory_report::log_startup_memory;
@@ -117,10 +115,7 @@ pub use snapshot::{
     EntriesLookupFn, EntryLookupFn, LedgerSnapshot, PoolShareTrustlinesByAccountFn,
     SnapshotBuilder, SnapshotHandle,
 };
-pub use soroban_state::{
-    ContractCodeMapEntry, ContractDataMapEntry, InMemorySorobanState, SharedSorobanState,
-    SorobanRentConfig, SorobanStateStats, TtlData,
-};
+pub use soroban_state::{InMemorySorobanState, SharedSorobanState};
 
 /// Result type for ledger operations.
 ///
@@ -182,92 +177,6 @@ impl From<&stellar_xdr::curr::LedgerHeader> for LedgerInfo {
             base_reserve: header.base_reserve,
             protocol_version: header.ledger_version,
         }
-    }
-}
-
-/// Fee calculation utilities for transaction processing.
-///
-/// This module provides functions for computing transaction fees and checking
-/// whether accounts have sufficient balance to pay fees. All fees are
-/// denominated in stroops (1 XLM = 10,000,000 stroops).
-///
-/// # Fee Model
-///
-/// Stellar uses a simple fee model where fees are charged per operation:
-///
-/// - **Base fee**: Network-wide minimum fee per operation (typically 100 stroops)
-/// - **Transaction fee**: `num_operations * base_fee` (minimum)
-/// - **Surge pricing**: During high load, fees may exceed the base fee
-///
-/// The transaction's `fee` field represents the maximum the sender is willing
-/// to pay. The actual charged fee is the minimum of this and the required fee.
-pub mod fees {
-    use stellar_xdr::curr::{AccountEntry, Transaction};
-
-    /// Calculate the fee for a transaction.
-    ///
-    /// Computes the minimum required fee based on operation count and base fee.
-    /// The actual charged fee is capped by the transaction's declared maximum.
-    ///
-    /// # Arguments
-    ///
-    /// * `tx` - The transaction to calculate fees for
-    /// * `base_fee` - The network base fee per operation in stroops
-    ///
-    /// # Returns
-    ///
-    /// The fee amount in stroops that would be charged for this transaction.
-    ///
-    /// # Limitations
-    ///
-    /// This is a simplified utility for classic transactions only. For fee-bump
-    /// transactions, use the outer fee. For Soroban transactions, the actual fee
-    /// includes the resource fee from `SorobanTransactionData`. The authoritative
-    /// fee charging happens in `processFeeSeqNum` during ledger close, not here.
-    pub fn calculate_fee(tx: &Transaction, base_fee: u32) -> u64 {
-        let num_ops = tx.operations.len() as u64;
-        let min_fee = num_ops * base_fee as u64;
-
-        // The transaction's fee field is the maximum the user is willing to pay.
-        // The actual charge is min(declared_fee, num_ops * base_fee).
-        std::cmp::min(tx.fee as u64, min_fee)
-    }
-
-    /// Check if an account can afford the fee.
-    ///
-    /// This checks the available balance (after accounting for selling liabilities)
-    /// against the required fee amount.
-    ///
-    /// # Note
-    ///
-    /// This is a simplified check that doesn't account for minimum balance
-    /// requirements. Use `reserves::available_to_send` for a complete check.
-    pub fn can_afford_fee(account: &AccountEntry, fee: u64) -> bool {
-        // Account must have enough XLM to pay the fee
-        // considering selling liabilities
-        let available = available_balance(account);
-        available >= fee as i64
-    }
-
-    /// Calculate the available balance for fee payment.
-    ///
-    /// Returns the account balance minus selling liabilities. This represents
-    /// the maximum amount that could be used for fees without affecting
-    /// outstanding offers.
-    ///
-    /// # Note
-    ///
-    /// This does not subtract the minimum balance requirement. The returned
-    /// value may exceed what's actually spendable.
-    pub fn available_balance(account: &AccountEntry) -> i64 {
-        let selling_liabilities = match &account.ext {
-            stellar_xdr::curr::AccountEntryExt::V0 => 0,
-            stellar_xdr::curr::AccountEntryExt::V1(v1) => v1.liabilities.selling,
-        };
-
-        // Available = balance - selling_liabilities
-        // (reserves are checked separately)
-        account.balance - selling_liabilities
     }
 }
 
@@ -392,47 +301,6 @@ pub mod reserves {
             .saturating_sub(min_bal)
             .saturating_sub(sell_liab)
     }
-
-    /// Calculate the available capacity to receive XLM.
-    ///
-    /// This is the maximum amount of XLM that can be received by the account
-    /// before hitting the maximum balance limit (i64::MAX stroops).
-    ///
-    /// # Formula
-    ///
-    /// `i64::MAX - balance - buying_liabilities`
-    ///
-    /// # Returns
-    ///
-    /// The available receiving capacity in stroops.
-    pub fn available_to_receive(account: &AccountEntry) -> i64 {
-        let buy_liab = buying_liabilities(account);
-        i64::MAX
-            .saturating_sub(account.balance)
-            .saturating_sub(buy_liab)
-    }
-
-    /// Check if an account can afford to add a new sub-entry.
-    ///
-    /// Adding a sub-entry (trustline, offer, signer, or data entry) increases
-    /// the minimum balance requirement by one base reserve. This function
-    /// checks whether the account has sufficient balance to support the new entry.
-    ///
-    /// # Arguments
-    ///
-    /// * `account` - The account to check
-    /// * `base_reserve` - The network base reserve in stroops
-    ///
-    /// # Returns
-    ///
-    /// `true` if the account can afford the additional reserve requirement.
-    pub fn can_add_sub_entry(account: &AccountEntry, base_reserve: u32) -> bool {
-        let current_min = minimum_balance(account, base_reserve);
-        let new_min = current_min + base_reserve as i64;
-        let sell_liab = selling_liabilities(account);
-
-        account.balance >= new_min + sell_liab
-    }
 }
 
 /// Trustline liability and balance constraint utilities.
@@ -489,21 +357,6 @@ pub mod trustlines {
         trustline
             .balance
             .saturating_sub(selling_liabilities(trustline))
-    }
-
-    /// Calculate the available capacity to receive on a trustline.
-    ///
-    /// This is the maximum amount of the asset that can be received before
-    /// hitting the trustline limit, accounting for buying liabilities.
-    ///
-    /// # Formula
-    ///
-    /// `limit - balance - buying_liabilities`
-    pub fn available_to_receive(trustline: &TrustLineEntry) -> i64 {
-        trustline
-            .limit
-            .saturating_sub(trustline.balance)
-            .saturating_sub(buying_liabilities(trustline))
     }
 
     /// Check if adding `delta` to selling liabilities would be valid.
@@ -799,43 +652,6 @@ mod tests {
         assert_eq!(reserves::buying_liabilities(&v1), 500);
     }
 
-    /// Buying liabilities constrain available_to_receive.
-    /// Parity: LiabilitiesTests.cpp:451 "cannot increase liabilities above INT64_MAX minus balance"
-    #[test]
-    fn test_buying_liabilities_constrain_available_to_receive() {
-        // No liabilities: can receive up to i64::MAX - balance
-        let a = create_account_with_liabilities(100_000_000, 0, 0, 0);
-        assert_eq!(reserves::available_to_receive(&a), i64::MAX - 100_000_000);
-
-        // With buying liabilities: capacity reduced
-        let b = create_account_with_liabilities(100_000_000, 0, 0, 50_000_000);
-        assert_eq!(
-            reserves::available_to_receive(&b),
-            i64::MAX - 100_000_000 - 50_000_000
-        );
-
-        // Maximum buying liabilities: no room left
-        let c = create_account_with_liabilities(100_000_000, 0, 0, i64::MAX - 100_000_000);
-        assert_eq!(reserves::available_to_receive(&c), 0);
-    }
-
-    /// Limiting values for buying liabilities.
-    /// Parity: LiabilitiesTests.cpp:520 "limiting values"
-    #[test]
-    fn test_buying_liabilities_limiting_values() {
-        // INT64_MAX balance: cannot receive anything more
-        let max_bal = create_account_with_liabilities(i64::MAX, 0, 0, 0);
-        assert_eq!(reserves::available_to_receive(&max_bal), 0);
-
-        // INT64_MAX - 1 balance: can receive 1
-        let near_max = create_account_with_liabilities(i64::MAX - 1, 0, 0, 0);
-        assert_eq!(reserves::available_to_receive(&near_max), 1);
-
-        // Half balance, half buying liabilities: can receive 1
-        let half = create_account_with_liabilities(i64::MAX / 2, 0, 0, i64::MAX / 2);
-        assert_eq!(reserves::available_to_receive(&half), 1);
-    }
-
     /// Buying liabilities do not affect available_to_send.
     #[test]
     fn test_buying_liabilities_do_not_affect_sending() {
@@ -853,16 +669,6 @@ mod tests {
     // and new_balance + buying_liab <= INT64_MAX (for increases).
     // We test these constraints via available_to_send / available_to_receive.
     // =========================================================================
-
-    /// Balance can increase from below minimum.
-    /// Parity: LiabilitiesTests.cpp:920 "can increase balance from below minimum"
-    #[test]
-    fn test_balance_increase_from_below_minimum() {
-        // Account below reserve can receive funds (balance stays or increases)
-        let below = create_account_with_liabilities(min_balance(0) - 1, 0, 0, 0);
-        // Available to receive is still very large
-        assert!(reserves::available_to_receive(&below) > 0);
-    }
 
     /// Balance cannot decrease below reserve plus selling liabilities.
     /// Parity: LiabilitiesTests.cpp:939 "cannot decrease balance below reserve plus selling liabilities"
@@ -889,60 +695,10 @@ mod tests {
         assert_eq!(reserves::available_to_send(&maxed, BASE_RESERVE), 0);
     }
 
-    /// Balance cannot increase above INT64_MAX minus buying liabilities.
-    /// Parity: LiabilitiesTests.cpp:967 "cannot increase balance above INT64_MAX minus buying liabilities"
-    #[test]
-    fn test_balance_cannot_exceed_max_minus_buying() {
-        // Maximum balance, no liabilities: can't receive
-        let at_max = create_account_with_liabilities(i64::MAX, 0, 0, 0);
-        assert_eq!(reserves::available_to_receive(&at_max), 0);
-
-        // Below max, no liabilities: can receive 1
-        let near_max = create_account_with_liabilities(i64::MAX - 1, 0, 0, 0);
-        assert_eq!(reserves::available_to_receive(&near_max), 1);
-
-        // Below max, with buying liabilities: reduced capacity
-        let with_buy = create_account_with_liabilities(i64::MAX - 2, 0, 0, 1);
-        assert_eq!(reserves::available_to_receive(&with_buy), 1);
-
-        // Buying liabilities consume all capacity
-        let full = create_account_with_liabilities(i64::MAX - 1, 0, 0, 1);
-        assert_eq!(reserves::available_to_receive(&full), 0);
-    }
-
     // =========================================================================
     // P1-6: Account add sub-entries
     // Parity: LiabilitiesTests.cpp:989 "account add subentries"
     // =========================================================================
-
-    #[test]
-    fn test_can_add_sub_entry_basic() {
-        // Account with enough balance: can add
-        let account = create_test_account(min_balance(0) + BASE_RESERVE as i64, 0);
-        assert!(reserves::can_add_sub_entry(&account, BASE_RESERVE));
-
-        // Account at min balance: cannot add (needs one more base_reserve)
-        let at_min = create_test_account(min_balance(0), 0);
-        assert!(!reserves::can_add_sub_entry(&at_min, BASE_RESERVE));
-
-        // Account below min balance: cannot add
-        let below_min = create_test_account(min_balance(0) - 1, 0);
-        assert!(!reserves::can_add_sub_entry(&below_min, BASE_RESERVE));
-    }
-
-    /// Sub-entry addition with selling liabilities.
-    /// Parity: LiabilitiesTests.cpp:1119 "cannot increase sub entries when balance is insufficient"
-    #[test]
-    fn test_can_add_sub_entry_with_selling_liabilities() {
-        // Balance = min(0) + reserve + 100, selling = 100: can add
-        let a =
-            create_account_with_liabilities(min_balance(0) + BASE_RESERVE as i64 + 100, 0, 100, 0);
-        assert!(reserves::can_add_sub_entry(&a, BASE_RESERVE));
-
-        // Balance = min(0) + reserve, selling = 1: cannot add (selling eats into reserve)
-        let b = create_account_with_liabilities(min_balance(0) + BASE_RESERVE as i64, 0, 1, 0);
-        assert!(!reserves::can_add_sub_entry(&b, BASE_RESERVE));
-    }
 
     /// Can always decrease sub-entries (removing returns reserve).
     /// Parity: LiabilitiesTests.cpp:1104 "can decrease sub entries when below min balance"
@@ -975,8 +731,6 @@ mod tests {
         );
         // min_balance = (2+0+0-2)*5M = 0
         assert_eq!(reserves::minimum_balance(&sponsored, BASE_RESERVE), 0);
-        // can_add_sub_entry: new_min = 0 + 5M = 5M, balance = 5M, sell=0 → 5M >= 5M+0
-        assert!(reserves::can_add_sub_entry(&sponsored, BASE_RESERVE));
     }
 
     // =========================================================================
@@ -1042,42 +796,6 @@ mod tests {
         );
     }
 
-    /// Account available limit: considers buying liabilities.
-    /// Parity: LiabilitiesTests.cpp:1336 "account available limit"
-    #[test]
-    fn test_account_available_limit_comprehensive() {
-        // No liabilities: can receive up to MAX - balance
-        assert_eq!(
-            reserves::available_to_receive(&create_account_with_liabilities(1000, 0, 0, 0)),
-            i64::MAX - 1000
-        );
-
-        // Buying liabilities reduce receive capacity
-        assert_eq!(
-            reserves::available_to_receive(&create_account_with_liabilities(1000, 0, 0, 500)),
-            i64::MAX - 1500
-        );
-
-        // At max: nothing receivable
-        assert_eq!(
-            reserves::available_to_receive(&create_account_with_liabilities(i64::MAX, 0, 0, 0)),
-            0
-        );
-
-        // Selling liabilities don't affect receive capacity
-        assert_eq!(
-            reserves::available_to_receive(&create_account_with_liabilities(1000, 0, 500, 0)),
-            i64::MAX - 1000
-        );
-
-        // With sub-entries: available to receive is not affected by min_balance
-        // (buying capacity is just MAX - balance - buying_liab)
-        assert_eq!(
-            reserves::available_to_receive(&create_account_with_liabilities(1000, 5, 0, 0)),
-            i64::MAX - 1000
-        );
-    }
-
     /// Sponsorship interactions with available balance.
     /// Parity: LiabilitiesTests.cpp sponsoring/sponsored loops in addSellingLiabilities
     #[test]
@@ -1110,41 +828,6 @@ mod tests {
     }
 
     // =========================================================================
-    // Fee calculation tests (expanded)
-    // =========================================================================
-
-    #[test]
-    fn test_can_afford_fee() {
-        let account = create_test_account(10_000, 0);
-        assert!(fees::can_afford_fee(&account, 1000));
-        assert!(fees::can_afford_fee(&account, 10_000));
-        assert!(!fees::can_afford_fee(&account, 10_001));
-    }
-
-    /// Fee affordability with selling liabilities.
-    #[test]
-    fn test_can_afford_fee_with_selling_liabilities() {
-        // balance=10000, selling=5000 → available for fee = 5000
-        let a = create_account_with_liabilities(10_000, 0, 5_000, 0);
-        assert!(fees::can_afford_fee(&a, 5000));
-        assert!(!fees::can_afford_fee(&a, 5001));
-    }
-
-    /// Fee available_balance is balance minus selling liabilities.
-    #[test]
-    fn test_fees_available_balance() {
-        let v0 = create_test_account(100, 0);
-        assert_eq!(fees::available_balance(&v0), 100);
-
-        let v1 = create_account_with_liabilities(100, 0, 30, 0);
-        assert_eq!(fees::available_balance(&v1), 70);
-
-        // buying liabilities don't affect fee balance
-        let v1b = create_account_with_liabilities(100, 0, 0, 999);
-        assert_eq!(fees::available_balance(&v1b), 100);
-    }
-
-    // =========================================================================
     // P1 Available to send/receive edge cases
     // =========================================================================
 
@@ -1165,31 +848,13 @@ mod tests {
         assert_eq!(reserves::available_to_send(&b, BASE_RESERVE), 1 - min_100);
     }
 
-    /// available_to_receive: at MAX balance, capacity is 0; beyond that saturates.
-    #[test]
-    fn test_available_to_receive_at_max() {
-        let a = create_account_with_liabilities(i64::MAX, 0, 0, 0);
-        assert_eq!(reserves::available_to_receive(&a), 0);
-
-        // With buying liabilities at MAX balance, capacity goes negative
-        // (saturating_sub saturates at i64::MIN not 0)
-        let b = create_account_with_liabilities(i64::MAX, 0, 0, 1);
-        assert!(reserves::available_to_receive(&b) <= 0);
-    }
-
-    /// Test interaction between selling and buying liabilities.
+    /// Test that selling liabilities reduce available_to_send.
     #[test]
     fn test_selling_and_buying_liabilities_independent() {
         let a = create_account_with_liabilities(min_balance(0) + 1000, 0, 300, 500);
 
-        // Selling affects available_to_send
+        // Selling affects available_to_send (buying does not)
         assert_eq!(reserves::available_to_send(&a, BASE_RESERVE), 700);
-
-        // Buying affects available_to_receive
-        assert_eq!(
-            reserves::available_to_receive(&a),
-            i64::MAX - (min_balance(0) + 1000) - 500
-        );
     }
 
     // =========================================================================
@@ -1476,78 +1141,16 @@ mod tests {
         ));
     }
 
-    /// Trustline available_to_receive is limit - balance - buying_liabilities.
-    #[test]
-    fn test_trustline_available_to_receive() {
-        // No liabilities
-        let a = create_trustline_with_liabilities(1000, 5000, 0, 0);
-        assert_eq!(trustlines::available_to_receive(&a), 4000);
-
-        // With buying liabilities
-        let b = create_trustline_with_liabilities(1000, 5000, 0, 500);
-        assert_eq!(trustlines::available_to_receive(&b), 3500);
-
-        // Buying liabilities fill remaining capacity
-        let c = create_trustline_with_liabilities(1000, 5000, 0, 4000);
-        assert_eq!(trustlines::available_to_receive(&c), 0);
-
-        // At limit: no room
-        let d = create_trustline_with_liabilities(5000, 5000, 0, 0);
-        assert_eq!(trustlines::available_to_receive(&d), 0);
-
-        // V0 trustline: buying = 0
-        let e = create_trustline_v0(1000, 5000);
-        assert_eq!(trustlines::available_to_receive(&e), 4000);
-    }
-
-    /// Parity: LiabilitiesTests.cpp:1488 "trustline available limit"
-    #[test]
-    fn test_trustline_available_to_receive_comprehensive() {
-        // Zero balance, large limit: can receive up to limit
-        assert_eq!(
-            trustlines::available_to_receive(&create_trustline_with_liabilities(0, 1000, 0, 0)),
-            1000
-        );
-
-        // Buying liabilities don't affect selling side
-        let tl = create_trustline_with_liabilities(100, 200, 999, 50);
-        assert_eq!(trustlines::available_to_receive(&tl), 50);
-    }
-
-    /// Selling and buying liabilities are independent on trustlines.
+    /// Selling liabilities reduce trustline available_to_send.
     #[test]
     fn test_trustline_selling_and_buying_independent() {
         let tl = create_trustline_with_liabilities(500, 1000, 200, 300);
 
-        // Selling affects available_to_send
+        // Selling affects available_to_send (buying does not)
         assert_eq!(trustlines::available_to_send(&tl), 300);
-
-        // Buying affects available_to_receive
-        assert_eq!(trustlines::available_to_receive(&tl), 200);
-
-        // Changing selling doesn't affect receive
-        let tl2 = create_trustline_with_liabilities(500, 1000, 0, 300);
-        assert_eq!(trustlines::available_to_receive(&tl2), 200); // same
 
         // Changing buying doesn't affect send
         let tl3 = create_trustline_with_liabilities(500, 1000, 200, 0);
         assert_eq!(trustlines::available_to_send(&tl3), 300); // same
-    }
-
-    /// Parity: LiabilitiesTests.cpp:1512 "trustline minimum limit"
-    /// Tests that trustline limit must be at least balance + buying_liabilities.
-    #[test]
-    fn test_trustline_minimum_limit() {
-        // Trustline at exactly limit: available_to_receive = 0
-        let at_limit = create_trustline_with_liabilities(1000, 1000, 0, 0);
-        assert_eq!(trustlines::available_to_receive(&at_limit), 0);
-
-        // With buying liabilities at limit: no room at all
-        let over = create_trustline_with_liabilities(900, 1000, 0, 100);
-        assert_eq!(trustlines::available_to_receive(&over), 0);
-
-        // Just barely under: 1 unit of room
-        let barely = create_trustline_with_liabilities(900, 1000, 0, 99);
-        assert_eq!(trustlines::available_to_receive(&barely), 1);
     }
 }

--- a/crates/ledger/src/offer.rs
+++ b/crates/ledger/src/offer.rs
@@ -4,11 +4,10 @@
 //!
 //! - [`OfferDescriptor`]: A lightweight reference to an offer's price and ID
 //! - [`AssetPair`]: A trading pair of buying and selling assets
-//! - [`is_better_offer`]: Determine which offer has a better price
 //!
 //! # Offer Ordering
 //!
-//! Offers are ordered by:
+//! Offers are ordered by `OfferDescriptor`'s [`Ord`] impl:
 //! 1. **Price** (ascending) - Lower price is better (seller wants less of buying asset per selling asset)
 //! 2. **Offer ID** (ascending) - For equal prices, older offers (lower ID) have priority
 //!
@@ -18,7 +17,7 @@
 //! # Example
 //!
 //! ```
-//! use henyey_ledger::offer::{OfferDescriptor, is_better_offer};
+//! use henyey_ledger::offer::OfferDescriptor;
 //! use stellar_xdr::curr::Price;
 //!
 //! let offer1 = OfferDescriptor {
@@ -32,7 +31,7 @@
 //! };
 //!
 //! // offer1 is better because it has a lower price
-//! assert!(is_better_offer(&offer1, &offer2));
+//! assert!(offer1 < offer2);
 //! ```
 
 use std::hash::{Hash, Hasher};
@@ -127,37 +126,6 @@ impl Hash for OfferDescriptor {
     }
 }
 
-/// Check if the left offer is better than the right offer.
-///
-/// An offer is considered "better" if:
-/// 1. It has a lower price (n/d ratio), or
-/// 2. For equal prices, it has a lower offer ID (older offers have priority)
-///
-/// # Arguments
-///
-/// * `lhs` - The left-hand offer descriptor
-/// * `rhs` - The right-hand offer descriptor
-///
-/// # Returns
-///
-/// `true` if `lhs` is a better offer than `rhs`.
-///
-/// # Example
-///
-/// ```
-/// use henyey_ledger::offer::{OfferDescriptor, is_better_offer};
-/// use stellar_xdr::curr::Price;
-///
-/// let cheaper = OfferDescriptor::new(Price { n: 1, d: 2 }, 100);
-/// let expensive = OfferDescriptor::new(Price { n: 2, d: 3 }, 50);
-///
-/// assert!(is_better_offer(&cheaper, &expensive));
-/// assert!(!is_better_offer(&expensive, &cheaper));
-/// ```
-pub fn is_better_offer(lhs: &OfferDescriptor, rhs: &OfferDescriptor) -> bool {
-    lhs < rhs
-}
-
 /// A trading pair of assets.
 ///
 /// This struct represents a pair of assets being traded in the DEX:
@@ -197,27 +165,6 @@ impl Hash for AssetPair {
     }
 }
 
-/// A comparator for sorting offers by price then ID.
-///
-/// This can be used with sorted collections to maintain offers
-/// in their proper order.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct IsBetterOfferComparator;
-
-impl IsBetterOfferComparator {
-    /// Compare two offer descriptors.
-    ///
-    /// Returns `true` if `lhs` should come before `rhs` in sorted order.
-    pub fn compare(&self, lhs: &OfferDescriptor, rhs: &OfferDescriptor) -> bool {
-        is_better_offer(lhs, rhs)
-    }
-}
-
-/// Sort offer descriptors by price and ID.
-pub fn sort_offer_descriptors(offers: &mut [OfferDescriptor]) {
-    offers.sort();
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -243,35 +190,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_better_offer_by_price() {
-        let cheaper = make_descriptor(1, 2, 100); // price = 0.5
-        let expensive = make_descriptor(2, 3, 50); // price = 0.67
-
-        assert!(is_better_offer(&cheaper, &expensive));
-        assert!(!is_better_offer(&expensive, &cheaper));
-    }
-
-    #[test]
-    fn test_is_better_offer_by_id() {
-        let older = make_descriptor(1, 2, 100);
-        let newer = make_descriptor(1, 2, 200);
-
-        // Same price, older (lower ID) is better
-        assert!(is_better_offer(&older, &newer));
-        assert!(!is_better_offer(&newer, &older));
-    }
-
-    #[test]
-    fn test_is_better_offer_equal() {
-        let d1 = make_descriptor(1, 2, 100);
-        let d2 = make_descriptor(1, 2, 100);
-
-        // Neither is better than equal
-        assert!(!is_better_offer(&d1, &d2));
-        assert!(!is_better_offer(&d2, &d1));
-    }
-
-    #[test]
     fn test_offer_descriptor_ordering() {
         let mut offers = vec![
             make_descriptor(3, 4, 300), // price = 0.75
@@ -280,7 +198,8 @@ mod tests {
             make_descriptor(2, 3, 50),  // price = 0.67
         ];
 
-        sort_offer_descriptors(&mut offers);
+        // Production ordering is OfferDescriptor's `Ord` impl.
+        offers.sort();
 
         // Expected order: 0.5 (ID 100), 0.5 (ID 200), 0.67, 0.75
         assert_eq!(offers[0], make_descriptor(1, 2, 100));
@@ -333,17 +252,6 @@ mod tests {
         // Different pair should not match
         let different = AssetPair::new(credit.clone(), native.clone());
         assert_eq!(map.get(&different), None);
-    }
-
-    #[test]
-    fn test_is_better_offer_comparator() {
-        let comparator = IsBetterOfferComparator;
-
-        let better = make_descriptor(1, 2, 100);
-        let worse = make_descriptor(2, 3, 50);
-
-        assert!(comparator.compare(&better, &worse));
-        assert!(!comparator.compare(&worse, &better));
     }
 
     #[test]

--- a/crates/ledger/src/snapshot.rs
+++ b/crates/ledger/src/snapshot.rs
@@ -37,7 +37,7 @@ use crate::execution::SorobanNetworkInfo;
 /// Tracks hits at each cache layer and fallback lookups. Shared across
 /// clones of the same SnapshotHandle via `Arc`.
 #[derive(Debug, Default)]
-pub struct SnapshotLookupStats {
+pub(crate) struct SnapshotLookupStats {
     /// Lookups served by the built-in snapshot cache (`inner.get_entry()`).
     pub snapshot_cache_hits: AtomicU64,
     /// Lookups served by the prefetch/read-through cache.
@@ -59,7 +59,7 @@ impl SnapshotLookupStats {
 
 /// Statistics from a prefetch operation.
 #[derive(Debug, Default)]
-pub struct PrefetchStats {
+pub(crate) struct PrefetchStats {
     /// Number of keys that needed loading (not already cached).
     pub requested: usize,
     /// Number of entries actually loaded from the bucket list.
@@ -209,11 +209,6 @@ impl LedgerSnapshot {
         self.soroban_network_info.as_ref()
     }
 
-    /// Get the bucket list hash.
-    pub fn bucket_list_hash(&self) -> Hash256 {
-        Hash256::from(self.header.bucket_list_hash.0)
-    }
-
     /// Look up an entry by key.
     pub fn get_entry(&self, key: &LedgerKey) -> Option<&LedgerEntry> {
         self.entries.get(key)
@@ -244,11 +239,6 @@ impl LedgerSnapshot {
     /// from the previous ledger, so that new offers get the correct IDs.
     pub fn set_id_pool(&mut self, id_pool: u64) {
         self.header.id_pool = id_pool;
-    }
-
-    /// Get the number of cached entries.
-    pub fn num_entries(&self) -> usize {
-        self.entries.len()
     }
 
     /// Iterate over all cached entries.
@@ -574,7 +564,7 @@ impl SnapshotHandle {
     ///
     /// Uses batch_lookup_fn for a single bucket list traversal.
     /// Keys already in the snapshot cache or prefetch cache are skipped.
-    pub fn prefetch(&self, keys: &[LedgerKey]) -> Result<PrefetchStats> {
+    pub(crate) fn prefetch(&self, keys: &[LedgerKey]) -> Result<PrefetchStats> {
         let mut needed = Vec::new();
         let cache = self.prefetch_cache.read();
 
@@ -626,7 +616,7 @@ impl SnapshotHandle {
     }
 
     /// Return the shared lookup statistics.
-    pub fn lookup_stats(&self) -> &SnapshotLookupStats {
+    pub(crate) fn lookup_stats(&self) -> &SnapshotLookupStats {
         &self.stats
     }
 


### PR DESCRIPTION
Closes #3443

## Summary

Pure cleanup of `henyey-ledger`: delete unreachable dead code and narrow over-broad `pub` visibility to `pub(crate)`. Net behavioral diff = 0 (deletion-heavy: ~559 deletions, ~34 insertions). Every disposition was build-verified with `cargo build -p henyey-ledger --all-targets` under `-Dwarnings`. The stale F1 finding (`apply_refund_to_account`) is dropped — it has a live production caller at `execution/tx_set.rs`.

### Per-finding outcome (build-verified)

- **F2** — delete dead `LedgerSnapshot::bucket_list_hash()` / `num_entries()` (0 callers).
- **F3** — drop dead root re-exports (`SortState`, `TxWithFee`, `CacheInitResult`, soroban_state map/config/stats types, `SKIP_1..4`, `SKIP_LIST_SIZE`, `is_before_protocol_version`); cascade-delete the now-orphaned `header.rs` `SKIP_LIST_SIZE` + `is_before_protocol_version` defs. `SKIP_1..4` defs kept (live in-crate). `StartupPhase`/`StartupPeakRssSampler` kept (external use via `peak_rss_sampler::*`).
- **F4** — narrow `SnapshotLookupStats`/`PrefetchStats` and their exposing methods `prefetch()`/`lookup_stats()` to `pub(crate)` (narrowing the structs alone fails `private_interfaces`).
- **F5** — narrow 5 of 8 execution symbols (`HotArchiveLookupImpl`, `SignatureTracker`, `PriorStageState`, `ClusterParams`, `warm_module_cache_from_entries`) to `pub(crate)`; keep `TxExecTimings`, `TransactionExecutionRequest`, `TxSetResult` `pub` (reachable via genuine public API).
- **F6** — delete dead `fees::{calculate_fee,can_afford_fee,available_balance}` + their tests (the whole `fees` module is now empty and removed). cfg(test)-only callers do not keep a `pub(crate)` alive under `-Dwarnings`, so delete-with-tests is the behavior-neutral choice.
- **F7** — delete dead `reserves::{available_to_receive,can_add_sub_entry}` and `trustlines::available_to_receive` + their tests; keep live `reserves::available_to_send` and all other reserve/trustline helpers + shared test helpers.
- **F8** — delete dead `offer::{is_better_offer,IsBetterOfferComparator,sort_offer_descriptors}` + their tests; production ordering is `OfferDescriptor::Ord` (kept). `test_offer_descriptor_ordering` converted to use `.sort()` so the surviving `Ord` path stays covered.

### PARITY_STATUS.md (per-row reword vs delete)

- **Reworded (stay Full via surviving symbol):** `isBetterOffer()` → `Ord impl on OfferDescriptor`; `Protocol version utilities` → `protocol_version()` only.
- **Deleted rows (no surviving Rust mirror):** `Fee calculation` / `fees::calculate_fee()`, `Available balance for fees` / `fees::available_balance()`, `Available to receive` / `reserves::available_to_receive()`, `Sub-entry affordability` / `reserves::can_add_sub_entry()`, `getMaxAmountReceive()` / `trustlines::available_to_receive()`.
- **Unchanged:** offer rows backed by `Ord`, `minimum_balance`, `available_to_send`, liabilities, and soroban_state type rows (defs kept; only root re-export dropped).
- Updated Full count 139 → 134 and the breakdown text (fee/reserve 8→4, trustline 7→6). Parity stays 94%.

Also updated downstream doc references to the deleted symbols (crate-level doc, `offer.rs` module doctest, ledger `README.md`).

## Parity ruling

Nothing touches live ledger-close sequencing, fee computation (`charge_fees()`/`processFeesSeqNums`), hash computation, or bucket-list assembly. The deleted symbols were parity-mirror utilities with only `#[cfg(test)]` callers; the authoritative live paths are unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3443#issuecomment-4748674966)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo build -p henyey-ledger --all-targets` under `-Dwarnings` — clean
- [x] `cargo test -p henyey-ledger` — all pass (476 lib unit tests + integration + doctests)
- [x] `cargo build --all` — clean
- [x] `cargo clippy --all -- -D warnings` — clean

## Deviations from plan

None. (Plan-implied downstream doc/doctest fixes for the deleted symbols were applied to keep the build warning-clean and doctests green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)