### PR TITLE
Clean up henyey-common: Copy derives, frame codec rewrite, narrow visibility, delete dead numerics

### DIFF
--- a/crates/common/PARITY_STATUS.md
+++ b/crates/common/PARITY_STATUS.md
@@ -96,12 +96,19 @@ Corresponds to: `numeric.h`, `numeric128.h`
 | `doubleToClampedUint32()` | `double_to_clamped_u32()` | Full |
 | `bigDivide()` | `big_divide()` | Full |
 | `bigDivideUnsigned()` | `big_divide_unsigned()` | Full |
-| `bigSquareRoot()` | `big_square_root()` | Full |
+| `bigSquareRoot()` | — | N/A |
 | `saturatingMultiply()` | `saturating_multiply()` | Full |
 | `bigDivide128()` | `big_divide_128()` | Full |
 | `bigDivideUnsigned128()` | `big_divide_unsigned_128()` | Full |
 | `bigMultiplyUnsigned()` | `big_multiply_unsigned()` | Full |
-| `bigMultiply()` | `big_multiply()` | Full |
+| `bigMultiply()` | — | N/A |
+
+> **N/A — `bigSquareRoot()` / `bigMultiply()`:** the `henyey-common` placeholders
+> were never wired to production and have been removed. The live numeric paths use
+> distinct `henyey-tx`-local helpers with different signatures
+> (`offer_exchange.rs::big_multiply` → `i128` saturating; `liquidity_pool.rs::big_square_root`
+> on `i64`), so a shared `henyey-common` implementation is not currently consumed.
+> Reintroduce a unified helper if a shared consumer appears.
 
 ### resource (`resource.rs`)
 

--- a/crates/common/src/math.rs
+++ b/crates/common/src/math.rs
@@ -38,7 +38,7 @@ pub enum Rounding {
 }
 
 /// Error type for math operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MathError {
     /// The result overflows the target type.
     Overflow,
@@ -219,21 +219,6 @@ pub(crate) fn big_multiply_unsigned(a: u64, b: u64) -> u128 {
     (a as u128) * (b as u128)
 }
 
-/// Multiplies two non-negative i64 values, returning a u128 result.
-///
-/// # Panics
-///
-/// Panics if either input is negative.
-#[inline]
-#[allow(dead_code)] // Parity with stellar-core; not yet called in production
-pub(crate) fn big_multiply(a: i64, b: i64) -> u128 {
-    assert!(
-        a >= 0 && b >= 0,
-        "big_multiply requires non-negative inputs"
-    );
-    big_multiply_unsigned(a as u64, b as u64)
-}
-
 /// Saturating multiplication: returns `a * b`, capped at `i64::MAX` on overflow.
 ///
 /// Both inputs must be non-negative.
@@ -294,70 +279,6 @@ pub(crate) fn double_to_clamped_u32(d: f64) -> u32 {
         return u32::MAX;
     }
     d.clamp(0.0, u32::MAX as f64) as u32
-}
-
-/// Computes the integer square root of `a * b`.
-///
-/// Returns x such that `x * x <= a * b < (x + 1) * (x + 1)`.
-///
-/// Uses the modified Babylonian method with 128-bit precision.
-#[allow(dead_code)] // Parity with stellar-core; not yet called in production
-pub(crate) fn big_square_root(a: u64, b: u64) -> u64 {
-    if a == 0 || b == 0 {
-        return 0;
-    }
-
-    let sqrt_ceil = big_square_root_ceil(a, b);
-
-    // Check if sqrt_ceil is exact
-    if big_multiply_unsigned(sqrt_ceil, sqrt_ceil) <= big_multiply_unsigned(a, b) {
-        return sqrt_ceil;
-    }
-
-    // sqrt_ceil > 0 because 0*0 <= a*b for all a, b
-    sqrt_ceil - 1
-}
-
-/// Computes ceil(sqrt(a * b)) using the modified Babylonian method.
-#[allow(dead_code)] // Called only by big_square_root (which is parity-only)
-fn big_square_root_ceil(a: u64, b: u64) -> u64 {
-    if a == 0 || b == 0 {
-        return 0;
-    }
-
-    // R = a * b - 1
-    let r = big_multiply_unsigned(a, b) - 1;
-
-    // Seed with a reasonable estimate: 2^(ceil(bits/2))
-    let num_bits = 128 - r.leading_zeros();
-    let seed_bits = num_bits.div_ceil(2);
-    let mut x = if seed_bits >= 64 {
-        u64::MAX
-    } else {
-        1u64 << seed_bits
-    };
-
-    let mut prev = 0u64;
-    while x != prev {
-        prev = x;
-
-        // y = ceil(R / x)
-        let y = match big_divide_unsigned_128(r, x, Rounding::Up) {
-            Ok(v) => v,
-            Err(_) => return x, // Overflow means we're done
-        };
-
-        // x = ceil((x + y) / 2)
-        if u64::MAX - x <= y {
-            // Handle potential overflow
-            let temp = (x as u128) + (y as u128);
-            x = temp.div_ceil(2) as u64;
-        } else {
-            x = (x + y).div_ceil(2);
-        }
-    }
-
-    x
 }
 
 #[cfg(test)]
@@ -474,40 +395,6 @@ mod tests {
             big_multiply_unsigned(u64::MAX, u64::MAX),
             (u64::MAX as u128) * (u64::MAX as u128)
         );
-    }
-
-    #[test]
-    fn test_big_square_root() {
-        // sqrt(100) = 10
-        assert_eq!(big_square_root(100, 1), 10);
-        assert_eq!(big_square_root(10, 10), 10);
-
-        // sqrt(99) = 9 (floor)
-        assert_eq!(big_square_root(99, 1), 9);
-
-        // sqrt(0) = 0
-        assert_eq!(big_square_root(0, 100), 0);
-        assert_eq!(big_square_root(100, 0), 0);
-
-        // sqrt(1) = 1
-        assert_eq!(big_square_root(1, 1), 1);
-
-        // sqrt(4) = 2
-        assert_eq!(big_square_root(4, 1), 2);
-        assert_eq!(big_square_root(2, 2), 2);
-    }
-
-    #[test]
-    fn test_big_square_root_large() {
-        // sqrt(10^18) = 10^9
-        let result = big_square_root(1_000_000_000, 1_000_000_000);
-        assert_eq!(result, 1_000_000_000);
-
-        // sqrt(10^18 - 1) should be 10^9 - 1 or close
-        let result = big_square_root(999_999_999, 1_000_000_001);
-        // 999999999 * 1000000001 = 10^18 - 1
-        // sqrt should be very close to 10^9
-        assert!(result >= 999_999_999 && result <= 1_000_000_000);
     }
 
     #[test]

--- a/crates/common/src/resource.rs
+++ b/crates/common/src/resource.rs
@@ -41,7 +41,7 @@ use std::ops::{Add, AddAssign, Sub, SubAssign};
 use crate::math::is_representable_as_i64;
 
 /// Error type for checked Resource arithmetic operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResourceError {
     /// The two Resources have different numbers of dimensions.
     SizeMismatch { lhs: usize, rhs: usize },

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -121,7 +121,7 @@ impl Hash256 {
     /// Prefer [`hash_xdr`] in production code where encoding failure is an
     /// invariant violation. Use this only when the caller genuinely needs to
     /// handle the error (e.g. encoding untrusted or partially-constructed data).
-    pub fn try_hash_xdr<T: stellar_xdr::curr::WriteXdr>(
+    pub(crate) fn try_hash_xdr<T: stellar_xdr::curr::WriteXdr>(
         value: &T,
     ) -> Result<Self, stellar_xdr::curr::Error> {
         use stellar_xdr::curr::Limited;

--- a/crates/common/src/xdr_stream.rs
+++ b/crates/common/src/xdr_stream.rs
@@ -77,20 +77,23 @@ pub fn xdr_encoded_len_u32(val: &impl WriteXdr) -> u32 {
 
 #[inline]
 fn encode_frame_header(size: u32) -> [u8; 4] {
-    [
-        ((size >> 24) & 0xFF) as u8 | FRAME_CONTINUATION_BIT,
-        ((size >> 16) & 0xFF) as u8,
-        ((size >> 8) & 0xFF) as u8,
-        (size & 0xFF) as u8,
-    ]
+    // Big-endian layout (MSB first), with the continuation bit OR'd into byte 0.
+    // Matches stellar-core `XDROutputFileStream::writeOne` record marking.
+    let mut header = size.to_be_bytes();
+    header[0] |= FRAME_CONTINUATION_BIT;
+    header
 }
 
 #[inline]
 fn decode_frame_size(header: [u8; 4]) -> u32 {
-    (((header[0] & !FRAME_CONTINUATION_BIT) as u32) << 24)
-        | ((header[1] as u32) << 16)
-        | ((header[2] as u32) << 8)
-        | (header[3] as u32)
+    // Strip the continuation bit from the MSB, then reassemble big-endian.
+    // Matches stellar-core `XDRInputFileStream::getXDRSize`.
+    u32::from_be_bytes([
+        header[0] & !FRAME_CONTINUATION_BIT,
+        header[1],
+        header[2],
+        header[3],
+    ])
 }
 
 /// Serialize a value to XDR and write it as a size-prefixed frame.


### PR DESCRIPTION
Closes #3452

## Summary

Applies the five re-verified `henyey-common` second-sweep cleanup findings, net behavior change = 0 (except the additive `Copy` derives). Re-verified against `origin/main` baseline `f01d489a`.

- **F1** — `math.rs` `MathError`: added `Copy` to the derive (3 unit variants; strict superset, parity-neutral).
- **F2** — `resource.rs` `ResourceError`: added `Copy` (usize-only variants; consumed by-ref cross-crate in herder, so purely additive).
- **F3** — `xdr_stream.rs`: rewrote `encode_frame_header`/`decode_frame_size` via `u32::to_be_bytes`/`from_be_bytes` with the continuation-bit OR/AND on byte 0. **Byte-identical** to the prior hand-rolled big-endian codec and to stellar-core `XDRStream.h` (`writeOne` 496–499 / `getXDRSize` 115–123); the `sz < MAX_FRAME_SIZE` assert is preserved. Roundtrip tests unchanged and passing.
- **F4** — `types.rs`: narrowed `try_hash_xdr` from `pub` to `pub(crate)` (in-crate `hash_xdr` keeps it alive under `-Dwarnings`; zero external callers; no `crates/common/tests/` dir, so no E0624).
- **F5** — `math.rs`: deleted the genuinely-dead `big_multiply(i64)` wrapper and the production-dead `big_square_root`/`big_square_root_ceil` plus their two unit tests. Kept `big_multiply_unsigned` and `test_big_multiply`. Marked the two deleted `numeric.h` rows N/A in `PARITY_STATUS.md` (the live numeric ops use distinct `henyey-tx`-local namesakes with different signatures; unify deferred).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3452#issuecomment-4749033482)

## Test plan

- [x] `RUSTFLAGS=-Dwarnings cargo build --workspace --all-targets` — GREEN across all crates (workspace-wide-depended crate)
- [x] `cargo test -p henyey-common` — 212 lib + 38 doc pass, 0 fail (incl. F3 xdr_stream roundtrip + F4 try_hash_xdr tests)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)