### PR TITLE
Remove dead wrapper, gate test-only counter, drop unused deps in henyey-tx

### DIFF
--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -17,9 +17,6 @@ soroban-env-host-p24.workspace = true
 soroban-env-host-p25.workspace = true
 soroban-env-host-p26.workspace = true
 
-# Serialization
-serde.workspace = true
-
 # Error handling
 thiserror.workspace = true
 tracing.workspace = true
@@ -31,6 +28,3 @@ hex.workspace = true
 
 # WASM parsing for cost input extraction
 wasmparser = "0.116.1"
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/tx/src/apply.rs
+++ b/crates/tx/src/apply.rs
@@ -307,6 +307,7 @@ impl TxChangeLog {
     }
 
     /// Get the total number of changes.
+    #[cfg(test)]
     pub fn change_count(&self) -> usize {
         self.created.len() + self.updated.len() + self.deleted.len()
     }

--- a/crates/tx/src/operations/execute/mod.rs
+++ b/crates/tx/src/operations/execute/mod.rs
@@ -724,17 +724,11 @@ struct RentChange {
     new_live_until_ledger: u32,
 }
 
-pub fn entry_size_for_rent_by_protocol(
-    protocol_version: u32,
-    entry: &stellar_xdr::curr::LedgerEntry,
-    entry_xdr_size: u32,
-) -> u32 {
-    entry_size_for_rent_by_protocol_with_cost_params(protocol_version, entry, entry_xdr_size, None)
-}
-
-/// Like `entry_size_for_rent_by_protocol`, but accepts optional on-chain cost
-/// parameters (cpu_cost_params, mem_cost_params) so that the budget used for
-/// computing WASM module memory cost matches the network configuration.
+/// Compute the entry size used for rent accounting, by protocol version.
+///
+/// Accepts optional on-chain cost parameters (cpu_cost_params, mem_cost_params)
+/// so that the budget used for computing WASM module memory cost matches the
+/// network configuration.
 ///
 /// When `cost_params` is `None`, falls back to `Budget::default()` which uses
 /// hard-coded cost model parameters. For deterministic parity with stellar-core


### PR DESCRIPTION
Closes #3465

## Summary

Three mechanical, behavior-preserving cleanups in parity-critical `crate:tx` on non-parity surfaces. Net runtime/codegen/parity diff = 0.

- **F1** — delete the dead `entry_size_for_rent_by_protocol` wrapper in `crates/tx/src/operations/execute/mod.rs` (zero call sites; pure delegation to `entry_size_for_rent_by_protocol_with_cost_params(.., None)`). The live rent-sizing logic in `_with_cost_params` is byte-identical and keeps all external callers (history replay, ledger soroban_state); its doc-comment is reworded so it no longer references the deleted name.
- **F2** — `#[cfg(test)]`-gate `TxChangeLog::change_count` in `crates/tx/src/apply.rs`. All 9 callers are asserts inside the single `#[cfg(test)] mod tests` block. Per #3384 the disposition is gate (not blind `pub(crate)`, not delete).
- **F3** — remove unused `serde` and `tempfile` deps from `crates/tx/Cargo.toml` (zero usage under crates/tx). Metadata-only; dropping `serde` is a proc-macro build-time win.

F4 (`check_valid_pre_seq_num`, parity-named result-code surface) is deliberately scoped out; F5 was dropped (already resolved by #3505).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3465#issuecomment-4751626281)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-tx --all-targets under -Dwarnings (#3384 build-verify)
- [x] cargo test -p henyey-tx — 1347 passed, 0 failed (incl. the 9 `change_count` asserts)
- [x] cargo build --all — no transitive breakage from the dep drop

## Parity

crate:tx is PARITY-CRITICAL but none of F1/F2/F3 touch a parity surface — no operation-apply / fee-refund / result-code / signature-threshold / ledger-mutation change. Net parity diff = 0 against v26.0.1.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)