### PR TITLE
Apply henyey-db cleanup batch: narrow visibility, hoist import, dedup peer decode, name opcode interval

### DIFF
--- a/crates/db/src/migrations.rs
+++ b/crates/db/src/migrations.rs
@@ -34,7 +34,7 @@ use tracing::info;
 /// This should be incremented whenever a new migration is added.
 /// The database initialization and migration system uses this to
 /// determine if upgrades are needed.
-pub(crate) const CURRENT_VERSION: i32 = 10;
+const CURRENT_VERSION: i32 = 10;
 
 /// Represents a single database migration.
 ///
@@ -187,7 +187,7 @@ const MIGRATIONS: &[Migration] = &[
 /// # Errors
 ///
 /// Returns an error if the stored version string cannot be parsed as an integer.
-pub(crate) fn get_schema_version(conn: &Connection) -> Result<i32> {
+fn get_schema_version(conn: &Connection) -> Result<i32> {
     let result: std::result::Result<String, _> = conn.query_row(
         "SELECT state FROM storestate WHERE statename = 'databaseschema'",
         [],
@@ -209,7 +209,7 @@ pub(crate) fn get_schema_version(conn: &Connection) -> Result<i32> {
 /// Records the schema version in the database.
 ///
 /// This is called after each successful migration to update the version tracker.
-pub(crate) fn set_schema_version(conn: &Connection, version: i32) -> Result<()> {
+fn set_schema_version(conn: &Connection, version: i32) -> Result<()> {
     conn.execute(
         "INSERT OR REPLACE INTO storestate (statename, state) VALUES ('databaseschema', ?)",
         [version.to_string()],

--- a/crates/db/src/queries/mod.rs
+++ b/crates/db/src/queries/mod.rs
@@ -65,6 +65,13 @@ use std::sync::Arc;
 
 use rusqlite::Connection;
 
+/// Number of SQLite VM opcodes between progress-handler callbacks.
+///
+/// Shared by [`install_query_budget`] at both the callback-count computation
+/// (`ceil(max_ops / N)`) and the `progress_handler` registration (`N` opcodes
+/// per callback), so the two stay coupled.
+const QUERY_BUDGET_OPCODE_INTERVAL: u32 = 1000;
+
 /// RAII guard that clears the connection-wide SQLite progress handler on drop.
 ///
 /// # Safety invariant
@@ -86,9 +93,10 @@ impl Drop for QueryBudgetGuard<'_> {
 /// Installs a SQLite progress handler that interrupts the query after
 /// approximately `max_ops` VM opcodes.
 ///
-/// The handler fires every 1000 opcodes and checks a counter against
-/// `ceil(max_ops / 1000)`. When the counter reaches the threshold the
-/// handler returns `true`, causing SQLite to raise `SQLITE_INTERRUPT`.
+/// The handler fires every [`QUERY_BUDGET_OPCODE_INTERVAL`] opcodes and checks
+/// a counter against `ceil(max_ops / QUERY_BUDGET_OPCODE_INTERVAL)`. When the
+/// counter reaches the threshold the handler returns `true`, causing SQLite to
+/// raise `SQLITE_INTERRUPT`.
 ///
 /// Returns `None` (no-op) when `max_ops == 0`, meaning "unlimited".
 ///
@@ -102,11 +110,11 @@ pub(crate) fn install_query_budget(
     if max_ops == 0 {
         return None;
     }
-    let max_callbacks = (max_ops as u64).div_ceil(1000) as u32;
+    let max_callbacks = (max_ops as u64).div_ceil(QUERY_BUDGET_OPCODE_INTERVAL as u64) as u32;
     let counter = Arc::new(AtomicU32::new(0));
     let counter_clone = counter.clone();
     conn.progress_handler(
-        1000,
+        QUERY_BUDGET_OPCODE_INTERVAL as i32,
         Some(move || {
             let count = counter_clone.fetch_add(1, Ordering::Relaxed);
             count + 1 >= max_callbacks

--- a/crates/db/src/queries/peers.rs
+++ b/crates/db/src/queries/peers.rs
@@ -9,6 +9,33 @@ use rusqlite::{params, Connection, OptionalExtension, Row};
 
 use crate::error::DbError;
 
+/// Decodes the three `PeerRecord` fields from a row at the given column indices.
+///
+/// The `next_attempt`, `num_failures`, and `type` columns live at different
+/// positions depending on the SELECT (`load_peers` puts them at 2/3/4, `load_peer`
+/// at 0/1/2), so the caller supplies the indices. `col_type` is also the column
+/// index reported in the `FromSqlConversionFailure` on a bad `type` value, so each
+/// caller's error payload stays tied to its own column.
+fn peer_record_from_row(
+    row: &Row<'_>,
+    col_next_attempt: usize,
+    col_num_failures: usize,
+    col_type: usize,
+) -> rusqlite::Result<PeerRecord> {
+    let raw_type: i32 = row.get(col_type)?;
+    Ok(PeerRecord {
+        next_attempt: row.get(col_next_attempt)?,
+        num_failures: row.get::<_, i64>(col_num_failures)? as u32,
+        peer_type: StoredPeerType::try_from(raw_type).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                col_type,
+                rusqlite::types::Type::Integer,
+                e.into(),
+            )
+        })?,
+    })
+}
+
 /// Extracts a `(host, port, PeerRecord)` tuple from a row.
 ///
 /// Column order matches the SELECT in `load_peers()`:
@@ -22,18 +49,7 @@ fn peer_row(row: &Row<'_>) -> rusqlite::Result<(String, u16, PeerRecord)> {
 
     let host: String = row.get(COL_HOST)?;
     let port: i64 = row.get(COL_PORT)?;
-    let raw_type: i32 = row.get(COL_TYPE)?;
-    let record = PeerRecord {
-        next_attempt: row.get(COL_NEXT_ATTEMPT)?,
-        num_failures: row.get::<_, i64>(COL_NUM_FAILURES)? as u32,
-        peer_type: StoredPeerType::try_from(raw_type).map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(
-                COL_TYPE,
-                rusqlite::types::Type::Integer,
-                e.into(),
-            )
-        })?,
-    };
+    let record = peer_record_from_row(row, COL_NEXT_ATTEMPT, COL_NUM_FAILURES, COL_TYPE)?;
     Ok((host, port as u16, record))
 }
 
@@ -128,20 +144,7 @@ impl PeerQueries for Connection {
             .query_row(
                 "SELECT nextattempt, numfailures, type FROM peers WHERE ip = ?1 AND port = ?2",
                 params![host, port as i64],
-                |row| {
-                    let raw_type: i32 = row.get(2)?;
-                    Ok(PeerRecord {
-                        next_attempt: row.get(0)?,
-                        num_failures: row.get::<_, i64>(1)? as u32,
-                        peer_type: StoredPeerType::try_from(raw_type).map_err(|e| {
-                            rusqlite::Error::FromSqlConversionFailure(
-                                2,
-                                rusqlite::types::Type::Integer,
-                                e.into(),
-                            )
-                        })?,
-                    })
-                },
+                |row| peer_record_from_row(row, 0, 1, 2),
             )
             .optional()?;
         Ok(result)

--- a/crates/db/src/queries/scp.rs
+++ b/crates/db/src/queries/scp.rs
@@ -23,6 +23,8 @@ use stellar_xdr::curr::{
 use crate::error::DbError;
 use crate::schema::state_keys;
 
+use super::state::StateQueries;
+
 const TX_SET_KEY_PREFIX: &str = "txset:";
 
 /// Query trait for SCP consensus state operations.
@@ -300,9 +302,6 @@ fn tx_set_key(hash: &Hash) -> String {
     format!("{TX_SET_KEY_PREFIX}{}", hex::encode(hash.0))
 }
 
-/// Delegates to [`StateQueries`] methods to avoid duplicating storestate SQL.
-use super::state::StateQueries;
-
 fn parse_slot_key(key: &str) -> Option<u64> {
     key.strip_prefix(&format!("{}:", state_keys::SCP_STATE))?
         .parse()
@@ -317,6 +316,7 @@ fn decode_tx_set_data(encoded: &str) -> Result<Vec<u8>, DbError> {
 /// Extended query trait for SCP state persistence (crash recovery).
 ///
 /// These methods support the herder's SCP state persistence for crash recovery.
+/// They delegate to [`StateQueries`] methods to avoid duplicating storestate SQL.
 pub trait ScpStatePersistenceQueries {
     /// Save SCP state for a slot as JSON.
     fn save_scp_slot_state(&self, slot: u64, state_json: &str) -> Result<(), DbError>;


### PR DESCRIPTION
Closes #3454

## Summary

Four behavior-preserving `henyey-db` quality cleanups from a single triage sweep, net behavioral diff = 0:

- **F1 (`migrations.rs`)** — narrow `CURRENT_VERSION`, `get_schema_version`, `set_schema_version` to **private** (only same-module callers, incl. `#[cfg(test)]`; per #3384 these reach a private item, not blind `pub(crate)`). KEEP `needs_migration`/`run_migrations`/`verify_schema`/`initialize_schema` `pub(crate)` — called from `database/mod.rs:118-124`.
- **F2 (`queries/scp.rs`)** — hoist the mid-file `use super::state::StateQueries;` into the top `use` block; delete the doc-comment-on-`use` and fold its sentence into the `ScpStatePersistenceQueries` trait doc.
- **F3 (`queries/peers.rs`)** — extract a column-index-parameterized `peer_record_from_row` shared by `peer_row` (cols 2/3/4) and `load_peer` (cols 0/1/2). The `FromSqlConversionFailure` failing-column index is a **parameter**, so each caller keeps its own column. SQL/order/casts/`try_from` unchanged → decoded `PeerRecord` + error variant byte-identical to main.
- **F4 (`queries/mod.rs`)** — bind the SQLite progress-handler opcode interval `1000` to `const QUERY_BUDGET_OPCODE_INTERVAL: u32 = 1000;`, used at both `div_ceil` and `progress_handler` (cast to `i32`).

No connection/pool/transaction/pragma behavior change. Strict v26.0.1 parity preserved (F3 decode byte-identical).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3454#issuecomment-4749563948)

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS=-Dwarnings cargo build -p henyey-db --all-targets` (F1 private-narrow gate — clean, no dead-code/unused-pub warnings)
- [x] `cargo test -p henyey-db` — 110 passed; 0 failed (incl. migration round-trips + peers query tests)
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build --all`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)