### PR TITLE
Clean up dead and over-exposed crate:scp API surface

### DIFF
--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -372,6 +372,7 @@ impl BallotProtocol {
     }
 
     /// Get the high ballot (highest confirmable).
+    #[cfg(test)]
     pub fn high_ballot(&self) -> Option<&ScpBallot> {
         self.high_ballot.as_ref()
     }

--- a/crates/scp/src/lib.rs
+++ b/crates/scp/src/lib.rs
@@ -79,7 +79,7 @@ pub use quorum::{
 pub(crate) use quorum::is_valid_quorum_set;
 pub use quorum_config::{
     config_to_quorum_set, node_id_to_strkey, parse_node_id, testnet_quorum_config,
-    validate_quorum_config, QuorumConfigError,
+    QuorumConfigError,
 };
 pub use scp::{SlotState, SCP};
 pub use slot::Slot;

--- a/crates/scp/src/nomination.rs
+++ b/crates/scp/src/nomination.rs
@@ -182,11 +182,13 @@ impl NominationProtocol {
     }
 
     /// Get the voted values.
+    #[cfg(test)]
     pub fn votes(&self) -> &[Value] {
         &self.votes
     }
 
     /// Get the accepted values.
+    #[cfg(test)]
     pub fn accepted(&self) -> &[Value] {
         &self.accepted
     }
@@ -277,6 +279,7 @@ impl NominationProtocol {
     }
 
     /// Get the timer expiration count.
+    #[cfg(test)]
     pub fn timer_exp_count(&self) -> u32 {
         self.timer_exp_count
     }

--- a/crates/scp/src/quorum.rs
+++ b/crates/scp/src/quorum.rs
@@ -171,19 +171,13 @@ where
     is_quorum_slice(quorum_set, &remaining_set, &get_quorum_set)
 }
 
-/// Check if a set of nodes is a blocking set.
+/// Check if a set of nodes is a v-blocking set for a given quorum set.
 ///
-/// A set B is a blocking set if it intersects every quorum slice.
-/// This means that no quorum can be formed without at least one
-/// node from B participating.
+/// A set B is v-blocking for node v if B intersects all of v's quorum slices.
 ///
 /// # Arguments
 /// * `quorum_set` - The quorum set to check against
 /// * `nodes` - The set of nodes to check
-///
-/// Check if a set of nodes is a v-blocking set for a given quorum set.
-///
-/// A set B is v-blocking for node v if B intersects all of v's quorum slices.
 ///
 /// # Returns
 /// True if the nodes form a v-blocking set.

--- a/crates/scp/src/quorum_config.rs
+++ b/crates/scp/src/quorum_config.rs
@@ -33,9 +33,8 @@
 
 use henyey_common::config::QuorumSetConfig;
 use stellar_xdr::curr::{NodeId, PublicKey, ScpQuorumSet, Uint256};
-use tracing::warn;
 
-use crate::{get_all_nodes, is_quorum_set_sane, is_valid_quorum_set};
+use crate::is_valid_quorum_set;
 
 /// Errors that can occur when parsing or validating quorum set configuration.
 ///
@@ -190,53 +189,6 @@ fn parse_hex_node_id(key_str: &str) -> Result<NodeId, QuorumConfigError> {
     Ok(NodeId(PublicKey::PublicKeyTypeEd25519(Uint256(arr))))
 }
 
-/// Validate that a quorum set configuration will produce valid consensus.
-///
-/// This checks:
-/// 1. The quorum set is structurally valid
-/// 2. Threshold is reasonable (not 0, not > 100%)
-/// 3. There are enough validators for safety
-pub fn validate_quorum_config(config: &QuorumSetConfig) -> Result<(), QuorumConfigError> {
-    // Check threshold is in range (ThresholdPercent already validated during deserialization)
-    let threshold_value: u32 = config.threshold_percent.into();
-    if threshold_value > 100 {
-        return Err(QuorumConfigError::InvalidThreshold {
-            threshold: threshold_value,
-            validator_count: 100,
-        });
-    }
-
-    // Convert to XDR to validate structure
-    let qs = config_to_quorum_set(config)?;
-
-    if let Err(err) = is_quorum_set_sane(&qs, false) {
-        return Err(QuorumConfigError::InvalidStructure(err));
-    }
-
-    // Check we have validators
-    let all_nodes = get_all_nodes(&qs);
-    if all_nodes.is_empty() && config.validators.is_empty() && config.inner_sets.is_empty() {
-        warn!("Quorum set has no validators - node will not be able to reach consensus");
-    }
-
-    // Warn if threshold is too low
-    if threshold_value < 51 {
-        warn!(
-            "Quorum threshold {}% is below 51% - this may compromise safety",
-            threshold_value
-        );
-    }
-
-    // Warn if threshold is 100% (no fault tolerance)
-    if threshold_value == 100 && !config.validators.is_empty() {
-        warn!(
-            "Quorum threshold is 100% - no fault tolerance, any validator failure blocks consensus"
-        );
-    }
-
-    Ok(())
-}
-
 /// Well-known validators for Stellar networks.
 ///
 /// This module provides public keys for SDF-operated validators on testnet
@@ -275,12 +227,6 @@ pub mod known_validators {
     ///
     /// With 67% threshold, the network can tolerate up to 1/3 faulty validators.
     pub const RECOMMENDED_THRESHOLD_PERCENT: u32 = 67;
-
-    /// Minimum safe threshold percentage (51%).
-    ///
-    /// Below 51%, the network may not have proper quorum intersection,
-    /// compromising safety guarantees.
-    pub const MINIMUM_SAFE_THRESHOLD_PERCENT: u32 = 51;
 }
 
 fn recommended_quorum_config(validators: &[&str]) -> QuorumSetConfig {
@@ -297,14 +243,6 @@ fn recommended_quorum_config(validators: &[&str]) -> QuorumSetConfig {
 /// Create a testnet quorum set configuration.
 pub fn testnet_quorum_config() -> QuorumSetConfig {
     recommended_quorum_config(known_validators::TESTNET_VALIDATORS)
-}
-
-/// Create a mainnet quorum set configuration using SDF validators.
-///
-/// Note: For production, you should configure your own quorum set
-/// based on validators you trust. This is just a starting point.
-pub fn mainnet_sdf_quorum_config() -> QuorumSetConfig {
-    recommended_quorum_config(known_validators::MAINNET_SDF_VALIDATORS)
 }
 
 /// Convert a NodeId to a strkey string (G... format).
@@ -347,20 +285,6 @@ mod tests {
         let qs = config_to_quorum_set(&config).unwrap();
         assert_eq!(qs.validators.len(), 3);
         assert_eq!(qs.threshold, 3); // 67% of 3 = 2.01 -> ceil -> 3
-    }
-
-    #[test]
-    fn test_validate_quorum_config() {
-        let config = QuorumSetConfig {
-            threshold_percent: 67.into(),
-            validators: vec![
-                "0000000000000000000000000000000000000000000000000000000000000001".to_string(),
-                "0000000000000000000000000000000000000000000000000000000000000002".to_string(),
-            ],
-            inner_sets: Vec::new(),
-        };
-
-        assert!(validate_quorum_config(&config).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Closes #3463

## Summary

Four behavior-preserving cleanups in `henyey-scp` (net behavioral diff = 0):

- **F1** — consolidate the duplicated docstring on `is_v_blocking` (`quorum.rs`): drop the stale leading "blocking set" paragraph (predates the v-blocking rename), keep the "v-blocking" prose, with a single `# Arguments` + `# Returns`. Function body untouched.
- **F2** — `#[cfg(test)]`-gate the test-only read-only accessor `high_ballot()` (`ballot/mod.rs`); `pub` kept.
- **F3** — `#[cfg(test)]`-gate the test-only read-only accessors `votes()` / `accepted()` / `timer_exp_count()` (`nomination.rs`); `pub` kept.
- **F4** — delete dead config scaffolding: `validate_quorum_config` (+ its test `test_validate_quorum_config` + the `lib.rs` re-export), the `MINIMUM_SAFE_THRESHOLD_PERCENT` const, and the unused `mainnet_sdf_quorum_config` fn; drop the now-orphaned `tracing::warn` / `get_all_nodes` / `is_quorum_set_sane` imports.

**Consensus-critical confirmation:** none of these modify the nomination/ballot state-machine logic, the runtime quorum-intersection check (`is_v_blocking`/`is_quorum_slice` bodies — F1 is docs only), or message validation. F2/F3 are read-only test accessors. The live `known_validators` consts (`MAINNET_SDF_VALIDATORS`/`TESTNET_VALIDATORS`/`RECOMMENDED_THRESHOLD_PERCENT`) consumed by `crates/app` and the sibling re-exports `testnet_quorum_config`/`config_to_quorum_set` are untouched. STRICT parity v26.0.1 preserved.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3463#issuecomment-4750897718)

## Test plan

- [x] `cargo build -p henyey-scp --all-targets` under `-Dwarnings` (#3384 build-verify)
- [x] `cargo build --all` under `-Dwarnings`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-scp` — 564 passed, 0 failed

## Deviations from plan

None. (The plan anticipated the orphaned-import cleanup via the `-Dwarnings` build-verify; `tracing::warn`/`get_all_nodes`/`is_quorum_set_sane` became unused after deleting `validate_quorum_config` and were removed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)