### PR TITLE
Test-gate dead-in-lib history symbols and drop redundant verify re-exports

### DIFF
--- a/crates/history/src/catchup_range.rs
+++ b/crates/history/src/catchup_range.rs
@@ -44,16 +44,19 @@ impl LedgerRange {
     }
 
     /// Check if the range is empty.
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.count == 0
     }
 
     /// Get the limit (one past the last ledger).
+    #[cfg(test)]
     pub fn limit(&self) -> u32 {
         self.first + self.count
     }
 
     /// Get the last ledger in the range (panics if empty).
+    #[cfg(test)]
     pub fn last(&self) -> u32 {
         assert!(self.count > 0, "cannot get last of empty range");
         self.first + self.count - 1

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -177,12 +177,6 @@ pub use publish_queue::{
 };
 pub use remote_archive::{RemoteArchive, RemoteArchiveConfig};
 pub use replay::{ReplayConfig, ReplayedLedgerState};
-pub use verify::{
-    compute_header_hash, verify_bucket_hash, verify_chain_anchors, verify_has_passphrase,
-    verify_header_chain, verify_header_chain_from_entries, verify_ledger_header_history_entry,
-    verify_reverse_walk, verify_tx_result_ordering, ChainTrustAnchors, ReverseWalkConfig,
-    ReverseWalkResult, TrustSource,
-};
 
 /// Result type for history operations.
 pub type Result<T> = std::result::Result<T, HistoryError>;

--- a/crates/history/src/replay/metadata.rs
+++ b/crates/history/src/replay/metadata.rs
@@ -4,22 +4,17 @@
 //! entry changes. This produces identical results to the original execution
 //! and is used for testing and specialized replay scenarios.
 
-// `metadata.rs` provides metadata-based ledger replay, which is currently
-// exercised only by tests. All items below are therefore `#[cfg(test)]`-gated,
-// along with the imports that support them.
-#[cfg(test)]
+// This whole module is `#[cfg(test)]`-gated at its declaration in `replay/mod.rs`
+// (it provides metadata-based ledger replay, exercised only by tests), so the
+// items below don't need individual `#[cfg(test)]` attributes.
 use crate::{verify, HistoryError, Result};
-#[cfg(test)]
 use henyey_ledger::TransactionSetVariant;
-#[cfg(test)]
 use stellar_xdr::curr::{
     LedgerEntry, LedgerHeader, LedgerKey, TransactionMeta, TransactionResultPair,
     TransactionResultSet, WriteXdr,
 };
 
-#[cfg(test)]
 use super::execution::soroban_entry_size;
-#[cfg(test)]
 use super::{LedgerReplayResult, ReplayConfig};
 
 /// Replays a single ledger from history data.
@@ -38,7 +33,6 @@ use super::{LedgerReplayResult, ReplayConfig};
 /// # Returns
 ///
 /// A `LedgerReplayResult` containing the changes to apply to ledger state.
-#[cfg(test)]
 pub(crate) fn replay_ledger(
     header: &LedgerHeader,
     tx_set: &TransactionSetVariant,
@@ -110,14 +104,12 @@ pub(crate) fn replay_ledger(
 /// - live_entries: Entries that were updated or restored
 /// - dead_entries: Keys of entries that were deleted
 /// Accumulated ledger entry changes from transaction meta.
-#[cfg(test)]
 struct LedgerChanges {
     init: Vec<LedgerEntry>,
     live: Vec<LedgerEntry>,
     dead: Vec<LedgerKey>,
 }
 
-#[cfg(test)]
 impl LedgerChanges {
     fn new() -> Self {
         Self {
@@ -143,7 +135,6 @@ impl LedgerChanges {
     }
 }
 
-#[cfg(test)]
 pub(crate) fn extract_ledger_changes(
     tx_metas: &[TransactionMeta],
 ) -> Result<(Vec<LedgerEntry>, Vec<LedgerEntry>, Vec<LedgerKey>)> {
@@ -153,7 +144,6 @@ pub(crate) fn extract_ledger_changes(
 }
 
 /// Count the total number of operations in a transaction set.
-#[cfg(test)]
 fn count_operations(tx_set: &TransactionSetVariant) -> u32 {
     tx_set
         .transactions()

--- a/crates/history/src/replay/mod.rs
+++ b/crates/history/src/replay/mod.rs
@@ -47,6 +47,10 @@
 
 pub(crate) mod diff;
 pub(crate) mod execution;
+// `metadata` provides metadata-based ledger replay, exercised only by tests.
+// The whole module is `#[cfg(test)]`-gated here (single source of truth), so
+// its items don't need individual `#[cfg(test)]` attributes.
+#[cfg(test)]
 pub(crate) mod metadata;
 
 use henyey_bucket::EvictionIterator;


### PR DESCRIPTION
Closes #3457

## Summary

Behavior-preserving `henyey-history` visibility cleanup (net runtime diff = 0). Three `/cleanup` findings, all test-only / namespace / module-gating touch-ups that leave the archive-publish and catchup runtime paths untouched:

- **F1** — `#[cfg(test)]`-gate `LedgerRange::{is_empty, limit, last}` (`catchup_range.rs:47,52,57`). All three are test-only post-#3440 (sole callers are same-file test asserts and the `#[cfg(test)]`-gated `CatchupRange::last`). `#[cfg(test)]` is the correct gate — `pub(crate)` would leave them dead-in-lib under `-Dwarnings` (#3384). The shared `pub use catchup_range::{… LedgerRange …}` line (lib.rs:146) is untouched; `LedgerRange` stays `pub`.
- **F2** — delete the 12-symbol crate-root `pub use verify::{…}` block (lib.rs:180–186). The symbols remain public via `pub mod verify;` (lib.rs:110); every consumer already reaches them via the `verify::` module path, and there are zero `henyey_history::<sym>` crate-root consumers workspace-wide. Pure namespace de-duplication.
- **F3** — `#[cfg(test)]`-gate `pub(crate) mod metadata;` at its declaration (`replay/mod.rs:50`) and drop the now-redundant per-item `#[cfg(test)]` attributes inside `metadata.rs` (single source of truth, triage fix (a)).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3457#issuecomment-4750354548)

## Test plan

- [x] `cargo build -p henyey-history --all-targets` (RUSTFLAGS=-Dwarnings) — clean (F1 cfg(test) confirmed not dead-in-lib)
- [x] `cargo build --all` — clean (F2 breaks no `verify::` consumer, incl. the app crate)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p henyey-history --lib` — 555 passed, 0 failed (net behavioral diff = 0)

## Deviations from plan

None. `kind: refactor` — no new tests added, per the converged plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)