### PR TITLE
Narrow over-exposed crate:ledger API surface to pub(crate)

### DIFF
--- a/crates/ledger/src/close.rs
+++ b/crates/ledger/src/close.rs
@@ -748,13 +748,13 @@ pub struct SorobanPhaseStructure {
 }
 
 /// Pre-extracted per-transaction metadata.
-pub struct TxMeta {
+pub(crate) struct TxMeta {
     pub fee_source: AccountId,
     pub is_soroban: bool,
 }
 
 /// Pre-parsed transaction set with all views computed once.
-pub struct PreparedTxSet {
+pub(crate) struct PreparedTxSet {
     /// Cached hash (XDR serialize + SHA-256, computed once).
     pub hash: Hash256,
     /// Classic phase transactions, sorted for sequential apply.
@@ -788,14 +788,9 @@ fn envelope_is_soroban(env: &TransactionEnvelope) -> bool {
 }
 
 impl TransactionSetVariant {
-    /// Parse the transaction set once, producing all views needed by `apply_transactions()`.
-    pub fn prepare(&self) -> PreparedTxSet {
-        self.prepare_with_hash(self.hash())
-    }
-
     /// Consuming variant that moves TX envelopes instead of cloning.
     /// Skips per-TX hashing and sorting — stages must already be in final order.
-    pub fn prepare_presorted(self, hash: Hash256) -> PreparedTxSet {
+    pub(crate) fn prepare_presorted(self, hash: Hash256) -> PreparedTxSet {
         let (classic_txs, soroban_phase, all_txs) = match self {
             TransactionSetVariant::Classic(set) => {
                 let txs: Vec<TxWithFee> = Vec::from(set.txs)
@@ -873,7 +868,7 @@ impl TransactionSetVariant {
         }
     }
 
-    pub fn prepare_with_hash(&self, hash: Hash256) -> PreparedTxSet {
+    pub(crate) fn prepare_with_hash(&self, hash: Hash256) -> PreparedTxSet {
         let (classic_txs, soroban_phase, all_txs) = match self {
             TransactionSetVariant::Classic(set) => {
                 let txs: Vec<TxWithFee> = set

--- a/crates/ledger/src/close_state.rs
+++ b/crates/ledger/src/close_state.rs
@@ -144,7 +144,7 @@ impl CloseLedgerState {
     ///
     /// Returns all live offer entries visible through the full read path:
     /// current delta + snapshot.
-    pub fn all_offers(&self) -> Result<Vec<LedgerEntry>> {
+    pub(crate) fn all_offers(&self) -> Result<Vec<LedgerEntry>> {
         // Start with all offers from the base snapshot
         let snapshot_entries = self.snapshot.all_entries()?;
 
@@ -293,7 +293,7 @@ impl CloseLedgerState {
     /// This is the proper terminal operation — consumes the delta's entry
     /// changes for the bucket list, leaving the `CloseLedgerState` in a
     /// drained state.
-    pub fn drain_for_bucket_update(&mut self) -> DeltaCategorization {
+    pub(crate) fn drain_for_bucket_update(&mut self) -> DeltaCategorization {
         self.current.drain_categorization_for_bucket_update()
     }
 
@@ -304,7 +304,7 @@ impl CloseLedgerState {
     /// soroban state snapshot held by the lookup closures, allowing
     /// `Arc::make_mut` on the live soroban state to mutate in-place instead
     /// of deep-cloning the entire HashMap.
-    pub fn release_snapshot_lookups(&mut self) {
+    pub(crate) fn release_snapshot_lookups(&mut self) {
         self.snapshot.release_lookups();
     }
 

--- a/crates/ledger/src/delta.rs
+++ b/crates/ledger/src/delta.rs
@@ -84,7 +84,7 @@ fn merge_ttl_current(
 /// - `Deleted` entries go to the "dead" batch
 #[derive(Debug, Clone)]
 /// Result of categorizing delta entries for bucket list update in a single pass.
-pub struct DeltaCategorization {
+pub(crate) struct DeltaCategorization {
     pub init_entries: Vec<LedgerEntry>,
     pub live_entries: Vec<LedgerEntry>,
     pub dead_keys: Vec<LedgerKey>,
@@ -712,7 +712,7 @@ impl LedgerDelta {
     /// Moves entries instead of cloning, saving ~50K clone operations.
     /// Metadata (fee_pool_delta, total_coins_delta) is preserved.
     /// Offer and pool share trustline changes are collected separately for commit_close.
-    pub fn drain_categorization_for_bucket_update(&mut self) -> DeltaCategorization {
+    pub(crate) fn drain_categorization_for_bucket_update(&mut self) -> DeltaCategorization {
         // Iterate using change_order for deterministic ordering.
         // drain() on a HashMap iterates in arbitrary order, which would
         // produce non-deterministic bucket list updates across nodes.

--- a/crates/ledger/src/execution/apply.rs
+++ b/crates/ledger/src/execution/apply.rs
@@ -57,7 +57,7 @@ pub(super) enum RestoreSource {
 /// Uses a single map to enforce that a key cannot appear in both hot-archive
 /// and live-BL sources simultaneously (type-enforced mutual exclusion).
 #[derive(Debug)]
-pub struct RestoredEntries {
+pub(crate) struct RestoredEntries {
     entries: HashMap<LedgerKey, RestoreSource>,
 }
 


### PR DESCRIPTION
Closes #3460

## Summary

Visibility-only cleanup of internal `crate:ledger` types and functions that have zero consumers outside the crate. All narrows are keyword-only changes (`pub` → `pub(crate)`) plus deletion of one dead zero-caller method; definitions and bodies are byte-identical, so there is no close-sequencing/fee/hash/bucket-list/tx-meta effect. `manager.rs` is not touched.

Per-finding:

- **F1** — `TxMeta` (close.rs:751) and `PreparedTxSet` (close.rs:757) → `pub(crate)`. Because Rust forbids a `pub` fn returning a more-private type (`private_interfaces`/E0446), each struct narrow is paired with narrowing its returner: `prepare_presorted` and `prepare_with_hash` → `pub(crate)`. The dead zero-caller `prepare()` wrapper (which would trigger `dead_code` once narrowed) is deleted. `ConfigUpgradeResult` / `apply_config_upgrades` are **kept `pub`** — the `upgrade_sequence_integration.rs` integration test calls `apply_config_upgrades`, which transitively pins `ConfigUpgradeResult` to `pub`.
- **F2** — `DeltaCategorization` (delta.rs:87) → `pub(crate)`, paired with both `drain_*` returners (`drain_categorization_for_bucket_update` in delta.rs, `drain_for_bucket_update` in close_state.rs).
- **F3** — `RestoredEntries` (apply.rs:60) → `pub(crate)`.
- **F4** — `all_offers` (close_state.rs:147) and `release_snapshot_lookups` (close_state.rs:307) → `pub(crate)`.

F5 excluded (already resolved by #3443); F6/F7 excluded (consensus-adjacent fee-event-assembly in `manager.rs`, and type-incompatible low-risk instances).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3460#issuecomment-4750367206)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build -p henyey-ledger --all-targets` under `RUSTFLAGS=-Dwarnings` (#3384 gate) — Finished, 0 errors
- [x] `cargo build --all` under `-Dwarnings` (incl. integration-test target pinning `ConfigUpgradeResult` pub) — Finished, 0 errors
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo test -p henyey-ledger` — 476 unit + integration suites, 0 failed (`upgrade_sequence_integration` green)

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)