### PR TITLE
Consolidate scheduler lookups and hoist cancelled guard in work crate

### DIFF
--- a/crates/work/src/scheduler.rs
+++ b/crates/work/src/scheduler.rs
@@ -105,7 +105,11 @@ impl Default for WorkSchedulerConfig {
 /// [`WorkSlot::InFlight`]). On successful completion, ownership is returned and
 /// the work item can be retried. On panic or task abort, the work item is
 /// permanently lost ([`WorkSlot::Lost`]) — this is safe because panics and aborts
-/// transition work to terminal states that are never re-run.
+/// transition work to terminal states that are never re-run. `Lost` is a
+/// write-only diagnostic marker: it is set once on the panic/abort path and is
+/// never re-read to drive behavior (the sole reader treats any non-`Idle` slot
+/// identically), so it is kept purely to distinguish "moved into a panicked or
+/// aborted task" from `InFlight` = "moved into a still-running task".
 ///
 /// # Example
 ///
@@ -235,6 +239,12 @@ enum WorkSlot {
     /// Work has been moved into a spawned task.
     InFlight,
     /// Work was irrecoverably lost due to panic or task abort (terminal).
+    ///
+    /// Write-only diagnostic marker: set once on the panic/abort path (from a
+    /// prior `InFlight` state) and never re-read to drive behavior — the sole
+    /// reader treats any non-`Idle` slot identically. Kept to distinguish a
+    /// panicked/aborted task from one that is still running (`InFlight`);
+    /// collapsing it into `InFlight` is a deliberately deferred design decision.
     Lost,
 }
 
@@ -373,7 +383,7 @@ impl WorkScheduler {
     pub(crate) fn cancel_all(&mut self) {
         let ids: Vec<WorkId> = self.entries.keys().copied().collect();
         for id in ids {
-            let _ = self.cancel(id);
+            self.cancel(id);
         }
     }
 
@@ -559,14 +569,18 @@ impl WorkScheduler {
             return false;
         }
 
-        let Some(attempts) = self.entries.get_mut(&id).map(|entry| entry.attempts) else {
-            return false;
-        };
-        if self
+        // Read both `attempts` and the cancel-token state out of a single
+        // immutable lookup into `Copy` locals, dropping the borrow before the
+        // `finish_terminal_state` call below (which needs `&mut self`). The
+        // mutate-and-spawn phase reacquires a `&mut` borrow via `get_mut`.
+        let Some((attempts, is_cancelled)) = self
             .entries
             .get(&id)
-            .is_some_and(|entry| entry.cancel_token.is_cancelled())
-        {
+            .map(|entry| (entry.attempts, entry.cancel_token.is_cancelled()))
+        else {
+            return false;
+        };
+        if is_cancelled {
             self.finish_terminal_state(id, WorkState::Cancelled, attempts);
             return false;
         }
@@ -702,33 +716,31 @@ impl WorkScheduler {
 
         self.finalize_entry(id, completion.work);
 
+        // Any cancellation — whether signalled via the cancel token/state
+        // (`cancelled`) or returned directly by the work item
+        // (`WorkOutcome::Cancelled`, which the unconditional arm below used to
+        // handle even when `cancelled` was false) — terminates as Cancelled
+        // with no further action. The `|| matches!(...)` clause is load-bearing:
+        // it preserves the old unconditional `Cancelled` arm so a genuine
+        // `Cancelled` outcome does not fall through to the match below.
+        if cancelled || matches!(completion.outcome, WorkOutcome::Cancelled) {
+            self.finish_terminal_state(id, WorkState::Cancelled, attempt);
+            return CompletionAction::None;
+        }
+
         match completion.outcome {
-            WorkOutcome::Cancelled => {
-                self.finish_terminal_state(id, WorkState::Cancelled, attempt);
-                CompletionAction::None
-            }
-            WorkOutcome::Success if cancelled => {
-                self.finish_terminal_state(id, WorkState::Cancelled, attempt);
-                CompletionAction::None
-            }
             WorkOutcome::Success => {
                 self.transition_state(id, WorkState::Success, attempt);
                 CompletionAction::Done { completed_id: id }
             }
-            WorkOutcome::Retry { delay: _ } if cancelled => {
-                self.finish_terminal_state(id, WorkState::Cancelled, attempt);
-                CompletionAction::None
-            }
             WorkOutcome::Retry { delay } => self.schedule_retry(id, attempt, delay),
-            WorkOutcome::Failed(_) if cancelled => {
-                self.finish_terminal_state(id, WorkState::Cancelled, attempt);
-                CompletionAction::None
-            }
             WorkOutcome::Failed(err) => {
                 warn!(work_id = id, error = %err, "work failed");
                 self.finish_terminal_state(id, WorkState::Failed, attempt);
                 CompletionAction::None
             }
+            // Cancelled is handled by the early guard above.
+            WorkOutcome::Cancelled => CompletionAction::None,
         }
     }
 
@@ -814,6 +826,10 @@ impl WorkScheduler {
 
         // Work item is permanently lost — it was moved into the panicked/aborted task.
         if let Some(entry) = self.entries.get_mut(&id) {
+            debug_assert!(
+                matches!(entry.work, WorkSlot::InFlight),
+                "Lost is only reachable from InFlight"
+            );
             entry.work = WorkSlot::Lost;
         }
     }


### PR DESCRIPTION
Closes #3466

## Summary

Behavior-preserving cleanup of four low-severity findings in `crates/work/src/scheduler.rs`. Net observable scheduler behavior diff = 0; the existing `crates/work/tests/scheduler.rs` suite is the behavior-preservation oracle and continues to pass.

- **F1 (`start_work`):** folded the duplicate `attempts` read and the `is_cancelled` check into a single immutable `get(...).map(...)` that copies `attempts` (u32) + the cancel bool into locals, dropping the borrow before `finish_terminal_state` (which needs `&mut self`). The trailing `get_mut().expect()` stays as a separate `&mut` borrow for the mutate-and-spawn phase. 3 lookups → 2; ordering and side-effects unchanged.
- **F2 (`handle_completion`):** hoisted the four cancelled arms into one early guard `if cancelled || matches!(completion.outcome, WorkOutcome::Cancelled) { finish Cancelled; return None }` before the residual match. The `|| matches!` clause is load-bearing (preserves the old unconditional `Cancelled` arm). `warn!("work failed")` still fires only on the genuine non-cancelled `Failed` path. A guarded-unreachable `Cancelled => None` arm keeps the match exhaustive (Rust cannot prove the runtime guard removes the variant); behavior identical. Truth-table verified identical.
- **F3 (`WorkSlot::Lost`):** kept the variant (full removal deliberately scoped out as a separate design call). Added `debug_assert!(matches!(entry.work, WorkSlot::InFlight), …)` at the sole write site, and clarified the ownership doc + variant doc that `Lost` is a write-only diagnostic marker never re-read to drive behavior.
- **F4 (`cancel_all`):** `let _ = self.cancel(id);` → `self.cancel(id);` (`cancel` returns `bool`, no `#[must_use]` — warning-free).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3466#issuecomment-4751635383)

## Test plan

- [x] cargo fmt --check
- [x] cargo build -p henyey-work --all-targets (RUSTFLAGS=-Dwarnings)
- [x] cargo test -p henyey-work — 12/12 scheduler tests pass (panic/abort tests exercise the F3 debug_assert under the debug test profile)
- [x] cargo clippy --all -- -D warnings
- [x] cargo build --all

## Deviations from plan

- F2's residual match keeps an explicit `WorkOutcome::Cancelled => CompletionAction::None` arm. The plan's pseudocode showed a 3-arm match, but Rust's exhaustiveness check cannot prove the runtime early-guard removes the `Cancelled` variant, so the arm is required to compile. It is unreachable at runtime (guarded) and returns `None`, so behavior is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)