### PR TITLE
Simplify rpc disk-read-entry count and dispatch param validation

### DIFF
--- a/crates/rpc/src/dispatch.rs
+++ b/crates/rpc/src/dispatch.rs
@@ -26,9 +26,8 @@ pub async fn dispatch(
         | "getEvents"
         | "sendTransaction"
         | "simulateTransaction" => {
-            if let Err(e) = util::require_params_object(&params) {
-                Err(e)
-            } else {
+            async {
+                util::require_params_object(&params)?;
                 match method {
                     "getLedgerEntries" => methods::get_ledger_entries::handle(ctx, params).await,
                     "getTransaction" => methods::get_transaction::handle(ctx, params).await,
@@ -40,6 +39,7 @@ pub async fn dispatch(
                     _ => unreachable!(),
                 }
             }
+            .await
         }
         _ => Err(JsonRpcError::method_not_found(method)),
     };

--- a/crates/rpc/src/simulate/resources.rs
+++ b/crates/rpc/src/simulate/resources.rs
@@ -203,17 +203,13 @@ pub(super) fn compute_invoke_resource_fee(
     // only non-Soroban entries (accounts, trustlines etc.) count, since Soroban
     // entries (ContractData/ContractCode) are cached in memory and don't require
     // disk reads. Auto-restored entries also count.
-    let mut disk_read_entries = 0u32;
-    for k in resources.footprint.read_only.iter() {
-        if !henyey_common::is_soroban_key(k) {
-            disk_read_entries += 1;
-        }
-    }
-    for k in resources.footprint.read_write.iter() {
-        if !henyey_common::is_soroban_key(k) {
-            disk_read_entries += 1;
-        }
-    }
+    let mut disk_read_entries = resources
+        .footprint
+        .read_only
+        .iter()
+        .chain(resources.footprint.read_write.iter())
+        .filter(|k| !henyey_common::is_soroban_key(k))
+        .count() as u32;
     disk_read_entries += restored_entry_count;
 
     compute_resource_fee_core(&ResourceFeeParams {


### PR DESCRIPTION
Closes #3462

## Summary

Two behavior-preserving `henyey-rpc` code-quality cleanups from the converged plan (F1 + F3; F2 dropped), with net behavioral diff = 0 and zero RPC API-surface change.

- **F1 (`crates/rpc/src/simulate/resources.rs`):** Collapse the two `read_only`/`read_write` accumulation loops into a single `iter().chain(...).filter(|k| !is_soroban_key(k)).count() as u32`, keeping `+ restored_entry_count` as a trailing statement. A `.count()` is order-independent, so the `disk_read_entries` fee scalar fed to `compute_resource_fee_core` is identical. `disk_read_entries` is not a named/shaped RPC response field.
- **F3 (`crates/rpc/src/dispatch.rs`):** Un-nest the `if let Err(e) {Err(e)} else {match}` antipattern into `util::require_params_object(&params)?` inside an inline async block within the EXISTING combined 7-method arm. Validation stays gated to exactly those 7 methods (`getLedgerEntries`, `getTransaction`, `getTransactions`, `getLedgers`, `getEvents`, `sendTransaction`, `simulateTransaction`); the 5 ungated methods (`getHealth`/`getNetwork`/`getLatestLedger`/`getVersionInfo`/`getFeeStats`) and `method_not_found` are untouched, and the terminal `match result {...}` wrapper is kept verbatim — so all success/error JSON is byte-identical.
- **F2 (`server.rs:390`):** DROPPED per plan (not touched).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3462#issuecomment-4750889159)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-rpc --all-targets (RUSTFLAGS=-Dwarnings)
- [x] cargo build --all
- [x] cargo test -p henyey-rpc — 37+1 passed; the param-gating guard `fake_type_validation_root_params_object`, the `*_not_ready_beats_invalid_params` tests, and the 5 non-gated success tests all pass

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)