### PR TITLE
Narrow visibility and fix stale doc comments in henyey-app

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -1,4 +1,4 @@
-//! Core application struct and component initialization for rs-stellar-core.
+//! Core application struct and component initialization for henyey.
 //!
 //! This module contains the [`App`] struct, which is the central coordinator for all
 //! Stellar Core subsystems. It manages the lifecycle of:

--- a/crates/app/src/catchup_cmd.rs
+++ b/crates/app/src/catchup_cmd.rs
@@ -1,4 +1,4 @@
-//! Catchup command implementation for rs-stellar-core.
+//! Catchup command implementation for henyey.
 //!
 //! The catchup command synchronizes a node with the Stellar network by downloading
 //! ledger history from archives and applying it to rebuild local state. This is
@@ -11,9 +11,9 @@
 //! # Command Line Usage
 //!
 //! ```text
-//! rs-stellar-core catchup current        # Catch up to the latest ledger
-//! rs-stellar-core catchup 1000000        # Catch up to ledger 1000000
-//! rs-stellar-core catchup 1000000/100    # Catch up to ledger 1000000 with 100 ledgers history
+//! henyey catchup current        # Catch up to the latest ledger
+//! henyey catchup 1000000        # Catch up to ledger 1000000
+//! henyey catchup 1000000/100    # Catch up to ledger 1000000 with 100 ledgers history
 //! ```
 //!
 //! # Catchup Modes

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -1,4 +1,4 @@
-//! Configuration loading and validation for rs-stellar-core.
+//! Configuration loading and validation for henyey.
 //!
 //! This module provides a comprehensive configuration system that supports:
 //!

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,4 +1,4 @@
-//! Application orchestration for rs-stellar-core.
+//! Application orchestration for henyey.
 //!
 //! This crate provides the top-level application layer that wires together all
 //! subsystems of a Stellar Core node. It is responsible for:
@@ -71,7 +71,7 @@ pub mod survey;
 pub use app::bootstrap::{initialize_genesis, GenesisConfig};
 pub use app::{App, AppState, FallbackCatchup, LedgerSummary, RestoreResult, SimulationDebugStats};
 pub use catchup_cmd::{run_catchup, CatchupMode, CatchupOptions};
-pub use config::{AppConfig, BuildMetadata, MaintenanceAppConfig};
+pub use config::{AppConfig, BuildMetadata};
 pub use logging::{LogConfig, LogFormat};
 pub use run_cmd::{run_node, ExtraServerSpawner, RunMode, RunOptions};
 

--- a/crates/app/src/logging.rs
+++ b/crates/app/src/logging.rs
@@ -1,4 +1,4 @@
-//! Logging setup and progress tracking for rs-stellar-core.
+//! Logging setup and progress tracking for henyey.
 //!
 //! This module provides:
 //!

--- a/crates/app/src/maintainer.rs
+++ b/crates/app/src/maintainer.rs
@@ -1,4 +1,4 @@
-//! Database maintenance scheduler for rs-stellar-core.
+//! Database maintenance scheduler for henyey.
 //!
 //! The Maintainer is responsible for periodically cleaning up old data from the
 //! database to prevent unbounded growth. It runs in the background and performs

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -14,8 +14,6 @@
 //! invocation below. The macro generates the public constant, description,
 //! pre-registration, and test inventory from that one declaration.
 
-use std::sync::OnceLock;
-
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
@@ -1506,7 +1504,9 @@ fn configure_histogram_buckets(builder: PrometheusBuilder) -> PrometheusBuilder 
 /// The `metrics` global recorder is one-shot per process. Since Rust tests
 /// run in parallel within the same process, this helper ensures the recorder
 /// is installed exactly once. Subsequent calls return the same handle.
-pub fn ensure_test_recorder() -> &'static PrometheusHandle {
+#[cfg(test)]
+pub(crate) fn ensure_test_recorder() -> &'static PrometheusHandle {
+    use std::sync::OnceLock;
     static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
     HANDLE.get_or_init(|| {
         configure_histogram_buckets(PrometheusBuilder::new())

--- a/crates/app/src/run_cmd.rs
+++ b/crates/app/src/run_cmd.rs
@@ -1,4 +1,4 @@
-//! Run command implementation for rs-stellar-core.
+//! Run command implementation for henyey.
 //!
 //! The run command starts the node and keeps it synchronized with the network.
 //! This is the primary operational mode for a Stellar Core node.
@@ -15,9 +15,9 @@
 //! # Command Line Usage
 //!
 //! ```text
-//! rs-stellar-core run                    # Run as a full node
-//! rs-stellar-core run --validator        # Run as a validator
-//! rs-stellar-core run --watcher          # Run as a watcher (no catchup)
+//! henyey run                    # Run as a full node
+//! henyey run --validator        # Run as a validator
+//! henyey run --watcher          # Run as a watcher (no catchup)
 //! ```
 //!
 //! # Running Modes


### PR DESCRIPTION
Closes #3450

## Summary

Behavior-preserving cleanup in `crate:app` (net observable diff = 0), implementing the converged plan's three taken findings:

- **F1** — drop the unused `MaintenanceAppConfig` from the `pub use config::{…}` re-export in `lib.rs`. It has 0 `henyey_app::MaintenanceAppConfig` callers anywhere in the repo and stays reachable as `config::MaintenanceAppConfig`. `AppConfig`/`BuildMetadata` (externally used) are kept.
- **F2** — replace the stale `rs-stellar-core` binary token with `henyey` in all 13 doc-comment occurrences across 7 files (`app/mod.rs`, `lib.rs`, `logging.rs`, `config.rs`, `maintainer.rs`, `catchup_cmd.rs`, `run_cmd.rs`), including the `run`/`catchup` CLI examples. The subcommands/flags were already correct against the live clap surface — only the binary name was wrong. Examples are ` ```text ``` ` fences, so doc-tests are unaffected.
- **F3** — gate `ensure_test_recorder` as `#[cfg(test)] pub(crate)` (0 external callers; only invoked from sibling `cfg(test)` blocks in `app/mod.rs`, `app/publish.rs`). Per the plan's build-verified wrinkle, the fn's sole `use std::sync::OnceLock;` was moved to a function-local `use` so the non-test lib build has no orphaned import under `-D unused-imports`. `install_recorder` stays `pub`.
- **F4** — deferred per the converged plan (metric trait-impl macro consolidation); no follow-up.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3450#issuecomment-4749028253)

## Test plan

- [x] `RUSTFLAGS=-Dwarnings cargo build -p henyey-app` — clean (the non-test profile where the orphaned `OnceLock` import would fail)
- [x] `RUSTFLAGS=-Dwarnings cargo build -p henyey-app --all-targets` — clean
- [x] `cargo test -p henyey-app` — all pass (incl. doc-tests; sibling `cfg(test)` callers of `ensure_test_recorder` compile under the new gate)
- [x] `cargo build --all` — clean
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Deviations from plan

None. F1 landed at `lib.rs:74` (the plan cited line 76; content-matched, not line-matched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)