### PR TITLE
Apply mechanical hygiene cleanups in henyey-simulation

### DIFF
--- a/crates/simulation/src/applyload.rs
+++ b/crates/simulation/src/applyload.rs
@@ -482,7 +482,7 @@ impl ApplyLoad {
             let result = self.tx_gen.invoke_soroban_load_transaction(
                 ledger_num,
                 account_id,
-                &load_instance,
+                load_instance,
                 Some(1_000_000),
             );
 
@@ -1227,7 +1227,7 @@ impl ApplyLoad {
                         ledger_num,
                         account_idx,
                         &self.batch_transfer_instances[cluster_id as usize],
-                        &sac_instance,
+                        sac_instance,
                         destinations,
                         None,
                     )?;
@@ -1246,7 +1246,7 @@ impl ApplyLoad {
                     ledger_num,
                     account_idx,
                     to_address,
-                    &sac_instance,
+                    sac_instance,
                     100,
                     None,
                 )?;
@@ -1399,7 +1399,7 @@ impl ApplyLoad {
             }),
             // 11: CONFIG_SETTING_CONTRACT_EXECUTION_LANES
             ConfigSettingEntry::ContractExecutionLanes(ConfigSettingContractExecutionLanesV0 {
-                ledger_max_tx_count: ledger_max_tx_count,
+                ledger_max_tx_count,
             }),
             // 14: CONFIG_SETTING_CONTRACT_PARALLEL_COMPUTE_V0
             ConfigSettingEntry::ContractParallelComputeV0(ConfigSettingContractParallelComputeV0 {

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -1953,13 +1953,13 @@ impl Drop for Simulation {
                 node.app.shutdown();
                 tracing::debug!(node = %id, "Simulation::drop: shutdown requested");
             }
-            for (_id, node) in self.running_apps.drain() {
+            for node in self.running_apps.values() {
                 node.task.handle.abort();
             }
         }
 
         #[cfg(test)]
-        for (_id, node) in self.test_nodes.drain() {
+        for node in self.test_nodes.values() {
             node.handle.abort();
         }
     }

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -564,7 +564,7 @@ impl TxGenerator {
                 }
             } else {
                 let name = format!("TestAccount-{}", account_id);
-                let initial_seq = (ledger_num as i64) << 32;
+                let initial_seq = (ledger_num as i64) << INITIAL_SEQ_LEDGER_SHIFT;
                 let mut account = TestAccount::from_name(&name, initial_seq);
                 // Try to load real sequence from DB
                 match self.app.load_account_sequence(&account.account_id) {
@@ -613,7 +613,7 @@ impl TxGenerator {
         balance: i64,
     ) -> Vec<Operation> {
         let mut ops = Vec::with_capacity(count as usize);
-        let initial_seq = (ledger_num as i64) << 32;
+        let initial_seq = (ledger_num as i64) << INITIAL_SEQ_LEDGER_SHIFT;
         for i in start..start + count {
             let name = format!("TestAccount-{}", i);
             let account = TestAccount::from_name(&name, initial_seq);
@@ -1038,10 +1038,7 @@ impl TxGenerator {
     ) -> anyhow::Result<(u64, TransactionEnvelope)> {
         let fee = self.generate_fee(max_fee_rate, 1, source_account_id);
         let sac_address = make_contract_address(&sac_instance.contract_id);
-        let dest_vals: Vec<ScVal> = destinations
-            .into_iter()
-            .map(|a| ScVal::Address(a))
-            .collect();
+        let dest_vals: Vec<ScVal> = destinations.into_iter().map(ScVal::Address).collect();
         let (sk, seq) = self.next_source_sequence(source_account_id, ledger_num);
         let builder = self.soroban_builder();
         let envelope = builder.invoke_batch_transfer_tx(

--- a/crates/simulation/src/loadgen_pregenerated.rs
+++ b/crates/simulation/src/loadgen_pregenerated.rs
@@ -34,6 +34,7 @@ impl PregeneratedTxReader {
     }
 
     /// Construct a reader over an in-memory record-marked buffer (testing).
+    #[cfg(test)]
     pub fn from_bytes(data: Vec<u8>) -> Self {
         Self { data, offset: 0 }
     }


### PR DESCRIPTION
Closes #3464

## Summary

Six mechanical, behavior-preserving hygiene fixes in the `henyey-simulation` loadgen/applyload test harness, batched into one PR per the converged plan. Net behavioral diff = 0 — no generated-load determinism, tx-set, or XDR byte change.

- **F1** (`loadgen.rs`): replace bare `<< 32` with the named `<< INITIAL_SEQ_LEDGER_SHIFT` const (== 32) at two sites.
- **F2** (`applyload.rs`): drop the no-op leading `&` on three already-`&ContractInstance` arguments. The sibling `&self.batch_transfer_instances[…]` (a genuine owned-slice borrow) is left intact.
- **F3** (`loadgen.rs`): `.map(|a| ScVal::Address(a))` → `.map(ScVal::Address)` (identical XDR).
- **F4** (`loadgen_pregenerated.rs`): `#[cfg(test)]`-gate the test-only `from_bytes` constructor (all 3 callers are in `#[cfg(test)] mod tests`).
- **F6** (`lib.rs`): drop the dead `_id` key binding in two `Drop` loops (`drain()` → `values()`; `abort()` only needs `&self`).
- **F7** (`applyload.rs`): field shorthand for `ledger_max_tx_count`.

**F5** (`setup_upgrade_contract`) is deliberately left untouched — it is an intentional parity placeholder mirroring core's `setupUpgradeContract()`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3464#issuecomment-4750915581)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `RUSTFLAGS="-Dwarnings" cargo build -p henyey-simulation --all-targets` (#3384 build-verify for F4 — clean)
- [x] `cargo test -p henyey-simulation` — all pass
- [x] `cargo build --all` — clean

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)