### PR TITLE
Narrow SharedHistoryState to pub(crate) and drop needless borrow

### DIFF
--- a/crates/historywork/PARITY_STATUS.md
+++ b/crates/historywork/PARITY_STATUS.md
@@ -52,7 +52,7 @@ Corresponds to: `GetHistoryArchiveStateWork.h`
 | stellar-core | Rust | Status |
 |--------------|------|--------|
 | `GetHistoryArchiveStateWork(app, seq, archive, report, maxRetries)` | `GetHistoryArchiveStateWork { archive, checkpoint, state }` | Full |
-| `getHistoryArchiveState()` | `SharedHistoryState.has` | Full |
+| `getHistoryArchiveState()` | `HistoryWorkState.has` | Full |
 | `getArchive()` | `GetHistoryArchiveStateWork.archive` | Full |
 | `getStatus()` | `get_progress()` / `HistoryWorkProgress` | Full |
 | `doWork()` | `Work::run()` | Full |

--- a/crates/historywork/README.md
+++ b/crates/historywork/README.md
@@ -22,7 +22,7 @@ graph TD
     TX[DownloadTransactionsWork]
     RES[DownloadTxResultsWork]
     SCP[DownloadScpHistoryWork]
-    STATE[SharedHistoryState]
+    STATE[HistoryWorkState]
     DATA[build_checkpoint_data]
 
     HAS --> BKT
@@ -44,8 +44,7 @@ graph TD
 
 | Type | Description |
 |------|-------------|
-| `HistoryWorkState` | Shared single-checkpoint state holding HAS, bucket directory, downloaded XDR payloads, and progress. |
-| `SharedHistoryState` | `Arc<Mutex<HistoryWorkState>>` handle shared across work items. |
+| `HistoryWorkState` | Shared single-checkpoint state holding HAS, bucket directory, downloaded XDR payloads, and progress. Wrapped in an `Arc<Mutex<HistoryWorkState>>` handle shared across work items (internally aliased as the crate-private `SharedHistoryState`). |
 | `HistoryWorkStage` | Progress enum covering HAS, bucket, header, transaction, result, and SCP download stages. |
 | `HistoryWorkProgress` | Human-readable progress snapshot returned by `get_progress()`. |
 | `HistoryWorkBuilder` | Registers the checkpoint download DAG with a `WorkScheduler`. |
@@ -61,14 +60,15 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use henyey_history::archive::HistoryArchive;
-use henyey_historywork::{build_checkpoint_data, HistoryWorkBuilder, SharedHistoryState};
+use henyey_historywork::{build_checkpoint_data, HistoryWorkBuilder, HistoryWorkState};
 use henyey_work::{WorkScheduler, WorkSchedulerConfig};
+use tokio::sync::Mutex;
 
 # async fn example() -> anyhow::Result<()> {
 let archive = Arc::new(HistoryArchive::new(
     "https://history.stellar.org/prd/core-testnet/core_testnet_001",
 )?);
-let state: SharedHistoryState = Default::default();
+let state = Arc::new(Mutex::new(HistoryWorkState::default()));
 let builder = HistoryWorkBuilder::new(
     archive,
     63,
@@ -89,9 +89,12 @@ assert_eq!(checkpoint.has.current_ledger, 63);
 ### Monitor progress
 
 ```rust
-use henyey_historywork::{get_progress, HistoryWorkStage, SharedHistoryState};
+use std::sync::Arc;
 
-# async fn example(state: SharedHistoryState) {
+use henyey_historywork::{get_progress, HistoryWorkStage, HistoryWorkState};
+use tokio::sync::Mutex;
+
+# async fn example(state: Arc<Mutex<HistoryWorkState>>) {
 let progress = get_progress(&state).await;
 if let Some(HistoryWorkStage::DownloadBuckets) = progress.stage {
     tracing::info!(message = %progress.message, "history download progress");
@@ -102,9 +105,12 @@ if let Some(HistoryWorkStage::DownloadBuckets) = progress.stage {
 ### Consume assembled checkpoint data
 
 ```rust
-use henyey_historywork::{build_checkpoint_data, SharedHistoryState};
+use std::sync::Arc;
 
-# async fn example(state: SharedHistoryState) -> anyhow::Result<()> {
+use henyey_historywork::{build_checkpoint_data, HistoryWorkState};
+use tokio::sync::Mutex;
+
+# async fn example(state: Arc<Mutex<HistoryWorkState>>) -> anyhow::Result<()> {
 let checkpoint_data = build_checkpoint_data(&state).await?;
 
 // Pass the verified checkpoint data to catchup code without cloning the XDR.
@@ -125,7 +131,7 @@ assert!(!checkpoint_data.headers.is_empty());
 
 - Buckets are verified and written to disk during download so catchup does not
   keep multi-GB bucket payloads resident in memory.
-- `build_checkpoint_data()` moves data out of `SharedHistoryState`; callers
+- `build_checkpoint_data()` moves data out of the shared `HistoryWorkState`; callers
   should invoke it once after all scheduled work has completed.
 - Retry budgets come from `henyey_history::download` constants so the work DAG
   follows the same `RETRY_A_FEW` and `RETRY_A_LOT` policy as catchup.

--- a/crates/historywork/src/builder.rs
+++ b/crates/historywork/src/builder.rs
@@ -66,12 +66,13 @@ pub struct HistoryWorkIds {
 /// # Example
 ///
 /// ```rust,ignore
-/// use henyey_historywork::{HistoryWorkBuilder, SharedHistoryState};
+/// use henyey_historywork::{HistoryWorkBuilder, HistoryWorkState};
 /// use henyey_work::WorkScheduler;
 /// use std::sync::Arc;
+/// use tokio::sync::Mutex;
 ///
 /// // Create shared state and builder
-/// let state: SharedHistoryState = Default::default();
+/// let state = Arc::new(Mutex::new(HistoryWorkState::default()));
 /// let builder = HistoryWorkBuilder::new(archive.clone(), checkpoint, state.clone());
 ///
 /// // Register download work items

--- a/crates/historywork/src/download.rs
+++ b/crates/historywork/src/download.rs
@@ -208,7 +208,7 @@ impl Work for DownloadBucketsWork {
         let to_download: Vec<_> = hashes
             .iter()
             .filter(|hash| {
-                let path = bucket_dir.join(canonical_bucket_filename(&hash));
+                let path = bucket_dir.join(canonical_bucket_filename(hash));
                 !path.exists()
             })
             .cloned()

--- a/crates/historywork/src/lib.rs
+++ b/crates/historywork/src/lib.rs
@@ -40,8 +40,8 @@
 //!             └─────────────┘ └─────────────┘
 //! ```
 //!
-//! All work items share state through [`SharedHistoryState`], a thread-safe container
-//! that accumulates downloaded data as work progresses.
+//! All work items share state through a thread-safe `Arc<Mutex<`[`HistoryWorkState`]`>>`
+//! handle that accumulates downloaded data as work progresses.
 //!
 //! # Usage
 //!
@@ -50,12 +50,14 @@
 //! Use [`HistoryWorkBuilder`] to register download work items with a scheduler:
 //!
 //! ```rust,ignore
-//! use henyey_historywork::{HistoryWorkBuilder, SharedHistoryState};
+//! use henyey_historywork::{HistoryWorkBuilder, HistoryWorkState};
 //! use henyey_work::{WorkScheduler, WorkSchedulerConfig};
+//! use std::sync::Arc;
 //! use std::path::PathBuf;
+//! use tokio::sync::Mutex;
 //!
 //! // Create shared state for work items
-//! let state: SharedHistoryState = Default::default();
+//! let state = Arc::new(Mutex::new(HistoryWorkState::default()));
 //!
 //! // Build and register work items
 //! let builder = HistoryWorkBuilder::new(
@@ -109,9 +111,9 @@ pub use builder::{HistoryWorkBuilder, HistoryWorkIds};
 ///
 /// # Thread Safety
 ///
-/// This type is wrapped in [`SharedHistoryState`] (an `Arc<Mutex<...>>`) for
-/// safe sharing between concurrent work items. Work items acquire the lock
-/// briefly to read dependencies or write their output.
+/// This type is wrapped in an `Arc<Mutex<...>>` for safe sharing between
+/// concurrent work items. Work items acquire the lock briefly to read
+/// dependencies or write their output.
 ///
 /// # Fields
 ///
@@ -166,20 +168,27 @@ pub struct HistoryWorkState {
 
 /// Thread-safe handle to shared history work state.
 ///
-/// This type alias wraps [`HistoryWorkState`] in an `Arc<Mutex<...>>` for
-/// safe sharing between work items. Use `state.lock().await` to access
-/// the underlying state.
+/// Internal crate-private alias wrapping [`HistoryWorkState`] in an
+/// `Arc<Mutex<...>>` for safe sharing between work items. The public functions
+/// and [`HistoryWorkBuilder`] accept this handle as a plain
+/// `Arc<Mutex<HistoryWorkState>>`; external callers construct it directly rather
+/// than importing this alias name. Use `state.lock().await` to access the
+/// underlying state.
 ///
 /// # Example
 ///
 /// ```rust,ignore
-/// let state: SharedHistoryState = Default::default();
+/// use henyey_historywork::HistoryWorkState;
+/// use std::sync::Arc;
+/// use tokio::sync::Mutex;
+///
+/// let state = Arc::new(Mutex::new(HistoryWorkState::default()));
 ///
 /// // In a work item:
 /// let mut guard = state.lock().await;
 /// guard.has = Some(downloaded_has);
 /// ```
-pub type SharedHistoryState = Arc<Mutex<HistoryWorkState>>;
+pub(crate) type SharedHistoryState = Arc<Mutex<HistoryWorkState>>;
 
 /// Identifies the current stage of history work execution.
 ///


### PR DESCRIPTION
Closes #3458

## Summary

Two behavior-preserving cleanups in `henyey-historywork` (net diff = 0):

- **F1:** drop the needless borrow in the on-disk bucket cache-existence filter in `download.rs` (`canonical_bucket_filename(&hash)` → `(hash)`). The closure binds `hash: &&Hash256`; both forms deref-coerce to `&Hash256` identically, so this is a pure no-op.
- **F2:** narrow the `SharedHistoryState` type alias (`lib.rs`) from `pub` to `pub(crate)` (plan decision = option a). Nothing imports the alias name outside the crate — the downstream catchup consumer constructs `Arc<Mutex<HistoryWorkState>>` directly. A type alias is transparent for privacy, so the public `get_progress` / `build_checkpoint_data` / `HistoryWorkBuilder::new` signatures keep compiling warning-free under `-Dwarnings`, and external callers passing a raw `Arc<Mutex<HistoryWorkState>>` still coerce. Reconciled README, lib.rs/builder.rs doc examples, and PARITY_STATUS.md prose to stop advertising the alias as importable public API, pointing readers at the public `HistoryWorkState` type and functions instead.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3458#issuecomment-4750319623)

## Test plan

- [x] `cargo fmt --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-historywork --all-targets` — clean (confirms the pub(crate) narrow does not trip `private_interfaces`)
- [x] `cargo build -p henyey-app` — clean (cross-crate check: narrow does not break the downstream catchup consumer)
- [x] `cargo build --all` — clean
- [x] `cargo test -p henyey-historywork` — passes (3 tests + 5 ignored doctests)
- [x] `cargo clippy --all -- -D warnings` — clean

## Deviations from plan

Two minor scope-consistent additions beyond the plan's enumerated locations, both part of the same F2 "stop advertising the alias as importable" intent:
- F1 line was 211 on current `origin/main` (plan cited 221); applied to the correct `to_download` `.filter` closure. A second `canonical_bucket_filename(&hash)` at line 236 is a genuine borrow of an owned `Hash256` and was correctly left unchanged.
- `builder.rs` had an additional doc example importing the alias (`HistoryWorkBuilder, SharedHistoryState`); reconciled it the same way as the lib.rs/README examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)