### PR TITLE
Clean up henyey-crypto: gate dead helpers, fix doc examples, regroup imports

### DIFF
--- a/crates/crypto/src/curve25519.rs
+++ b/crates/crypto/src/curve25519.rs
@@ -55,6 +55,9 @@
 //! ```
 
 use crate::{hkdf_extract, random_bytes, CryptoError};
+use std::hash::{Hash, Hasher};
+use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::ZeroizeOnDrop;
 
 /// Ordering of public keys when deriving a shared key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -64,9 +67,6 @@ pub enum KeyOrdering {
     /// Remote public key comes first in concatenation.
     RemoteFirst,
 }
-use std::hash::{Hash, Hasher};
-use x25519_dalek::{PublicKey, StaticSecret};
-use zeroize::ZeroizeOnDrop;
 
 /// A secret Curve25519 scalar for ECDH key exchange.
 ///

--- a/crates/crypto/src/hash.rs
+++ b/crates/crypto/src/hash.rs
@@ -19,25 +19,11 @@
 //! let hash = blake2(b"hello world");
 //! ```
 //!
-//! # HMAC-SHA256
+//! # HMAC-SHA256 and HKDF
 //!
-//! ```ignore
-//! use henyey_crypto::{hmac_sha256, hmac_sha256_verify};
-//!
-//! let key = [0u8; 32];
-//! let mac = hmac_sha256(&key, b"message");
-//! assert!(hmac_sha256_verify(&mac, &key, b"message"));
-//! ```
-//!
-//! # HKDF Key Derivation
-//!
-//! ```ignore
-//! use henyey_crypto::{hkdf_extract, hkdf_expand};
-//!
-//! let ikm = b"input keying material";
-//! let prk = hkdf_extract(ikm);
-//! let derived = hkdf_expand(&prk, b"context info");
-//! ```
+//! This module also provides crate-internal HMAC-SHA256 and HKDF
+//! (RFC 5869) key-derivation primitives used by the Curve25519 shared-key
+//! derivation path. These are not part of the public API.
 
 use blake2::Blake2b;
 use henyey_common::Hash256;
@@ -182,15 +168,6 @@ fn hmac_sha256_chunks(key: &[u8], chunks: &[&[u8]]) -> [u8; 32] {
 /// # Returns
 ///
 /// A 32-byte message authentication code.
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::hmac_sha256;
-///
-/// let key = [0u8; 32];
-/// let mac = hmac_sha256(&key, b"message");
-/// ```
 pub(crate) fn hmac_sha256(key: &[u8; 32], data: &[u8]) -> [u8; 32] {
     hmac_sha256_chunks(key, &[data])
 }
@@ -209,17 +186,6 @@ pub(crate) fn hmac_sha256(key: &[u8; 32], data: &[u8]) -> [u8; 32] {
 /// # Returns
 ///
 /// `true` if the MAC is valid, `false` otherwise.
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::{hmac_sha256, hmac_sha256_verify};
-///
-/// let key = [0u8; 32];
-/// let mac = hmac_sha256(&key, b"message");
-/// assert!(hmac_sha256_verify(&mac, &key, b"message"));
-/// assert!(!hmac_sha256_verify(&mac, &key, b"tampered"));
-/// ```
 #[cfg(test)]
 fn hmac_sha256_verify(mac: &[u8; 32], key: &[u8; 32], data: &[u8]) -> bool {
     let mut verifier = new_hmac(key);
@@ -239,15 +205,6 @@ fn hmac_sha256_verify(mac: &[u8; 32], key: &[u8; 32], data: &[u8]) -> bool {
 /// # Returns
 ///
 /// A 32-byte Pseudo-Random Key (PRK).
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::hkdf_extract;
-///
-/// let ikm = b"some input keying material";
-/// let prk = hkdf_extract(ikm);
-/// ```
 pub(crate) fn hkdf_extract(ikm: &[u8]) -> [u8; 32] {
     let zero_salt = [0u8; 32];
     hmac_sha256(&zero_salt, ikm)
@@ -268,15 +225,6 @@ pub(crate) fn hkdf_extract(ikm: &[u8]) -> [u8; 32] {
 /// # Returns
 ///
 /// A 32-byte derived key.
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::{hkdf_extract, hkdf_expand};
-///
-/// let prk = hkdf_extract(b"ikm");
-/// let key = hkdf_expand(&prk, b"context");
-/// ```
 #[cfg(test)]
 fn hkdf_expand(prk: &[u8; 32], info: &[u8]) -> [u8; 32] {
     let counter = [0x01];
@@ -295,14 +243,6 @@ fn hkdf_expand(prk: &[u8; 32], info: &[u8]) -> [u8; 32] {
 /// # Returns
 ///
 /// A 32-byte derived key.
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::hkdf;
-///
-/// let derived = hkdf(b"input keying material", b"context");
-/// ```
 #[cfg(test)]
 fn hkdf(ikm: &[u8], info: &[u8]) -> [u8; 32] {
     let prk = hkdf_extract(ikm);
@@ -321,16 +261,6 @@ fn hkdf(ikm: &[u8], info: &[u8]) -> [u8; 32] {
 /// # Returns
 ///
 /// The SHA-256 hash of the XDR-encoded value, or an error if encoding fails.
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::xdr_sha256;
-/// use stellar_xdr::curr::LedgerHeader;
-///
-/// let header: LedgerHeader = /* ... */;
-/// let hash = xdr_sha256(&header)?;
-/// ```
 #[cfg(test)]
 fn xdr_sha256<T: WriteXdr>(value: &T) -> Result<Hash256, stellar_xdr::curr::Error> {
     let bytes = value.to_xdr(stellar_xdr::curr::Limits::none())?;

--- a/crates/crypto/src/keys.rs
+++ b/crates/crypto/src/keys.rs
@@ -104,6 +104,7 @@ impl PublicKey {
     ///
     /// This is used for sealed box encryption, which uses X25519 key exchange.
     /// The Ed25519 key is converted to its Curve25519 equivalent.
+    #[cfg(test)]
     pub fn to_curve25519_bytes(&self) -> [u8; 32] {
         self.0.to_montgomery().to_bytes()
     }
@@ -239,6 +240,7 @@ impl SecretKey {
     ///
     /// This is used for sealed box operations, which use X25519 key exchange.
     /// The Ed25519 secret key is converted to its Curve25519 equivalent.
+    #[cfg(test)]
     pub fn to_curve25519_bytes(&self) -> [u8; 32] {
         self.inner.to_scalar_bytes()
     }

--- a/crates/crypto/src/random.rs
+++ b/crates/crypto/src/random.rs
@@ -9,36 +9,14 @@
 //! - Nonce/IV generation
 //! - Random challenges
 //!
-//! # Example
-//!
-//! ```ignore
-//! use henyey_crypto::{random_bytes, random_u64, fill_random};
-//!
-//! // Generate a fixed-size random array
-//! let key: [u8; 32] = random_bytes();
-//!
-//! // Generate a random integer
-//! let nonce = random_u64();
-//!
-//! // Fill an existing buffer with random data
-//! let mut buffer = [0u8; 64];
-//! fill_random(&mut buffer);
-//! ```
+//! These helpers are crate-internal (used for key/nonce material within the
+//! crypto crate) and are not part of the public API.
 
 use rand::{rngs::OsRng, RngCore};
 
 /// Generates a fixed-size array of cryptographically secure random bytes.
 ///
 /// The size is determined by the const generic parameter `N`.
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::random_bytes;
-///
-/// let key: [u8; 32] = random_bytes();
-/// let nonce: [u8; 24] = random_bytes();
-/// ```
 pub(crate) fn random_bytes<const N: usize>() -> [u8; N] {
     let mut bytes = [0u8; N];
     OsRng.fill_bytes(&mut bytes);
@@ -54,15 +32,6 @@ fn random_u64() -> u64 {
 /// Fills a mutable slice with cryptographically secure random bytes.
 ///
 /// This is useful when you need to fill a dynamically-sized buffer.
-///
-/// # Example
-///
-/// ```ignore
-/// use henyey_crypto::fill_random;
-///
-/// let mut buffer = vec![0u8; 128];
-/// fill_random(&mut buffer);
-/// ```
 #[cfg(test)]
 fn fill_random(dest: &mut [u8]) {
     OsRng.fill_bytes(dest);

--- a/crates/crypto/src/sealed_box.rs
+++ b/crates/crypto/src/sealed_box.rs
@@ -32,18 +32,22 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use henyey_crypto::{SecretKey, seal_to_public_key, open_from_secret_key};
+//! ```
+//! use henyey_crypto::{
+//!     Curve25519Secret, seal_to_curve25519_public_key, open_from_curve25519_secret_key,
+//! };
 //!
-//! let recipient_secret = SecretKey::generate();
-//! let recipient_public = recipient_secret.public_key();
+//! let recipient_secret = Curve25519Secret::random();
+//! let recipient_public = recipient_secret.derive_public();
 //!
-//! // Encrypt a message
+//! // Encrypt a message to the recipient's Curve25519 public key.
 //! let plaintext = b"secret survey response";
-//! let ciphertext = seal_to_public_key(&recipient_public, plaintext).unwrap();
+//! let ciphertext =
+//!     seal_to_curve25519_public_key(&recipient_public.to_bytes(), plaintext).unwrap();
 //!
-//! // Decrypt the message
-//! let decrypted = open_from_secret_key(&recipient_secret, &ciphertext).unwrap();
+//! // Decrypt with the recipient's Curve25519 secret key.
+//! let decrypted =
+//!     open_from_curve25519_secret_key(&recipient_secret.to_bytes(), &ciphertext).unwrap();
 //! assert_eq!(decrypted, plaintext);
 //! ```
 

--- a/crates/crypto/src/short_hash.rs
+++ b/crates/crypto/src/short_hash.rs
@@ -26,14 +26,13 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use henyey_crypto::{compute_hash, initialize};
+//! ```
+//! use henyey_crypto::xdr_compute_hash;
+//! use stellar_xdr::curr::LedgerEntry;
 //!
-//! // Initialize with a random key (optional, happens automatically)
-//! initialize();
-//!
-//! // Compute a short hash
-//! let hash = compute_hash(b"some data");
+//! // Hash an XDR-encoded value using the process-global key.
+//! let entry = LedgerEntry::default();
+//! let hash = xdr_compute_hash(&entry).unwrap();
 //! ```
 
 use crate::random;


### PR DESCRIPTION
Closes #3453

## Summary

Three behavior-preserving cleanups in the PARITY-CRITICAL `henyey-crypto` crate (net behavioral diff = 0):

- **F1 — dead public API.** `PublicKey::to_curve25519_bytes` and `SecretKey::to_curve25519_bytes` are now `#[cfg(test)]`-gated. Their only callers are the `#[cfg(test)]` sealed-box helpers `seal_to_public_key`/`open_from_secret_key`, so they were unreachable public API in release builds. `#[cfg(test)]` is the only disposition that builds clean under `-Dwarnings` — `pub(crate)` trips `dead_code` because the callers are test-only (the #3384 trap in reverse).
- **F2 — misleading rustdoc.** Removed all 13 ` ```ignore ` blocks that existed solely to hide a non-compiling `use henyey_crypto::{...}` of `pub(crate)`/`#[cfg(test)]` symbols, across `hash.rs` (8), `random.rs` (3), `short_hash.rs` (1), and `sealed_box.rs` (1). Bright-line rule applied: examples on genuinely-public items rewritten to the public API and untagged to runnable doctests (`short_hash.rs`, `sealed_box.rs`); examples on non-public items dropped. **No visibility qualifier changed** (pinned by `PARITY_STATUS.md:59-62`).
- **F3 — split import block.** Regrouped the three stranded `use` lines in `curve25519.rs` above the `KeyOrdering` enum so all imports precede the first definition.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3453#issuecomment-4749574676)

## Test plan

- [x] `cargo fmt --check` (crypto)
- [x] `RUSTFLAGS=-Dwarnings cargo build -p henyey-crypto --all-targets` — clean (the mandatory F1 gate)
- [x] `cargo test -p henyey-crypto` — 82 unit + 12 doctests pass, 0 ignored (previously-ignored examples now run as real doctests)
- [x] `cargo build --all`
- [x] `cargo clippy --all -- -D warnings`

## Parity considerations

crate:crypto is PARITY-CRITICAL. No parity-mapped primitive (`derive_shared_key`/`Curve25519Secret`/`hmac_sha256`/`hkdf_extract`) is touched in signature, visibility, or behavior. The parity-mapped sealed-box wrappers (`seal_to_public_key`/`open_from_secret_key`, `PARITY_STATUS.md:109-110`) are already `#[cfg(test)]` on main and still consume the now-test-gated helper — no row's mapping or status changes, so **`PARITY_STATUS.md` requires no edit**.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)