### PR TITLE
Narrow visibility and remove dead deprecated APIs in henyey-bucket

### DIFF
--- a/crates/bucket/SPEC_ADHERENCE.md
+++ b/crates/bucket/SPEC_ADHERENCE.md
@@ -189,12 +189,14 @@ that mirrors stellar-core's `BucketOutputIterator::maybePut`.
 
 ### §7.1 FutureBucket State Machine
 The state diagram (Clear, HashOutput, HashInputs, LiveOutput, LiveInputs)
-is implemented at `future_bucket.rs:279-308` as a Rust enum
-(`FutureBucketInner`) where each variant carries exactly the fields it
-needs — making the spec's "invalid" combinations unrepresentable. The
-`check_state()` method at line 444-473 is retained for API compatibility
-but is now a no-op (deprecated, asserts only hash/bucket consistency
-in debug builds).
+is implemented as a Rust enum (`FutureBucketInner`) where each variant
+carries exactly the fields it needs — making the spec's "invalid"
+combinations unrepresentable at compile time. Consequently there is no
+runtime invariant-checker: stellar-core's `FutureBucket::checkState()`
+(and the `mInputCurrBucket`/`mInputSnapBucket` it `releaseAssert`s over)
+have no henyey counterpart because the enum design renders the invalid
+states it guards against unconstructable. The `LiveMerging` variant
+therefore retains only the input *hashes*, not the input buckets.
 
 ### §7.3 MergeKey
 `MergeKey` at `future_bucket.rs:81-99` is `(keep_tombstones, curr_hash, snap_hash)`.

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -79,9 +79,6 @@ use henyey_common::{is_persistent_entry, is_soroban_entry, is_temporary_entry};
 /// Number of levels in the BucketList (matches stellar-core's `kNumLevels`).
 pub const BUCKET_LIST_LEVELS: usize = 11;
 
-// HAS_NEXT_STATE constants moved to crates/history/src/archive_state.rs
-// (they are HAS-JSON-format concerns, not bucket-domain concepts)
-
 // ============================================================================
 // Bucket list arithmetic helpers (shared by BucketList and HotArchiveBucketList)
 // ============================================================================
@@ -2190,17 +2187,13 @@ impl BucketList {
 
     /// Return all live entries as of the current bucket list state.
     ///
-    /// # Deprecation
-    ///
-    /// This method materializes all entries into memory, which is problematic
-    /// for mainnet scale (~60M entries = ~52 GB RAM). Prefer using
-    /// [`live_entries_iter()`](Self::live_entries_iter) for memory-efficient
-    /// streaming iteration.
-    #[deprecated(
-        since = "0.2.0",
-        note = "Use live_entries_iter() for memory-efficient streaming iteration"
-    )]
-    pub fn live_entries(&self) -> Result<Vec<LedgerEntry>> {
+    /// Test-only materializing oracle: it collects every live entry into memory
+    /// (~52 GB at mainnet scale), so production code uses the streaming
+    /// [`live_entries_iter()`](Self::live_entries_iter) instead. This helper is
+    /// retained solely as an independent cross-check for the iterator in
+    /// `live_iterator::tests::test_matches_live_entries`.
+    #[cfg(test)]
+    pub(crate) fn live_entries(&self) -> Result<Vec<LedgerEntry>> {
         let mut seen: HashSet<Vec<u8>> = HashSet::new();
         let mut entries = Vec::new();
 

--- a/crates/bucket/src/eviction.rs
+++ b/crates/bucket/src/eviction.rs
@@ -604,7 +604,7 @@ pub(crate) fn bucket_update_period(level: u32, is_curr: bool) -> u32 {
 /// scanSize < bucket.getSize()`, the bucket is too large to fully scan within
 /// its update period, so the scan can never complete a pass over it. Returns
 /// `true` in that "stuck" case so the caller can record an incomplete-scan.
-pub fn eviction_scan_is_stuck(
+pub(crate) fn eviction_scan_is_stuck(
     iter: &EvictionIterator,
     scan_size: u32,
     bucket_byte_size: u64,

--- a/crates/bucket/src/future_bucket.rs
+++ b/crates/bucket/src/future_bucket.rs
@@ -296,10 +296,17 @@ enum FutureBucketInner {
         output_hash: Hash256,
     },
 
-    /// Async merge in progress with live input references.
+    /// Async merge in progress.
+    ///
+    /// Only the input *hashes* are retained, not the input buckets themselves:
+    /// the merge task consumes its own clones of the inputs, and snapshot
+    /// serialization persists only the hex hashes. This diverges from
+    /// stellar-core's `FutureBucket`, which keeps `mInputCurrBucket`/
+    /// `mInputSnapBucket` solely so `checkState()` can `releaseAssert` the live
+    /// bucket hashes match the stored hashes. Here the enum makes those invalid
+    /// state combinations unrepresentable, so the input-bucket mirrors (and the
+    /// runtime check that read them) are unnecessary.
     LiveMerging {
-        curr: Arc<Bucket>,
-        snap: Arc<Bucket>,
         curr_hash: Hash256,
         snap_hash: Hash256,
         merge_handle: MergeHandle,
@@ -367,8 +374,6 @@ impl FutureBucket {
 
         Self {
             inner: FutureBucketInner::LiveMerging {
-                curr,
-                snap,
                 curr_hash,
                 snap_hash,
                 merge_handle: MergeHandle::new(receiver),
@@ -439,37 +444,6 @@ impl FutureBucket {
             FutureBucketInner::LiveOutput { .. } => FutureBucketState::LiveOutput,
             FutureBucketInner::LiveMerging { .. } => FutureBucketState::LiveInputs,
         }
-    }
-
-    /// Validate internal field invariants for the current state.
-    ///
-    /// With the enum-based design, invalid states are unrepresentable at compile
-    /// time. This method is retained for API compatibility but always returns Ok.
-    ///
-    /// Spec: BUCKETLISTDB_SPEC §7.1 — FutureBucket state validation.
-    #[deprecated(note = "Invariants are now enforced at compile time by the enum design")]
-    pub fn check_state(&self) -> Result<()> {
-        // Hash consistency assertions in debug builds
-        debug_assert!(
-            {
-                match &self.inner {
-                    FutureBucketInner::LiveOutput {
-                        output,
-                        output_hash,
-                    } => output.hash() == *output_hash,
-                    FutureBucketInner::LiveMerging {
-                        curr,
-                        snap,
-                        curr_hash,
-                        snap_hash,
-                        ..
-                    } => curr.hash() == *curr_hash && snap.hash() == *snap_hash,
-                    _ => true,
-                }
-            },
-            "hash/bucket consistency violated"
-        );
-        Ok(())
     }
 
     /// Check if this FutureBucket is in a live state (has bucket references).
@@ -744,8 +718,6 @@ impl FutureBucket {
                 });
 
                 self.inner = FutureBucketInner::LiveMerging {
-                    curr,
-                    snap,
                     curr_hash: ch,
                     snap_hash: sh,
                     merge_handle: MergeHandle::new(receiver),
@@ -840,8 +812,6 @@ impl FutureBucket {
             inner: FutureBucketInner::LiveMerging {
                 curr_hash: curr.hash(),
                 snap_hash: snap.hash(),
-                curr,
-                snap,
                 merge_handle,
                 keep_tombstones: DeadEntryPolicy::Keep,
             },
@@ -1592,18 +1562,6 @@ mod tests {
         assert_eq!(fb.state(), FutureBucketState::LiveInputs);
         assert!(fb.is_merging());
         assert!(fb.is_live());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_check_state_always_ok() {
-        let fb = FutureBucket::clear();
-        assert!(fb.check_state().is_ok());
-
-        let entry = make_account_entry([1u8; 32], 100);
-        let bucket = Arc::new(Bucket::from_entries(vec![BucketEntry::Liveentry(entry)]).unwrap());
-        let fb = FutureBucket::from_output(bucket);
-        assert!(fb.check_state().is_ok());
     }
 
     #[test]

--- a/crates/bucket/src/live_iterator.rs
+++ b/crates/bucket/src/live_iterator.rs
@@ -514,7 +514,6 @@ mod tests {
         }
 
         // Get entries via both methods
-        #[allow(deprecated)]
         let old_entries = bucket_list.live_entries().unwrap();
         let new_entries: Vec<_> = LiveEntriesIterator::new(&bucket_list)
             .collect::<Result<Vec<_>>>()

--- a/crates/bucket/src/merge.rs
+++ b/crates/bucket/src/merge.rs
@@ -605,7 +605,6 @@ pub fn merge_in_memory(
     let old_entries = old_bucket.get_in_memory_entries().unwrap();
     let new_entries = new_bucket.get_in_memory_entries().unwrap();
 
-    // DEBUG: Print merge inputs
     tracing::debug!(
         old_entries_count = old_entries.len(),
         new_entries_count = new_entries.len(),
@@ -659,7 +658,7 @@ pub fn merge_in_memory(
         // Serialize entry for hash using reusable buffer
         entry_buf.clear();
         {
-            let mut limited = Limited::new(&mut entry_buf as &mut Vec<u8>, Limits::none());
+            let mut limited = Limited::new(&mut entry_buf, Limits::none());
             entry.write_xdr(&mut limited).map_err(|e| {
                 BucketError::Serialization(format!("Failed to serialize entry: {}", e))
             })?;
@@ -713,7 +712,6 @@ pub fn merge_in_memory(
     // Compute final hash
     let hash = Hash256::from_sha256(hasher);
 
-    // DEBUG: Print merge output
     tracing::debug!(
         merged_count = all_entries.len(),
         has_meta = all_entries.first().map(|e| e.is_metadata()).unwrap_or(false),


### PR DESCRIPTION
Closes #3451

## Summary

Six low-severity `henyey-bucket` cleanups from a /cleanup audit, all build-verified under `-Dwarnings`; net behavioral diff = 0. `crate:bucket` is determinism-critical, but none of these alter live hash/merge/persist output.

- **F1** `eviction.rs` — `eviction_scan_is_stuck` `pub` → `pub(crate)` (all callers in-crate; non-test caller at `bucket_list.rs:3587` keeps it lib-live, no E0624).
- **F2** `future_bucket.rs` — deleted the deprecated `check_state` method + its in-file test. **Cascade:** removing `check_state` made the `LiveMerging` variant's `curr`/`snap` `Arc<Bucket>` fields dead (the `debug_assert!` was their sole reader), so those two fields and the three construction sites that set them were also removed. Parity-neutral: the merge consumes its own clones of the inputs and `to_snapshot` persists only hex hashes, so the stash was write-only. Documented the divergence from stellar-core (which keeps `mInputCurr/SnapBucket` only for `checkState`'s `releaseAssert`) in `SPEC_ADHERENCE.md` §7.1 + the variant doc.
- **F3** `bucket_list.rs` — deprecated `pub fn live_entries` → `#[cfg(test)] pub(crate)` (NOT deleted) to keep the `live_iterator` oracle test `test_matches_live_entries`. `pub(crate)` is required: a private `#[cfg(test)] fn` fails E0624 across the `bucket_list`→`live_iterator` module boundary.
- **F4** `bucket_list.rs` — deleted the stale HAS_NEXT_STATE tombstone comment.
- **F5** `merge.rs` — deleted two `// DEBUG:` scaffolding comments (kept the `tracing::debug!` lines).
- **F6** `merge.rs` — dropped the redundant `as &mut Vec<u8>` identity reborrow; byte-identical serialized output (53 merge hash tests pass).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3451#issuecomment-4749021785)

## Test plan

- [x] `cargo build -p henyey-bucket --all-targets` under `-Dwarnings` — clean
- [x] `cargo test -p henyey-bucket` — 507 + 32 + 5 + 6 pass (incl. the 53 merge tests, 24 future_bucket tests, and the `test_matches_live_entries` oracle)
- [x] `cargo build --all` — clean
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Deviations from plan

None. Implemented exactly as the converged plan specified (F1–F6 including the F2 field cascade and F3 `#[cfg(test)] pub(crate)` disposition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)