### PR TITLE
Clean up dead/test-only overlay symbols and fix stale bit-31 docs

### DIFF
--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -932,7 +932,7 @@ mod tests {
         assert_eq!(hello.ledger_version, 26);
     }
 
-    // ---- G14: Auth flag (bit 31) gates MAC verification in unwrap_message ----
+    // ---- G14: receiver auth state (not the wire bit-31 flag) gates MAC verification in unwrap_message ----
 
     /// Helper: Complete a full handshake between two AuthContexts.
     /// Returns (initiator, acceptor) both in Authenticated state.
@@ -994,7 +994,7 @@ mod tests {
         let msg = StellarMessage::Peers(xdr::VecM::default());
         let wrapped = ctx_a.wrap_message(msg.clone()).unwrap();
 
-        // message_is_authenticated=true → MAC should be verified
+        // Receiver is authenticated → MAC is verified (and passes for a valid MAC).
         let unwrapped = ctx_b.unwrap_message(wrapped).unwrap();
         assert!(matches!(unwrapped, StellarMessage::Peers(_)));
     }
@@ -1002,7 +1002,7 @@ mod tests {
     #[test]
     fn test_unwrap_bad_mac_rejected_when_authenticated_g14() {
         // After handshake, a message with a wrong MAC should be rejected
-        // when bit 31 is set (message_is_authenticated=true).
+        // because the receiver's own auth state is authenticated.
         let (mut ctx_a, mut ctx_b) = complete_handshake();
 
         let msg = StellarMessage::Peers(xdr::VecM::default());

--- a/crates/overlay/src/codec.rs
+++ b/crates/overlay/src/codec.rs
@@ -48,7 +48,13 @@ pub struct MessageFrame {
     /// Size of the message body in bytes (not including length prefix).
     pub raw_len: usize,
 
-    /// Whether bit 31 was set in the length prefix.
+    /// Whether bit 31 of the 4-byte length prefix was set.
+    ///
+    /// Invariant: bit 31 is the XDR record-marking "last fragment"
+    /// (continuation) bit, NOT an authentication flag. stellar-core treats
+    /// it identically (`TCPPeer.cpp:679`: `length &= 0x7f` clears the XDR
+    /// continuation bit). MAC/auth gating is on the receiver's own auth
+    /// state (see `AuthContext::unwrap_message`), never on this wire bit.
     pub is_last_fragment: bool,
 }
 

--- a/crates/overlay/src/flood.rs
+++ b/crates/overlay/src/flood.rs
@@ -463,19 +463,6 @@ pub struct FloodGateStats {
     pub evictions_total: u64,
 }
 
-impl FloodGateStats {
-    /// Calculates the duplicate rate as a percentage.
-    ///
-    /// Returns 0.0 if no messages have been processed.
-    pub fn duplicate_rate(&self) -> f64 {
-        if self.total_messages == 0 {
-            0.0
-        } else {
-            (self.duplicate_messages as f64 / self.total_messages as f64) * 100.0
-        }
-    }
-}
-
 /// Computes the BLAKE2b-256 hash of a message for flood tracking.
 ///
 /// This matches stellar-core's `xdrBlake2()` used in `Floodgate::broadcast()`.

--- a/crates/overlay/src/lib.rs
+++ b/crates/overlay/src/lib.rs
@@ -110,16 +110,14 @@ pub use loopback::LoopbackConnectionFactory;
 #[doc(hidden)]
 pub use manager::TestPeerReceiver;
 pub use manager::{AddPeerOutcome, OverlayManager, OverlayMessage, OverlayStats, PeerSnapshot};
-pub use metrics::{
-    Counter, OverlayMessageKind, OverlayMetrics, OverlayMetricsSnapshot, Timer, TimerSnapshot,
-};
+pub use metrics::{Counter, OverlayMessageKind, OverlayMetrics, OverlayMetricsSnapshot};
 pub use peer::{Peer, PeerInfo, PeerState, PeerStats, PeerStatsSnapshot};
 pub use peer_manager::{
     BackOffUpdate, PeerManager, PeerQuery, PeerRecord, PeerTypeFilter, StoredPeerType, TypeUpdate,
 };
 pub use survey::{
     CollectingNodeData, CollectingPeerData, SurveyConfig, SurveyManager, SurveyManagerStats,
-    SurveyPhase, TimeSlicedNodeData, TimeSlicedPeerData, SURVEY_THROTTLE_TIMEOUT_MULT,
+    SurveyPhase, TimeSlicedNodeData, TimeSlicedPeerData,
 };
 
 use std::collections::HashSet;

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -345,12 +345,6 @@ impl KnownPeerSet {
         entries.extend(self.discovered.iter().cloned());
         entries
     }
-
-    /// Total known peer count.
-    #[allow(dead_code)]
-    pub(super) fn len(&self) -> usize {
-        self.config_entries.len() + self.discovered.len()
-    }
 }
 
 /// An overlay message received from a peer, ready for dispatch to subscribers.

--- a/crates/overlay/src/metrics.rs
+++ b/crates/overlay/src/metrics.rs
@@ -23,7 +23,6 @@
 //! All metrics use atomic operations and are safe to access from multiple threads.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant};
 
 use stellar_xdr::curr::StellarMessage;
 
@@ -67,167 +66,10 @@ impl Counter {
     }
 }
 
-/// Simple timer for tracking operation latencies.
-#[derive(Debug)]
-pub struct Timer {
-    /// Total duration of all recorded operations.
-    total_duration_us: AtomicU64,
-    /// Number of operations recorded.
-    count: AtomicU64,
-    /// Minimum duration in microseconds.
-    min_us: AtomicU64,
-    /// Maximum duration in microseconds.
-    max_us: AtomicU64,
-}
-
-impl Default for Timer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Timer {
-    /// Create a new timer.
-    pub fn new() -> Self {
-        Self {
-            total_duration_us: AtomicU64::new(0),
-            count: AtomicU64::new(0),
-            min_us: AtomicU64::new(u64::MAX),
-            max_us: AtomicU64::new(0),
-        }
-    }
-
-    /// Record a duration.
-    pub fn record(&self, duration: Duration) {
-        let us = duration.as_micros() as u64;
-        self.total_duration_us.fetch_add(us, Ordering::Relaxed);
-        self.count.fetch_add(1, Ordering::Relaxed);
-
-        // Update min (compare-and-swap loop)
-        loop {
-            let current_min = self.min_us.load(Ordering::Relaxed);
-            if us >= current_min {
-                break;
-            }
-            if self
-                .min_us
-                .compare_exchange_weak(current_min, us, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
-        }
-
-        // Update max
-        loop {
-            let current_max = self.max_us.load(Ordering::Relaxed);
-            if us <= current_max {
-                break;
-            }
-            if self
-                .max_us
-                .compare_exchange_weak(current_max, us, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
-        }
-    }
-
-    /// Start timing an operation. Returns a guard that records the duration when dropped.
-    pub fn start(&self) -> TimerGuard<'_> {
-        TimerGuard {
-            timer: self,
-            start: Instant::now(),
-        }
-    }
-
-    /// Get the number of recorded operations.
-    pub fn count(&self) -> u64 {
-        self.count.load(Ordering::Relaxed)
-    }
-
-    /// Get the total duration of all recorded operations.
-    pub fn total_duration(&self) -> Duration {
-        Duration::from_micros(self.total_duration_us.load(Ordering::Relaxed))
-    }
-
-    /// Get the average duration (returns 0 if no operations recorded).
-    pub fn avg_duration(&self) -> Duration {
-        let count = self.count();
-        if count == 0 {
-            return Duration::ZERO;
-        }
-        let total = self.total_duration_us.load(Ordering::Relaxed);
-        Duration::from_micros(total / count)
-    }
-
-    /// Get the minimum duration (returns MAX if no operations recorded).
-    pub fn min_duration(&self) -> Duration {
-        let min = self.min_us.load(Ordering::Relaxed);
-        if min == u64::MAX {
-            Duration::ZERO
-        } else {
-            Duration::from_micros(min)
-        }
-    }
-
-    /// Get the maximum duration.
-    pub fn max_duration(&self) -> Duration {
-        Duration::from_micros(self.max_us.load(Ordering::Relaxed))
-    }
-
-    /// Get a snapshot of timer statistics.
-    pub fn snapshot(&self) -> TimerSnapshot {
-        TimerSnapshot {
-            count: self.count(),
-            total: self.total_duration(),
-            avg: self.avg_duration(),
-            min: self.min_duration(),
-            max: self.max_duration(),
-        }
-    }
-
-    /// Reset all values.
-    pub fn reset(&self) {
-        self.total_duration_us.store(0, Ordering::Relaxed);
-        self.count.store(0, Ordering::Relaxed);
-        self.min_us.store(u64::MAX, Ordering::Relaxed);
-        self.max_us.store(0, Ordering::Relaxed);
-    }
-}
-
-/// Guard that records timer duration when dropped.
-pub struct TimerGuard<'a> {
-    timer: &'a Timer,
-    start: Instant,
-}
-
-impl Drop for TimerGuard<'_> {
-    fn drop(&mut self) {
-        self.timer.record(self.start.elapsed());
-    }
-}
-
 fn reset_counters(counters: &[&Counter]) {
     for counter in counters {
         counter.reset();
     }
-}
-
-/// Snapshot of timer statistics.
-#[derive(Debug, Clone)]
-pub struct TimerSnapshot {
-    /// Number of operations.
-    pub count: u64,
-    /// Total duration.
-    pub total: Duration,
-    /// Average duration.
-    pub avg: Duration,
-    /// Minimum duration.
-    pub min: Duration,
-    /// Maximum duration.
-    pub max: Duration,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -820,61 +662,6 @@ mod tests {
     }
 
     #[test]
-    fn test_timer_basic() {
-        let timer = Timer::new();
-        assert_eq!(timer.count(), 0);
-
-        timer.record(Duration::from_millis(10));
-        timer.record(Duration::from_millis(20));
-        timer.record(Duration::from_millis(30));
-
-        assert_eq!(timer.count(), 3);
-
-        let snapshot = timer.snapshot();
-        assert_eq!(snapshot.count, 3);
-        // Total should be around 60ms (60000 us)
-        assert!(snapshot.total.as_micros() >= 59000);
-        assert!(snapshot.total.as_micros() <= 61000);
-        // Min should be around 10ms
-        assert!(snapshot.min.as_millis() >= 9);
-        assert!(snapshot.min.as_millis() <= 11);
-        // Max should be around 30ms
-        assert!(snapshot.max.as_millis() >= 29);
-        assert!(snapshot.max.as_millis() <= 31);
-    }
-
-    #[test]
-    fn test_timer_guard() {
-        let timer = Timer::new();
-
-        {
-            let _guard = timer.start();
-            thread::sleep(Duration::from_millis(5));
-        }
-
-        assert_eq!(timer.count(), 1);
-        assert!(timer.total_duration().as_millis() >= 4);
-    }
-
-    #[test]
-    fn test_timer_concurrent() {
-        let timer = Timer::new();
-        let timer_ref = &timer;
-
-        thread::scope(|s| {
-            for _ in 0..10 {
-                s.spawn(|| {
-                    for _ in 0..10 {
-                        timer_ref.record(Duration::from_micros(100));
-                    }
-                });
-            }
-        });
-
-        assert_eq!(timer.count(), 100);
-    }
-
-    #[test]
     fn test_overlay_metrics_creation() {
         let metrics = OverlayMetrics::new();
 
@@ -927,14 +714,6 @@ mod tests {
 
         assert_eq!(metrics.messages_read.get(), 0);
         assert_eq!(metrics.bytes_read.get(), 0);
-    }
-
-    #[test]
-    fn test_timer_empty_avg() {
-        let timer = Timer::new();
-        assert_eq!(timer.avg_duration(), Duration::ZERO);
-        assert_eq!(timer.min_duration(), Duration::ZERO);
-        assert_eq!(timer.max_duration(), Duration::ZERO);
     }
 
     #[test]

--- a/crates/overlay/src/survey.rs
+++ b/crates/overlay/src/survey.rs
@@ -53,6 +53,7 @@ const NUM_LEDGERS_BEFORE_IGNORE: u32 = 6;
 const MAX_REQUEST_LIMIT_PER_LEDGER: u32 = 10;
 
 /// Throttle timeout multiplier for survey requests.
+#[cfg(test)]
 pub const SURVEY_THROTTLE_TIMEOUT_MULT: u32 = 3;
 
 /// Survey throttle timeout in milliseconds.


### PR DESCRIPTION
Closes #3461

## Summary

Behavior-preserving overlay hygiene from the second `/cleanup` sweep, implementing the RE-PLANNED converged scope (F4/F5 corrected and build-verified after the prior `## Do: Plan Wrong` bounce). Net runtime behavior diff = 0; wire format unchanged.

- **F1** — delete dead `FloodGateStats::duplicate_rate()` (sole method in its impl block, 0 callers; `seen_count`/`total_messages`/`duplicate_messages` fields kept, still consumed externally).
- **F3** — delete dead `KnownPeerSet::len()` and its `#[allow(dead_code)]`.
- **F4-Timer** — delete the test-only `Timer`/`TimerGuard`/`TimerSnapshot` types, the 4 dedicated Timer tests (`test_timer_basic`, `test_timer_guard`, `test_timer_concurrent`, `test_timer_empty_avg`), the now-unused `use std::time::{Duration, Instant}`, and the `lib.rs` `Timer`/`TimerSnapshot` re-exports. `#[cfg(test)]`-gating these types instead fails `-Dwarnings` (`Timer::reset`/`TimerSnapshot::avg` unused even in the test build), so deletion is the only build-clean option.
- **F4-Counter** — intentionally NOT done: `Counter` stays `pub`. `OverlayMetrics` has 47 `pub Counter` fields, so narrowing would force 47 private-in-public errors — out of proportion for a low-sev cleanup.
- **F5** — `#[cfg(test)]`-gate `SURVEY_THROTTLE_TIMEOUT_MULT` (its only consumer is a `#[cfg(test)]` spec test; `pub(crate)` would be dead-in-lib under `-Dwarnings`, the #3384 trap). Spec value `= 3` and `test_survey_throttle_timeout_mult_is_3` preserved; drops the `lib.rs` re-export.
- **F6** (docs-only) — correct stale bit-31 "auth flag" explanatory prose in `auth.rs` test comments. MAC verification is gated on the receiver's own auth state, not the wire bit. Test bodies, test names, assertion-message strings (incl. "…clearing the wire auth flag"), and all bit-31 mask expressions preserved verbatim.
- **F7** (docs-only) — add an invariant comment on the wire-facing `is_last_fragment` field (`codec.rs:52`): bit 31 is the XDR record-marking continuation bit, not an auth flag, matching stellar-core `TCPPeer.cpp:679`. Edited by field name; no field removal.

F2/F8 remain scoped out as follow-ups #3517 / #3518.

## Parity

`crate:overlay` is parity-sensitive (P2P wire protocol). None of F1/F3/F4/F5/F6/F7 changes message framing, MAC/auth verification, flooding, or peer-selection behavior. Bit-31 masks (`raw_len & 0x80000000`, `& 0x7FFFFFFF`) and AUDIT-C1 MAC-gating are untouched. Strict parity v26.0.1 maintained (anchor: stellar-core `TCPPeer.cpp:679`).

## Plan reference

[Converged Plan (RE-PLAN) comment](https://github.com/stellar-experimental/henyey/issues/3461#issuecomment-4751089095)

## Test plan

- [x] `cargo build -p henyey-overlay --all-targets` (`RUSTFLAGS=-Dwarnings`) → EXIT 0
- [x] `cargo build --all` (`RUSTFLAGS=-Dwarnings`) → EXIT 0
- [x] `cargo fmt --check` → clean
- [x] `cargo clippy --all -- -D warnings` → clean
- [x] `cargo test -p henyey-overlay --lib` → 468 passed, 0 failed (incl. `test_survey_throttle_timeout_mult_is_3`)
- [x] `cargo test -p henyey-overlay` (integration + doc) → all pass

## Deviations from plan

None. Diff: 7 files, +13/-248 (F1/F3/F4/F5 deletes + F6/F7 docs), matching the plan's expected shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)