### PR TITLE
Apply henyey-herder cleanup: tombstones, doc block, module list, re-export narrowing

### DIFF
--- a/crates/herder/src/lib.rs
+++ b/crates/herder/src/lib.rs
@@ -95,6 +95,11 @@
 //! - `pending`: Pending SCP envelope management (future slots)
 //! - `fetching_envelopes`: Envelopes waiting for TxSet/QuorumSet from peers
 //! - `quorum_tracker`: Quorum participation and security tracking
+//! - `quorum_set_tracker`: Quorum-set fetching and reference tracking
+//! - `quorum_intersection_state`: Quorum intersection monitoring (diagnostic)
+//! - `tx_set_tracker`: Transaction-set fetching and reference tracking
+//! - `externalize_lag`: Externalize timing/lag measurement (diagnostic)
+//! - `tracked_lock`: Lock-acquisition instrumentation (diagnostic)
 //! - `persistence`: SCP state persistence for crash recovery (SQLite)
 //! - `upgrades`: Ledger upgrade scheduling and validation
 //! - `ledger_close_data`: Ledger close data for consensus output
@@ -131,8 +136,6 @@ mod surge_pricing;
 pub mod sync_recovery;
 pub(crate) mod timer_manager;
 mod tracked_lock;
-// tx_broadcast module removed — flood scheduling is now handled by
-// TransactionQueue::broadcast_with_visitor() + the app-layer flood timer.
 mod tx_queue;
 mod tx_queue_limiter;
 mod tx_set_tracker;
@@ -148,25 +151,24 @@ pub use herder::{
     EnvelopeState, Herder, HerderConfig, HerderStats, LastExternalizedLedger, LedgerCloseInfo,
     NextConsensusSlot, TimeoutOutcome, TriggerOutcome, TX_SET_GC_DELAY_SECS,
 };
-pub use metrics::{ScpMetrics, ScpMetricsSnapshot};
+pub use metrics::ScpMetricsSnapshot;
 pub use pending::{PendingConfig, PendingEnvelopes, PendingResult, PendingStats};
 pub use quorum_tracker::{ExpandError, QuorumTracker, SlotQuorumTracker};
 pub use scp_driver::{
-    CachedTxSet, ExternalizeTimingSnapshot, ExternalizedSlot, HerderScpCallback, PendingTxSet,
-    ScpDriver, ScpDriverCacheSizes, ScpDriverConfig, ValidatorEntryInfo, ValidatorQuality,
+    HerderScpCallback, PendingTxSet, ScpDriver, ValidatorEntryInfo, ValidatorQuality,
     ValidatorWeightConfig, ValueValidation,
 };
 pub use state::HerderState;
 pub use tx_queue::{
-    BroadcastBudget, BroadcastCandidate, BroadcastVisitResult, QueuedTransaction, SorobanTxLimits,
-    TransactionQueue, TransactionSet, TxQueueConfig, TxQueueResult, TxQueueStats, TxSetBody,
-    SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER, TRANSACTION_QUEUE_SIZE_MULTIPLIER,
+    BroadcastBudget, BroadcastVisitResult, SorobanTxLimits, TransactionQueue, TransactionSet,
+    TxQueueConfig, TxQueueResult, SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER,
+    TRANSACTION_QUEUE_SIZE_MULTIPLIER,
 };
 
 // Persistence
 pub use persistence::{
-    get_quorum_set_hash, get_tx_set_hashes, Database, InMemoryScpPersistence, PersistedSlotState,
-    RestoredScpState, ScpPersistenceManager, ScpStatePersistence, SqliteScpPersistence,
+    get_tx_set_hashes, Database, PersistedSlotState, RestoredScpState, ScpPersistenceManager,
+    ScpStatePersistence, SqliteScpPersistence,
 };
 
 // HerderUtils
@@ -193,23 +195,18 @@ pub use tx_queue::SnapshotProviders;
 pub use parallel_tx_set_builder::build_two_phase_tx_set;
 
 // TxQueueLimiter and surge pricing
-pub use surge_pricing::VisitTxResult;
 pub use tx_queue_limiter::{FloodQueueNotInitialized, TxQueueLimiter};
 
 // Timer management
 pub use timer_manager::{
-    TimerCallback, TimerCommand, TimerManager, TimerManagerHandle, TimerManagerWithStats,
-    TimerStats, TimerType,
+    TimerCallback, TimerManager, TimerManagerHandle, TimerManagerWithStats, TimerStats, TimerType,
 };
 
 // Sync recovery
 pub use sync_recovery::{
-    SyncRecoveryCallback, SyncRecoveryCommand, SyncRecoveryHandle, SyncRecoveryManager,
-    SyncRecoveryStats, SyncRecoveryStatsTracker, CONSENSUS_STUCK_TIMEOUT, LEDGER_VALIDITY_BRACKET,
-    OUT_OF_SYNC_RECOVERY_INTERVAL,
+    SyncRecoveryCallback, SyncRecoveryHandle, SyncRecoveryManager, CONSENSUS_STUCK_TIMEOUT,
+    LEDGER_VALIDITY_BRACKET, OUT_OF_SYNC_RECOVERY_INTERVAL,
 };
-
-// (TxBroadcastManager removed — see TransactionQueue::broadcast_with_visitor)
 
 // Dead node detection
 pub use dead_node_tracker::{DeadNodeTracker, CHECK_FOR_DEAD_NODES_MINUTES};

--- a/crates/herder/src/tx_queue/flood_queue.rs
+++ b/crates/herder/src/tx_queue/flood_queue.rs
@@ -3,7 +3,7 @@
 //! The [`FloodQueue`] tracks which transactions need to be advertised to peers.
 //! It is populated on admission (via [`QueueStore::insert`]) and destructively
 //! drained by [`TransactionQueue::broadcast_with_visitor`]. This matches
-
+//!
 //! stellar-core's persistent `mTxsToFlood` inside `TxQueueLimiter`.
 //!
 //! # Design Rationale


### PR DESCRIPTION
Closes #3456

## Summary

Behavior-preserving cleanup of the consensus-critical `henyey-herder` crate — visibility and documentation only, net behavioral diff = 0. No SCP, quorum, recovery, value-validation, or tx-set logic is touched.

- **F4** — delete two stale tombstone comments in `lib.rs` (`// tx_broadcast module removed …` and `// (TxBroadcastManager removed …)`).
- **F5** — replace the stray blank line that split the `//!` doc block in `tx_queue/flood_queue.rs` with `//!` so the block is contiguous.
- **F7** — add the 5 missing `# Modules` bullets (`externalize_lag`, `quorum_intersection_state`, `quorum_set_tracker`, `tracked_lock`, `tx_set_tracker`).
- **F6** — narrow **17** herder-internal `pub use` re-exports out of the crate public surface (each underlying `pub` definition is retained). `HerderScpCallback` and `ValueValidation` are kept `pub` (consensus-critical, scoped out per the plan).

F1/F2/F3 were dropped — already resolved on main (stale).

## #3384 build-verify outcome

Applied all 21 candidate narrows, then ran the mandatory gate. Under `RUSTFLAGS=-Dwarnings`, dropping the re-export of **4** candidates turned them into dead-code errors (their *only* keep-alive was the public re-export — no external consumer either):

- `PendingTxSet` (field `hash` never read)
- `TRANSACTION_QUEUE_SIZE_MULTIPLIER` (const never used)
- `TimerManagerWithStats` (struct + impl never used)
- `TimerStats` (struct never constructed)

Per the build-verify discipline these 4 were reverted to `pub` (no-op vs main for those symbols). The remaining **17** narrows are applied and the workspace is clean. `cargo build --all` confirms no cross-crate consumer of any of the 17.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3456#issuecomment-4749570290)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `RUSTFLAGS=-Dwarnings cargo build -p henyey-herder --all-targets`
- [x] `RUSTFLAGS=-Dwarnings cargo build --all`
- [x] `cargo test -p henyey-herder` (1185 unit + all integration + doc-tests pass)

## Deviations from plan

- 4 of the 21 F6 narrow candidates (`PendingTxSet`, `TRANSACTION_QUEUE_SIZE_MULTIPLIER`, `TimerManagerWithStats`, `TimerStats`) were reverted to `pub` because narrowing them produces `-Dwarnings` dead-code errors. This is the build-verify gate behaving exactly as the plan specified ("revert that one symbol + note it"). 17 narrows applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)