### PR TITLE
Tidy invariant-check internals in henyey-invariant

### DIFF
--- a/crates/invariant/src/entry_valid.rs
+++ b/crates/invariant/src/entry_valid.rs
@@ -13,8 +13,8 @@
 
 use stellar_xdr::curr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, ContractEvent, DataEntry,
-    LedgerEntry, LedgerEntryData, OfferEntry, Operation, OperationResult, TrustLineAsset,
-    TrustLineEntry, TrustLineEntryExt, TrustLineEntryV1Ext, TrustLineFlags,
+    LedgerEntry, LedgerEntryData, LedgerEntryExt, OfferEntry, Operation, OperationResult,
+    TrustLineAsset, TrustLineEntry, TrustLineEntryExt, TrustLineEntryV1Ext, TrustLineFlags,
 };
 
 use crate::{Invariant, OperationDelta};
@@ -81,21 +81,18 @@ fn check_entry(
         LedgerEntryData::Data(data) => check_data(data),
         LedgerEntryData::ClaimableBalance(_) => {
             // ClaimableBalance must be sponsored.
-            match &entry.ext {
-                stellar_xdr::curr::LedgerEntryExt::V1(v1) => {
-                    if v1.sponsoring_id.0.is_none() {
-                        return Err("ClaimableBalance is not sponsored".to_string());
-                    }
-                }
-                _ => {
-                    return Err("ClaimableBalance is not sponsored".to_string());
-                }
+            let sponsored = matches!(
+                &entry.ext,
+                LedgerEntryExt::V1(v1) if v1.sponsoring_id.0.is_some()
+            );
+            if !sponsored {
+                return Err("ClaimableBalance is not sponsored".to_string());
             }
             Ok(())
         }
         LedgerEntryData::LiquidityPool(_) => {
             // LiquidityPool must not be sponsored.
-            if !matches!(&entry.ext, stellar_xdr::curr::LedgerEntryExt::V0) {
+            if !matches!(&entry.ext, LedgerEntryExt::V0) {
                 return Err("LiquidityPool is sponsored".to_string());
             }
             Ok(())

--- a/crates/invariant/src/sub_entries.rs
+++ b/crates/invariant/src/sub_entries.rs
@@ -173,11 +173,11 @@ impl Invariant for AccountSubEntriesCountIsValid {
                     .get(&account.account_id)
                     .copied()
                     .unwrap_or_default();
-                let num_signers =
-                    account.num_sub_entries as i32 + change.num_sub_entries - change.signers;
-                if num_signers != account.signers.len() as i32 {
-                    let other_sub_entries =
-                        account.num_sub_entries as i32 - account.signers.len() as i32;
+                let num_sub_entries = account.num_sub_entries as i32;
+                let num_account_signers = account.signers.len() as i32;
+                let num_signers = num_sub_entries + change.num_sub_entries - change.signers;
+                if num_signers != num_account_signers {
+                    let other_sub_entries = num_sub_entries - num_account_signers;
                     return Err(format!(
                         "Deleted Account {:?} has {} subentries other than signers",
                         account.account_id, other_sub_entries


### PR DESCRIPTION
Closes #3459

## Summary

Three behavior-neutral cleanups in `henyey-invariant`, all byte-identical to stellar-core v26.0.1:

- **F1** (`entry_valid.rs`): collapse the two-arm ClaimableBalance `match` (both arms emitted the identical `"ClaimableBalance is not sponsored"` string) into one `matches!`-guarded check. The fire condition is now `ext != V1 || sponsoring_id.is_none()` — the De Morgan dual of core `LedgerEntryIsValid.cpp:122` `le.ext.v() != 1 || !sponsoringID`, fired unconditionally of protocol version. Error string unchanged.
- **F2** (`sub_entries.rs`): hoist `account.num_sub_entries as i32` and `account.signers.len() as i32` into two locals in the `delete_states` loop. Operand order, `i32` cast widths, the `numSigners != (int32_t)signers.size()` firing condition, and the `otherSubEntries` arithmetic (`AccountSubEntriesCountIsValid.cpp:192-204`) are preserved. The pre-existing `.copied()` is left intact.
- **F3** (`entry_valid.rs`): add `LedgerEntryExt` to the `use` block and shorten the two fully-qualified refs (V1, V0). Pure import hygiene; both sites consume it, so no unused-import under `-Dwarnings`.

Net behavioral diff = 0 (kind: refactor).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3459#issuecomment-4750296712)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build -p henyey-invariant --all-targets` under `RUSTFLAGS=-Dwarnings` (#3384) — clean, F3 import consumed at both sites
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo build --all` — clean
- [x] `cargo test -p henyey-invariant` — 16 passed, 0 failed

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)