### PR TITLE
Apply henyey binary-crate cleanup batch (F1-F7)

### DIFF
--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -1908,7 +1908,7 @@ async fn cmd_run(
     }
 
     // In local mode, auto-initialize database and history if needed.
-    let config = if local {
+    let mut config = if local {
         let db_path = &config.database.path;
 
         // Ensure data directory exists.
@@ -1967,7 +1967,6 @@ async fn cmd_run(
     };
 
     // Set in-memory mode on the config so it flows through to App::new.
-    let mut config = config;
     config.database.in_memory = in_memory;
     if in_memory {
         tracing::info!("In-memory mode requested via --in-memory flag");
@@ -3242,14 +3241,10 @@ fn bucket_info(path: &std::path::Path) -> anyhow::Result<()> {
         println!();
         println!("Total: {} files, {} bytes", count, total_size);
     } else {
-        // Single bucket file
-        println!("Bucket file: {}", path.display());
-
-        let metadata = std::fs::metadata(path)?;
-        println!("Size: {} bytes", metadata.len());
-
-        // Would parse and display bucket contents
-        println!("(Bucket content parsing not yet implemented)");
+        anyhow::bail!(
+            "bucket-info expects a directory; got file {}",
+            path.display()
+        );
     }
 
     Ok(())
@@ -3414,12 +3409,6 @@ async fn cmd_dump_ledger(
     Ok(())
 }
 
-/// Perform offline self-checks (equivalent to stellar-core self-check command).
-///
-/// This command performs comprehensive diagnostic checks:
-/// 1. Header chain verification - ensures ledger headers form a valid chain
-/// 2. Bucket hash verification - verifies all bucket files have correct hashes
-/// 3. Crypto benchmarking - measures Ed25519 sign/verify performance
 /// Verify ledger header chain integrity going backwards.
 /// Returns false if any break in the chain is detected.
 fn self_check_header_chain(db: &henyey_db::Database, latest_seq: u32) -> anyhow::Result<bool> {
@@ -3563,6 +3552,12 @@ fn self_check_crypto_benchmark() {
     println!("  Benchmarked {} verifications / sec", verify_per_sec);
 }
 
+/// Perform offline self-checks (equivalent to stellar-core self-check command).
+///
+/// This command performs comprehensive diagnostic checks:
+/// 1. Header chain verification - ensures ledger headers form a valid chain
+/// 2. Bucket hash verification - verifies all bucket files have correct hashes
+/// 3. Crypto benchmarking - measures Ed25519 sign/verify performance
 async fn cmd_self_check(config: AppConfig) -> anyhow::Result<()> {
     let db = henyey_db::Database::open(&config.database.path)?;
 

--- a/crates/henyey/src/publish_history.rs
+++ b/crates/henyey/src/publish_history.rs
@@ -98,8 +98,8 @@ pub(crate) async fn cmd_publish_history(config: AppConfig, force: bool) -> anyho
 
     println!("Latest publishable checkpoint: {}", latest_checkpoint);
 
-    let queued_checkpoints = db.load_publish_queue(None)?;
-    let mut queued_checkpoints = queued_checkpoints
+    let mut queued_checkpoints = db
+        .load_publish_queue(None)?
         .into_iter()
         .filter(|checkpoint| *checkpoint <= latest_checkpoint)
         .collect::<Vec<_>>();
@@ -314,9 +314,9 @@ pub(crate) async fn cmd_publish_history(config: AppConfig, force: bool) -> anyho
             published_any = true;
         }
 
-        if let Some((ref publish_dir, _)) = command_publish_dir {
-            write_scp_history_file(publish_dir, checkpoint, &scp_entries)?;
-            let plan = henyey_history::upload::UploadPlan::from_staging_dir(publish_dir)?;
+        if let Some((publish_dir, publish_tmp)) = command_publish_dir {
+            write_scp_history_file(&publish_dir, checkpoint, &scp_entries)?;
+            let plan = henyey_history::upload::UploadPlan::from_staging_dir(&publish_dir)?;
             for archive in &command_targets {
                 let remote_archive =
                     henyey_history::RemoteArchive::new(henyey_history::RemoteArchiveConfig {
@@ -329,9 +329,7 @@ pub(crate) async fn cmd_publish_history(config: AppConfig, force: bool) -> anyho
                 println!("OK (command: {})", archive.name);
                 published_any = true;
             }
-        }
 
-        if let Some((_publish_dir, publish_tmp)) = command_publish_dir {
             if let Err(err) = publish_tmp.close() {
                 tracing::warn!(
                     error = %err,
@@ -368,7 +366,6 @@ fn build_scp_history_entries(
     start_ledger: u32,
     checkpoint: u32,
 ) -> anyhow::Result<Vec<stellar_xdr::curr::ScpHistoryEntry>> {
-    use henyey_common::Hash256;
     use std::collections::HashSet;
     use stellar_xdr::curr::{LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0};
 

--- a/crates/henyey/src/verify_execution/run.rs
+++ b/crates/henyey/src/verify_execution/run.rs
@@ -594,12 +594,12 @@ fn print_eviction_and_entry_diagnostics(
     lcm: &stellar_xdr::curr::LedgerCloseMeta,
     result_header: &stellar_xdr::curr::LedgerHeader,
 ) {
-    let cdp_evicted_keys = henyey_history::cdp::extract_evicted_keys(&lcm);
-    let tx_metas = henyey_history::cdp::extract_transaction_metas(&lcm);
+    let cdp_evicted_keys = henyey_history::cdp::extract_evicted_keys(lcm);
+    let tx_metas = henyey_history::cdp::extract_transaction_metas(lcm);
     let cdp_restored_keys = henyey_history::cdp::extract_restored_keys(&tx_metas);
 
     // Count CDP entry changes (including upgrade-meta create/update counts).
-    let cdp_upgrade_metas = henyey_history::cdp::extract_upgrade_metas(&lcm);
+    let cdp_upgrade_metas = henyey_history::cdp::extract_upgrade_metas(lcm);
     let (cdp_creates, cdp_updates, cdp_deletes, upgrade_creates, upgrade_updates) =
         cdp_change_counts(&tx_metas, &cdp_upgrade_metas);
 


### PR DESCRIPTION
Closes #3455

## Summary

Applies seven behavior-preserving mechanical cleanups (F1–F7) in the `henyey` binary crate, as one small PR. F8 was dropped per the converged plan (the sibling `download_buckets` is `pub(super)`, so the suggested dedup would force a disproportionate cross-crate `pub` extraction).

- **F1** (`publish_history.rs`): merge the two consecutive `if let Some(...) = command_publish_dir` blocks in `cmd_publish_history` into one owning `if let Some((publish_dir, publish_tmp))`. `published_any` stays in the outer-loop scope; `publish_tmp.close()` remains the last statement so the `TempDir` isn't dropped early.
- **F2** (`verify_execution/run.rs`): drop the redundant `&` on `&lcm` in `print_eviction_and_entry_diagnostics` (param is already `&LedgerCloseMeta`; debug `println!` only).
- **F3** (`main.rs`): replace the unimplemented single-file `bucket-info` placeholder (`println!("(Bucket content parsing not yet implemented)")`) with `bail!("bucket-info expects a directory; got file ...")`. Only observable change in the batch — a CLI error string on an unimplemented path.
- **F4** (`publish_history.rs`): collapse the double `queued_checkpoints` binding into one chain.
- **F5** (`main.rs`): move the `cmd_self_check` doc banner off `self_check_header_chain` onto the real `async fn cmd_self_check` (doc-only).
- **F6** (`publish_history.rs`): remove the redundant inner `use henyey_common::Hash256;` (kept the sibling inner `use`s).
- **F7** (`main.rs`): make the `cmd_run` config binding `let mut config = if local {…}` and drop the later `let mut config = config;` rebind.

Net behavioral diff is zero except F3's CLI error string. Non-parity path (binary/CLI/offline-verify/publish tooling).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3455#issuecomment-4749562577)

## Test plan

- [x] `RUSTFLAGS=-Dwarnings cargo build -p henyey --all-targets` — clean
- [x] `cargo test -p henyey` — all pass (64 + 1 + 1)
- [x] `cargo build --all` — clean
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Deviations from plan

None. F8 dropped per the converged plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)