### PR TITLE
Migrate stellar_xdr::curr:: to stellar_xdr:: for stellar-xdr 27.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rust-version = "1.76"
 # Stellar official crates
 # We support multiple protocol versions by including multiple soroban-env-host versions.
 # Each host version is labeled with the MAXIMUM protocol it supports.
-stellar-xdr = { version = "=26.0.0", default-features = false, features = ["std", "curr", "serde", "serde_json"] }
+stellar-xdr = { version = "=27.0.0", default-features = false, features = ["std", "serde", "serde_json", "base64"] }
 stellar-strkey = "0.0.11"
 
 # Soroban host crates — pinned to exact git revs from the stellar-core

--- a/crates/app/src/app/bootstrap.rs
+++ b/crates/app/src/app/bootstrap.rs
@@ -96,7 +96,7 @@ pub fn initialize_genesis(
     use henyey_db::schema::state_keys;
     use henyey_history::build_history_archive_state;
     use henyey_ledger::{calculate_skip_values, compute_header_hash};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         BucketListType, Hash, LedgerHeader, LedgerHeaderExt, Limits, StellarValue, StellarValueExt,
         TimePoint, TransactionHistoryEntry, TransactionHistoryEntryExt,
         TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
@@ -266,8 +266,8 @@ pub(crate) fn build_genesis_entries(
     passphrase: &str,
     test_account_count: u32,
     total_coins: i64,
-) -> Vec<stellar_xdr::curr::LedgerEntry> {
-    use stellar_xdr::curr::{
+) -> Vec<stellar_xdr::LedgerEntry> {
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, LedgerEntry, LedgerEntryData, LedgerEntryExt,
         PublicKey, SequenceNumber, Thresholds, Uint256, VecM,
     };
@@ -298,7 +298,7 @@ pub(crate) fn build_genesis_entries(
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
+                home_domain: stellar_xdr::String32::default(),
                 thresholds: Thresholds([1, 0, 0, 0]),
                 signers: VecM::default(),
                 ext: AccountEntryExt::V0,
@@ -386,7 +386,7 @@ impl App {
         let mut bucket_list = BucketList::new();
         bucket_list.set_bucket_dir(bucket_dir.clone());
         {
-            use stellar_xdr::curr::BucketListType;
+            use stellar_xdr::BucketListType;
             bucket_list
                 .add_batch(1, 0, BucketListType::Live, genesis_entries, vec![], vec![])
                 .map_err(|e| anyhow::anyhow!("Failed to create genesis bucket list: {}", e))?;
@@ -484,7 +484,7 @@ mod tests {
         let db = henyey_db::Database::open_in_memory().unwrap();
 
         // Write a stale header without setting LCL.
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, Limits, StellarValue, StellarValueExt, TimePoint,
             VecM, WriteXdr,
         };
@@ -576,8 +576,8 @@ mod tests {
 
     /// Collect the `ConfigSettingId`s present in the genesis Soroban config set
     /// for the given protocol.
-    fn genesis_config_setting_ids(protocol: u32) -> Vec<stellar_xdr::curr::ConfigSettingId> {
-        use stellar_xdr::curr::LedgerEntryData;
+    fn genesis_config_setting_ids(protocol: u32) -> Vec<stellar_xdr::ConfigSettingId> {
+        use stellar_xdr::LedgerEntryData;
         let network_id = NetworkId::from_passphrase(PASSPHRASE);
         let entries =
             henyey_ledger::build_genesis_soroban_config_entries(protocol, &network_id).unwrap();
@@ -600,7 +600,7 @@ mod tests {
     /// zero ConfigSetting entries — bootstrap.rs:80).
     #[test]
     fn test_genesis_config_for_genesis_matches_core_3492() {
-        use stellar_xdr::curr::ConfigSettingId;
+        use stellar_xdr::ConfigSettingId;
 
         let db = henyey_db::Database::open_in_memory().unwrap();
         let protocol = 25;

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -340,7 +340,7 @@ impl App {
                     .to_json()
                     .map_err(|e| anyhow::anyhow!("Failed to serialize HAS after catchup: {}", e))?;
                 let header_xdr = final_header
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                     .map_err(|e| {
                         anyhow::anyhow!("Failed to serialize header XDR after catchup: {}", e)
                     })?;
@@ -1146,7 +1146,7 @@ impl App {
         mut message_rx: tokio::sync::mpsc::UnboundedReceiver<OverlayMessage>,
     ) {
         use std::collections::HashSet;
-        use stellar_xdr::curr::{Limits, ScpStatementPledges};
+        use stellar_xdr::{Limits, ScpStatementPledges};
 
         let mut cached_tx_sets = 0u32;
         let mut requested_tx_sets = 0u32;
@@ -1254,7 +1254,7 @@ impl App {
                             let overlay = self.overlay().await;
                             if let Some(overlay) = overlay {
                                 match overlay
-                                    .request_tx_set(&stellar_xdr::curr::Uint256(tx_set_hash.0))
+                                    .request_tx_set(&stellar_xdr::Uint256(tx_set_hash.0))
                                     .await
                                 {
                                     Ok(peer_count) => {
@@ -4403,7 +4403,7 @@ mod tests {
                     None
                 },
                 upgrades: vec![],
-                stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
             }
         };
 
@@ -5056,9 +5056,7 @@ mod tests {
 
     /// Helper: create a valid StellarValue XDR blob for seeding externalized slots.
     fn mk_stellar_value_xdr_for_slot(tx_set_hash: [u8; 32]) -> Vec<u8> {
-        use stellar_xdr::curr::{
-            Hash, Limits, StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr,
-        };
+        use stellar_xdr::{Hash, Limits, StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr};
         let sv = StellarValue {
             tx_set_hash: Hash(tx_set_hash),
             close_time: TimePoint(12345),
@@ -5069,8 +5067,8 @@ mod tests {
     }
 
     /// Helper: wrap XDR bytes into a Value for record_externalized.
-    fn mk_value_for_slot(xdr_bytes: Vec<u8>) -> stellar_xdr::curr::Value {
-        stellar_xdr::curr::Value(
+    fn mk_value_for_slot(xdr_bytes: Vec<u8>) -> stellar_xdr::Value {
+        stellar_xdr::Value(
             xdr_bytes
                 .try_into()
                 .expect("StellarValue XDR fits in Value"),
@@ -5121,7 +5119,7 @@ mod tests {
                     tx_set_hash: henyey_common::Hash256::from_bytes([0x50; 32]),
                     tx_set: None,
                     upgrades: Vec::new(),
-                    stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
                 },
             );
         }
@@ -7222,7 +7220,7 @@ mod tests {
         slot: u64,
         previous_ledger_hash: henyey_common::types::Hash256,
     ) {
-        use stellar_xdr::curr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
+        use stellar_xdr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
 
         let tx_set = henyey_herder::TransactionSet::new(previous_ledger_hash, vec![]);
         let tx_set_hash = *tx_set.hash();
@@ -7232,13 +7230,12 @@ mod tests {
 
         // Build a StellarValue with the matching tx_set_hash.
         let sv = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(1000),
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Basic,
         };
-        let value =
-            stellar_xdr::curr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap());
+        let value = stellar_xdr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap());
 
         // Record the slot as externalized.
         app.herder
@@ -7284,17 +7281,16 @@ mod tests {
         // Case 2: slot target+1 is externalized but WITHOUT a cached tx-set.
         // Build a StellarValue with a tx_set_hash that has no cached tx-set.
         {
-            use stellar_xdr::curr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
+            use stellar_xdr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
 
             let fake_hash = henyey_common::types::Hash256([99u8; 32]);
             let sv = StellarValue {
-                tx_set_hash: stellar_xdr::curr::Hash(fake_hash.0),
+                tx_set_hash: stellar_xdr::Hash(fake_hash.0),
                 close_time: TimePoint(2000),
                 upgrades: vec![].try_into().unwrap(),
                 ext: StellarValueExt::Basic,
             };
-            let value =
-                stellar_xdr::curr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap());
+            let value = stellar_xdr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap());
 
             app.herder
                 .scp_driver()

--- a/crates/app/src/app/close.rs
+++ b/crates/app/src/app/close.rs
@@ -6,7 +6,7 @@
 use std::sync::atomic::Ordering;
 
 use henyey_herder::{sync_recovery::SyncRecoveryCallback, HerderCallback};
-use stellar_xdr::curr::{ScpEnvelope, StellarValueExt, UpgradeType};
+use stellar_xdr::{ScpEnvelope, StellarValueExt, UpgradeType};
 
 use super::types::{decode_upgrades, PendingLedgerClose};
 use super::App;

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -1336,7 +1336,7 @@ impl App {
     pub(super) async fn send_quorum_set(
         &self,
         peer_id: &henyey_overlay::PeerId,
-        requested_hash: stellar_xdr::curr::Uint256,
+        requested_hash: stellar_xdr::Uint256,
     ) {
         let Some(overlay) = self.overlay().await else {
             return;
@@ -1348,8 +1348,8 @@ impl App {
                 tracing::debug!(peer = %peer_id, error = %e, "Failed to send quorum set");
             }
         } else {
-            let msg = StellarMessage::DontHave(stellar_xdr::curr::DontHave {
-                type_: stellar_xdr::curr::MessageType::ScpQuorumset,
+            let msg = StellarMessage::DontHave(stellar_xdr::DontHave {
+                type_: stellar_xdr::MessageType::ScpQuorumset,
                 req_hash: requested_hash,
             });
             if let Err(e) = overlay.try_send_to(peer_id, msg) {
@@ -1362,7 +1362,7 @@ impl App {
     pub(super) async fn handle_quorum_set(
         &self,
         _peer_id: &henyey_overlay::PeerId,
-        quorum_set: stellar_xdr::curr::ScpQuorumSet,
+        quorum_set: stellar_xdr::ScpQuorumSet,
     ) {
         let hash = henyey_scp::hash_quorum_set(&quorum_set);
 

--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -83,8 +83,8 @@ fn consume_skip_marker_if_matches(
 /// DB write preserves the same ordering as `processExternalized()`.
 struct ScpHistoryBatch {
     ledger_seq: u32,
-    envelopes: Vec<stellar_xdr::curr::ScpEnvelope>,
-    quorum_sets: Vec<(Hash256, stellar_xdr::curr::ScpQuorumSet)>,
+    envelopes: Vec<stellar_xdr::ScpEnvelope>,
+    quorum_sets: Vec<(Hash256, stellar_xdr::ScpQuorumSet)>,
 }
 
 /// Raw inputs for a ledger-close persist job, captured on the event loop.
@@ -93,7 +93,7 @@ struct ScpHistoryBatch {
 /// serialization). The persist task performs all serialization on a
 /// blocking thread via [`LedgerPersistInputs::serialize_and_write_to_db`].
 struct LedgerPersistInputs {
-    header: stellar_xdr::curr::LedgerHeader,
+    header: stellar_xdr::LedgerHeader,
     tx_history_entry: TransactionHistoryEntry,
     tx_result_entry: TransactionHistoryResultEntry,
     ordered_txs: Vec<std::sync::Arc<TransactionEnvelope>>,
@@ -156,7 +156,7 @@ impl LedgerPersistInputs {
 
         let header_xdr = self
             .header
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .map_err(|e| anyhow::anyhow!("Failed to serialize header XDR: {}", e))?;
 
         // Diagnostic: compare HAS-derived bucket_list_hash against header.
@@ -216,15 +216,15 @@ impl LedgerPersistInputs {
                     .map_err(|e| henyey_db::DbError::Integrity(e.to_string()))?;
                 let tx_id = tx_hash.to_hex();
 
-                let tx_body = tx.to_xdr(stellar_xdr::curr::Limits::none())?;
-                let tx_result_xdr = tx_result.to_xdr(stellar_xdr::curr::Limits::none())?;
+                let tx_body = tx.to_xdr(stellar_xdr::Limits::none())?;
+                let tx_result_xdr = tx_result.to_xdr(stellar_xdr::Limits::none())?;
                 let tx_meta_xdr = match tx_meta {
-                    Some(meta) => Some(meta.to_xdr(stellar_xdr::curr::Limits::none())?),
+                    Some(meta) => Some(meta.to_xdr(stellar_xdr::Limits::none())?),
                     None => None,
                 };
 
                 let status = {
-                    use stellar_xdr::curr::TransactionResultCode;
+                    use stellar_xdr::TransactionResultCode;
                     let code = tx_result.result.result.discriminant();
                     if code == TransactionResultCode::TxSuccess
                         || code == TransactionResultCode::TxFeeBumpInnerSuccess
@@ -464,7 +464,7 @@ impl App {
     /// on a blocking thread — not on the event loop.
     fn build_persist_inputs(
         &self,
-        header: &stellar_xdr::curr::LedgerHeader,
+        header: &stellar_xdr::LedgerHeader,
         tx_set_variant: &TransactionSetVariant,
         tx_results: &[TransactionResultPair],
         tx_metas: Option<&[TransactionMeta]>,
@@ -564,13 +564,13 @@ impl App {
     /// Extract contract events from transaction metadata for indexing.
     fn extract_contract_events(
         ledger_seq: u32,
-        ordered_txs: &[std::sync::Arc<stellar_xdr::curr::TransactionEnvelope>],
+        ordered_txs: &[std::sync::Arc<stellar_xdr::TransactionEnvelope>],
         tx_results: &[TransactionResultPair],
         tx_metas: &[TransactionMeta],
         network_id: NetworkId,
     ) -> anyhow::Result<Vec<henyey_db::EventRecord>> {
         use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-        use stellar_xdr::curr::{ContractEvent, Limits, TransactionResultCode};
+        use stellar_xdr::{ContractEvent, Limits, TransactionResultCode};
 
         let mut all_events = Vec::new();
 
@@ -640,7 +640,7 @@ impl App {
 
                 // Serialize topics — propagate errors instead of silently dropping
                 let topics: Vec<String> = match &event.body {
-                    stellar_xdr::curr::ContractEventBody::V0(body) => body
+                    stellar_xdr::ContractEventBody::V0(body) => body
                         .topics
                         .iter()
                         .map(|t| {
@@ -1072,8 +1072,8 @@ impl App {
         }
 
         let ledger_flags = match &header.ext {
-            stellar_xdr::curr::LedgerHeaderExt::V0 => 0,
-            stellar_xdr::curr::LedgerHeaderExt::V1(ext) => ext.flags,
+            stellar_xdr::LedgerHeaderExt::V0 => 0,
+            stellar_xdr::LedgerHeaderExt::V1(ext) => ext.flags,
         };
 
         self.herder.tx_queue().update_validation_context(
@@ -1232,7 +1232,7 @@ impl App {
     async fn reconstruct_bucket_lists(
         &self,
         has: &HistoryArchiveState,
-        header: &stellar_xdr::curr::LedgerHeader,
+        header: &stellar_xdr::LedgerHeader,
         lcl_seq: u32,
     ) -> anyhow::Result<(BucketList, HotArchiveBucketList)> {
         // Start-of-restore checkpoint (#3239) — this cold-catchup path is
@@ -2047,7 +2047,7 @@ impl App {
         let our_header_hash = snapshot.hash;
         if our_header_hash != tx_set.previous_ledger_hash() {
             // Log header XDR bytes for hash debugging (mirrors manager.rs:2122-2140)
-            use stellar_xdr::curr::{Limits, WriteXdr};
+            use stellar_xdr::{Limits, WriteXdr};
             let header = &snapshot.header;
             match header.to_xdr(Limits::none()) {
                 Ok(header_xdr) => {
@@ -2473,7 +2473,7 @@ impl App {
         let meta_xdr = result
             .meta
             .as_ref()
-            .and_then(|meta| meta.to_xdr(stellar_xdr::curr::Limits::none()).ok());
+            .and_then(|meta| meta.to_xdr(stellar_xdr::Limits::none()).ok());
 
         // Build (envelope, seq_num) pairs for all txs (applied + failed) so
         // sequence-based removal drops superseded queued txs for the same account.
@@ -2488,7 +2488,7 @@ impl App {
             let seq_num = envelope_sequence_number(tx);
             all_txs.push((tx.clone(), seq_num));
 
-            use stellar_xdr::curr::TransactionResultResult;
+            use stellar_xdr::TransactionResultResult;
             let is_success = matches!(
                 tx_result.result.result,
                 TransactionResultResult::TxSuccess(_)
@@ -2673,8 +2673,8 @@ impl App {
             let prep_start = std::time::Instant::now();
 
             let ledger_flags = match &result_header.ext {
-                stellar_xdr::curr::LedgerHeaderExt::V0 => 0,
-                stellar_xdr::curr::LedgerHeaderExt::V1(ext) => ext.flags,
+                stellar_xdr::LedgerHeaderExt::V0 => 0,
+                stellar_xdr::LedgerHeaderExt::V1(ext) => ext.flags,
             };
             let close_time_ctx = result_header.scp_value.close_time.0;
             let base_fee = result_header.base_fee;
@@ -3050,7 +3050,7 @@ mod extract_contract_events_tests {
     use super::*;
     use std::sync::Arc;
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractEvent, ContractEventBody, ContractEventType, ContractEventV0, ExtensionPoint, Hash,
         Memo, MuxedAccount, Preconditions, ScVal, SequenceNumber, SorobanTransactionMeta,
         SorobanTransactionMetaExt, Transaction, TransactionEnvelope, TransactionExt,
@@ -3179,7 +3179,7 @@ mod extract_contract_events_tests {
 
     #[test]
     fn test_extract_v4_per_op_events() {
-        use stellar_xdr::curr::{OperationMetaV2, TransactionMetaV4};
+        use stellar_xdr::{OperationMetaV2, TransactionMetaV4};
 
         let env = test_envelope();
         let result = test_result_pair(true);
@@ -3605,17 +3605,17 @@ mod restore_result_tests {
                     &has_json,
                 )?;
                 // Store a minimal ledger header at seq 100.
-                let header = stellar_xdr::curr::LedgerHeader {
+                let header = stellar_xdr::LedgerHeader {
                     ledger_version: 20,
-                    previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                    scp_value: stellar_xdr::curr::StellarValue {
-                        tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                        close_time: stellar_xdr::curr::TimePoint(1234567890),
+                    previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+                    scp_value: stellar_xdr::StellarValue {
+                        tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                        close_time: stellar_xdr::TimePoint(1234567890),
                         upgrades: vec![].try_into().unwrap(),
-                        ext: stellar_xdr::curr::StellarValueExt::Basic,
+                        ext: stellar_xdr::StellarValueExt::Basic,
                     },
-                    tx_set_result_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                    bucket_list_hash: stellar_xdr::curr::Hash([1u8; 32]),
+                    tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+                    bucket_list_hash: stellar_xdr::Hash([1u8; 32]),
                     ledger_seq: 100,
                     total_coins: 100_000_000_000_000_000,
                     fee_pool: 0,
@@ -3624,11 +3624,11 @@ mod restore_result_tests {
                     base_fee: 100,
                     base_reserve: 5_000_000,
                     max_tx_set_size: 100,
-                    skip_list: std::array::from_fn(|_| stellar_xdr::curr::Hash([0u8; 32])),
-                    ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                    skip_list: std::array::from_fn(|_| stellar_xdr::Hash([0u8; 32])),
+                    ext: stellar_xdr::LedgerHeaderExt::V0,
                 };
-                use stellar_xdr::curr::WriteXdr;
-                let data = header.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+                use stellar_xdr::WriteXdr;
+                let data = header.to_xdr(stellar_xdr::Limits::none()).unwrap();
                 conn.store_ledger_header(&header, &data)?;
                 Ok::<_, henyey_db::DbError>(())
             })
@@ -3727,7 +3727,7 @@ mod fatal_shutdown_tests {
 mod refresh_stale_buffer_tests {
     use super::*;
     use henyey_common::Hash256;
-    use stellar_xdr::curr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
+    use stellar_xdr::{Limits, StellarValue, StellarValueExt, TimePoint, WriteXdr};
 
     /// Helper: create a minimal App for testing.
     ///
@@ -3767,13 +3767,13 @@ mod refresh_stale_buffer_tests {
 
         // Build a valid StellarValue XDR for the externalized slot.
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: Default::default(),
             ext: StellarValueExt::Basic,
         };
         let value_bytes = stellar_value.to_xdr(Limits::none()).unwrap();
-        let value = stellar_xdr::curr::Value(value_bytes.try_into().unwrap());
+        let value = stellar_xdr::Value(value_bytes.try_into().unwrap());
 
         // Seed the herder: record the slot as externalized (with valid XDR).
         app.herder
@@ -3830,13 +3830,13 @@ mod refresh_stale_buffer_tests {
         let tx_set_hash = *tx_set.hash();
 
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: Default::default(),
             ext: StellarValueExt::Basic,
         };
         let value_bytes = stellar_value.to_xdr(Limits::none()).unwrap();
-        let value = stellar_xdr::curr::Value(value_bytes.try_into().unwrap());
+        let value = stellar_xdr::Value(value_bytes.try_into().unwrap());
 
         app.herder
             .scp_driver()
@@ -4034,8 +4034,8 @@ mod publish_skip_marker_tests {
 
     /// Convenience: minimal LedgerHeader fixture for the persist path.
     /// Mirrors `persist::tests::make_header` but is private to this module.
-    fn persist_test_header(seq: u32) -> (stellar_xdr::curr::LedgerHeader, Vec<u8>) {
-        use stellar_xdr::curr::{
+    fn persist_test_header(seq: u32) -> (stellar_xdr::LedgerHeader, Vec<u8>) {
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderExtensionV1,
             LedgerHeaderExtensionV1Ext, Limits, StellarValue, StellarValueExt, WriteXdr,
         };
@@ -4044,7 +4044,7 @@ mod publish_skip_marker_tests {
             previous_ledger_hash: Hash([0; 32]),
             scp_value: StellarValue {
                 tx_set_hash: Hash([0; 32]),
-                close_time: stellar_xdr::curr::TimePoint(0),
+                close_time: stellar_xdr::TimePoint(0),
                 upgrades: vec![].try_into().unwrap(),
                 ext: StellarValueExt::Basic,
             },
@@ -4086,7 +4086,7 @@ mod scp_history_persistence_ordering_tests {
     use henyey_history::HistoryArchiveState;
     use henyey_scp::hash_quorum_set;
     use std::sync::Arc;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, NodeId, PublicKey, ScpBallot, ScpEnvelope,
         ScpQuorumSet, ScpStatement, ScpStatementExternalize, ScpStatementPledges, Signature,
         StellarValue, StellarValueExt, TimePoint, TransactionHistoryEntry,

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -1654,13 +1654,9 @@ impl App {
             StellarMessage::DontHave(dont_have) => {
                 let is_tx_set = matches!(
                     dont_have.type_,
-                    stellar_xdr::curr::MessageType::TxSet
-                        | stellar_xdr::curr::MessageType::GeneralizedTxSet
+                    stellar_xdr::MessageType::TxSet | stellar_xdr::MessageType::GeneralizedTxSet
                 );
-                let is_ping = matches!(
-                    dont_have.type_,
-                    stellar_xdr::curr::MessageType::ScpQuorumset
-                );
+                let is_ping = matches!(dont_have.type_, stellar_xdr::MessageType::ScpQuorumset);
                 if is_tx_set {
                     tracing::debug!(
                         peer = %msg.from_peer,
@@ -1760,13 +1756,11 @@ impl App {
 
             StellarMessage::TxSet(tx_set) => {
                 // Compute hash for logging
-                let computed_hash = match stellar_xdr::curr::WriteXdr::to_xdr(
-                    &tx_set,
-                    stellar_xdr::curr::Limits::none(),
-                ) {
-                    Ok(xdr_bytes) => format!("{}", henyey_common::Hash256::hash(&xdr_bytes)),
-                    Err(e) => format!("<encoding failed: {e}>"),
-                };
+                let computed_hash =
+                    match stellar_xdr::WriteXdr::to_xdr(&tx_set, stellar_xdr::Limits::none()) {
+                        Ok(xdr_bytes) => format!("{}", henyey_common::Hash256::hash(&xdr_bytes)),
+                        Err(e) => format!("<encoding failed: {e}>"),
+                    };
                 tracing::info!(
                     peer = %msg.from_peer,
                     computed_hash = %computed_hash,
@@ -1779,13 +1773,11 @@ impl App {
 
             StellarMessage::GeneralizedTxSet(gen_tx_set) => {
                 // Compute hash for logging
-                let computed_hash = match stellar_xdr::curr::WriteXdr::to_xdr(
-                    &gen_tx_set,
-                    stellar_xdr::curr::Limits::none(),
-                ) {
-                    Ok(xdr_bytes) => format!("{}", henyey_common::Hash256::hash(&xdr_bytes)),
-                    Err(e) => format!("<encoding failed: {e}>"),
-                };
+                let computed_hash =
+                    match stellar_xdr::WriteXdr::to_xdr(&gen_tx_set, stellar_xdr::Limits::none()) {
+                        Ok(xdr_bytes) => format!("{}", henyey_common::Hash256::hash(&xdr_bytes)),
+                        Err(e) => format!("<encoding failed: {e}>"),
+                    };
                 tracing::debug!(
                     peer = %msg.from_peer,
                     computed_hash = %computed_hash,
@@ -1853,7 +1845,7 @@ impl App {
         let Some(overlay) = self.overlay().await else {
             return;
         };
-        let request = StellarMessage::GetTxSet(stellar_xdr::curr::Uint256(tx_set_hash.0));
+        let request = StellarMessage::GetTxSet(stellar_xdr::Uint256(tx_set_hash.0));
         if let Err(e) = overlay.try_send_to(peer, request) {
             tracing::debug!(
                 peer = %peer,
@@ -2441,11 +2433,8 @@ impl App {
 
         let tx_set_hash = if is_externalize {
             match &envelope.statement.pledges {
-                stellar_xdr::curr::ScpStatementPledges::Externalize(ext) => {
-                    match StellarValue::from_xdr(
-                        &ext.commit.value.0,
-                        stellar_xdr::curr::Limits::none(),
-                    ) {
+                stellar_xdr::ScpStatementPledges::Externalize(ext) => {
+                    match StellarValue::from_xdr(&ext.commit.value.0, stellar_xdr::Limits::none()) {
                         Ok(stellar_value) => Some(Hash256::from_bytes(stellar_value.tx_set_hash.0)),
                         Err(err) => {
                             tracing::warn!(
@@ -2531,8 +2520,7 @@ impl App {
             if self.herder.request_quorum_set(hash256, sender_node_id) {
                 if let Some(peer) = from_peer_opt.as_ref() {
                     if let Some(overlay) = self.overlay().await {
-                        let request =
-                            StellarMessage::GetScpQuorumset(stellar_xdr::curr::Uint256(hash.0));
+                        let request = StellarMessage::GetScpQuorumset(stellar_xdr::Uint256(hash.0));
                         if let Err(e) = overlay.try_send_to(peer, request) {
                             tracing::debug!(peer = %peer, error = %e, "Failed to request quorum set");
                         }
@@ -2687,7 +2675,7 @@ impl App {
                     if let Some(peer) = from_peer_opt.as_ref() {
                         if let Some(overlay) = self.overlay().await {
                             let request =
-                                StellarMessage::GetTxSet(stellar_xdr::curr::Uint256(tx_set_hash.0));
+                                StellarMessage::GetTxSet(stellar_xdr::Uint256(tx_set_hash.0));
                             if let Err(e) = overlay.try_send_to(peer, request) {
                                 tracing::debug!(
                                     peer = %peer,
@@ -2722,7 +2710,7 @@ mod pump_tests {
     use henyey_herder::scp_verify::{PipelinedIntake, Verdict, VerifiedEnvelope};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         NodeId, PublicKey as XdrPublicKey, ScpBallot, ScpEnvelope, ScpStatement,
         ScpStatementPledges, ScpStatementPrepare, Signature, Uint256, Value,
     };
@@ -2731,7 +2719,7 @@ mod pump_tests {
         let node_id = NodeId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
         let value = Value(vec![].try_into().unwrap());
         let pledges = ScpStatementPledges::Prepare(ScpStatementPrepare {
-            quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
             ballot: ScpBallot {
                 counter: 1,
                 value: value.clone(),
@@ -2801,7 +2789,7 @@ mod pump_tests {
 mod scp_dedup_pipeline_tests {
     use super::App;
     use henyey_overlay::OverlayMessage;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash as XdrHash, Limits, NodeId as XdrNodeId, PublicKey as XdrPublicKey, ScpBallot,
         ScpEnvelope, ScpStatement, ScpStatementPledges, ScpStatementPrepare,
         Signature as XdrSignature, StellarMessage, StellarValue, StellarValueExt, TimePoint,

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -92,7 +92,7 @@ use henyey_overlay::{
 use henyey_scp::hash_quorum_set;
 use henyey_tx::{envelope_sequence_number, TransactionFrame};
 use henyey_work::{WorkScheduler, WorkSchedulerConfig, WorkState};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Curve25519Public, EncryptedBody, FloodAdvert, FloodDemand, Hash, LedgerCloseMeta,
     LedgerScpMessages, ReadXdr, ScpEnvelope, ScpHistoryEntry, ScpHistoryEntryV0,
     ScpStatementPledges, SignedTimeSlicedSurveyResponseMessage, StellarMessage, StellarValue,
@@ -112,7 +112,7 @@ use crate::meta_stream::{MetaStreamError, MetaStreamManager};
 use crate::meta_writer::MetaWriter;
 use crate::survey::{HerderLedgerSource, SurveyDataManager, SurveyMessageLimiter, SurveyState};
 use henyey_ledger::{close_time as ledger_close_time, compute_header_hash, verify_header_chain};
-use stellar_xdr::curr::TransactionEnvelope;
+use stellar_xdr::TransactionEnvelope;
 
 const TIME_SLICED_PEERS_MAX: usize = 25;
 const PEER_MAX_FAILURES_TO_SEND: u32 = 10;
@@ -1765,7 +1765,7 @@ impl App {
     fn build_herder_config(
         config: &AppConfig,
         keypair: &henyey_crypto::SecretKey,
-        local_quorum_set: Option<stellar_xdr::curr::ScpQuorumSet>,
+        local_quorum_set: Option<stellar_xdr::ScpQuorumSet>,
     ) -> HerderConfig {
         let freq = checkpoint_frequency();
         HerderConfig {
@@ -2209,7 +2209,7 @@ impl App {
     /// Used by the simulation LoadGenerator to refresh cached sequence numbers.
     pub fn load_account_sequence(
         &self,
-        account_id: &stellar_xdr::curr::AccountId,
+        account_id: &stellar_xdr::AccountId,
     ) -> henyey_ledger::Result<Option<i64>> {
         let snapshot = self.ledger_manager.create_snapshot()?;
         let Some(account) = snapshot.get_account(account_id)? else {
@@ -2229,8 +2229,8 @@ impl App {
     /// Used by the compat HTTP `/testacc` endpoint.
     pub fn load_account(
         &self,
-        account_id: &stellar_xdr::curr::AccountId,
-    ) -> henyey_ledger::Result<Option<stellar_xdr::curr::AccountEntry>> {
+        account_id: &stellar_xdr::AccountId,
+    ) -> henyey_ledger::Result<Option<stellar_xdr::AccountEntry>> {
         let snapshot = self.ledger_manager.create_snapshot()?;
         snapshot.get_account(account_id)
     }
@@ -2238,10 +2238,7 @@ impl App {
     /// Check whether a ledger entry exists in the current bucket list.
     ///
     /// Used by the simulation LoadGenerator to verify Soroban state is synced.
-    pub fn has_ledger_entry(
-        &self,
-        key: &stellar_xdr::curr::LedgerKey,
-    ) -> henyey_ledger::Result<bool> {
+    pub fn has_ledger_entry(&self, key: &stellar_xdr::LedgerKey) -> henyey_ledger::Result<bool> {
         let snapshot = self.ledger_manager.create_snapshot()?;
         Ok(snapshot.get_entry(key)?.is_some())
     }
@@ -2254,17 +2251,15 @@ impl App {
     /// `ConfigUpgradeSet` from live network configuration.
     pub fn load_config_setting(
         &self,
-        id: stellar_xdr::curr::ConfigSettingId,
-    ) -> henyey_ledger::Result<Option<stellar_xdr::curr::ConfigSettingEntry>> {
-        let key = stellar_xdr::curr::LedgerKey::ConfigSetting(
-            stellar_xdr::curr::LedgerKeyConfigSetting {
-                config_setting_id: id,
-            },
-        );
+        id: stellar_xdr::ConfigSettingId,
+    ) -> henyey_ledger::Result<Option<stellar_xdr::ConfigSettingEntry>> {
+        let key = stellar_xdr::LedgerKey::ConfigSetting(stellar_xdr::LedgerKeyConfigSetting {
+            config_setting_id: id,
+        });
         let snapshot = self.ledger_manager.create_snapshot()?;
         match snapshot.get_entry(&key)? {
             Some(entry) => match entry.data {
-                stellar_xdr::curr::LedgerEntryData::ConfigSetting(cs) => Ok(Some(cs)),
+                stellar_xdr::LedgerEntryData::ConfigSetting(cs) => Ok(Some(cs)),
                 _ => Ok(None),
             },
             None => Ok(None),
@@ -2275,7 +2270,7 @@ impl App {
     /// herder's transaction queue.
     ///
     /// Matches stellar-core `Herder::sourceAccountPending()`.
-    pub fn source_account_pending(&self, account_id: &stellar_xdr::curr::AccountId) -> bool {
+    pub fn source_account_pending(&self, account_id: &stellar_xdr::AccountId) -> bool {
         self.herder.source_account_pending(account_id)
     }
 
@@ -2724,7 +2719,7 @@ impl App {
     /// SCP envelopes (e.g., self-echo tests). Delegates to
     /// `Herder::get_scp_envelopes`.
     #[cfg(feature = "test-utils")]
-    pub fn get_scp_envelopes(&self, slot: u64) -> Vec<stellar_xdr::curr::ScpEnvelope> {
+    pub fn get_scp_envelopes(&self, slot: u64) -> Vec<stellar_xdr::ScpEnvelope> {
         self.herder.get_scp_envelopes(slot)
     }
 
@@ -3229,7 +3224,7 @@ impl App {
     }
 
     /// Return the local quorum set if configured.
-    pub fn local_quorum_set(&self) -> Option<stellar_xdr::curr::ScpQuorumSet> {
+    pub fn local_quorum_set(&self) -> Option<stellar_xdr::ScpQuorumSet> {
         self.herder.local_quorum_set()
     }
 
@@ -3987,7 +3982,7 @@ pub(crate) struct PesIterationGate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::StellarValueExt;
+    use stellar_xdr::StellarValueExt;
     use tempfile;
 
     /// #3478: the best-effort GC path must SKIP (not crash) on a transient-IO
@@ -4092,17 +4087,17 @@ mod tests {
     /// Minimal successful `LedgerCloseResult` for the given sequence.
     fn make_successful_close_result(seq: u32) -> henyey_ledger::LedgerCloseResult {
         henyey_ledger::LedgerCloseResult {
-            header: stellar_xdr::curr::LedgerHeader {
+            header: stellar_xdr::LedgerHeader {
                 ledger_version: 24,
-                previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                scp_value: stellar_xdr::curr::StellarValue {
-                    tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                    close_time: stellar_xdr::curr::TimePoint(seq as u64),
-                    upgrades: stellar_xdr::curr::VecM::default(),
-                    ext: stellar_xdr::curr::StellarValueExt::Basic,
+                previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+                scp_value: stellar_xdr::StellarValue {
+                    tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                    close_time: stellar_xdr::TimePoint(seq as u64),
+                    upgrades: stellar_xdr::VecM::default(),
+                    ext: stellar_xdr::StellarValueExt::Basic,
                 },
-                tx_set_result_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                bucket_list_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+                bucket_list_hash: stellar_xdr::Hash([0u8; 32]),
                 ledger_seq: seq,
                 total_coins: 0,
                 fee_pool: 0,
@@ -4112,12 +4107,12 @@ mod tests {
                 base_reserve: 5_000_000,
                 max_tx_set_size: 100,
                 skip_list: [
-                    stellar_xdr::curr::Hash([0u8; 32]),
-                    stellar_xdr::curr::Hash([0u8; 32]),
-                    stellar_xdr::curr::Hash([0u8; 32]),
-                    stellar_xdr::curr::Hash([0u8; 32]),
+                    stellar_xdr::Hash([0u8; 32]),
+                    stellar_xdr::Hash([0u8; 32]),
+                    stellar_xdr::Hash([0u8; 32]),
+                    stellar_xdr::Hash([0u8; 32]),
                 ],
-                ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                ext: stellar_xdr::LedgerHeaderExt::V0,
             },
             header_hash: henyey_common::Hash256::ZERO,
             tx_results: Vec::new(),
@@ -4892,7 +4887,7 @@ mod tests {
         let far_ahead_close_time = now_secs + 61;
         let mut header = app.ledger_manager().current_header();
         header.ledger_seq = 10;
-        header.scp_value.close_time = stellar_xdr::curr::TimePoint(far_ahead_close_time);
+        header.scp_value.close_time = stellar_xdr::TimePoint(far_ahead_close_time);
         app.ledger_manager()
             .set_header_for_test(header, henyey_common::Hash256::ZERO);
 
@@ -5032,7 +5027,7 @@ mod tests {
         let now_secs: u64 = 1_700_000_000;
         app.herder.set_test_clock_seconds(now_secs);
         let mut header = app.ledger_manager().current_header();
-        header.scp_value.close_time = stellar_xdr::curr::TimePoint(now_secs + 61);
+        header.scp_value.close_time = stellar_xdr::TimePoint(now_secs + 61);
         let lcl_seq = header.ledger_seq;
         app.ledger_manager()
             .set_header_for_test(header, henyey_common::Hash256::ZERO);
@@ -5107,7 +5102,7 @@ mod tests {
         let now_secs: u64 = 1_700_000_000;
         app.herder.set_test_clock_seconds(now_secs);
         let mut header = app.ledger_manager().current_header();
-        header.scp_value.close_time = stellar_xdr::curr::TimePoint(now_secs + 61);
+        header.scp_value.close_time = stellar_xdr::TimePoint(now_secs + 61);
         app.ledger_manager()
             .set_header_for_test(header, henyey_common::Hash256::ZERO);
 
@@ -5349,7 +5344,7 @@ mod tests {
     /// in the syncing_ledgers entry is cleared.
     #[tokio::test]
     async fn test_try_start_ledger_close_rejects_malformed_tx_set() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, TransactionPhase, TransactionSetV1, TxSetComponent,
             TxSetComponentTxsMaybeDiscountedFee,
         };
@@ -5982,13 +5977,13 @@ mod tests {
         // Verify the message type matching pattern used in the broadcast
         // handler to skip fetch response messages (they go through the
         // dedicated channel instead).
-        use stellar_xdr::curr::StellarMessage;
+        use stellar_xdr::StellarMessage;
 
         let test_messages = vec![
             (
-                StellarMessage::GeneralizedTxSet(stellar_xdr::curr::GeneralizedTransactionSet::V1(
-                    stellar_xdr::curr::TransactionSetV1 {
-                        previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                StellarMessage::GeneralizedTxSet(stellar_xdr::GeneralizedTransactionSet::V1(
+                    stellar_xdr::TransactionSetV1 {
+                        previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
                         phases: vec![].try_into().unwrap(),
                     },
                 )),
@@ -5996,9 +5991,9 @@ mod tests {
                 "GeneralizedTxSet",
             ),
             (
-                StellarMessage::DontHave(stellar_xdr::curr::DontHave {
-                    type_: stellar_xdr::curr::MessageType::TxSet,
-                    req_hash: stellar_xdr::curr::Uint256([0u8; 32]),
+                StellarMessage::DontHave(stellar_xdr::DontHave {
+                    type_: stellar_xdr::MessageType::TxSet,
+                    req_hash: stellar_xdr::Uint256([0u8; 32]),
                 }),
                 true,
                 "DontHave",
@@ -7926,17 +7921,17 @@ mod tests {
         let pending = PendingLedgerClose {
             handle: tokio::task::spawn_blocking(|| {
                 Ok(henyey_ledger::LedgerCloseResult {
-                    header: stellar_xdr::curr::LedgerHeader {
+                    header: stellar_xdr::LedgerHeader {
                         ledger_version: 24,
-                        previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                        scp_value: stellar_xdr::curr::StellarValue {
-                            tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                            close_time: stellar_xdr::curr::TimePoint(1),
-                            upgrades: stellar_xdr::curr::VecM::default(),
-                            ext: stellar_xdr::curr::StellarValueExt::Basic,
+                        previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+                        scp_value: stellar_xdr::StellarValue {
+                            tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                            close_time: stellar_xdr::TimePoint(1),
+                            upgrades: stellar_xdr::VecM::default(),
+                            ext: stellar_xdr::StellarValueExt::Basic,
                         },
-                        tx_set_result_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                        bucket_list_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                        tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+                        bucket_list_hash: stellar_xdr::Hash([0u8; 32]),
                         ledger_seq: 1,
                         total_coins: 0,
                         fee_pool: 0,
@@ -7946,12 +7941,12 @@ mod tests {
                         base_reserve: 5_000_000,
                         max_tx_set_size: 100,
                         skip_list: [
-                            stellar_xdr::curr::Hash([0u8; 32]),
-                            stellar_xdr::curr::Hash([0u8; 32]),
-                            stellar_xdr::curr::Hash([0u8; 32]),
-                            stellar_xdr::curr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
                         ],
-                        ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                        ext: stellar_xdr::LedgerHeaderExt::V0,
                     },
                     header_hash: henyey_common::Hash256::ZERO,
                     tx_results: Vec::new(),
@@ -8136,17 +8131,17 @@ mod tests {
         let pending = PendingLedgerClose {
             handle: tokio::task::spawn_blocking(|| {
                 Ok(henyey_ledger::LedgerCloseResult {
-                    header: stellar_xdr::curr::LedgerHeader {
+                    header: stellar_xdr::LedgerHeader {
                         ledger_version: 24,
-                        previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                        scp_value: stellar_xdr::curr::StellarValue {
-                            tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                            close_time: stellar_xdr::curr::TimePoint(1),
-                            upgrades: stellar_xdr::curr::VecM::default(),
-                            ext: stellar_xdr::curr::StellarValueExt::Basic,
+                        previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+                        scp_value: stellar_xdr::StellarValue {
+                            tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                            close_time: stellar_xdr::TimePoint(1),
+                            upgrades: stellar_xdr::VecM::default(),
+                            ext: stellar_xdr::StellarValueExt::Basic,
                         },
-                        tx_set_result_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                        bucket_list_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                        tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+                        bucket_list_hash: stellar_xdr::Hash([0u8; 32]),
                         ledger_seq: 1,
                         total_coins: 0,
                         fee_pool: 0,
@@ -8156,12 +8151,12 @@ mod tests {
                         base_reserve: 5_000_000,
                         max_tx_set_size: 100,
                         skip_list: [
-                            stellar_xdr::curr::Hash([0u8; 32]),
-                            stellar_xdr::curr::Hash([0u8; 32]),
-                            stellar_xdr::curr::Hash([0u8; 32]),
-                            stellar_xdr::curr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
+                            stellar_xdr::Hash([0u8; 32]),
                         ],
-                        ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                        ext: stellar_xdr::LedgerHeaderExt::V0,
                     },
                     header_hash: henyey_common::Hash256::ZERO,
                     tx_results: Vec::new(),
@@ -8267,7 +8262,7 @@ mod tests {
     /// empty tx_queue and subtract.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_post_close_revalidation_is_single_snapshot() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
             Preconditions, SequenceNumber, SignatureHint, Transaction, TransactionExt,
             TransactionV1Envelope, Uint256,
@@ -8278,12 +8273,11 @@ mod tests {
         /// every `load_account` call returns `None` — exercising the full
         /// re-validation path (source lookup, ops-auth lookup) without
         /// needing a populated bucket list.
-        fn make_synthetic_envelope(seed: u8) -> stellar_xdr::curr::TransactionEnvelope {
+        fn make_synthetic_envelope(seed: u8) -> stellar_xdr::TransactionEnvelope {
             let source = MuxedAccount::Ed25519(Uint256([seed; 32]));
-            let dest =
-                stellar_xdr::curr::AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                    Uint256([seed.wrapping_add(1); 32]),
-                ));
+            let dest = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                Uint256([seed.wrapping_add(1); 32]),
+            ));
             let tx = Transaction {
                 source_account: source,
                 fee: 100,
@@ -8301,11 +8295,11 @@ mod tests {
                 .unwrap(),
                 ext: TransactionExt::V0,
             };
-            stellar_xdr::curr::TransactionEnvelope::Tx(TransactionV1Envelope {
+            stellar_xdr::TransactionEnvelope::Tx(TransactionV1Envelope {
                 tx,
                 signatures: vec![DecoratedSignature {
                     hint: SignatureHint([0u8; 4]),
-                    signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                    signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
                 }]
                 .try_into()
                 .unwrap(),
@@ -8317,17 +8311,17 @@ mod tests {
             let pending = PendingLedgerClose {
                 handle: tokio::task::spawn_blocking(|| {
                     Ok(henyey_ledger::LedgerCloseResult {
-                        header: stellar_xdr::curr::LedgerHeader {
+                        header: stellar_xdr::LedgerHeader {
                             ledger_version: 24,
-                            previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                            scp_value: stellar_xdr::curr::StellarValue {
-                                tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                                close_time: stellar_xdr::curr::TimePoint(1),
-                                upgrades: stellar_xdr::curr::VecM::default(),
-                                ext: stellar_xdr::curr::StellarValueExt::Basic,
+                            previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+                            scp_value: stellar_xdr::StellarValue {
+                                tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                                close_time: stellar_xdr::TimePoint(1),
+                                upgrades: stellar_xdr::VecM::default(),
+                                ext: stellar_xdr::StellarValueExt::Basic,
                             },
-                            tx_set_result_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                            bucket_list_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                            tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+                            bucket_list_hash: stellar_xdr::Hash([0u8; 32]),
                             ledger_seq: 1,
                             total_coins: 0,
                             fee_pool: 0,
@@ -8337,12 +8331,12 @@ mod tests {
                             base_reserve: 5_000_000,
                             max_tx_set_size: 100,
                             skip_list: [
-                                stellar_xdr::curr::Hash([0u8; 32]),
-                                stellar_xdr::curr::Hash([0u8; 32]),
-                                stellar_xdr::curr::Hash([0u8; 32]),
-                                stellar_xdr::curr::Hash([0u8; 32]),
+                                stellar_xdr::Hash([0u8; 32]),
+                                stellar_xdr::Hash([0u8; 32]),
+                                stellar_xdr::Hash([0u8; 32]),
+                                stellar_xdr::Hash([0u8; 32]),
                             ],
-                            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                            ext: stellar_xdr::LedgerHeaderExt::V0,
                         },
                         header_hash: henyey_common::Hash256::ZERO,
                         tx_results: Vec::new(),
@@ -8473,9 +8467,7 @@ mod tests {
     /// Helper: construct a valid signed XDR blob for StellarValue with the
     /// given tx_set_hash so check_ledger_close parses it successfully.
     fn mk_stellar_value_xdr(tx_set_hash: [u8; 32]) -> Vec<u8> {
-        use stellar_xdr::curr::{
-            Hash, Limits, StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr,
-        };
+        use stellar_xdr::{Hash, Limits, StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr};
         let sv = StellarValue {
             tx_set_hash: Hash(tx_set_hash),
             close_time: TimePoint(12345),
@@ -8487,8 +8479,8 @@ mod tests {
 
     /// Helper: wrap the XDR bytes into a `Value` (BytesM<64>-ish type for
     /// ScpDriver::record_externalized).
-    fn mk_value(xdr_bytes: Vec<u8>) -> stellar_xdr::curr::Value {
-        stellar_xdr::curr::Value(
+    fn mk_value(xdr_bytes: Vec<u8>) -> stellar_xdr::Value {
+        stellar_xdr::Value(
             xdr_bytes
                 .try_into()
                 .expect("StellarValue XDR fits in Value"),
@@ -8544,7 +8536,7 @@ mod tests {
                     tx_set_hash: henyey_common::Hash256::from_bytes([0x11; 32]),
                     tx_set: None,
                     upgrades: Vec::new(),
-                    stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
                 },
             );
             buf.insert(
@@ -8555,7 +8547,7 @@ mod tests {
                     tx_set_hash: henyey_common::Hash256::from_bytes([0x77; 32]),
                     tx_set: None,
                     upgrades: Vec::new(),
-                    stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
                 },
             );
         }
@@ -8700,7 +8692,7 @@ mod tests {
                     tx_set_hash: missing_hash,
                     tx_set: None,
                     upgrades: Vec::new(),
-                    stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
                 },
             );
         }
@@ -8770,7 +8762,7 @@ mod tests {
                     tx_set_hash: hash_a,
                     tx_set: None,
                     upgrades: Vec::new(),
-                    stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
                 },
             );
         }
@@ -9199,7 +9191,7 @@ mod tests {
     /// The tx will fail validation (no real account), but the freshness
     /// gate fires before validation, so the tx content doesn't matter.
     fn make_dummy_tx_envelope() -> TransactionEnvelope {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
             Preconditions, SequenceNumber, SignatureHint, Transaction, TransactionExt,
             TransactionV1Envelope, Uint256,
@@ -9213,8 +9205,8 @@ mod tests {
             operations: vec![Operation {
                 source_account: None,
                 body: OperationBody::CreateAccount(CreateAccountOp {
-                    destination: stellar_xdr::curr::AccountId(
-                        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32])),
+                    destination: stellar_xdr::AccountId(
+                        stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32])),
                     ),
                     starting_balance: 1_000_000_000,
                 }),
@@ -9227,7 +9219,7 @@ mod tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -10894,12 +10886,10 @@ mod tests {
         // Activate survey_data so the Idle path sees survey_is_active() == true.
         {
             let mut state = app.survey_state.write().await;
-            let msg = stellar_xdr::curr::TimeSlicedSurveyStartCollectingMessage {
-                surveyor_id: stellar_xdr::curr::NodeId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                        [0u8; 32],
-                    )),
-                ),
+            let msg = stellar_xdr::TimeSlicedSurveyStartCollectingMessage {
+                surveyor_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0u8; 32]),
+                )),
                 nonce: 99,
                 ledger_num: 1,
             };
@@ -11219,7 +11209,7 @@ mod tests {
             tx_set_hash,
             tx_set,
             upgrades: Vec::new(),
-            stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+            stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
         }
     }
 
@@ -11392,7 +11382,7 @@ mod tests {
                     tx_set_hash: henyey_common::Hash256::from_bytes([0xAA; 32]),
                     tx_set: None,
                     upgrades: Vec::new(),
-                    stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
                 },
             );
         }
@@ -11429,7 +11419,7 @@ mod tests {
                     tx_set_hash: henyey_common::Hash256::from_bytes([0xBB; 32]),
                     tx_set: None,
                     upgrades: Vec::new(),
-                    stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
                 },
             );
         }
@@ -12638,9 +12628,9 @@ mod tests {
     // ---- SurveyMessageSigner / SurveyRequestSigner tests ----
 
     /// Helper: construct the expected local node ID from an App's keypair.
-    fn expected_node_id(app: &App) -> stellar_xdr::curr::NodeId {
-        stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*app.keypair.public_key().as_bytes()),
+    fn expected_node_id(app: &App) -> stellar_xdr::NodeId {
+        stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*app.keypair.public_key().as_bytes()),
         ))
     }
 
@@ -12689,8 +12679,8 @@ mod tests {
     async fn test_survey_request_signer_build_request() {
         let app = survey_test_app().await;
         let nonce = 123u32;
-        let peer_id = henyey_overlay::PeerId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let peer_id = henyey_overlay::PeerId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
 
         app.herder.set_tracking_for_testing(31, 300);
@@ -12704,7 +12694,7 @@ mod tests {
         assert_eq!(signed.request.outbound_peers_index, 10);
         assert_eq!(
             signed.request.request.surveyed_peer_id,
-            stellar_xdr::curr::NodeId(peer_id.0.clone())
+            stellar_xdr::NodeId(peer_id.0.clone())
         );
         assert_eq!(
             signed.request.request.surveyor_peer_id,
@@ -12723,11 +12713,11 @@ mod tests {
     async fn test_survey_request_signer_reads_fresh_ledger_per_call() {
         let app = survey_test_app().await;
         let nonce = 200u32;
-        let peer_a = henyey_overlay::PeerId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([2u8; 32]),
+        let peer_a = henyey_overlay::PeerId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([2u8; 32]),
         ));
-        let peer_b = henyey_overlay::PeerId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([3u8; 32]),
+        let peer_b = henyey_overlay::PeerId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([3u8; 32]),
         ));
 
         // Set tracking to slot 11 (ledger_index = 10)
@@ -12781,7 +12771,7 @@ mod tests {
         let surveyor_id = expected_node_id(&app);
         {
             let mut state = app.survey_state.write().await;
-            let start_msg = stellar_xdr::curr::TimeSlicedSurveyStartCollectingMessage {
+            let start_msg = stellar_xdr::TimeSlicedSurveyStartCollectingMessage {
                 surveyor_id: surveyor_id.clone(),
                 nonce,
                 ledger_num: 10,
@@ -12857,7 +12847,7 @@ mod tests {
                 assert_eq!(signed.request.nonce, nonce, "nonce must match");
                 assert_eq!(
                     signed.request.request.surveyed_peer_id,
-                    stellar_xdr::curr::NodeId(peer_id.0.clone()),
+                    stellar_xdr::NodeId(peer_id.0.clone()),
                     "surveyed_peer_id must match injected peer"
                 );
                 assert_eq!(
@@ -13403,7 +13393,7 @@ mod tests {
         );
         for msg in &received {
             match msg {
-                stellar_xdr::curr::StellarMessage::GetScpState(seq) => {
+                stellar_xdr::StellarMessage::GetScpState(seq) => {
                     assert_eq!(
                         *seq, expected_seq,
                         "GetScpState should use low-watermark seq {}, got {}",
@@ -13427,7 +13417,7 @@ mod tests {
     /// which would have broadcast the older envelopes too.
     #[tokio::test]
     async fn test_out_of_sync_recovery_uses_latest_slot_rebroadcast_then_bounded_scp_pull() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             NodeId, PublicKey, ScpNomination, ScpStatement, ScpStatementPledges, Signature, Uint256,
         };
 
@@ -13460,7 +13450,7 @@ mod tests {
         let make_nom_envelope = |slot_index: u64, node_bytes: u8| -> ScpEnvelope {
             let node_id = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([node_bytes; 32])));
             let nomination = ScpNomination {
-                quorum_set_hash: stellar_xdr::curr::Hash([0xAA; 32]),
+                quorum_set_hash: stellar_xdr::Hash([0xAA; 32]),
                 votes: vec![vec![slot_index as u8].try_into().unwrap()]
                     .try_into()
                     .unwrap(),
@@ -13531,7 +13521,7 @@ mod tests {
 
         // Drain all messages from peers.
         let drain =
-            |rx: &mut henyey_overlay::TestPeerReceiver| -> Vec<stellar_xdr::curr::StellarMessage> {
+            |rx: &mut henyey_overlay::TestPeerReceiver| -> Vec<stellar_xdr::StellarMessage> {
                 let mut msgs = Vec::new();
                 while let Some(msg) = rx.try_recv() {
                     msgs.push(msg);
@@ -13547,7 +13537,7 @@ mod tests {
             .iter()
             .flat_map(|msgs| {
                 msgs.iter().filter_map(|m| match m {
-                    stellar_xdr::curr::StellarMessage::ScpMessage(env) => Some(env),
+                    stellar_xdr::StellarMessage::ScpMessage(env) => Some(env),
                     _ => None,
                 })
             })
@@ -13592,7 +13582,7 @@ mod tests {
             .iter()
             .map(|msgs| {
                 msgs.iter()
-                    .filter(|m| matches!(m, stellar_xdr::curr::StellarMessage::GetScpState(s) if *s == expected_seq))
+                    .filter(|m| matches!(m, stellar_xdr::StellarMessage::GetScpState(s) if *s == expected_seq))
                     .count()
             })
             .sum();
@@ -13708,7 +13698,7 @@ mod tests {
 
         // Drain all messages from the three peer receivers.
         let drain =
-            |rx: &mut henyey_overlay::TestPeerReceiver| -> Vec<stellar_xdr::curr::StellarMessage> {
+            |rx: &mut henyey_overlay::TestPeerReceiver| -> Vec<stellar_xdr::StellarMessage> {
                 let mut msgs = Vec::new();
                 while let Some(msg) = rx.try_recv() {
                     msgs.push(msg);
@@ -13727,7 +13717,7 @@ mod tests {
             .map(|msgs| {
                 msgs.iter()
                     .filter(|m| {
-                        matches!(m, stellar_xdr::curr::StellarMessage::GetScpState(s) if *s == expected_seq)
+                        matches!(m, stellar_xdr::StellarMessage::GetScpState(s) if *s == expected_seq)
                     })
                     .count()
             })

--- a/crates/app/src/app/peers.rs
+++ b/crates/app/src/app/peers.rs
@@ -104,7 +104,7 @@ impl App {
     pub async fn try_send_to_peer(
         &self,
         peer_id: &PeerId,
-        message: stellar_xdr::curr::StellarMessage,
+        message: stellar_xdr::StellarMessage,
     ) -> anyhow::Result<()> {
         let overlay = self
             .overlay()
@@ -256,7 +256,7 @@ impl App {
         };
 
         for (peer, hash) in to_ping {
-            let msg = StellarMessage::GetScpQuorumset(stellar_xdr::curr::Uint256(hash.0));
+            let msg = StellarMessage::GetScpQuorumset(stellar_xdr::Uint256(hash.0));
             if overlay.try_send_to(&peer, msg).is_err() {
                 tracing::debug!(peer = %peer, "Failed to send ping");
                 self.ping_state
@@ -293,7 +293,7 @@ impl App {
     /// Process a peer list received from the network.
     pub(super) async fn process_peer_list(
         &self,
-        peer_list: stellar_xdr::curr::VecM<stellar_xdr::curr::PeerAddress, 100>,
+        peer_list: stellar_xdr::VecM<stellar_xdr::PeerAddress, 100>,
     ) {
         let Some(overlay) = self.overlay().await else {
             return;
@@ -305,10 +305,10 @@ impl App {
             .filter_map(|xdr_addr| {
                 // Extract IP address from the XDR type
                 let ip = match &xdr_addr.ip {
-                    stellar_xdr::curr::PeerAddressIp::IPv4(bytes) => {
+                    stellar_xdr::PeerAddressIp::IPv4(bytes) => {
                         format!("{}.{}.{}.{}", bytes[0], bytes[1], bytes[2], bytes[3])
                     }
-                    stellar_xdr::curr::PeerAddressIp::IPv6(_) => {
+                    stellar_xdr::PeerAddressIp::IPv6(_) => {
                         return None;
                     }
                 };

--- a/crates/app/src/app/persist.rs
+++ b/crates/app/src/app/persist.rs
@@ -68,7 +68,7 @@ impl RecoverableShutdownHandle {
 /// [`PendingPersist`] task to avoid blocking inside `tokio::spawn`.
 #[derive(Clone)]
 pub(super) struct CatchupPersistData {
-    pub header: stellar_xdr::curr::LedgerHeader,
+    pub header: stellar_xdr::LedgerHeader,
     pub header_xdr: Vec<u8>,
     pub has_json: String,
     /// Whether checkpoint publishing is enabled for this run. Drives the
@@ -510,7 +510,7 @@ pub(super) fn fatal_persist_error(context: &str, error: &dyn std::fmt::Display) 
 mod tests {
     use super::*;
     use henyey_db::queries::StateQueries;
-    use stellar_xdr::curr::{Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt};
+    use stellar_xdr::{Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt};
 
     /// A detached `RecoverableShutdownHandle` for tests (no live App).
     fn test_recoverable_shutdown() -> RecoverableShutdownHandle {
@@ -576,13 +576,13 @@ mod tests {
     }
 
     fn make_header(seq: u32) -> (LedgerHeader, Vec<u8>) {
-        use stellar_xdr::curr::{LedgerHeaderExtensionV1, Limits, WriteXdr};
+        use stellar_xdr::{LedgerHeaderExtensionV1, Limits, WriteXdr};
         let header = LedgerHeader {
             ledger_version: 24,
             previous_ledger_hash: Hash([0; 32]),
             scp_value: StellarValue {
                 tx_set_hash: Hash([0; 32]),
-                close_time: stellar_xdr::curr::TimePoint(0),
+                close_time: stellar_xdr::TimePoint(0),
                 upgrades: vec![].try_into().unwrap(),
                 ext: StellarValueExt::Basic,
             },
@@ -599,7 +599,7 @@ mod tests {
             skip_list: [Hash([0; 32]), Hash([0; 32]), Hash([0; 32]), Hash([0; 32])],
             ext: LedgerHeaderExt::V1(LedgerHeaderExtensionV1 {
                 flags: 0,
-                ext: stellar_xdr::curr::LedgerHeaderExtensionV1Ext::V0,
+                ext: stellar_xdr::LedgerHeaderExtensionV1Ext::V0,
             }),
         };
         let xdr = header.to_xdr(Limits::none()).unwrap();

--- a/crates/app/src/app/publish.rs
+++ b/crates/app/src/app/publish.rs
@@ -259,10 +259,10 @@ impl App {
                 .get_ledger_header(seq)?
                 .ok_or_else(|| anyhow::anyhow!("Missing ledger header {}", seq))?;
             let hash = henyey_ledger::compute_header_hash(&header)?;
-            headers.push(stellar_xdr::curr::LedgerHeaderHistoryEntry {
+            headers.push(stellar_xdr::LedgerHeaderHistoryEntry {
                 header,
-                hash: stellar_xdr::curr::Hash(hash.0),
-                ext: stellar_xdr::curr::LedgerHeaderHistoryEntryExt::V0,
+                hash: stellar_xdr::Hash(hash.0),
+                ext: stellar_xdr::LedgerHeaderHistoryEntryExt::V0,
             });
 
             let tx_entry = self.db.get_tx_history_entry(seq)?;
@@ -464,10 +464,10 @@ impl App {
         &self,
         start_ledger: u32,
         checkpoint: u32,
-    ) -> anyhow::Result<Vec<stellar_xdr::curr::ScpHistoryEntry>> {
+    ) -> anyhow::Result<Vec<stellar_xdr::ScpHistoryEntry>> {
         use henyey_common::Hash256;
         use std::collections::HashSet;
-        use stellar_xdr::curr::{LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0};
+        use stellar_xdr::{LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0};
 
         let mut entries = Vec::new();
         for seq in start_ledger..=checkpoint {
@@ -523,7 +523,7 @@ impl App {
 fn write_scp_history_file(
     base_dir: &std::path::Path,
     checkpoint: u32,
-    entries: &[stellar_xdr::curr::ScpHistoryEntry],
+    entries: &[stellar_xdr::ScpHistoryEntry],
 ) -> anyhow::Result<()> {
     use henyey_history::paths::checkpoint_path;
 
@@ -550,7 +550,7 @@ mod tests {
     use henyey_db::schema::state_keys;
     use henyey_history::publish::build_history_archive_state;
     use henyey_ledger::TransactionSetVariant;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, Limits, StellarValue, StellarValueExt,
         TransactionHistoryEntry, TransactionHistoryEntryExt, TransactionHistoryResultEntry,
         TransactionHistoryResultEntryExt, TransactionResultSet, TransactionSet, VecM, WriteXdr,
@@ -599,7 +599,7 @@ mod tests {
             previous_ledger_hash: Hash(previous_ledger_hash.0),
             scp_value: StellarValue {
                 tx_set_hash: Hash(tx_set_hash.0),
-                close_time: stellar_xdr::curr::TimePoint(seq as u64),
+                close_time: stellar_xdr::TimePoint(seq as u64),
                 upgrades: VecM::default(),
                 ext: StellarValueExt::Basic,
             },
@@ -842,7 +842,7 @@ mod tests {
             .add_batch(
                 1,
                 0,
-                stellar_xdr::curr::BucketListType::Live,
+                stellar_xdr::BucketListType::Live,
                 genesis_entries.clone(),
                 vec![],
                 vec![],
@@ -862,7 +862,7 @@ mod tests {
             bl.add_batch(
                 1,
                 0,
-                stellar_xdr::curr::BucketListType::Live,
+                stellar_xdr::BucketListType::Live,
                 genesis_entries,
                 vec![],
                 vec![],
@@ -1094,11 +1094,11 @@ mod tests {
         use tempfile::TempDir;
 
         let tmp = TempDir::new().unwrap();
-        let entry = stellar_xdr::curr::ScpHistoryEntry::V0(stellar_xdr::curr::ScpHistoryEntryV0 {
-            quorum_sets: stellar_xdr::curr::VecM::default(),
-            ledger_messages: stellar_xdr::curr::LedgerScpMessages {
+        let entry = stellar_xdr::ScpHistoryEntry::V0(stellar_xdr::ScpHistoryEntryV0 {
+            quorum_sets: stellar_xdr::VecM::default(),
+            ledger_messages: stellar_xdr::LedgerScpMessages {
                 ledger_seq: 63,
-                messages: stellar_xdr::curr::VecM::default(),
+                messages: stellar_xdr::VecM::default(),
             },
         });
 

--- a/crates/app/src/app/survey_impl.rs
+++ b/crates/app/src/app/survey_impl.rs
@@ -31,7 +31,7 @@ impl<'a> SurveyMessageSigner<'a> {
     pub(super) fn build_start(
         &self,
     ) -> anyhow::Result<(
-        stellar_xdr::curr::SignedTimeSlicedSurveyStartCollectingMessage,
+        stellar_xdr::SignedTimeSlicedSurveyStartCollectingMessage,
         TimeSlicedSurveyStartCollectingMessage,
     )> {
         let ledger_num = self.app.survey_local_ledger();
@@ -41,10 +41,10 @@ impl<'a> SurveyMessageSigner<'a> {
             ledger_num,
         };
         let bytes = start
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .map_err(|e| anyhow::anyhow!("Failed to encode survey start message: {e}"))?;
         let signature = self.app.sign_survey_message(&bytes);
-        let signed = stellar_xdr::curr::SignedTimeSlicedSurveyStartCollectingMessage {
+        let signed = stellar_xdr::SignedTimeSlicedSurveyStartCollectingMessage {
             signature,
             start_collecting: start.clone(),
         };
@@ -56,7 +56,7 @@ impl<'a> SurveyMessageSigner<'a> {
     pub(super) fn build_stop(
         &self,
     ) -> anyhow::Result<(
-        stellar_xdr::curr::SignedTimeSlicedSurveyStopCollectingMessage,
+        stellar_xdr::SignedTimeSlicedSurveyStopCollectingMessage,
         TimeSlicedSurveyStopCollectingMessage,
     )> {
         let ledger_num = self.app.survey_local_ledger();
@@ -66,10 +66,10 @@ impl<'a> SurveyMessageSigner<'a> {
             ledger_num,
         };
         let bytes = stop
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .map_err(|e| anyhow::anyhow!("Failed to encode survey stop message: {e}"))?;
         let signature = self.app.sign_survey_message(&bytes);
-        let signed = stellar_xdr::curr::SignedTimeSlicedSurveyStopCollectingMessage {
+        let signed = stellar_xdr::SignedTimeSlicedSurveyStopCollectingMessage {
             signature,
             stop_collecting: stop.clone(),
         };
@@ -111,11 +111,11 @@ impl<'a> SurveyRequestSigner<'a> {
         peer_id: &henyey_overlay::PeerId,
         inbound_index: u32,
         outbound_index: u32,
-    ) -> anyhow::Result<stellar_xdr::curr::SignedTimeSlicedSurveyRequestMessage> {
+    ) -> anyhow::Result<stellar_xdr::SignedTimeSlicedSurveyRequestMessage> {
         let ledger_num = self.base.app.survey_local_ledger();
         let request = SurveyRequestMessage {
             surveyor_peer_id: self.base.app.local_node_id(),
-            surveyed_peer_id: stellar_xdr::curr::NodeId(peer_id.0.clone()),
+            surveyed_peer_id: stellar_xdr::NodeId(peer_id.0.clone()),
             ledger_num,
             encryption_key: self.encryption_key.clone(),
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
@@ -126,9 +126,9 @@ impl<'a> SurveyRequestSigner<'a> {
             inbound_peers_index: inbound_index,
             outbound_peers_index: outbound_index,
         };
-        let bytes = message.to_xdr(stellar_xdr::curr::Limits::none())?;
+        let bytes = message.to_xdr(stellar_xdr::Limits::none())?;
         let signature = self.base.app.sign_survey_message(&bytes);
-        Ok(stellar_xdr::curr::SignedTimeSlicedSurveyRequestMessage {
+        Ok(stellar_xdr::SignedTimeSlicedSurveyRequestMessage {
             request_signature: signature,
             request: message,
         })
@@ -417,7 +417,7 @@ impl App {
         };
 
         let local_node_id = self.local_node_id();
-        let message_bytes = match signed.request.to_xdr(stellar_xdr::curr::Limits::none()) {
+        let message_bytes = match signed.request.to_xdr(stellar_xdr::Limits::none()) {
             Ok(bytes) => bytes,
             Err(_) => return false,
         };
@@ -507,10 +507,10 @@ impl App {
     pub(super) async fn handle_survey_start_collecting(
         &self,
         peer_id: &henyey_overlay::PeerId,
-        signed: stellar_xdr::curr::SignedTimeSlicedSurveyStartCollectingMessage,
+        signed: stellar_xdr::SignedTimeSlicedSurveyStartCollectingMessage,
     ) {
         let message = &signed.start_collecting;
-        let message_bytes = match message.to_xdr(stellar_xdr::curr::Limits::none()) {
+        let message_bytes = match message.to_xdr(stellar_xdr::Limits::none()) {
             Ok(bytes) => bytes,
             Err(e) => {
                 tracing::debug!(peer = %peer_id, error = %e, "Failed to encode survey start message");
@@ -573,10 +573,10 @@ impl App {
     pub(super) async fn handle_survey_stop_collecting(
         &self,
         peer_id: &henyey_overlay::PeerId,
-        signed: stellar_xdr::curr::SignedTimeSlicedSurveyStopCollectingMessage,
+        signed: stellar_xdr::SignedTimeSlicedSurveyStopCollectingMessage,
     ) {
         let message = &signed.stop_collecting;
-        let message_bytes = match message.to_xdr(stellar_xdr::curr::Limits::none()) {
+        let message_bytes = match message.to_xdr(stellar_xdr::Limits::none()) {
             Ok(bytes) => bytes,
             Err(e) => {
                 tracing::debug!(peer = %peer_id, error = %e, "Failed to encode survey stop message");
@@ -631,10 +631,10 @@ impl App {
     pub(super) async fn handle_survey_request(
         &self,
         peer_id: &henyey_overlay::PeerId,
-        signed: stellar_xdr::curr::SignedTimeSlicedSurveyRequestMessage,
+        signed: stellar_xdr::SignedTimeSlicedSurveyRequestMessage,
     ) {
         let request = &signed.request;
-        let request_bytes = match request.to_xdr(stellar_xdr::curr::Limits::none()) {
+        let request_bytes = match request.to_xdr(stellar_xdr::Limits::none()) {
             Ok(bytes) => bytes,
             Err(e) => {
                 tracing::debug!(peer = %peer_id, error = %e, "Failed to encode survey request");
@@ -676,7 +676,7 @@ impl App {
             return;
         }
         let response_body = match request.request.command_type {
-            stellar_xdr::curr::SurveyMessageCommandType::TimeSlicedSurveyTopology => {
+            stellar_xdr::SurveyMessageCommandType::TimeSlicedSurveyTopology => {
                 let survey_state = self.survey_state.read().await;
                 match survey_state.data().fill_survey_data(request) {
                     Some(body) => body,
@@ -689,7 +689,7 @@ impl App {
         };
 
         let response_body = SurveyResponseBody::SurveyTopologyResponseV2(response_body);
-        let response_body_bytes = match response_body.to_xdr(stellar_xdr::curr::Limits::none()) {
+        let response_body_bytes = match response_body.to_xdr(stellar_xdr::Limits::none()) {
             Ok(bytes) => bytes,
             Err(e) => {
                 tracing::debug!(peer = %peer_id, error = %e, "Failed to encode survey response body");
@@ -727,7 +727,7 @@ impl App {
             nonce: request.nonce,
         };
 
-        let response_bytes = match response_message.to_xdr(stellar_xdr::curr::Limits::none()) {
+        let response_bytes = match response_message.to_xdr(stellar_xdr::Limits::none()) {
             Ok(bytes) => bytes,
             Err(e) => {
                 tracing::debug!(peer = %peer_id, error = %e, "Failed to encode survey response");
@@ -737,7 +737,7 @@ impl App {
 
         let signature = self.sign_survey_message(&response_bytes);
 
-        let signed_response = stellar_xdr::curr::SignedTimeSlicedSurveyResponseMessage {
+        let signed_response = stellar_xdr::SignedTimeSlicedSurveyResponseMessage {
             response_signature: signature,
             response: response_message,
         };
@@ -758,7 +758,7 @@ impl App {
         signed: SignedTimeSlicedSurveyResponseMessage,
     ) {
         let response_message = signed.response.clone();
-        let response_bytes = match response_message.to_xdr(stellar_xdr::curr::Limits::none()) {
+        let response_bytes = match response_message.to_xdr(stellar_xdr::Limits::none()) {
             Ok(bytes) => bytes,
             Err(e) => {
                 tracing::debug!(peer = %peer_id, error = %e, "Failed to encode survey response");
@@ -825,7 +825,7 @@ impl App {
 
         let response_body = match SurveyResponseBody::from_xdr(
             decrypted.as_slice(),
-            stellar_xdr::curr::Limits::none(),
+            stellar_xdr::Limits::none(),
         ) {
             Ok(body) => body,
             Err(e) => {
@@ -866,9 +866,9 @@ impl App {
         }
     }
 
-    fn local_node_id(&self) -> stellar_xdr::curr::NodeId {
-        stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*self.keypair.public_key().as_bytes()),
+    fn local_node_id(&self) -> stellar_xdr::NodeId {
+        stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*self.keypair.public_key().as_bytes()),
         ))
     }
 
@@ -940,7 +940,7 @@ impl App {
         selected
     }
 
-    fn sign_survey_message(&self, message: &[u8]) -> stellar_xdr::curr::Signature {
+    fn sign_survey_message(&self, message: &[u8]) -> stellar_xdr::Signature {
         let sig = self.keypair.sign(message);
         sig.into()
     }
@@ -983,9 +983,9 @@ impl App {
     /// rejected message.
     fn verify_survey_signature_or_drop(
         &self,
-        node_id: &stellar_xdr::curr::NodeId,
+        node_id: &stellar_xdr::NodeId,
         message: &[u8],
-        signature: &stellar_xdr::curr::Signature,
+        signature: &stellar_xdr::Signature,
         relaying_peer: Option<(&Arc<OverlayManager>, &henyey_overlay::PeerId)>,
     ) -> bool {
         if self.verify_survey_signature(node_id, message, signature) {
@@ -994,7 +994,7 @@ impl App {
         if let Some((overlay, peer_id)) = relaying_peer {
             overlay.send_error_and_drop(
                 peer_id,
-                stellar_xdr::curr::ErrorCode::Misc,
+                stellar_xdr::ErrorCode::Misc,
                 "Survey has invalid signature",
             );
         }
@@ -1003,9 +1003,9 @@ impl App {
 
     fn verify_survey_signature(
         &self,
-        node_id: &stellar_xdr::curr::NodeId,
+        node_id: &stellar_xdr::NodeId,
         message: &[u8],
-        signature: &stellar_xdr::curr::Signature,
+        signature: &stellar_xdr::Signature,
     ) -> bool {
         let key_bytes = match Self::node_id_bytes(node_id) {
             Some(bytes) => bytes,
@@ -1018,13 +1018,13 @@ impl App {
         henyey_crypto::verify_from_raw_key(&key_bytes, message, &sig).is_ok()
     }
 
-    fn node_id_bytes(node_id: &stellar_xdr::curr::NodeId) -> Option<[u8; 32]> {
+    fn node_id_bytes(node_id: &stellar_xdr::NodeId) -> Option<[u8; 32]> {
         match &node_id.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => Some(key.0),
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => Some(key.0),
         }
     }
 
-    fn surveyor_permitted(&self, surveyor_id: &stellar_xdr::curr::NodeId) -> bool {
+    fn surveyor_permitted(&self, surveyor_id: &stellar_xdr::NodeId) -> bool {
         let allowed_keys = &self.config.overlay.surveyor_keys;
         if allowed_keys.is_empty() {
             let quorum_nodes = self.herder.local_quorum_nodes();
@@ -1427,9 +1427,9 @@ mod survey_invalid_signature_tests {
         (app, peer_id, receiver)
     }
 
-    fn surveyor_node_id(secret: &henyey_crypto::SecretKey) -> stellar_xdr::curr::NodeId {
-        stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*secret.public_key().as_bytes()),
+    fn surveyor_node_id(secret: &henyey_crypto::SecretKey) -> stellar_xdr::NodeId {
+        stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*secret.public_key().as_bytes()),
         ))
     }
 
@@ -1440,15 +1440,15 @@ mod survey_invalid_signature_tests {
         app: &App,
         surveyor_secret: &henyey_crypto::SecretKey,
         signing_secret: &henyey_crypto::SecretKey,
-    ) -> stellar_xdr::curr::SignedTimeSlicedSurveyStartCollectingMessage {
-        let start = stellar_xdr::curr::TimeSlicedSurveyStartCollectingMessage {
+    ) -> stellar_xdr::SignedTimeSlicedSurveyStartCollectingMessage {
+        let start = stellar_xdr::TimeSlicedSurveyStartCollectingMessage {
             surveyor_id: surveyor_node_id(surveyor_secret),
             nonce: 1,
             ledger_num: app.survey_local_ledger(),
         };
-        let bytes = start.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
-        let signature: stellar_xdr::curr::Signature = signing_secret.sign(&bytes).into();
-        stellar_xdr::curr::SignedTimeSlicedSurveyStartCollectingMessage {
+        let bytes = start.to_xdr(stellar_xdr::Limits::none()).unwrap();
+        let signature: stellar_xdr::Signature = signing_secret.sign(&bytes).into();
+        stellar_xdr::SignedTimeSlicedSurveyStartCollectingMessage {
             signature,
             start_collecting: start,
         }
@@ -1470,8 +1470,8 @@ mod survey_invalid_signature_tests {
         app.handle_survey_start_collecting(&peer_id, signed).await;
 
         match receiver.try_recv() {
-            Some(stellar_xdr::curr::StellarMessage::ErrorMsg(err)) => {
-                assert_eq!(err.code, stellar_xdr::curr::ErrorCode::Misc);
+            Some(stellar_xdr::StellarMessage::ErrorMsg(err)) => {
+                assert_eq!(err.code, stellar_xdr::ErrorCode::Misc);
                 assert_eq!(err.msg.to_string(), "Survey has invalid signature");
             }
             other => {
@@ -1507,14 +1507,14 @@ mod survey_invalid_signature_tests {
 
         // Build a VALIDLY-signed message but with a wildly out-of-range ledger
         // so the limiter's ledger gate rejects it before the signature closure.
-        let start = stellar_xdr::curr::TimeSlicedSurveyStartCollectingMessage {
+        let start = stellar_xdr::TimeSlicedSurveyStartCollectingMessage {
             surveyor_id: surveyor_node_id(&surveyor),
             nonce: 1,
             ledger_num: 1_000_000,
         };
-        let bytes = start.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
-        let signature: stellar_xdr::curr::Signature = surveyor.sign(&bytes).into();
-        let signed = stellar_xdr::curr::SignedTimeSlicedSurveyStartCollectingMessage {
+        let bytes = start.to_xdr(stellar_xdr::Limits::none()).unwrap();
+        let signature: stellar_xdr::Signature = surveyor.sign(&bytes).into();
+        let signed = stellar_xdr::SignedTimeSlicedSurveyStartCollectingMessage {
             signature,
             start_collecting: start,
         };
@@ -1535,7 +1535,7 @@ mod survey_invalid_signature_tests {
         let (app, _peer_id, _receiver) = app_with_permitted_surveyor(&surveyor).await;
 
         let message = b"some survey bytes";
-        let signature: stellar_xdr::curr::Signature = forger.sign(message).into();
+        let signature: stellar_xdr::Signature = forger.sign(message).into();
         // Invalid signature (wrong key), but None peer → returns false, no drop.
         let result = app.verify_survey_signature_or_drop(
             &surveyor_node_id(&surveyor),

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -741,7 +741,7 @@ impl App {
     }
 
     /// Handle a TxSet message from the network.
-    pub(super) async fn handle_tx_set(&self, tx_set: stellar_xdr::curr::TransactionSet) {
+    pub(super) async fn handle_tx_set(&self, tx_set: stellar_xdr::TransactionSet) {
         use henyey_herder::TransactionSet;
 
         // Build internal TransactionSet from wire data — hash computed internally
@@ -791,7 +791,7 @@ impl App {
     /// Handle a GeneralizedTxSet message from the network.
     pub(super) async fn handle_generalized_tx_set(
         &self,
-        gen_tx_set: stellar_xdr::curr::GeneralizedTransactionSet,
+        gen_tx_set: stellar_xdr::GeneralizedTransactionSet,
     ) {
         // Time the full body (#1759 diagnostics): this runs inline on
         // the event loop for every GeneralizedTxSet, including the
@@ -805,7 +805,7 @@ impl App {
 
     async fn handle_generalized_tx_set_inner(
         &self,
-        gen_tx_set: stellar_xdr::curr::GeneralizedTransactionSet,
+        gen_tx_set: stellar_xdr::GeneralizedTransactionSet,
     ) {
         use henyey_herder::TransactionSet;
 
@@ -883,13 +883,13 @@ impl App {
                     let ledger_version = self.ledger_manager.current_header().ledger_version;
                     let message_type =
                         if protocol_version_starts_from(ledger_version, ProtocolVersion::V20) {
-                            stellar_xdr::curr::MessageType::GeneralizedTxSet
+                            stellar_xdr::MessageType::GeneralizedTxSet
                         } else {
-                            stellar_xdr::curr::MessageType::TxSet
+                            stellar_xdr::MessageType::TxSet
                         };
-                    let msg = StellarMessage::DontHave(stellar_xdr::curr::DontHave {
+                    let msg = StellarMessage::DontHave(stellar_xdr::DontHave {
                         type_: message_type,
-                        req_hash: stellar_xdr::curr::Uint256(hash.0),
+                        req_hash: stellar_xdr::Uint256(hash.0),
                     });
                     if let Err(e) = overlay.try_send_to(peer_id, msg) {
                         tracing::debug!(hash = hex::encode(hash.0), peer = %peer_id, error = %e, "Failed to send DontHave for TxSet");
@@ -927,7 +927,7 @@ impl App {
 
         // Convert to legacy XDR TransactionSet
         let prev_hash = tx_set.previous_ledger_hash();
-        let xdr_tx_set = stellar_xdr::curr::TransactionSet {
+        let xdr_tx_set = stellar_xdr::TransactionSet {
             previous_ledger_hash: Hash::from(prev_hash),
             txs: tx_set.transactions_owned().try_into().unwrap_or_default(),
         };
@@ -1127,7 +1127,7 @@ impl App {
 
         for (hash, peer_id) in requests {
             tracing::debug!(hash = %hash, peer = %peer_id, "Requesting tx set");
-            let request = StellarMessage::GetTxSet(stellar_xdr::curr::Uint256(hash.0));
+            let request = StellarMessage::GetTxSet(stellar_xdr::Uint256(hash.0));
             if let Err(e) = overlay.try_send_to(&peer_id, request) {
                 tracing::warn!(hash = %hash, peer = %peer_id, error = %e, "Failed to request TxSet");
             }
@@ -1304,7 +1304,7 @@ impl App {
                 peer_count = peers.len(),
                 "Retrying exhausted tx_set fetch — broadcasting to all eligible peers"
             );
-            let msg = StellarMessage::GetTxSet(stellar_xdr::curr::Uint256(hash.0));
+            let msg = StellarMessage::GetTxSet(stellar_xdr::Uint256(hash.0));
             for peer in &peers {
                 let _ = overlay.try_send_to(peer, msg.clone());
             }
@@ -1576,7 +1576,7 @@ mod tests {
     // ── Test helpers for collect_adverts_for_peers ────────────────────────
 
     use henyey_herder::{TransactionQueue, TxQueueConfig, TxQueueResult};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, AlphaNum4, Asset, AssetCode4, DecoratedSignature, ManageSellOfferOp, Memo,
         MuxedAccount, Operation, OperationBody, Preconditions, Price, PublicKey, SequenceNumber,
         Signature, SignatureHint, Transaction, TransactionEnvelope, TransactionExt,
@@ -1597,7 +1597,7 @@ mod tests {
         let operations: Vec<Operation> = (0..ops)
             .map(|_| Operation {
                 source_account: None,
-                body: OperationBody::BumpSequence(stellar_xdr::curr::BumpSequenceOp {
+                body: OperationBody::BumpSequence(stellar_xdr::BumpSequenceOp {
                     bump_to: SequenceNumber(0),
                 }),
             })
@@ -2008,7 +2008,7 @@ mod tests {
     /// content validation at the receive layer (Peer::recvGeneralizedTxSet).
     #[tokio::test]
     async fn test_handle_generalized_tx_set_accepts_low_base_fee() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, ParallelTxsComponent, TransactionPhase,
             TransactionSetV1, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
         };
@@ -2085,7 +2085,7 @@ mod tests {
     /// tx set has a generalized form whose hash matches the requested hash.
     #[tokio::test]
     async fn test_send_tx_set_sends_generalized_for_matching_hash() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, ParallelTxsComponent, TransactionPhase,
             TransactionSetV1, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
         };
@@ -2192,11 +2192,7 @@ mod tests {
         let peer_id = make_peer_id(99);
         let hash_bytes = [0x42u8; 32];
         let advert = FloodAdvert {
-            tx_hashes: TxAdvertVector(
-                vec![stellar_xdr::curr::Hash(hash_bytes)]
-                    .try_into()
-                    .unwrap(),
-            ),
+            tx_hashes: TxAdvertVector(vec![stellar_xdr::Hash(hash_bytes)].try_into().unwrap()),
         };
         let hash256 = Hash256(hash_bytes);
 

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -14,7 +14,7 @@ use henyey_common::Hash256;
 use henyey_herder::{AccountProvider, FeeBalanceProvider, Herder, NextConsensusSlot};
 use henyey_ledger::{HeaderSnapshot, LedgerManager};
 use henyey_overlay::{PeerId, ScpQueueCallback};
-use stellar_xdr::curr::{Hash, LedgerUpgrade, ReadXdr, TopologyResponseBodyV2, UpgradeType};
+use stellar_xdr::{Hash, LedgerUpgrade, ReadXdr, TopologyResponseBodyV2, UpgradeType};
 
 use crate::survey::SurveyPhase;
 
@@ -122,9 +122,9 @@ pub struct SurveyPeerReport {
 pub struct SurveyReport {
     pub phase: SurveyPhase,
     pub nonce: Option<u32>,
-    pub local_node: Option<stellar_xdr::curr::TimeSlicedNodeData>,
-    pub inbound_peers: Vec<stellar_xdr::curr::TimeSlicedPeerData>,
-    pub outbound_peers: Vec<stellar_xdr::curr::TimeSlicedPeerData>,
+    pub local_node: Option<stellar_xdr::TimeSlicedNodeData>,
+    pub inbound_peers: Vec<stellar_xdr::TimeSlicedPeerData>,
+    pub outbound_peers: Vec<stellar_xdr::TimeSlicedPeerData>,
     pub peer_reports: std::collections::BTreeMap<u32, Vec<SurveyPeerReport>>,
     pub survey_in_progress: bool,
     pub backlog: Vec<String>,
@@ -292,8 +292,8 @@ impl LedgerSummary {
     /// because it depends on the system clock (which only the caller has).
     pub fn from_snapshot(snap: &HeaderSnapshot, age: u64) -> Self {
         let flags = match &snap.header.ext {
-            stellar_xdr::curr::LedgerHeaderExt::V0 => 0,
-            stellar_xdr::curr::LedgerHeaderExt::V1(ext) => ext.flags,
+            stellar_xdr::LedgerHeaderExt::V0 => 0,
+            stellar_xdr::LedgerHeaderExt::V1(ext) => ext.flags,
         };
         LedgerSummary {
             num: snap.header.ledger_seq,
@@ -1136,16 +1136,16 @@ pub(super) struct LedgerFeeBalanceProvider {
 impl FeeBalanceProvider for LedgerFeeBalanceProvider {
     fn get_available_balance(
         &self,
-        account_id: &stellar_xdr::curr::AccountId,
+        account_id: &stellar_xdr::AccountId,
     ) -> henyey_ledger::Result<Option<i64>> {
         let snapshot = self.ledger_manager.create_snapshot()?;
-        let key = stellar_xdr::curr::LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = stellar_xdr::LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
         let Some(entry) = snapshot.get_entry(&key)? else {
             return Ok(None);
         };
-        if let stellar_xdr::curr::LedgerEntryData::Account(acc) = &entry.data {
+        if let stellar_xdr::LedgerEntryData::Account(acc) = &entry.data {
             let base_reserve = snapshot.header().base_reserve;
             Ok(Some(henyey_ledger::reserves::available_to_send(
                 acc,
@@ -1170,8 +1170,8 @@ pub(super) struct LedgerAccountProvider {
 impl AccountProvider for LedgerAccountProvider {
     fn load_account(
         &self,
-        account_id: &stellar_xdr::curr::AccountId,
-    ) -> henyey_ledger::Result<Option<stellar_xdr::curr::AccountEntry>> {
+        account_id: &stellar_xdr::AccountId,
+    ) -> henyey_ledger::Result<Option<stellar_xdr::AccountEntry>> {
         // Create a snapshot per call for the queue-admission path.
         // The SCP validation path uses SnapshotValidationProviders
         // which holds a single snapshot for the entire validation run.
@@ -1225,8 +1225,8 @@ impl SnapshotValidationProviders {
 impl AccountProvider for SnapshotValidationProviders {
     fn load_account(
         &self,
-        account_id: &stellar_xdr::curr::AccountId,
-    ) -> henyey_ledger::Result<Option<stellar_xdr::curr::AccountEntry>> {
+        account_id: &stellar_xdr::AccountId,
+    ) -> henyey_ledger::Result<Option<stellar_xdr::AccountEntry>> {
         self.inner.load_account(account_id)
     }
 }
@@ -1234,7 +1234,7 @@ impl AccountProvider for SnapshotValidationProviders {
 impl FeeBalanceProvider for SnapshotValidationProviders {
     fn get_available_balance(
         &self,
-        account_id: &stellar_xdr::curr::AccountId,
+        account_id: &stellar_xdr::AccountId,
     ) -> henyey_ledger::Result<Option<i64>> {
         self.inner.get_available_balance(account_id)
     }
@@ -1247,7 +1247,7 @@ pub(super) fn decode_upgrades(upgrades: Vec<UpgradeType>) -> Vec<LedgerUpgrade> 
         .into_iter()
         .filter_map(|upgrade| {
             let bytes = upgrade.0.as_slice();
-            match LedgerUpgrade::from_xdr(bytes, stellar_xdr::curr::Limits::none()) {
+            match LedgerUpgrade::from_xdr(bytes, stellar_xdr::Limits::none()) {
                 Ok(decoded) => Some(decoded),
                 Err(err) => {
                     tracing::warn!(error = %err, "Failed to decode ledger upgrade");
@@ -1610,7 +1610,7 @@ mod tests {
     #[test]
     fn test_ledger_summary_from_snapshot_v0() {
         use henyey_ledger::HeaderSnapshot;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let header = LedgerHeader {
             ledger_version: 25,
@@ -1655,7 +1655,7 @@ mod tests {
     #[test]
     fn test_ledger_summary_from_snapshot_v1_flags() {
         use henyey_ledger::HeaderSnapshot;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let header = LedgerHeader {
             ledger_version: 25,
@@ -1793,7 +1793,7 @@ mod tests {
     fn test_peer_tx_adverts_queue_incoming_stamps_history() {
         let mut adverts = PeerTxAdverts::new();
         let hash_bytes = [7u8; 32];
-        let hashes = vec![stellar_xdr::curr::Hash(hash_bytes)];
+        let hashes = vec![stellar_xdr::Hash(hash_bytes)];
 
         adverts.queue_incoming(&hashes, 15, 100);
 

--- a/crates/app/src/app/upgrades.rs
+++ b/crates/app/src/app/upgrades.rs
@@ -16,7 +16,7 @@ impl App {
         )
     }
 
-    pub fn proposed_upgrades(&self) -> Vec<stellar_xdr::curr::LedgerUpgrade> {
+    pub fn proposed_upgrades(&self) -> Vec<stellar_xdr::LedgerUpgrade> {
         self.config.upgrades.to_ledger_upgrades()
     }
 
@@ -46,7 +46,7 @@ impl App {
     /// * `Err` - I/O error or invariant violation reading from ledger
     pub fn get_config_upgrade_set(
         &self,
-        key: &stellar_xdr::curr::ConfigUpgradeSetKey,
+        key: &stellar_xdr::ConfigUpgradeSetKey,
     ) -> Result<Option<serde_json::Value>, henyey_ledger::LedgerError> {
         let frame = match self.ledger_manager.get_config_upgrade_set(key)? {
             Some(f) => f,

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -988,7 +988,7 @@ fn build_validator_weight_config(
     validator_entries: &[(String, String, Option<String>, Option<String>)], // (pubkey, name, home_domain, quality)
     domain_quality_map: &HashMap<String, ValidatorQuality>,
 ) -> anyhow::Result<Option<ValidatorWeightConfig>> {
-    use stellar_xdr::curr::NodeId;
+    use stellar_xdr::NodeId;
 
     let mut entries: Vec<(NodeId, ValidatorEntryInfo)> = Vec::new();
 
@@ -1092,13 +1092,11 @@ fn build_validator_weight_config(
 }
 
 /// Parse a public key string into a NodeId.
-fn parse_node_id(pubkey: &str) -> anyhow::Result<stellar_xdr::curr::NodeId> {
+fn parse_node_id(pubkey: &str) -> anyhow::Result<stellar_xdr::NodeId> {
     let pk = henyey_crypto::PublicKey::from_strkey(pubkey)
         .map_err(|e| anyhow::anyhow!("Invalid public key '{}': {}", pubkey, e))?;
-    Ok(stellar_xdr::curr::NodeId(
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-            *pk.as_bytes(),
-        )),
+    Ok(stellar_xdr::NodeId(
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(*pk.as_bytes())),
     ))
 }
 

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -323,7 +323,7 @@ pub(crate) async fn compat_upgrades_handler(
         if let Some(key_str) = params.get("configupgradesetkey") {
             // configupgradesetkey is a base64-encoded ConfigUpgradeSetKey XDR
             use base64::{engine::general_purpose::STANDARD, Engine};
-            use stellar_xdr::curr::{ConfigUpgradeSetKey, Limits, ReadXdr};
+            use stellar_xdr::{ConfigUpgradeSetKey, Limits, ReadXdr};
             if let Ok(bytes) = STANDARD.decode(key_str) {
                 if let Ok(key) = ConfigUpgradeSetKey::from_xdr(&bytes, Limits::none()) {
                     upgrade_params.config_upgrade_set_key = Some(
@@ -1045,9 +1045,9 @@ mod tests {
 
     /// Build the base64-encoded `configupgradesetkey` XDR that SSC sends, and
     /// return both the wire string and the decoded key for round-trip checks.
-    fn ssc_config_upgrade_set_key() -> (String, stellar_xdr::curr::ConfigUpgradeSetKey) {
+    fn ssc_config_upgrade_set_key() -> (String, stellar_xdr::ConfigUpgradeSetKey) {
         use base64::{engine::general_purpose::STANDARD, Engine};
-        use stellar_xdr::curr::{ConfigUpgradeSetKey, ContractId, Hash, Limits, WriteXdr};
+        use stellar_xdr::{ConfigUpgradeSetKey, ContractId, Hash, Limits, WriteXdr};
         let key = ConfigUpgradeSetKey {
             contract_id: ContractId(Hash([0xAB; 32])),
             content_hash: Hash([0xCD; 32]),

--- a/crates/app/src/compat_http/handlers/testacc.rs
+++ b/crates/app/src/compat_http/handlers/testacc.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use henyey_common::network::NetworkId;
 use henyey_crypto::SecretKey;
-use stellar_xdr::curr::{AccountId, PublicKey, Uint256};
+use stellar_xdr::{AccountId, PublicKey, Uint256};
 
 use crate::compat_http::CompatServerState;
 

--- a/crates/app/src/compat_http/handlers/tx.rs
+++ b/crates/app/src/compat_http/handlers/tx.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use henyey_tx::TransactionResultCodeExt;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Limits, ReadXdr, TransactionEnvelope, TransactionResult, TransactionResultExt,
     TransactionResultResult, WriteXdr,
 };
@@ -147,7 +147,7 @@ pub(crate) async fn compat_tx_handler(
 fn encode_tx_result(
     result: TransactionResultResult,
     fee_charged: i64,
-) -> Result<String, stellar_xdr::curr::Error> {
+) -> Result<String, stellar_xdr::Error> {
     let tx_result = TransactionResult {
         fee_charged,
         result,
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn test_encode_tx_result_round_trip_all_variants() {
         use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-        use stellar_xdr::curr::TransactionResultCode;
+        use stellar_xdr::TransactionResultCode;
 
         let cases: &[(TransactionResultResult, i64, TransactionResultCode)] = &[
             (

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -349,8 +349,8 @@ impl QuorumSetConfig {
     /// invalid inner sets, or an invalid threshold_percent. Errors from
     /// nested inner sets are propagated with path context rather than
     /// silently dropped.
-    pub fn to_xdr(&self) -> anyhow::Result<stellar_xdr::curr::ScpQuorumSet> {
-        use stellar_xdr::curr::{NodeId, PublicKey, ScpQuorumSet, Uint256};
+    pub fn to_xdr(&self) -> anyhow::Result<stellar_xdr::ScpQuorumSet> {
+        use stellar_xdr::{NodeId, PublicKey, ScpQuorumSet, Uint256};
 
         if self.is_empty() {
             anyhow::bail!("Quorum set has no validators or inner sets");
@@ -826,21 +826,19 @@ pub struct UpgradeConfig {
 }
 
 impl UpgradeConfig {
-    pub fn to_ledger_upgrades(&self) -> Vec<stellar_xdr::curr::LedgerUpgrade> {
+    pub fn to_ledger_upgrades(&self) -> Vec<stellar_xdr::LedgerUpgrade> {
         let mut upgrades = Vec::new();
         if let Some(version) = self.protocol_version {
-            upgrades.push(stellar_xdr::curr::LedgerUpgrade::Version(version));
+            upgrades.push(stellar_xdr::LedgerUpgrade::Version(version));
         }
         if let Some(fee) = self.base_fee {
-            upgrades.push(stellar_xdr::curr::LedgerUpgrade::BaseFee(fee));
+            upgrades.push(stellar_xdr::LedgerUpgrade::BaseFee(fee));
         }
         if let Some(reserve) = self.base_reserve {
-            upgrades.push(stellar_xdr::curr::LedgerUpgrade::BaseReserve(reserve));
+            upgrades.push(stellar_xdr::LedgerUpgrade::BaseReserve(reserve));
         }
         if let Some(max_tx_set_size) = self.max_tx_set_size {
-            upgrades.push(stellar_xdr::curr::LedgerUpgrade::MaxTxSetSize(
-                max_tx_set_size,
-            ));
+            upgrades.push(stellar_xdr::LedgerUpgrade::MaxTxSetSize(max_tx_set_size));
         }
         upgrades
     }
@@ -2373,7 +2371,7 @@ fn validate_port_collisions(config: &AppConfig) -> anyhow::Result<()> {
 /// validation level. Ports stellar-core's `computeDefaultThreshold`
 /// (Config.cpp:91-123).
 fn compute_default_threshold(
-    qset: &stellar_xdr::curr::ScpQuorumSet,
+    qset: &stellar_xdr::ScpQuorumSet,
     level: ValidationThresholdLevel,
 ) -> u32 {
     let top_size = (qset.validators.len() + qset.inner_sets.len()) as u32;
@@ -2393,7 +2391,7 @@ fn compute_default_threshold(
 /// Validate quorum safety for a compat config, mirroring stellar-core's
 /// `Config::validateConfig` (Config.cpp:2306-2357).
 fn validate_quorum_safety(
-    quorum_set: &stellar_xdr::curr::ScpQuorumSet,
+    quorum_set: &stellar_xdr::ScpQuorumSet,
     safety: &CompatQuorumSafety,
 ) -> anyhow::Result<()> {
     use std::collections::HashSet;
@@ -2455,8 +2453,8 @@ fn validate_quorum_safety(
 
 /// Recursively collect all node IDs from a quorum set.
 fn collect_nodes(
-    qset: &stellar_xdr::curr::ScpQuorumSet,
-    nodes: &mut std::collections::HashSet<stellar_xdr::curr::NodeId>,
+    qset: &stellar_xdr::ScpQuorumSet,
+    nodes: &mut std::collections::HashSet<stellar_xdr::NodeId>,
 ) {
     for v in qset.validators.iter() {
         nodes.insert(v.clone());
@@ -2715,9 +2713,7 @@ mod tests {
         let bytes: Vec<[u8; 32]> = validators
             .iter()
             .map(|node_id| match &node_id.0 {
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                    bytes,
-                )) => *bytes,
+                stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => *bytes,
             })
             .collect();
         assert!(bytes[0] <= bytes[1]);

--- a/crates/app/src/http/handlers/info.rs
+++ b/crates/app/src/http/handlers/info.rs
@@ -218,9 +218,7 @@ pub(crate) async fn quorum_handler(State(state): State<Arc<ServerState>>) -> Jso
     Json(QuorumResponse { local })
 }
 
-pub(crate) fn quorum_set_response(
-    quorum_set: &stellar_xdr::curr::ScpQuorumSet,
-) -> QuorumSetResponse {
+pub(crate) fn quorum_set_response(quorum_set: &stellar_xdr::ScpQuorumSet) -> QuorumSetResponse {
     use henyey_scp::hash_quorum_set;
 
     let hash = hash_quorum_set(quorum_set).to_hex();
@@ -247,7 +245,7 @@ pub(crate) async fn dumpproposedsettings_handler(
     Query(params): Query<DumpProposedSettingsParams>,
 ) -> impl IntoResponse {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    use stellar_xdr::curr::{ConfigUpgradeSetKey, Limits, ReadXdr};
+    use stellar_xdr::{ConfigUpgradeSetKey, Limits, ReadXdr};
 
     let Some(blob) = params.blob else {
         return (

--- a/crates/app/src/http/handlers/query.rs
+++ b/crates/app/src/http/handlers/query.rs
@@ -22,7 +22,7 @@ use henyey_bucket::{
     get_ttl_key, get_ttl_live_until, is_persistent_key, is_soroban_key, BucketSnapshotManager,
     SearchableBucketListSnapshot, SearchableHotArchiveBucketListSnapshot,
 };
-use stellar_xdr::curr::{HotArchiveBucketEntry, LedgerEntry, LedgerKey, Limits, ReadXdr, WriteXdr};
+use stellar_xdr::{HotArchiveBucketEntry, LedgerEntry, LedgerKey, Limits, ReadXdr, WriteXdr};
 
 use crate::http::types::query::{
     GetLedgerEntryRawResponse, GetLedgerEntryResponse, LedgerEntryResult, LedgerEntryState,

--- a/crates/app/src/http/handlers/tx.rs
+++ b/crates/app/src/http/handlers/tx.rs
@@ -18,7 +18,7 @@ pub(crate) async fn submit_tx_handler(
     Json(request): Json<SubmitTxRequest>,
 ) -> impl IntoResponse {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    use stellar_xdr::curr::{Limits, ReadXdr, TransactionEnvelope};
+    use stellar_xdr::{Limits, ReadXdr, TransactionEnvelope};
 
     // Decode and validate the transaction
     let tx_bytes = match STANDARD.decode(&request.tx) {

--- a/crates/app/src/http/helpers.rs
+++ b/crates/app/src/http/helpers.rs
@@ -2,7 +2,7 @@
 
 use henyey_crypto::PublicKey as CryptoPublicKey;
 use henyey_overlay::{PeerAddress, PeerId};
-use stellar_xdr::curr::LedgerUpgrade;
+use stellar_xdr::LedgerUpgrade;
 
 use super::types::{ConnectParams, UpgradeItem};
 
@@ -48,19 +48,17 @@ pub(super) fn parse_peer_id(value: &str) -> Result<PeerId, String> {
 }
 
 /// Convert a NodeId to its strkey representation.
-pub(super) fn node_id_to_strkey(node_id: &stellar_xdr::curr::NodeId) -> Option<String> {
+pub(super) fn node_id_to_strkey(node_id: &stellar_xdr::NodeId) -> Option<String> {
     match &node_id.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => {
-            CryptoPublicKey::from_bytes(&key.0)
-                .ok()
-                .map(|pk| pk.to_strkey())
-        }
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => CryptoPublicKey::from_bytes(&key.0)
+            .ok()
+            .map(|pk| pk.to_strkey()),
     }
 }
 
 /// Convert a PeerId to its strkey representation.
 pub(crate) fn peer_id_to_strkey(peer_id: PeerId) -> Option<String> {
-    node_id_to_strkey(&stellar_xdr::curr::NodeId(peer_id.0))
+    node_id_to_strkey(&stellar_xdr::NodeId(peer_id.0))
 }
 
 /// Map a LedgerUpgrade to an UpgradeItem for JSON serialization.

--- a/crates/app/src/maintainer.rs
+++ b/crates/app/src/maintainer.rs
@@ -507,7 +507,7 @@ mod tests {
                     op_index: 0,
                     tx_hash: "aabb".to_string(),
                     contract_id: Some("CABC".to_string()),
-                    event_type: stellar_xdr::curr::ContractEventType::Contract,
+                    event_type: stellar_xdr::ContractEventType::Contract,
                     topics: vec!["t1".to_string()],
                     event_xdr: "deadbeef".to_string(),
                     in_successful_contract_call: true,

--- a/crates/app/src/meta_stream.rs
+++ b/crates/app/src/meta_stream.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use henyey_common::xdr_stream::XdrOutputStream;
-use stellar_xdr::curr::LedgerCloseMeta;
+use stellar_xdr::LedgerCloseMeta;
 
 use crate::config::MetadataConfig;
 
@@ -288,7 +288,7 @@ impl MetaStreamManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{LedgerCloseMetaV2, ReadXdr};
+    use stellar_xdr::{LedgerCloseMetaV2, ReadXdr};
 
     #[test]
     fn test_emit_meta_to_temp_file() {
@@ -322,7 +322,7 @@ mod tests {
             | ((data[2] as u32) << 8)
             | (data[3] as u32);
         let decoded =
-            LedgerCloseMeta::from_xdr(&data[4..4 + sz as usize], stellar_xdr::curr::Limits::none())
+            LedgerCloseMeta::from_xdr(&data[4..4 + sz as usize], stellar_xdr::Limits::none())
                 .unwrap();
         assert!(matches!(decoded, LedgerCloseMeta::V2(_)));
     }

--- a/crates/app/src/meta_writer.rs
+++ b/crates/app/src/meta_writer.rs
@@ -12,7 +12,7 @@
 use crate::meta_stream::{MetaStreamError, MetaStreamManager};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use stellar_xdr::curr::LedgerCloseMeta;
+use stellar_xdr::LedgerCloseMeta;
 use tokio::sync::mpsc;
 
 /// Capacity of the bounded write channel.
@@ -247,20 +247,20 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Channel should be closed now
-        let meta = LedgerCloseMeta::V0(stellar_xdr::curr::LedgerCloseMetaV0 {
-            ledger_header: stellar_xdr::curr::LedgerHeaderHistoryEntry {
-                hash: stellar_xdr::curr::Hash([0; 32]),
-                header: stellar_xdr::curr::LedgerHeader {
+        let meta = LedgerCloseMeta::V0(stellar_xdr::LedgerCloseMetaV0 {
+            ledger_header: stellar_xdr::LedgerHeaderHistoryEntry {
+                hash: stellar_xdr::Hash([0; 32]),
+                header: stellar_xdr::LedgerHeader {
                     ledger_version: 21,
-                    previous_ledger_hash: stellar_xdr::curr::Hash([0; 32]),
-                    scp_value: stellar_xdr::curr::StellarValue {
-                        tx_set_hash: stellar_xdr::curr::Hash([0; 32]),
-                        close_time: stellar_xdr::curr::TimePoint(0),
+                    previous_ledger_hash: stellar_xdr::Hash([0; 32]),
+                    scp_value: stellar_xdr::StellarValue {
+                        tx_set_hash: stellar_xdr::Hash([0; 32]),
+                        close_time: stellar_xdr::TimePoint(0),
                         upgrades: vec![].try_into().unwrap(),
-                        ext: stellar_xdr::curr::StellarValueExt::Basic,
+                        ext: stellar_xdr::StellarValueExt::Basic,
                     },
-                    tx_set_result_hash: stellar_xdr::curr::Hash([0; 32]),
-                    bucket_list_hash: stellar_xdr::curr::Hash([0; 32]),
+                    tx_set_result_hash: stellar_xdr::Hash([0; 32]),
+                    bucket_list_hash: stellar_xdr::Hash([0; 32]),
                     ledger_seq: 1,
                     total_coins: 0,
                     fee_pool: 0,
@@ -270,17 +270,17 @@ mod tests {
                     base_reserve: 5000000,
                     max_tx_set_size: 100,
                     skip_list: [
-                        stellar_xdr::curr::Hash([0; 32]),
-                        stellar_xdr::curr::Hash([0; 32]),
-                        stellar_xdr::curr::Hash([0; 32]),
-                        stellar_xdr::curr::Hash([0; 32]),
+                        stellar_xdr::Hash([0; 32]),
+                        stellar_xdr::Hash([0; 32]),
+                        stellar_xdr::Hash([0; 32]),
+                        stellar_xdr::Hash([0; 32]),
                     ],
-                    ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                    ext: stellar_xdr::LedgerHeaderExt::V0,
                 },
-                ext: stellar_xdr::curr::LedgerHeaderHistoryEntryExt::V0,
+                ext: stellar_xdr::LedgerHeaderHistoryEntryExt::V0,
             },
-            tx_set: stellar_xdr::curr::TransactionSet {
-                previous_ledger_hash: stellar_xdr::curr::Hash([0; 32]),
+            tx_set: stellar_xdr::TransactionSet {
+                previous_ledger_hash: stellar_xdr::Hash([0; 32]),
                 txs: vec![].try_into().unwrap(),
             },
             tx_processing: vec![].try_into().unwrap(),

--- a/crates/app/src/survey.rs
+++ b/crates/app/src/survey.rs
@@ -45,7 +45,7 @@ use henyey_herder::Herder;
 use henyey_ledger::LedgerManager;
 use henyey_overlay::{PeerId, PeerSnapshot};
 use serde::Serialize;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     NodeId, PeerStats, SurveyMessageCommandType, SurveyRequestMessage, SurveyResponseMessage,
     TimeSlicedNodeData, TimeSlicedPeerData, TimeSlicedPeerDataList, TimeSlicedSurveyRequestMessage,
     TimeSlicedSurveyStartCollectingMessage, TimeSlicedSurveyStopCollectingMessage,
@@ -553,7 +553,7 @@ impl SurveyDataManager {
     pub fn stop_collecting_by_identity(
         &mut self,
         nonce: u32,
-        surveyor_id: &stellar_xdr::curr::NodeId,
+        surveyor_id: &stellar_xdr::NodeId,
         inbound_peers: &[PeerSnapshot],
         outbound_peers: &[PeerSnapshot],
         added_peers_total: u64,
@@ -991,7 +991,7 @@ impl SurveyState {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use stellar_xdr::curr::{NodeId, PublicKey, Uint256};
+    use stellar_xdr::{NodeId, PublicKey, Uint256};
 
     /// Mock ledger source for tests — returns a controllable ledger number.
     #[derive(Debug)]
@@ -1112,7 +1112,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32]))),
             ledger_num: 100,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         }
     }
@@ -1227,7 +1227,7 @@ mod tests {
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32]))),
             ledger_num: 100,
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
-            encrypted_body: stellar_xdr::curr::EncryptedBody(vec![].try_into().unwrap()),
+            encrypted_body: stellar_xdr::EncryptedBody(vec![].try_into().unwrap()),
         };
         let is_valid = state.record_and_validate_response(&response, 42, || true);
         assert!(is_valid);
@@ -1288,7 +1288,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32]))),
             ledger_num: 94,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         };
         assert!(limiter.add_and_validate_request(&request_at_94, &local_node, || true));
@@ -1328,7 +1328,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([id; 32]))),
             ledger_num,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         };
 
@@ -1353,7 +1353,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([id; 32]))),
             ledger_num,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         };
 
@@ -1377,7 +1377,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32]))),
             ledger_num: 94,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         };
         assert!(limiter.add_and_validate_request(&request_94, &local_node, || true));
@@ -1409,7 +1409,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32]))),
             ledger_num: 100,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         };
 
@@ -1429,7 +1429,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([id; 32]))),
             ledger_num: 100,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         };
 
@@ -1450,7 +1450,7 @@ mod tests {
             surveyor_peer_id: test_node_id(),
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([id; 32]))),
             ledger_num: 100,
-            encryption_key: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            encryption_key: stellar_xdr::Curve25519Public { key: [0u8; 32] },
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
         };
 
@@ -1469,7 +1469,7 @@ mod tests {
             surveyed_peer_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([2u8; 32]))),
             ledger_num: 100,
             command_type: SurveyMessageCommandType::TimeSlicedSurveyTopology,
-            encrypted_body: stellar_xdr::curr::EncryptedBody(vec![].try_into().unwrap()),
+            encrypted_body: stellar_xdr::EncryptedBody(vec![].try_into().unwrap()),
         };
 
         // No request was registered, so response is rejected.

--- a/crates/bucket/src/applicator.rs
+++ b/crates/bucket/src/applicator.rs
@@ -38,7 +38,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use stellar_xdr::curr::{LedgerEntry, LedgerEntryType, LedgerKey};
+use stellar_xdr::{LedgerEntry, LedgerEntryType, LedgerKey};
 
 use crate::bucket::Bucket;
 use crate::entry::{ledger_entry_data_type, ledger_key_type, BucketEntry};
@@ -423,7 +423,7 @@ impl std::fmt::Debug for BucketApplicator {
 mod tests {
     use super::*;
     use crate::entry::BucketEntry; // Use our BucketEntry, not the XDR one
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_account_id(byte: u8) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([byte; 32])))

--- a/crates/bucket/src/bloom_filter.rs
+++ b/crates/bucket/src/bloom_filter.rs
@@ -46,7 +46,7 @@
 
 use siphasher::sip::SipHasher24;
 use std::hash::Hasher;
-use stellar_xdr::curr::{LedgerKey, Limits, WriteXdr};
+use stellar_xdr::{LedgerKey, Limits, WriteXdr};
 use xorf::{BinaryFuse16, Filter};
 
 use crate::{BucketError, Result};
@@ -239,7 +239,7 @@ impl std::fmt::Debug for BucketBloomFilter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_test_seed() -> HashSeed {
         [

--- a/crates/bucket/src/bucket.rs
+++ b/crates/bucket/src/bucket.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
-use stellar_xdr::curr::{LedgerEntry, LedgerKey, Limits, ReadXdr, WriteXdr};
+use stellar_xdr::{LedgerEntry, LedgerKey, Limits, ReadXdr, WriteXdr};
 
 use henyey_common::Hash256;
 
@@ -230,7 +230,7 @@ impl Bucket {
     pub fn from_sorted_entries(entries: Vec<BucketEntry>) -> Result<Self> {
         use crate::entry::assert_sorted_no_duplicates;
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::{Limited, WriteXdr};
+        use stellar_xdr::{Limited, WriteXdr};
 
         assert_sorted_no_duplicates(&entries)?;
 
@@ -548,7 +548,7 @@ impl Bucket {
         );
 
         while let Some(record) = records.next_record()? {
-            match stellar_xdr::curr::BucketEntry::from_xdr(record.body, Limits::none()) {
+            match stellar_xdr::BucketEntry::from_xdr(record.body, Limits::none()) {
                 Ok(xdr_entry) => {
                     entries.push(xdr_entry);
                 }
@@ -576,7 +576,7 @@ impl Bucket {
     /// This format is used for bucket files and hash computation.
     /// Each entry is prefixed with a 4-byte mark: high bit set + 31-bit size in big-endian.
     fn serialize_entries(entries: &[BucketEntry]) -> Result<Vec<u8>> {
-        use stellar_xdr::curr::Limited;
+        use stellar_xdr::Limited;
         let mut bytes = Vec::new();
 
         for entry in entries {
@@ -1064,7 +1064,7 @@ impl Bucket {
     pub fn from_sorted_entries_with_in_memory(entries: Vec<BucketEntry>) -> Result<Self> {
         use crate::entry::assert_sorted_no_duplicates;
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::{Limited, WriteXdr};
+        use stellar_xdr::{Limited, WriteXdr};
 
         assert_sorted_no_duplicates(&entries)?;
 
@@ -1238,7 +1238,7 @@ impl Eq for Bucket {}
 mod tests {
     use super::*;
     use crate::BucketEntry;
-    use stellar_xdr::curr::*; // Re-import to shadow XDR's BucketEntry
+    use stellar_xdr::*; // Re-import to shadow XDR's BucketEntry
 
     fn make_account_id(bytes: [u8; 32]) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(bytes)))
@@ -1476,7 +1476,7 @@ mod tests {
 
     #[test]
     fn test_disk_backed_bucket_with_metadata() {
-        use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt};
+        use stellar_xdr::{BucketMetadata, BucketMetadataExt};
 
         // Create entries with metadata (as stellar-core buckets would have)
         let entries = vec![
@@ -1640,9 +1640,7 @@ mod tests {
 
     #[test]
     fn test_bucket_mixed_entry_types_ordering() {
-        use stellar_xdr::curr::{
-            AlphaNum4, AssetCode4, OfferEntry, TrustLineAsset, TrustLineEntry,
-        };
+        use stellar_xdr::{AlphaNum4, AssetCode4, OfferEntry, TrustLineAsset, TrustLineEntry};
 
         // Create helper functions for different entry types
         let make_offer_entry = |seller: [u8; 32], offer_id: i64| -> LedgerEntry {
@@ -1651,12 +1649,12 @@ mod tests {
                 data: LedgerEntryData::Offer(OfferEntry {
                     seller_id: make_account_id(seller),
                     offer_id: offer_id,
-                    selling: stellar_xdr::curr::Asset::Native,
-                    buying: stellar_xdr::curr::Asset::Native,
+                    selling: stellar_xdr::Asset::Native,
+                    buying: stellar_xdr::Asset::Native,
                     amount: 1000,
-                    price: stellar_xdr::curr::Price { n: 1, d: 1 },
+                    price: stellar_xdr::Price { n: 1, d: 1 },
                     flags: 0,
-                    ext: stellar_xdr::curr::OfferEntryExt::V0,
+                    ext: stellar_xdr::OfferEntryExt::V0,
                 }),
                 ext: LedgerEntryExt::V0,
             }
@@ -1674,7 +1672,7 @@ mod tests {
                     balance: 1000,
                     limit: 10000,
                     flags: 0, // No flags set
-                    ext: stellar_xdr::curr::TrustLineEntryExt::V0,
+                    ext: stellar_xdr::TrustLineEntryExt::V0,
                 }),
                 ext: LedgerEntryExt::V0,
             }
@@ -2018,7 +2016,7 @@ mod tests {
 
     #[test]
     fn test_bucket_protocol_version_in_memory_path() {
-        use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt};
+        use stellar_xdr::{BucketMetadata, BucketMetadataExt};
 
         let entries = vec![
             BucketEntry::Metaentry(BucketMetadata {

--- a/crates/bucket/src/bucket_list.rs
+++ b/crates/bucket/src/bucket_list.rs
@@ -46,7 +46,7 @@ use henyey_common::{BucketListDbConfig, Hash256};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     BucketListType, BucketMetadata, BucketMetadataExt, LedgerEntry, LedgerKey, Limits,
     StateArchivalSettings, WriteXdr,
 };
@@ -1907,8 +1907,7 @@ impl BucketList {
             return;
         }
         let counters = self.sum_bucket_entry_counters();
-        let total_account_bytes =
-            counters.size_for_type(stellar_xdr::curr::LedgerEntryType::Account);
+        let total_account_bytes = counters.size_for_type(stellar_xdr::LedgerEntryType::Account);
         for level in &self.levels {
             for bucket in [&level.curr, &level.snap] {
                 if !bucket.is_empty() {
@@ -2111,7 +2110,7 @@ impl BucketList {
     /// `true` if iteration completed, `false` if stopped early by callback.
     pub fn scan_for_entries_of_type<F>(
         &self,
-        entry_type: stellar_xdr::curr::LedgerEntryType,
+        entry_type: stellar_xdr::LedgerEntryType,
         callback: F,
     ) -> Result<bool>
     where
@@ -2142,16 +2141,15 @@ impl BucketList {
     /// `true` if iteration completed, `false` if stopped early by callback.
     pub fn scan_for_entries_of_types<F>(
         &self,
-        entry_types: &[stellar_xdr::curr::LedgerEntryType],
+        entry_types: &[stellar_xdr::LedgerEntryType],
         mut callback: F,
     ) -> Result<bool>
     where
         F: FnMut(&BucketEntry) -> bool,
     {
-        use stellar_xdr::curr::LedgerKey;
+        use stellar_xdr::LedgerKey;
 
-        let type_set: HashSet<stellar_xdr::curr::LedgerEntryType> =
-            entry_types.iter().copied().collect();
+        let type_set: HashSet<stellar_xdr::LedgerEntryType> = entry_types.iter().copied().collect();
         let mut seen_keys: HashSet<LedgerKey> = HashSet::new();
 
         for level in &self.levels {
@@ -3735,7 +3733,7 @@ mod tests {
     use super::*;
     use crate::entry::BucketEntry as BucketListEntry;
     use crate::merge::{merge_buckets, MergeOptions};
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     const TEST_PROTOCOL: u32 = 25;
 

--- a/crates/bucket/src/cache.rs
+++ b/crates/bucket/src/cache.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use stellar_xdr::curr::{LedgerEntry, LedgerEntryData, LedgerKey};
+use stellar_xdr::{LedgerEntry, LedgerEntryData, LedgerKey};
 
 use crate::entry::BucketEntry;
 
@@ -437,7 +437,7 @@ pub struct CacheStats {
 mod tests {
     use super::*;
     use crate::entry::BucketEntry; // Use our BucketEntry, not the XDR one
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_account_id(byte: u8) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([byte; 32])))
@@ -560,7 +560,7 @@ mod tests {
         // Data key should NOT be cached
         let data_key = LedgerKey::Data(LedgerKeyData {
             account_id: make_account_id(1),
-            data_name: String64::from(stellar_xdr::curr::StringM::default()),
+            data_name: String64::from(stellar_xdr::StringM::default()),
         });
         assert!(!BucketEntryCache::is_cached_type(&data_key));
     }

--- a/crates/bucket/src/disk_bucket.rs
+++ b/crates/bucket/src/disk_bucket.rs
@@ -40,9 +40,7 @@ use std::sync::{Arc, OnceLock};
 use memmap2::Mmap;
 
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{
-    BucketEntry as XdrBucketEntry, LedgerEntryType, LedgerKey, Limits, ReadXdr,
-};
+use stellar_xdr::{BucketEntry as XdrBucketEntry, LedgerEntryType, LedgerKey, Limits, ReadXdr};
 
 use henyey_common::{BucketListDbConfig, Hash256};
 
@@ -227,17 +225,16 @@ impl Iterator for StreamingXdrEntryIterator {
             }
             self.record_count += 1;
 
-            let xdr_entry =
-                match stellar_xdr::curr::BucketEntry::from_xdr(record.body, Limits::none()) {
-                    Ok(entry) => entry,
-                    Err(e) => {
-                        self.failed = true;
-                        return Some(Err(BucketError::Serialization(format!(
-                            "Failed to parse bucket entry at offset {}: {}",
-                            record.offset, e
-                        ))));
-                    }
-                };
+            let xdr_entry = match stellar_xdr::BucketEntry::from_xdr(record.body, Limits::none()) {
+                Ok(entry) => entry,
+                Err(e) => {
+                    self.failed = true;
+                    return Some(Err(BucketError::Serialization(format!(
+                        "Failed to parse bucket entry at offset {}: {}",
+                        record.offset, e
+                    ))));
+                }
+            };
 
             // Validate sorted-unique invariant before filtering metadata
             if let Err(e) = self.validator.validate(&xdr_entry) {
@@ -801,8 +798,8 @@ impl DiskBucket {
                 format!("no XDR record at offset {}", offset),
             ))
         })?;
-        let xdr_entry = stellar_xdr::curr::BucketEntry::from_xdr(record.body, Limits::none())
-            .map_err(|e| {
+        let xdr_entry =
+            stellar_xdr::BucketEntry::from_xdr(record.body, Limits::none()).map_err(|e| {
                 BucketError::Serialization(format!(
                     "Failed to parse entry at offset {}: {}",
                     record.offset, e
@@ -842,8 +839,8 @@ impl DiskBucket {
             let Some(record) = records.next_record()? else {
                 break;
             };
-            let entry = stellar_xdr::curr::BucketEntry::from_xdr(record.body, Limits::none())
-                .map_err(|e| {
+            let entry =
+                stellar_xdr::BucketEntry::from_xdr(record.body, Limits::none()).map_err(|e| {
                     BucketError::Serialization(format!(
                         "Failed to parse entry at offset {} during page scan: {}",
                         record.offset, e
@@ -960,7 +957,7 @@ impl Iterator for DiskBucketIter {
                 return Some(Err(e));
             }
         };
-        match stellar_xdr::curr::BucketEntry::from_xdr(record.body, Limits::none()) {
+        match stellar_xdr::BucketEntry::from_xdr(record.body, Limits::none()) {
             Ok(xdr_entry) => Some(Ok(xdr_entry)),
             Err(e) => {
                 self.failed = true;
@@ -1005,7 +1002,7 @@ impl Iterator for DiskBucketOffsetIter {
             }
         };
         let total_record_size = record.next_offset - record.offset;
-        match stellar_xdr::curr::BucketEntry::from_xdr(record.body, Limits::none()) {
+        match stellar_xdr::BucketEntry::from_xdr(record.body, Limits::none()) {
             Ok(xdr_entry) => Some(Ok((xdr_entry, total_record_size))),
             Err(e) => {
                 self.failed = true;
@@ -1022,11 +1019,11 @@ impl Iterator for DiskBucketOffsetIter {
 mod tests {
     use super::*;
     use crate::error::BucketError;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
     use tempfile::tempdir;
 
     fn make_test_bucket_bytes() -> Vec<u8> {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         let mut bytes = Vec::new();
 
@@ -1050,7 +1047,7 @@ mod tests {
             ext: LedgerEntryExt::V0,
         };
 
-        let bucket_entry = stellar_xdr::curr::BucketEntry::Liveentry(entry);
+        let bucket_entry = stellar_xdr::BucketEntry::Liveentry(entry);
         let entry_bytes = bucket_entry.to_xdr(Limits::none()).unwrap();
 
         // Write with record mark
@@ -1212,7 +1209,7 @@ mod tests {
     }
 
     fn make_multi_entry_bucket_bytes(count: usize) -> Vec<u8> {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         let mut bytes = Vec::new();
 
@@ -1239,7 +1236,7 @@ mod tests {
                 ext: LedgerEntryExt::V0,
             };
 
-            let bucket_entry = stellar_xdr::curr::BucketEntry::Liveentry(entry);
+            let bucket_entry = stellar_xdr::BucketEntry::Liveentry(entry);
             let entry_bytes = bucket_entry.to_xdr(Limits::none()).unwrap();
 
             // Write with record mark
@@ -1384,7 +1381,7 @@ mod tests {
 
     /// Build raw XDR bytes for a single account entry with the given key byte.
     fn make_entry_bytes(key_byte: u8) -> Vec<u8> {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         let account = AccountEntry {
             account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([key_byte; 32]))),
@@ -1403,7 +1400,7 @@ mod tests {
             data: LedgerEntryData::Account(account),
             ext: LedgerEntryExt::V0,
         };
-        let bucket_entry = stellar_xdr::curr::BucketEntry::Liveentry(entry);
+        let bucket_entry = stellar_xdr::BucketEntry::Liveentry(entry);
         let entry_bytes = bucket_entry.to_xdr(Limits::none()).unwrap();
 
         let mut bytes = Vec::new();
@@ -1415,7 +1412,7 @@ mod tests {
 
     /// Build a `BucketEntry::Liveentry(account)` for the given key byte, matching
     /// the on-disk record produced by `make_entry_bytes`.
-    fn make_account_bucket_entry(key_byte: u8) -> stellar_xdr::curr::BucketEntry {
+    fn make_account_bucket_entry(key_byte: u8) -> stellar_xdr::BucketEntry {
         let account = AccountEntry {
             account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([key_byte; 32]))),
             balance: 100,
@@ -1433,7 +1430,7 @@ mod tests {
             data: LedgerEntryData::Account(account),
             ext: LedgerEntryExt::V0,
         };
-        stellar_xdr::curr::BucketEntry::Liveentry(entry)
+        stellar_xdr::BucketEntry::Liveentry(entry)
     }
 
     /// Build a DiskBucket backed by a forced `DiskIndex` (via a zero
@@ -1445,7 +1442,7 @@ mod tests {
 
         // Write sorted account records to disk and collect (entry, offset) pairs.
         let mut file_bytes = Vec::new();
-        let mut entries: Vec<(stellar_xdr::curr::BucketEntry, u64)> = Vec::new();
+        let mut entries: Vec<(stellar_xdr::BucketEntry, u64)> = Vec::new();
         for key_byte in 1..=n {
             let offset = file_bytes.len() as u64;
             file_bytes.extend(make_entry_bytes(key_byte));
@@ -1575,9 +1572,9 @@ mod tests {
     }
 
     fn make_metaentry_bytes(ledger_version: u32) -> Vec<u8> {
-        use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt, WriteXdr};
+        use stellar_xdr::{BucketMetadata, BucketMetadataExt, WriteXdr};
 
-        let entry = stellar_xdr::curr::BucketEntry::Metaentry(BucketMetadata {
+        let entry = stellar_xdr::BucketEntry::Metaentry(BucketMetadata {
             ledger_version,
             ext: BucketMetadataExt::V0,
         });

--- a/crates/bucket/src/entry.rs
+++ b/crates/bucket/src/entry.rs
@@ -36,7 +36,7 @@
 use std::cmp::Ordering;
 
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     BucketEntryType, Hash, LedgerEntry, LedgerEntryData, LedgerKey, LedgerKeyTtl, Limits, ReadXdr,
     WriteXdr,
 };
@@ -57,7 +57,7 @@ use crate::{BucketError, Result};
 /// | `Deadentry`  | A tombstone marking deletion                     | Shadows any older entry     |
 /// | `Initentry`  | Entry created in this merge window (CAP-0020)    | Special annihilation rules  |
 /// | `Metaentry`  | Bucket metadata (protocol version, type)         | Merged by taking max version|
-pub type BucketEntry = stellar_xdr::curr::BucketEntry;
+pub type BucketEntry = stellar_xdr::BucketEntry;
 
 /// Extension trait adding bucket-specific convenience methods to the XDR `BucketEntry`.
 pub trait BucketEntryExt {
@@ -154,7 +154,7 @@ pub(crate) fn compare_keys(a: &LedgerKey, b: &LedgerKey) -> Ordering {
 /// Returns the ledger entry type for a given ledger key.
 ///
 /// Delegates to the XDR crate's inherent `LedgerKey::discriminant()` method.
-pub(crate) fn ledger_key_type(key: &LedgerKey) -> stellar_xdr::curr::LedgerEntryType {
+pub(crate) fn ledger_key_type(key: &LedgerKey) -> stellar_xdr::LedgerEntryType {
     key.discriminant()
 }
 
@@ -162,8 +162,8 @@ pub(crate) fn ledger_key_type(key: &LedgerKey) -> stellar_xdr::curr::LedgerEntry
 ///
 /// Delegates to the XDR crate's inherent `LedgerEntryData::discriminant()` method.
 pub(crate) fn ledger_entry_data_type(
-    data: &stellar_xdr::curr::LedgerEntryData,
-) -> stellar_xdr::curr::LedgerEntryType {
+    data: &stellar_xdr::LedgerEntryData,
+) -> stellar_xdr::LedgerEntryType {
     data.discriminant()
 }
 
@@ -338,8 +338,8 @@ pub fn get_ttl_live_until(ttl_entry: &LedgerEntry) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
-    // Disambiguate: super::BucketEntry (type alias) vs stellar_xdr::curr::BucketEntry
+    use stellar_xdr::*;
+    // Disambiguate: super::BucketEntry (type alias) vs stellar_xdr::BucketEntry
     use super::BucketEntry;
 
     fn make_account_id(bytes: [u8; 32]) -> AccountId {

--- a/crates/bucket/src/eviction.rs
+++ b/crates/bucket/src/eviction.rs
@@ -80,7 +80,7 @@
 use std::collections::HashSet;
 
 use henyey_common::protocol::MIN_SOROBAN_PROTOCOL_VERSION;
-use stellar_xdr::curr::{LedgerEntry, LedgerKey, StateArchivalSettings};
+use stellar_xdr::{LedgerEntry, LedgerKey, StateArchivalSettings};
 
 use crate::bucket::Bucket;
 use crate::bucket_list::BUCKET_LIST_LEVELS;
@@ -103,7 +103,7 @@ pub(crate) const DEFAULT_STARTING_EVICTION_SCAN_LEVEL: u32 = 6;
 ///
 /// 1. Level N curr bucket → Level N snap bucket → Level N+1 curr bucket → ...
 /// 2. Wraps back to starting level when reaching the top.
-pub type EvictionIterator = stellar_xdr::curr::EvictionIterator;
+pub type EvictionIterator = stellar_xdr::EvictionIterator;
 
 /// Extension trait adding eviction-specific methods to the XDR `EvictionIterator`.
 pub trait EvictionIteratorExt {
@@ -1140,7 +1140,7 @@ mod tests {
 
     // --- EvictionResult::resolve() tests ---
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, Hash, LedgerEntry,
         LedgerEntryData, LedgerEntryExt, ScAddress, ScVal,
     };
@@ -1495,20 +1495,20 @@ mod tests {
     #[test]
     #[should_panic(expected = "Soroban entry")]
     fn test_eviction_candidate_rejects_non_soroban_entry() {
-        use stellar_xdr::curr::{AccountEntry, AccountId, PublicKey, Thresholds, Uint256};
+        use stellar_xdr::{AccountEntry, AccountId, PublicKey, Thresholds, Uint256};
         let non_soroban_entry = LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::Account(AccountEntry {
                 account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0; 32]))),
                 balance: 100,
-                seq_num: stellar_xdr::curr::SequenceNumber(1),
+                seq_num: stellar_xdr::SequenceNumber(1),
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
+                home_domain: stellar_xdr::String32::default(),
                 thresholds: Thresholds([1, 0, 0, 0]),
-                signers: stellar_xdr::curr::VecM::default(),
-                ext: stellar_xdr::curr::AccountEntryExt::V0,
+                signers: stellar_xdr::VecM::default(),
+                ext: stellar_xdr::AccountEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,
         };

--- a/crates/bucket/src/future_bucket.rs
+++ b/crates/bucket/src/future_bucket.rs
@@ -823,7 +823,7 @@ impl FutureBucket {
 mod tests {
     use super::*;
     use crate::entry::BucketEntry;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_account_id(bytes: [u8; 32]) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(bytes)))

--- a/crates/bucket/src/hot_archive.rs
+++ b/crates/bucket/src/hot_archive.rs
@@ -30,7 +30,7 @@ use std::collections::BTreeMap;
 use std::io::{BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     BucketListType, BucketMetadata, BucketMetadataExt, HotArchiveBucketEntry, LedgerEntry,
     LedgerKey, Limits, ReadXdr, WriteXdr,
 };
@@ -1927,7 +1927,7 @@ pub fn merge_hot_archive_buckets(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_contract_data_key(contract_id: [u8; 32], key_bytes: &[u8]) -> LedgerKey {
         LedgerKey::ContractData(LedgerKeyContractData {

--- a/crates/bucket/src/index.rs
+++ b/crates/bucket/src/index.rs
@@ -20,7 +20,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Asset, LedgerEntry, LedgerEntryData, LedgerEntryType, LedgerKey, Limits, PoolId,
     TrustLineAsset, WriteXdr,
 };
@@ -377,9 +377,8 @@ impl InMemoryIndex {
                 // Extract pool mappings from liquidity pool entries
                 if let BucketEntry::Liveentry(e) | BucketEntry::Initentry(e) = &entry {
                     if let LedgerEntryData::LiquidityPool(pool) = &e.data {
-                        let stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(
-                            cp,
-                        ) = &pool.body;
+                        let stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) =
+                            &pool.body;
                         asset_to_pool_id.add_pool(
                             pool.liquidity_pool_id.clone(),
                             &cp.params.asset_a,
@@ -601,9 +600,8 @@ impl DiskIndex {
                 // Extract pool mappings
                 if let BucketEntry::Liveentry(e) | BucketEntry::Initentry(e) = &entry {
                     if let LedgerEntryData::LiquidityPool(pool) = &e.data {
-                        let stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(
-                            cp,
-                        ) = &pool.body;
+                        let stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) =
+                            &pool.body;
                         asset_to_pool_id.add_pool(
                             pool.liquidity_pool_id.clone(),
                             &cp.params.asset_a,
@@ -1020,7 +1018,7 @@ impl LiveBucketIndex {
     /// the asset.
     pub fn get_pool_share_trustline_keys(
         &self,
-        account_id: &stellar_xdr::curr::AccountId,
+        account_id: &stellar_xdr::AccountId,
         asset: &Asset,
     ) -> Vec<LedgerKey> {
         let pools = self.get_pools_for_asset(asset);
@@ -1028,7 +1026,7 @@ impl LiveBucketIndex {
         pools
             .into_iter()
             .map(|pool_id| {
-                LedgerKey::Trustline(stellar_xdr::curr::LedgerKeyTrustLine {
+                LedgerKey::Trustline(stellar_xdr::LedgerKeyTrustLine {
                     account_id: account_id.clone(),
                     asset: TrustLineAsset::PoolShare(pool_id),
                 })
@@ -1065,7 +1063,7 @@ impl LiveBucketIndex {
 mod tests {
     use super::*;
     use crate::entry::BucketEntry;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_account_id(byte: u8) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([byte; 32])))
@@ -1405,7 +1403,7 @@ mod tests {
         key_val: i32,
         durability: ContractDataDurability,
     ) -> LedgerEntry {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ContractData(ContractDataEntry {
@@ -1574,7 +1572,7 @@ mod tests {
     // the index entry counters.
 
     fn make_contract_code_entry(seed: u8) -> LedgerEntry {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ContractCode(ContractCodeEntry {

--- a/crates/bucket/src/index_persistence.rs
+++ b/crates/bucket/src/index_persistence.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 use henyey_common::Hash256;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
-use stellar_xdr::curr::{LedgerEntryType, LedgerKey, Limits, PoolId, ReadXdr, WriteXdr};
+use stellar_xdr::{LedgerEntryType, LedgerKey, Limits, PoolId, ReadXdr, WriteXdr};
 use xorf::BinaryFuse16;
 
 use crate::bloom_filter::BucketBloomFilter;
@@ -127,7 +127,7 @@ impl SerializableAssetPoolIdMap {
     }
 
     fn to_asset_pool_map(&self) -> AssetPoolIdMap {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let asset_to_pools = self
             .entries
             .iter()
@@ -601,7 +601,7 @@ mod tests {
     use super::*;
     use crate::index::DEFAULT_PAGE_SIZE;
     use henyey_common::LIQUIDITY_POOL_FEE_V18;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
     use tempfile::tempdir;
 
     /// Create a dummy bucket file for testing and return its SHA-256 hash.
@@ -971,7 +971,7 @@ mod tests {
 
     #[test]
     fn test_save_load_with_asset_pool_map() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AlphaNum4, Asset, AssetCode4, Hash, LiquidityPoolConstantProductParameters,
             LiquidityPoolEntryBody, LiquidityPoolEntryConstantProduct,
         };
@@ -992,7 +992,7 @@ mod tests {
         // Create entries with a liquidity pool
         let pool_entry = LedgerEntry {
             last_modified_ledger_seq: 1,
-            data: LedgerEntryData::LiquidityPool(stellar_xdr::curr::LiquidityPoolEntry {
+            data: LedgerEntryData::LiquidityPool(stellar_xdr::LiquidityPoolEntry {
                 liquidity_pool_id: pool_id.clone(),
                 body: LiquidityPoolEntryBody::LiquidityPoolConstantProduct(
                     LiquidityPoolEntryConstantProduct {

--- a/crates/bucket/src/iterator.rs
+++ b/crates/bucket/src/iterator.rs
@@ -39,7 +39,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use henyey_common::Hash256;
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::BucketMetadata;
+use stellar_xdr::BucketMetadata;
 
 use crate::entry::{compare_entries, BucketEntry, BucketEntryExt};
 use crate::{BucketError, Result};
@@ -400,7 +400,7 @@ impl BucketOutputIterator {
         ) {
             let metadata = BucketMetadata {
                 ledger_version: self.protocol_version,
-                ext: stellar_xdr::curr::BucketMetadataExt::V0,
+                ext: stellar_xdr::BucketMetadataExt::V0,
             };
             let entry = BucketEntry::Metaentry(metadata);
             self.write_entry_raw(&entry)?;
@@ -715,7 +715,7 @@ impl MergeInput for FileMergeInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, LedgerEntry, LedgerEntryData, LedgerEntryExt,
         LedgerKey, LedgerKeyAccount, PublicKey, SequenceNumber, String32, Thresholds, Uint256,
     };

--- a/crates/bucket/src/lib.rs
+++ b/crates/bucket/src/lib.rs
@@ -63,7 +63,7 @@
 //!
 //! ```ignore
 //! use henyey_bucket::{BucketList, BucketManager};
-//! use stellar_xdr::curr::BucketListType;
+//! use stellar_xdr::BucketListType;
 //!
 //! // Create a bucket manager for disk storage
 //! let manager = BucketManager::new("/tmp/buckets".into())?;
@@ -287,7 +287,7 @@ pub type Result<T> = std::result::Result<T, BucketError>;
 mod tests {
     use super::*;
     use crate::BucketEntry;
-    use stellar_xdr::curr::*; // Re-import to shadow XDR's BucketEntry
+    use stellar_xdr::*; // Re-import to shadow XDR's BucketEntry
 
     const TEST_PROTOCOL: u32 = 25;
 

--- a/crates/bucket/src/live_iterator.rs
+++ b/crates/bucket/src/live_iterator.rs
@@ -51,7 +51,7 @@
 
 use std::collections::HashSet;
 
-use stellar_xdr::curr::{LedgerEntry, LedgerKey};
+use stellar_xdr::{LedgerEntry, LedgerKey};
 
 use crate::bucket::{Bucket, BucketIter};
 use crate::entry::BucketEntry;
@@ -277,7 +277,7 @@ impl LiveEntriesStats {
 mod tests {
     use super::*;
     use crate::BucketList;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_account_id(bytes: [u8; 32]) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(bytes)))

--- a/crates/bucket/src/manager.rs
+++ b/crates/bucket/src/manager.rs
@@ -45,7 +45,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-use stellar_xdr::curr::{LedgerEntry, LedgerKey, Limits, WriteXdr};
+use stellar_xdr::{LedgerEntry, LedgerKey, Limits, WriteXdr};
 
 use henyey_common::fs_utils::durable_rename;
 use henyey_common::{BucketListDbConfig, Hash256};
@@ -1006,7 +1006,7 @@ impl BucketManager {
     pub fn visit_ledger_entries_of_type<A>(
         &self,
         bucket_hashes: &[Hash256],
-        entry_type: stellar_xdr::curr::LedgerEntryType,
+        entry_type: stellar_xdr::LedgerEntryType,
         accept_entry: A,
         min_ledger: Option<u32>,
     ) -> Result<bool>
@@ -1129,7 +1129,7 @@ impl BucketManager {
 
             for entry in bucket.try_iter()? {
                 match entry? {
-                    stellar_xdr::curr::HotArchiveBucketEntry::Archived(ref ledger_entry) => {
+                    stellar_xdr::HotArchiveBucketEntry::Archived(ref ledger_entry) => {
                         let key = henyey_common::entry_to_key(ledger_entry);
                         let key_bytes = key.to_xdr(Limits::none()).map_err(|e| {
                             BucketError::Serialization(format!(
@@ -1139,7 +1139,7 @@ impl BucketManager {
                         })?;
                         state.insert(key_bytes, ledger_entry.clone());
                     }
-                    stellar_xdr::curr::HotArchiveBucketEntry::Live(ref key) => {
+                    stellar_xdr::HotArchiveBucketEntry::Live(ref key) => {
                         // Live = restore marker (tombstone) — remove from archive
                         let key_bytes = key.to_xdr(Limits::none()).map_err(|e| {
                             BucketError::Serialization(format!(
@@ -1149,7 +1149,7 @@ impl BucketManager {
                         })?;
                         state.remove(&key_bytes);
                     }
-                    stellar_xdr::curr::HotArchiveBucketEntry::Metaentry(_) => {
+                    stellar_xdr::HotArchiveBucketEntry::Metaentry(_) => {
                         // Skip metadata entries
                     }
                 }
@@ -1180,7 +1180,7 @@ impl BucketManager {
         bucket_hashes: &[Hash256],
         protocol_version: u32,
     ) -> Result<Arc<Bucket>> {
-        use stellar_xdr::curr::BucketMetadata;
+        use stellar_xdr::BucketMetadata;
 
         // Load complete state
         let entries = self.load_complete_ledger_state(bucket_hashes)?;
@@ -1195,7 +1195,7 @@ impl BucketManager {
         // Add metadata
         bucket_entries.push(crate::BucketEntry::Metaentry(BucketMetadata {
             ledger_version: protocol_version,
-            ext: stellar_xdr::curr::BucketMetadataExt::V0,
+            ext: stellar_xdr::BucketMetadataExt::V0,
         }));
 
         // Add all entries as LIVE (not INIT since these are resolved entries)
@@ -1544,7 +1544,7 @@ mod tests {
     use crate::future_bucket::MergeKey;
     use crate::merge::DeadEntryPolicy;
     use crate::BucketEntry; // Re-import to shadow XDR's BucketEntry
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
     use tempfile::TempDir;
 
     fn make_account_id(bytes: [u8; 32]) -> AccountId {

--- a/crates/bucket/src/merge.rs
+++ b/crates/bucket/src/merge.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 
 use henyey_common::Hash256;
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt, LedgerKey, Limits, WriteXdr};
+use stellar_xdr::{BucketMetadata, BucketMetadataExt, LedgerKey, Limits, WriteXdr};
 
 use crate::bucket::{Bucket, BucketIter};
 use crate::entry::{compare_keys, BucketEntry, BucketEntryExt};
@@ -621,7 +621,7 @@ pub fn merge_in_memory(
             ext: BucketMetadataExt::V0,
         };
         if protocol_version_starts_from(max_protocol_version, ProtocolVersion::V23) {
-            meta.ext = BucketMetadataExt::V1(stellar_xdr::curr::BucketListType::Live);
+            meta.ext = BucketMetadataExt::V1(stellar_xdr::BucketListType::Live);
         }
         Some(BucketEntry::Metaentry(meta))
     } else {
@@ -653,7 +653,7 @@ pub fn merge_in_memory(
     // Helper to add entry to output with incremental hashing
     // Uses reusable buffers to minimize allocations
     let mut add_entry = |entry: BucketEntry| -> Result<()> {
-        use stellar_xdr::curr::Limited;
+        use stellar_xdr::Limited;
 
         // Serialize entry for hash using reusable buffer
         entry_buf.clear();
@@ -1125,7 +1125,7 @@ fn build_output_metadata(
     // For Protocol 23+, Live buckets must use V1 extension with BucketListType::LIVE.
     // merge_buckets is specifically for the Live bucket list.
     if protocol_version_starts_from(protocol_version, ProtocolVersion::V23) {
-        output.ext = BucketMetadataExt::V1(stellar_xdr::curr::BucketListType::Live);
+        output.ext = BucketMetadataExt::V1(stellar_xdr::BucketListType::Live);
     }
 
     Ok((protocol_version, Some(BucketEntry::Metaentry(output))))
@@ -1135,7 +1135,7 @@ fn build_output_metadata(
 mod tests {
     use super::*;
     use crate::BucketEntry;
-    use stellar_xdr::curr::*; // Re-import to shadow XDR's BucketEntry
+    use stellar_xdr::*; // Re-import to shadow XDR's BucketEntry
 
     const TEST_PROTOCOL: u32 = 25;
 

--- a/crates/bucket/src/merge_map.rs
+++ b/crates/bucket/src/merge_map.rs
@@ -621,14 +621,14 @@ mod tests {
 
         // Create a non-empty bucket (use a known non-zero hash)
         let bucket = Arc::new(
-            Bucket::from_entries(vec![stellar_xdr::curr::BucketEntry::Liveentry(
-                stellar_xdr::curr::LedgerEntry {
+            Bucket::from_entries(vec![stellar_xdr::BucketEntry::Liveentry(
+                stellar_xdr::LedgerEntry {
                     last_modified_ledger_seq: 1,
-                    data: stellar_xdr::curr::LedgerEntryData::Ttl(stellar_xdr::curr::TtlEntry {
-                        key_hash: stellar_xdr::curr::Hash([1; 32]),
+                    data: stellar_xdr::LedgerEntryData::Ttl(stellar_xdr::TtlEntry {
+                        key_hash: stellar_xdr::Hash([1; 32]),
                         live_until_ledger_seq: 100,
                     }),
-                    ext: stellar_xdr::curr::LedgerEntryExt::V0,
+                    ext: stellar_xdr::LedgerEntryExt::V0,
                 },
             )])
             .unwrap(),

--- a/crates/bucket/src/snapshot.rs
+++ b/crates/bucket/src/snapshot.rs
@@ -55,7 +55,7 @@ use crate::{
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, HotArchiveBucketEntry, LedgerEntry, LedgerEntryData, LedgerEntryType,
     LedgerHeader, LedgerKey, LedgerKeyTrustLine, PoolId, StateArchivalSettings, TrustLineAsset,
 };
@@ -402,7 +402,7 @@ impl BucketListSnapshot {
             return Ok(None);
         }
 
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
         let key_bytes = key.to_xdr(Limits::none()).map_err(|e| {
             crate::BucketError::Serialization(format!("Failed to serialize key: {}", e))
         })?;
@@ -431,7 +431,7 @@ impl BucketListSnapshot {
     ///
     /// OFFER keys are skipped (matching stellar-core's `typeNotSupported`).
     pub fn load_keys_result(&self, keys: &[LedgerKey]) -> crate::Result<Vec<LedgerEntry>> {
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
 
         let mut result = Vec::with_capacity(keys.len());
 
@@ -1051,7 +1051,7 @@ impl SearchableBucketListSnapshot {
                                 }
 
                                 // Check if pool contains the asset
-                                let stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(
+                                let stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(
                                     cp,
                                 ) = &pool.body;
                                 if &cp.params.asset_a == asset || &cp.params.asset_b == asset {
@@ -1444,7 +1444,7 @@ impl BucketSnapshotManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_test_header(ledger_seq: u32) -> LedgerHeader {
         LedgerHeader {

--- a/crates/bucket/tests/bucket_list_integration.rs
+++ b/crates/bucket/tests/bucket_list_integration.rs
@@ -8,7 +8,7 @@ use henyey_bucket::{
     HotArchiveBucketList,
 };
 use henyey_common::Hash256;
-use stellar_xdr::curr::*;
+use stellar_xdr::*;
 
 const TEST_PROTOCOL: u32 = 25;
 
@@ -920,7 +920,7 @@ async fn test_eviction_scan_shadowed_entries_not_evicted() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eviction_scan_incremental() {
     use henyey_bucket::EvictionIterator;
-    use stellar_xdr::curr::StateArchivalSettings;
+    use stellar_xdr::StateArchivalSettings;
 
     let mut bl = BucketList::new();
 
@@ -2003,7 +2003,7 @@ async fn test_scan_for_entries_of_types_soroban_combined() {
 #[tokio::test]
 async fn test_eviction_scan_zero_budget_does_not_advance_iterator() {
     use henyey_bucket::EvictionIterator;
-    use stellar_xdr::curr::StateArchivalSettings;
+    use stellar_xdr::StateArchivalSettings;
 
     let mut bl = BucketList::new();
 

--- a/crates/bucket/tests/test_pool_share_query.rs
+++ b/crates/bucket/tests/test_pool_share_query.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 
 use henyey_bucket::{BucketList, BucketListSnapshot, SearchableBucketListSnapshot};
 use henyey_common::LIQUIDITY_POOL_FEE_V18;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, AlphaNum4, Asset, AssetCode4, Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt,
     LedgerHeader, LedgerHeaderExt, LiquidityPoolConstantProductParameters, LiquidityPoolEntry,
     LiquidityPoolEntryBody, LiquidityPoolEntryConstantProduct, PoolId, PublicKey, StellarValue,
@@ -85,7 +85,7 @@ fn make_ledger_header(ledger_seq: u32) -> LedgerHeader {
         previous_ledger_hash: Hash([0u8; 32]),
         scp_value: StellarValue {
             tx_set_hash: Hash([0u8; 32]),
-            close_time: stellar_xdr::curr::TimePoint(0),
+            close_time: stellar_xdr::TimePoint(0),
             upgrades: Vec::new().try_into().unwrap(),
             ext: StellarValueExt::Basic,
         },
@@ -157,7 +157,7 @@ async fn test_load_pool_share_trustlines_by_account_and_asset() {
         .add_batch(
             1,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![
                 pool1.clone(),
                 pool2.clone(),
@@ -224,7 +224,7 @@ async fn test_load_pool_share_trustlines_no_match() {
         .add_batch(
             1,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![pool, tl],
             vec![],
             vec![],
@@ -262,7 +262,7 @@ async fn test_load_pool_share_trustlines_deleted_pool() {
         .add_batch(
             1,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![pool, tl],
             vec![],
             vec![],
@@ -277,15 +277,14 @@ async fn test_load_pool_share_trustlines_deleted_pool() {
     assert_eq!(result.len(), 1);
 
     // Delete the pool
-    let pool_key =
-        stellar_xdr::curr::LedgerKey::LiquidityPool(stellar_xdr::curr::LedgerKeyLiquidityPool {
-            liquidity_pool_id: pool_id,
-        });
+    let pool_key = stellar_xdr::LedgerKey::LiquidityPool(stellar_xdr::LedgerKeyLiquidityPool {
+        liquidity_pool_id: pool_id,
+    });
     bucket_list
         .add_batch(
             2,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![],
             vec![],
             vec![pool_key],
@@ -322,7 +321,7 @@ async fn test_load_pool_share_trustlines_multi_version() {
         .add_batch(
             1,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![pool, tl.clone()],
             vec![],
             vec![],
@@ -339,7 +338,7 @@ async fn test_load_pool_share_trustlines_multi_version() {
         .add_batch(
             2,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![],
             vec![tl.clone()],
             vec![],
@@ -424,7 +423,7 @@ async fn test_load_trustlines_for_account() {
         .add_batch(
             1,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![tl1, tl2, tl3],
             vec![],
             vec![],
@@ -463,7 +462,7 @@ async fn test_load_pool_share_trustlines_asset_in_b_position() {
         .add_batch(
             1,
             TEST_PROTOCOL,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             vec![pool, tl],
             vec![],
             vec![],

--- a/crates/common/src/asset.rs
+++ b/crates/common/src/asset.rs
@@ -14,7 +14,7 @@
 //! assert!(!is_string_valid("Hello\x00World")); // Contains control character
 //! ```
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, AssetCode12, AssetCode4, BucketEntry, ChangeTrustAsset,
     HotArchiveBucketEntry, LedgerKey, TrustLineAsset,
 };
@@ -108,7 +108,7 @@ pub fn str_to_asset_code<const N: usize>(s: &str) -> [u8; N] {
 ///
 /// ```rust
 /// use henyey_common::asset::asset_to_string;
-/// use stellar_xdr::curr::{Asset, AssetCode4, AlphaNum4, PublicKey, Uint256};
+/// use stellar_xdr::{Asset, AssetCode4, AlphaNum4, PublicKey, Uint256};
 ///
 /// // Native asset
 /// let native = Asset::Native;
@@ -165,7 +165,7 @@ pub fn is_asset_code12_valid(code: &AssetCode12) -> bool {
 ///
 /// ```rust
 /// use henyey_common::asset::is_asset_valid;
-/// use stellar_xdr::curr::Asset;
+/// use stellar_xdr::Asset;
 ///
 /// // Native assets are always valid
 /// assert!(is_asset_valid(&Asset::Native, 25));
@@ -201,7 +201,7 @@ pub fn is_change_trust_asset_valid(asset: &ChangeTrustAsset, ledger_version: u32
                 return false;
             }
 
-            let stellar_xdr::curr::LiquidityPoolParameters::LiquidityPoolConstantProduct(cp) = lp;
+            let stellar_xdr::LiquidityPoolParameters::LiquidityPoolConstantProduct(cp) = lp;
 
             is_asset_valid(&cp.asset_a, ledger_version)
                 && is_asset_valid(&cp.asset_b, ledger_version)
@@ -237,7 +237,7 @@ impl std::error::Error for NoIssuerError {}
 ///
 /// ```rust
 /// use henyey_common::asset::get_issuer;
-/// use stellar_xdr::curr::Asset;
+/// use stellar_xdr::Asset;
 ///
 /// // Native assets have no issuer
 /// assert!(get_issuer(&Asset::Native).is_err());
@@ -367,8 +367,8 @@ pub fn add_balance(balance: i64, delta: i64, max_balance: i64) -> Option<i64> {
 /// Checks:
 /// 1. `balance + delta` must not overflow `i64::MAX` or go negative.
 /// 2. `new_balance` must not exceed `i64::MAX - buying_liabilities`.
-pub fn try_add_account_balance(acc: &mut stellar_xdr::curr::AccountEntry, delta: i64) -> bool {
-    use stellar_xdr::curr::AccountEntryExt;
+pub fn try_add_account_balance(acc: &mut stellar_xdr::AccountEntry, delta: i64) -> bool {
+    use stellar_xdr::AccountEntryExt;
 
     // 1. Overflow / underflow check via add_balance
     let new_balance = match add_balance(acc.balance, delta, i64::MAX) {
@@ -428,7 +428,7 @@ pub(crate) fn get_bucket_ledger_key(be: &BucketEntry) -> LedgerKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{AlphaNum12, AlphaNum4, PublicKey, Uint256};
+    use stellar_xdr::{AlphaNum12, AlphaNum4, PublicKey, Uint256};
 
     fn make_account_id(n: u8) -> AccountId {
         let mut bytes = [0u8; 32];

--- a/crates/common/src/checked_types.rs
+++ b/crates/common/src/checked_types.rs
@@ -12,9 +12,7 @@
 
 use std::fmt;
 
-use stellar_xdr::curr::{
-    AccountEntry, AccountEntryExt, Liabilities, TrustLineEntry, TrustLineEntryExt,
-};
+use stellar_xdr::{AccountEntry, AccountEntryExt, Liabilities, TrustLineEntry, TrustLineEntryExt};
 
 /// Error type for checked arithmetic operations on consensus-critical values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -465,7 +463,7 @@ mod tests {
     // ── Balance direction guard tests ──
 
     fn make_account(balance: i64) -> AccountEntry {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         AccountEntry {
             account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0; 32]))),
             balance,
@@ -481,7 +479,7 @@ mod tests {
     }
 
     fn make_trustline(balance: i64, limit: i64) -> TrustLineEntry {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         TrustLineEntry {
             account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0; 32]))),
             asset: TrustLineAsset::CreditAlphanum4(AlphaNum4 {

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     ///
     /// Occurs when serializing or deserializing Stellar XDR types fails.
     #[error("XDR error: {0}")]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     /// I/O error.
     ///

--- a/crates/common/src/fs_utils.rs
+++ b/crates/common/src/fs_utils.rs
@@ -198,7 +198,7 @@ pub fn atomic_gzip_copy(from: &Path, to: &Path) -> io::Result<()> {
 /// Atomically write a slice of XDR items to `final_path` as RFC 5531
 /// record-marked entries, gzip-compressed, then durably rename.
 ///
-/// Each item is serialized via [`stellar_xdr::curr::WriteXdr`] and prefixed
+/// Each item is serialized via [`stellar_xdr::WriteXdr`] and prefixed
 /// with a 4-byte big-endian length whose high bit is set (the RFC 5531
 /// "last fragment" flag). The output is gzip-compressed and written via
 /// [`atomic_write_with`], inheriting its durability and error contract.
@@ -218,7 +218,7 @@ pub fn atomic_gzip_copy(from: &Path, to: &Path) -> io::Result<()> {
 /// the temp file and leave `final_path` untouched.
 pub fn atomic_gzip_xdr_write_slice<T>(final_path: &Path, items: &[T]) -> io::Result<()>
 where
-    T: stellar_xdr::curr::WriteXdr,
+    T: stellar_xdr::WriteXdr,
 {
     atomic_gzip_xdr_write_inner(final_path, |encoder| {
         for item in items {
@@ -251,7 +251,7 @@ where
 pub fn atomic_gzip_xdr_write_iter<T, I, E>(final_path: &Path, items: I) -> io::Result<()>
 where
     I: IntoIterator<Item = Result<T, E>>,
-    T: stellar_xdr::curr::WriteXdr,
+    T: stellar_xdr::WriteXdr,
     E: std::error::Error + Send + Sync + 'static,
 {
     atomic_gzip_xdr_write_inner(final_path, |encoder| {
@@ -296,10 +296,10 @@ where
 fn write_record_marked_xdr_to<W, T>(writer: &mut W, item: &T) -> io::Result<()>
 where
     W: io::Write,
-    T: stellar_xdr::curr::WriteXdr,
+    T: stellar_xdr::WriteXdr,
 {
     let bytes = item
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     let len = bytes.len() as u32;
     let marked_len = len | 0x8000_0000;
@@ -626,7 +626,7 @@ mod tests {
     /// Used only by tests — `henyey-common` cannot reuse the equivalent
     /// helper in `henyey-history` due to the dep cycle.
     #[cfg(test)]
-    fn parse_gz_record_marked_xdr_stream<T: stellar_xdr::curr::ReadXdr>(bytes: &[u8]) -> Vec<T> {
+    fn parse_gz_record_marked_xdr_stream<T: stellar_xdr::ReadXdr>(bytes: &[u8]) -> Vec<T> {
         use flate2::read::GzDecoder;
         use std::io::Read;
         let mut decoded = Vec::new();
@@ -644,7 +644,7 @@ mod tests {
             let len = (mark & 0x7FFF_FFFF) as usize;
             pos += 4;
             let payload = &decoded[pos..pos + len];
-            let item = T::from_xdr(payload, stellar_xdr::curr::Limits::none()).expect("decode XDR");
+            let item = T::from_xdr(payload, stellar_xdr::Limits::none()).expect("decode XDR");
             out.push(item);
             pos += len;
             // XDR pad to 4-byte boundary.
@@ -665,7 +665,7 @@ mod tests {
 
     #[test]
     fn test_atomic_gzip_xdr_write_slice_roundtrip() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("out.xdr.gz");
 
@@ -680,7 +680,7 @@ mod tests {
 
     #[test]
     fn test_write_record_marked_xdr_padding_bytes_pinned() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
 
         // (a) Pin the exact on-disk byte layout produced by the production
         // path for a representative `WriteXdr` item. A `Hash` encodes to 32
@@ -720,7 +720,7 @@ mod tests {
 
     #[test]
     fn test_atomic_gzip_xdr_write_iter_roundtrip() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("out.xdr.gz");
 
@@ -739,7 +739,7 @@ mod tests {
 
     #[test]
     fn test_atomic_gzip_xdr_write_iter_propagates_error_no_temp() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("out.xdr.gz");
 
@@ -762,7 +762,7 @@ mod tests {
 
     #[test]
     fn test_atomic_gzip_xdr_write_empty_slice_produces_valid_empty_gzip() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("out.xdr.gz");
 
@@ -784,7 +784,7 @@ mod tests {
     fn test_atomic_gzip_xdr_write_pinned_payload() {
         use flate2::read::GzDecoder;
         use std::io::Read;
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
 
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("pinned.xdr.gz");

--- a/crates/common/src/header_validation.rs
+++ b/crates/common/src/header_validation.rs
@@ -6,7 +6,7 @@
 //! Placed in `henyey-common` so both `henyey-ledger` and `henyey-db` can
 //! call it without introducing a circular crate dependency.
 
-use stellar_xdr::curr::LedgerHeader;
+use stellar_xdr::LedgerHeader;
 
 /// Validate ledger header field invariants.
 ///
@@ -60,7 +60,7 @@ pub fn validate_header_fields(header: &LedgerHeader) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{Hash, StellarValue, StellarValueExt};
+    use stellar_xdr::{Hash, StellarValue, StellarValueExt};
 
     fn make_valid_header() -> LedgerHeader {
         LedgerHeader {
@@ -68,8 +68,8 @@ mod tests {
             previous_ledger_hash: Hash([0u8; 32]),
             scp_value: StellarValue {
                 tx_set_hash: Hash([0u8; 32]),
-                close_time: stellar_xdr::curr::TimePoint(1_000_000),
-                upgrades: stellar_xdr::curr::VecM::default(),
+                close_time: stellar_xdr::TimePoint(1_000_000),
+                upgrades: stellar_xdr::VecM::default(),
                 ext: StellarValueExt::Basic,
             },
             tx_set_result_hash: Hash([0u8; 32]),
@@ -83,7 +83,7 @@ mod tests {
             base_reserve: 100_000_000,
             max_tx_set_size: 100,
             skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
-            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            ext: stellar_xdr::LedgerHeaderExt::V0,
         }
     }
 
@@ -141,14 +141,14 @@ mod tests {
     #[test]
     fn test_close_time_at_i64_max_passes() {
         let mut header = make_valid_header();
-        header.scp_value.close_time = stellar_xdr::curr::TimePoint(i64::MAX as u64);
+        header.scp_value.close_time = stellar_xdr::TimePoint(i64::MAX as u64);
         assert!(validate_header_fields(&header).is_ok());
     }
 
     #[test]
     fn test_close_time_exceeds_i64_max_fails() {
         let mut header = make_valid_header();
-        header.scp_value.close_time = stellar_xdr::curr::TimePoint(i64::MAX as u64 + 1);
+        header.scp_value.close_time = stellar_xdr::TimePoint(i64::MAX as u64 + 1);
         let err = validate_header_fields(&header).unwrap_err();
         assert!(err.contains("close_time exceeds i64::MAX"), "{}", err);
     }

--- a/crates/common/src/ledger_type_utils.rs
+++ b/crates/common/src/ledger_type_utils.rs
@@ -8,7 +8,7 @@
 //! XDR discriminant lives inside the `.data` field (whereas stellar-core's
 //! C++ templates operate on the discriminant directly via `.type()`).
 
-use stellar_xdr::curr::*;
+use stellar_xdr::*;
 
 /// Returns `true` if the entry is a Soroban entry (`ContractData` or `ContractCode`).
 ///

--- a/crates/common/src/meta.rs
+++ b/crates/common/src/meta.rs
@@ -33,7 +33,7 @@
 
 use crate::types::entry_to_key;
 use crate::Hash256;
-use stellar_xdr::curr::{LedgerEntryChange, LedgerEntryChanges, LedgerKey, TransactionMeta};
+use stellar_xdr::{LedgerEntryChange, LedgerEntryChanges, LedgerKey, TransactionMeta};
 
 /// Extracts the ledger key from a ledger entry change.
 fn change_key(change: &LedgerEntryChange) -> LedgerKey {
@@ -65,7 +65,7 @@ fn change_type_order(change: &LedgerEntryChange) -> u8 {
 /// deterministic ordering regardless of the original order. Uses
 /// `LedgerKey::cmp` (derived `Ord`) which matches stellar-core's xdrpp
 /// `operator<` ordering — see `crates/bucket/src/entry.rs:143-151`.
-fn sort_changes(changes: &mut LedgerEntryChanges) -> Result<(), stellar_xdr::curr::Error> {
+fn sort_changes(changes: &mut LedgerEntryChanges) -> Result<(), stellar_xdr::Error> {
     let mut entries: Vec<(LedgerKey, u8, [u8; 32], LedgerEntryChange)> =
         Vec::with_capacity(changes.0.len());
 
@@ -83,16 +83,14 @@ fn sort_changes(changes: &mut LedgerEntryChanges) -> Result<(), stellar_xdr::cur
     });
 
     let sorted: Vec<LedgerEntryChange> = entries.into_iter().map(|(_, _, _, c)| c).collect();
-    changes.0 = sorted
-        .try_into()
-        .map_err(|_| stellar_xdr::curr::Error::Invalid)?;
+    changes.0 = sorted.try_into().map_err(|_| stellar_xdr::Error::Invalid)?;
     Ok(())
 }
 
 fn normalize_ops<T>(
-    ops: &mut stellar_xdr::curr::VecM<T>,
+    ops: &mut stellar_xdr::VecM<T>,
     mut changes: impl FnMut(&mut T) -> &mut LedgerEntryChanges,
-) -> Result<(), stellar_xdr::curr::Error> {
+) -> Result<(), stellar_xdr::Error> {
     for op in ops.iter_mut() {
         sort_changes(changes(op))?;
     }
@@ -104,9 +102,9 @@ fn normalize_ops<T>(
 fn normalize_v2_style<T>(
     tx_changes_before: &mut LedgerEntryChanges,
     tx_changes_after: &mut LedgerEntryChanges,
-    operations: &mut stellar_xdr::curr::VecM<T>,
+    operations: &mut stellar_xdr::VecM<T>,
     changes: impl FnMut(&mut T) -> &mut LedgerEntryChanges,
-) -> Result<(), stellar_xdr::curr::Error> {
+) -> Result<(), stellar_xdr::Error> {
     sort_changes(tx_changes_before)?;
     sort_changes(tx_changes_after)?;
     normalize_ops(operations, changes)?;
@@ -122,9 +120,7 @@ fn normalize_v2_style<T>(
 /// # Errors
 ///
 /// Returns an error if XDR serialization fails during sorting.
-pub fn normalize_transaction_meta(
-    meta: &mut TransactionMeta,
-) -> Result<(), stellar_xdr::curr::Error> {
+pub fn normalize_transaction_meta(meta: &mut TransactionMeta) -> Result<(), stellar_xdr::Error> {
     match meta {
         TransactionMeta::V0(ops) => {
             normalize_ops(ops, |op| &mut op.changes)?;
@@ -158,7 +154,7 @@ pub fn normalize_transaction_meta(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     /// Verify that sort_changes uses LedgerKey::cmp (struct ordering), not XDR
     /// byte ordering. For ContractData keys with variable-length ScVal fields,

--- a/crates/common/src/meta_walk.rs
+++ b/crates/common/src/meta_walk.rs
@@ -4,7 +4,7 @@
 //! pattern, avoiding duplication across crates that need to walk ledger
 //! entry changes from transaction metadata.
 
-use stellar_xdr::curr::{LedgerEntryChange, TransactionMeta};
+use stellar_xdr::{LedgerEntryChange, TransactionMeta};
 
 /// Walk change groups in a single `TransactionMeta`, invoking `f` once per
 /// contiguous slice of changes in field traversal order.
@@ -81,7 +81,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, ExtensionPoint, LedgerEntry, LedgerEntryChanges,
         LedgerEntryData, LedgerEntryExt, OperationMeta, OperationMetaV2, PublicKey, SequenceNumber,
         String32, Thresholds, TransactionMetaV1, TransactionMetaV2, TransactionMetaV3,

--- a/crates/common/src/network.rs
+++ b/crates/common/src/network.rs
@@ -100,9 +100,9 @@ impl NetworkId {
     }
 }
 
-impl From<NetworkId> for stellar_xdr::curr::Hash {
+impl From<NetworkId> for stellar_xdr::Hash {
     fn from(id: NetworkId) -> Self {
-        stellar_xdr::curr::Hash(id.0 .0)
+        stellar_xdr::Hash(id.0 .0)
     }
 }
 

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -286,11 +286,11 @@ pub const MASK_LEDGER_HEADER_FLAGS: u32 = 0x7;
 /// - `Flags`: protocol >= V18 and no bits outside `MASK_LEDGER_HEADER_FLAGS`
 /// - `MaxSorobanTxSetSize`: protocol >= V20
 pub fn upgrade_valid_for_apply_non_config(
-    upgrade: &stellar_xdr::curr::LedgerUpgrade,
+    upgrade: &stellar_xdr::LedgerUpgrade,
     current_version: u32,
     max_protocol_version: u32,
 ) -> bool {
-    use stellar_xdr::curr::LedgerUpgrade;
+    use stellar_xdr::LedgerUpgrade;
     match upgrade {
         LedgerUpgrade::Version(new_version) => {
             *new_version <= max_protocol_version && *new_version > current_version
@@ -326,7 +326,7 @@ pub fn upgrade_valid_for_apply_non_config(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LclContext {
     /// Hash of the LCL (becomes `previous_ledger_hash` in synthesized tx sets).
-    lcl_hash: stellar_xdr::curr::Hash,
+    lcl_hash: stellar_xdr::Hash,
     /// The LCL's protocol version (determines Classic vs Generalized format).
     protocol_version: u32,
 }
@@ -339,7 +339,7 @@ impl LclContext {
     /// provides this guarantee structurally.
     pub fn new(protocol_version: u32, lcl_hash: crate::Hash256) -> Self {
         Self {
-            lcl_hash: stellar_xdr::curr::Hash(lcl_hash.0),
+            lcl_hash: stellar_xdr::Hash(lcl_hash.0),
             protocol_version,
         }
     }
@@ -350,13 +350,13 @@ impl LclContext {
     /// and the protocol version is 0 (Classic format).
     pub fn pre_genesis() -> Self {
         Self {
-            lcl_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            lcl_hash: stellar_xdr::Hash([0u8; 32]),
             protocol_version: 0,
         }
     }
 
     /// The LCL hash (used as `previous_ledger_hash` in synthesized tx sets).
-    pub fn lcl_hash(&self) -> &stellar_xdr::curr::Hash {
+    pub fn lcl_hash(&self) -> &stellar_xdr::Hash {
         &self.lcl_hash
     }
 
@@ -409,7 +409,7 @@ mod tests {
     fn test_lcl_context_pre_genesis() {
         let lcl = LclContext::pre_genesis();
         assert_eq!(lcl.protocol_version(), 0);
-        assert_eq!(lcl.lcl_hash(), &stellar_xdr::curr::Hash([0u8; 32]));
+        assert_eq!(lcl.lcl_hash(), &stellar_xdr::Hash([0u8; 32]));
     }
 
     #[test]
@@ -417,14 +417,14 @@ mod tests {
         let hash = crate::Hash256([42u8; 32]);
         let lcl = LclContext::new(23, hash);
         assert_eq!(lcl.protocol_version(), 23);
-        assert_eq!(lcl.lcl_hash(), &stellar_xdr::curr::Hash([42u8; 32]));
+        assert_eq!(lcl.lcl_hash(), &stellar_xdr::Hash([42u8; 32]));
     }
 
     // ---- upgrade_valid_for_apply_non_config -------------------------------
 
     #[test]
     fn test_upgrade_valid_version_monotonic_and_range() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
         // Strictly increasing and within max → valid.
         assert!(upgrade_valid_for_apply_non_config(
             &LedgerUpgrade::Version(26),
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn test_upgrade_valid_base_fee_nonzero() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
         assert!(upgrade_valid_for_apply_non_config(
             &LedgerUpgrade::BaseFee(100),
             25,
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_upgrade_valid_base_reserve_nonzero() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
         assert!(upgrade_valid_for_apply_non_config(
             &LedgerUpgrade::BaseReserve(5_000_000),
             25,
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn test_upgrade_valid_max_tx_set_size_always_valid() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
         assert!(upgrade_valid_for_apply_non_config(
             &LedgerUpgrade::MaxTxSetSize(0),
             25,
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_upgrade_valid_flags_mask_and_protocol() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
         // Valid: within mask, protocol >= V18.
         assert!(upgrade_valid_for_apply_non_config(
             &LedgerUpgrade::Flags(MASK_LEDGER_HEADER_FLAGS),
@@ -522,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_upgrade_valid_max_soroban_tx_set_size_protocol_gate() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
         assert!(upgrade_valid_for_apply_non_config(
             &LedgerUpgrade::MaxSorobanTxSetSize(100),
             20,
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn test_upgrade_valid_config_delegated_returns_true() {
-        use stellar_xdr::curr::{ConfigUpgradeSetKey, ContractId, Hash, LedgerUpgrade};
+        use stellar_xdr::{ConfigUpgradeSetKey, ContractId, Hash, LedgerUpgrade};
         let key = ConfigUpgradeSetKey {
             contract_id: ContractId(Hash([0u8; 32])),
             content_hash: Hash([0u8; 32]),

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -112,7 +112,7 @@ impl Hash256 {
     /// Panics if XDR serialization fails. For in-memory, already-validated
     /// values encoded with `Limits::none()`, this is an internal invariant
     /// violation and should never happen in practice.
-    pub fn hash_xdr<T: stellar_xdr::curr::WriteXdr>(value: &T) -> Self {
+    pub fn hash_xdr<T: stellar_xdr::WriteXdr>(value: &T) -> Self {
         Self::try_hash_xdr(value).expect("XDR encoding of in-memory value must not fail")
     }
 
@@ -121,10 +121,10 @@ impl Hash256 {
     /// Prefer [`hash_xdr`] in production code where encoding failure is an
     /// invariant violation. Use this only when the caller genuinely needs to
     /// handle the error (e.g. encoding untrusted or partially-constructed data).
-    pub(crate) fn try_hash_xdr<T: stellar_xdr::curr::WriteXdr>(
+    pub(crate) fn try_hash_xdr<T: stellar_xdr::WriteXdr>(
         value: &T,
-    ) -> Result<Self, stellar_xdr::curr::Error> {
-        use stellar_xdr::curr::Limited;
+    ) -> Result<Self, stellar_xdr::Error> {
+        use stellar_xdr::Limited;
 
         struct Sha256Writer(Sha256);
         impl std::io::Write for Sha256Writer {
@@ -138,7 +138,7 @@ impl Hash256 {
         }
 
         let mut writer = Sha256Writer(Sha256::new());
-        let mut limited = Limited::new(&mut writer, stellar_xdr::curr::Limits::none());
+        let mut limited = Limited::new(&mut writer, stellar_xdr::Limits::none());
         value.write_xdr(&mut limited)?;
         let result = writer.0.finalize();
         Ok(Self(result.into()))
@@ -214,15 +214,15 @@ impl fmt::Display for Hash256 {
     }
 }
 
-impl From<stellar_xdr::curr::Hash> for Hash256 {
-    fn from(hash: stellar_xdr::curr::Hash) -> Self {
+impl From<stellar_xdr::Hash> for Hash256 {
+    fn from(hash: stellar_xdr::Hash) -> Self {
         Self(hash.0)
     }
 }
 
-impl From<Hash256> for stellar_xdr::curr::Hash {
+impl From<Hash256> for stellar_xdr::Hash {
     fn from(hash: Hash256) -> Self {
-        stellar_xdr::curr::Hash(hash.0)
+        stellar_xdr::Hash(hash.0)
     }
 }
 
@@ -265,8 +265,8 @@ impl std::ops::BitXor for Hash256 {
 /// This is the canonical, infallible conversion from a ledger entry to its
 /// corresponding key. The match is exhaustive over all `LedgerEntryData`
 /// variants, so it always succeeds.
-pub fn entry_to_key(entry: &stellar_xdr::curr::LedgerEntry) -> stellar_xdr::curr::LedgerKey {
-    use stellar_xdr::curr::*;
+pub fn entry_to_key(entry: &stellar_xdr::LedgerEntry) -> stellar_xdr::LedgerKey {
+    use stellar_xdr::*;
 
     match &entry.data {
         LedgerEntryData::Account(a) => LedgerKey::Account(LedgerKeyAccount {
@@ -311,7 +311,7 @@ pub fn entry_to_key(entry: &stellar_xdr::curr::LedgerEntry) -> stellar_xdr::curr
 
 /// Type alias: `ThresholdLevel` is now `ThresholdIndexes` from the XDR crate.
 /// Variants: `MasterWeight = 0`, `Low = 1`, `Med = 2`, `High = 3`.
-pub type ThresholdLevel = stellar_xdr::curr::ThresholdIndexes;
+pub type ThresholdLevel = stellar_xdr::ThresholdIndexes;
 
 /// Deterministic seed derivation matching stellar-core `txtest::getAccount()`.
 ///
@@ -332,8 +332,8 @@ pub fn deterministic_seed(name: &str) -> [u8; 32] {
 /// Different SCP pledge types store the quorum set hash in different fields:
 /// `Nominate`, `Prepare`, and `Confirm` use `quorum_set_hash`, while
 /// `Externalize` uses `commit_quorum_set_hash`.
-pub fn scp_quorum_set_hash(statement: &stellar_xdr::curr::ScpStatement) -> stellar_xdr::curr::Hash {
-    use stellar_xdr::curr::ScpStatementPledges;
+pub fn scp_quorum_set_hash(statement: &stellar_xdr::ScpStatement) -> stellar_xdr::Hash {
+    use stellar_xdr::ScpStatementPledges;
     match &statement.pledges {
         ScpStatementPledges::Nominate(nom) => nom.quorum_set_hash.clone(),
         ScpStatementPledges::Prepare(prep) => prep.quorum_set_hash.clone(),
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_hash_xdr_and_try_hash_xdr_agree() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let value = Hash([99u8; 32]);
         let infallible = Hash256::hash_xdr(&value);
         let fallible = Hash256::try_hash_xdr(&value).unwrap();
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn test_hash_xdr_deterministic() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let value = Hash([1u8; 32]);
         assert_eq!(Hash256::hash_xdr(&value), Hash256::hash_xdr(&value));
     }

--- a/crates/common/src/xdr_stream.rs
+++ b/crates/common/src/xdr_stream.rs
@@ -18,7 +18,7 @@ use std::fs::File;
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
-use stellar_xdr::curr::{Limits, ReadXdr, WriteXdr};
+use stellar_xdr::{Limits, ReadXdr, WriteXdr};
 
 const FRAME_CONTINUATION_BIT: u8 = 0x80;
 const MAX_FRAME_SIZE: u32 = 0x8000_0000;
@@ -61,7 +61,7 @@ pub fn xdr_encoded_len(val: &impl WriteXdr) -> usize {
             Ok(())
         }
     }
-    let mut w = stellar_xdr::curr::Limited::new(CountingWriter(0), Limits::none());
+    let mut w = stellar_xdr::Limited::new(CountingWriter(0), Limits::none());
     val.write_xdr(&mut w)
         .expect("XDR encoding of in-memory value must not fail");
     w.inner.0
@@ -315,7 +315,7 @@ impl XdrInputStream {
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
-    use stellar_xdr::curr::{LedgerCloseMeta, LedgerCloseMetaV2, ReadXdr};
+    use stellar_xdr::{LedgerCloseMeta, LedgerCloseMetaV2, ReadXdr};
 
     /// A thread-safe in-memory writer that allows reading the buffer after writing.
     #[derive(Clone)]
@@ -375,11 +375,10 @@ mod tests {
         assert_eq!(bytes_written, data.len());
 
         // Verify the payload decodes back to the same value
-        let decoded =
-            LedgerCloseMeta::from_xdr(&data[4..], stellar_xdr::curr::Limits::none()).unwrap();
+        let decoded = LedgerCloseMeta::from_xdr(&data[4..], stellar_xdr::Limits::none()).unwrap();
         assert_eq!(
-            decoded.to_xdr(stellar_xdr::curr::Limits::none()).unwrap(),
-            meta.to_xdr(stellar_xdr::curr::Limits::none()).unwrap()
+            decoded.to_xdr(stellar_xdr::Limits::none()).unwrap(),
+            meta.to_xdr(stellar_xdr::Limits::none()).unwrap()
         );
     }
 
@@ -401,15 +400,14 @@ mod tests {
         let sz1 = read_frame_size(&data, 0);
         let frame1_end = 4 + sz1 as usize;
         let _decoded1 =
-            LedgerCloseMeta::from_xdr(&data[4..frame1_end], stellar_xdr::curr::Limits::none())
-                .unwrap();
+            LedgerCloseMeta::from_xdr(&data[4..frame1_end], stellar_xdr::Limits::none()).unwrap();
 
         // Decode second frame
         let sz2 = read_frame_size(&data, frame1_end);
         let frame2_end = frame1_end + 4 + sz2 as usize;
         let _decoded2 = LedgerCloseMeta::from_xdr(
             &data[frame1_end + 4..frame2_end],
-            stellar_xdr::curr::Limits::none(),
+            stellar_xdr::Limits::none(),
         )
         .unwrap();
     }
@@ -554,7 +552,7 @@ mod tests {
         assert!(data[0] & FRAME_CONTINUATION_BIT != 0);
         let sz = read_frame_size(&data, 0);
         let _decoded =
-            LedgerCloseMeta::from_xdr(&data[4..4 + sz as usize], stellar_xdr::curr::Limits::none())
+            LedgerCloseMeta::from_xdr(&data[4..4 + sz as usize], stellar_xdr::Limits::none())
                 .unwrap();
     }
 
@@ -635,7 +633,7 @@ mod tests {
 
     #[test]
     fn test_xdr_to_bytes_roundtrips() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let hash = Hash([42u8; 32]);
         let bytes = xdr_to_bytes(&hash);
         let decoded = Hash::from_xdr(&bytes, Limits::none()).unwrap();
@@ -644,14 +642,14 @@ mod tests {
 
     #[test]
     fn test_xdr_encoded_len_matches_xdr_to_bytes() {
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
         let hash = Hash([0xABu8; 32]);
         assert_eq!(xdr_encoded_len(&hash), xdr_to_bytes(&hash).len());
     }
 
     #[test]
     fn test_xdr_encoded_len_u32_matches_xdr_to_bytes() {
-        use stellar_xdr::curr::{Hash, TtlEntry};
+        use stellar_xdr::{Hash, TtlEntry};
         // Simple type
         let hash = Hash([0xCDu8; 32]);
         assert_eq!(xdr_encoded_len_u32(&hash), xdr_to_bytes(&hash).len() as u32);

--- a/crates/crypto/src/curve25519.rs
+++ b/crates/crypto/src/curve25519.rs
@@ -232,29 +232,29 @@ impl Hash for Curve25519Public {
     }
 }
 
-impl From<stellar_xdr::curr::Curve25519Public> for Curve25519Public {
-    fn from(xdr: stellar_xdr::curr::Curve25519Public) -> Self {
+impl From<stellar_xdr::Curve25519Public> for Curve25519Public {
+    fn from(xdr: stellar_xdr::Curve25519Public) -> Self {
         Self::from_bytes(xdr.key)
     }
 }
 
-impl From<Curve25519Public> for stellar_xdr::curr::Curve25519Public {
+impl From<Curve25519Public> for stellar_xdr::Curve25519Public {
     fn from(key: Curve25519Public) -> Self {
-        stellar_xdr::curr::Curve25519Public {
+        stellar_xdr::Curve25519Public {
             key: key.to_bytes(),
         }
     }
 }
 
-impl From<stellar_xdr::curr::Curve25519Secret> for Curve25519Secret {
-    fn from(xdr: stellar_xdr::curr::Curve25519Secret) -> Self {
+impl From<stellar_xdr::Curve25519Secret> for Curve25519Secret {
+    fn from(xdr: stellar_xdr::Curve25519Secret) -> Self {
         Self::from_bytes(xdr.key)
     }
 }
 
-impl From<Curve25519Secret> for stellar_xdr::curr::Curve25519Secret {
+impl From<Curve25519Secret> for stellar_xdr::Curve25519Secret {
     fn from(key: Curve25519Secret) -> Self {
-        stellar_xdr::curr::Curve25519Secret {
+        stellar_xdr::Curve25519Secret {
             key: key.to_bytes(),
         }
     }
@@ -379,7 +379,7 @@ mod tests {
         let public = secret.derive_public();
 
         // Convert to XDR and back
-        let xdr_public: stellar_xdr::curr::Curve25519Public = public.into();
+        let xdr_public: stellar_xdr::Curve25519Public = public.into();
         let restored_public: Curve25519Public = xdr_public.into();
 
         assert_eq!(public.to_bytes(), restored_public.to_bytes());

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -65,7 +65,7 @@ pub enum CryptoError {
 
     /// XDR serialization or deserialization failed.
     #[error("XDR error: {0}")]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     /// Attempted to reseed the short hash with a different value after hashing.
     ///

--- a/crates/crypto/src/hash.rs
+++ b/crates/crypto/src/hash.rs
@@ -30,7 +30,7 @@ use henyey_common::Hash256;
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 #[cfg(test)]
-use stellar_xdr::curr::WriteXdr;
+use stellar_xdr::WriteXdr;
 
 /// Computes the SHA-256 hash of the given data.
 ///
@@ -262,8 +262,8 @@ fn hkdf(ikm: &[u8], info: &[u8]) -> [u8; 32] {
 ///
 /// The SHA-256 hash of the XDR-encoded value, or an error if encoding fails.
 #[cfg(test)]
-fn xdr_sha256<T: WriteXdr>(value: &T) -> Result<Hash256, stellar_xdr::curr::Error> {
-    let bytes = value.to_xdr(stellar_xdr::curr::Limits::none())?;
+fn xdr_sha256<T: WriteXdr>(value: &T) -> Result<Hash256, stellar_xdr::Error> {
+    let bytes = value.to_xdr(stellar_xdr::Limits::none())?;
     Ok(sha256(&bytes))
 }
 
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn test_xdr_sha256() {
-        use stellar_xdr::curr::Uint256;
+        use stellar_xdr::Uint256;
 
         let value = Uint256([0u8; 32]);
         let hash = xdr_sha256(&value).unwrap();
@@ -412,10 +412,10 @@ mod tests {
 
     #[test]
     fn test_xdr_sha256_matches_direct_hash() {
-        use stellar_xdr::curr::Uint256;
+        use stellar_xdr::Uint256;
 
         let value = Uint256([42u8; 32]);
-        let xdr_bytes = value.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+        let xdr_bytes = value.to_xdr(stellar_xdr::Limits::none()).unwrap();
 
         let sha256_hash = xdr_sha256(&value).unwrap();
         let direct_sha256 = sha256(&xdr_bytes);

--- a/crates/crypto/src/keys.rs
+++ b/crates/crypto/src/keys.rs
@@ -122,29 +122,27 @@ impl fmt::Display for PublicKey {
     }
 }
 
-impl TryFrom<&stellar_xdr::curr::PublicKey> for PublicKey {
+impl TryFrom<&stellar_xdr::PublicKey> for PublicKey {
     type Error = CryptoError;
 
-    fn try_from(xdr: &stellar_xdr::curr::PublicKey) -> Result<Self, Self::Error> {
+    fn try_from(xdr: &stellar_xdr::PublicKey) -> Result<Self, Self::Error> {
         match xdr {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                bytes,
-            )) => Self::from_bytes(bytes),
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => {
+                Self::from_bytes(bytes)
+            }
         }
     }
 }
 
-impl From<&PublicKey> for stellar_xdr::curr::PublicKey {
+impl From<&PublicKey> for stellar_xdr::PublicKey {
     fn from(pk: &PublicKey) -> Self {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-            *pk.as_bytes(),
-        ))
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(*pk.as_bytes()))
     }
 }
 
-impl From<&PublicKey> for stellar_xdr::curr::AccountId {
+impl From<&PublicKey> for stellar_xdr::AccountId {
     fn from(pk: &PublicKey) -> Self {
-        stellar_xdr::curr::AccountId(pk.into())
+        stellar_xdr::AccountId(pk.into())
     }
 }
 
@@ -273,9 +271,9 @@ impl Clone for SecretKey {
 ///
 /// This is a convenience function for converting the XDR AccountId type
 /// directly to a human-readable strkey format, suitable for logging.
-pub fn account_id_to_strkey(account_id: &stellar_xdr::curr::AccountId) -> String {
+pub fn account_id_to_strkey(account_id: &stellar_xdr::AccountId) -> String {
     match &account_id.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(bytes)) => {
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => {
             stellar_strkey::ed25519::PublicKey(*bytes).to_string()
         }
     }
@@ -309,11 +307,11 @@ impl fmt::Debug for Signature {
     }
 }
 
-impl From<Signature> for stellar_xdr::curr::Signature {
+impl From<Signature> for stellar_xdr::Signature {
     fn from(sig: Signature) -> Self {
         // Safety: Signature is always exactly 64 bytes, which is within
         // the XDR Signature's BytesM::<64> limit.
-        stellar_xdr::curr::Signature(
+        stellar_xdr::Signature(
             sig.0
                 .try_into()
                 .expect("64-byte signature always fits in BytesM::<64>"),
@@ -321,10 +319,10 @@ impl From<Signature> for stellar_xdr::curr::Signature {
     }
 }
 
-impl TryFrom<&stellar_xdr::curr::Signature> for Signature {
+impl TryFrom<&stellar_xdr::Signature> for Signature {
     type Error = CryptoError;
 
-    fn try_from(xdr: &stellar_xdr::curr::Signature) -> Result<Self, Self::Error> {
+    fn try_from(xdr: &stellar_xdr::Signature) -> Result<Self, Self::Error> {
         let bytes: [u8; 64] =
             xdr.0
                 .as_slice()

--- a/crates/crypto/src/short_hash.rs
+++ b/crates/crypto/src/short_hash.rs
@@ -28,7 +28,7 @@
 //!
 //! ```
 //! use henyey_crypto::xdr_compute_hash;
-//! use stellar_xdr::curr::LedgerEntry;
+//! use stellar_xdr::LedgerEntry;
 //!
 //! // Hash an XDR-encoded value using the process-global key.
 //! let entry = LedgerEntry::default();
@@ -40,7 +40,7 @@ use crate::CryptoError;
 use siphasher::sip::SipHasher24;
 use std::hash::Hasher;
 use std::sync::{Mutex, OnceLock};
-use stellar_xdr::curr::{Limits, WriteXdr};
+use stellar_xdr::{Limits, WriteXdr};
 
 /// Size of the SipHash key in bytes (128 bits).
 const KEY_BYTES: usize = 16;
@@ -166,7 +166,7 @@ pub fn xdr_compute_hash<T: WriteXdr>(value: &T) -> Result<u64, CryptoError> {
 mod tests {
     use super::*;
     use std::sync::{Mutex, MutexGuard, OnceLock};
-    use stellar_xdr::curr::LedgerEntry;
+    use stellar_xdr::LedgerEntry;
 
     fn test_guard() -> MutexGuard<'static, ()> {
         static GUARD: OnceLock<Mutex<()>> = OnceLock::new();

--- a/crates/crypto/src/signature.rs
+++ b/crates/crypto/src/signature.rs
@@ -168,8 +168,8 @@ pub fn verify_hash_from_raw_key(
 /// and `SignatureUtils::getSignedPayloadHint` in
 /// `src/transactions/SignatureUtils.cpp`.
 pub fn verify_ed25519_signed_payload(
-    sig: &stellar_xdr::curr::DecoratedSignature,
-    signed_payload: &stellar_xdr::curr::SignerKeyEd25519SignedPayload,
+    sig: &stellar_xdr::DecoratedSignature,
+    signed_payload: &stellar_xdr::SignerKeyEd25519SignedPayload,
 ) -> bool {
     // Compute expected XOR hint per stellar-core getSignedPayloadHint.
     let pubkey_hint = [
@@ -333,10 +333,10 @@ mod tests {
         payload: &[u8],
     ) -> (
         SecretKey,
-        stellar_xdr::curr::DecoratedSignature,
-        stellar_xdr::curr::SignerKeyEd25519SignedPayload,
+        stellar_xdr::DecoratedSignature,
+        stellar_xdr::SignerKeyEd25519SignedPayload,
     ) {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DecoratedSignature, SignatureHint, SignerKeyEd25519SignedPayload, Uint256,
         };
 
@@ -380,7 +380,7 @@ mod tests {
 
         let decorated = DecoratedSignature {
             hint: SignatureHint(xor_hint),
-            signature: stellar_xdr::curr::Signature(sig.as_bytes().try_into().unwrap()),
+            signature: stellar_xdr::Signature(sig.as_bytes().try_into().unwrap()),
         };
 
         (secret, decorated, signed_payload)
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_verify_ed25519_signed_payload_hint_mismatch() {
-        use stellar_xdr::curr::{DecoratedSignature, SignatureHint};
+        use stellar_xdr::{DecoratedSignature, SignatureHint};
 
         let payload = b"CAP-0040 test payload";
         let (_secret, sig, signed_payload) = make_signed_payload_fixture(payload);
@@ -431,13 +431,13 @@ mod tests {
 
     #[test]
     fn test_verify_ed25519_signed_payload_invalid_signature() {
-        use stellar_xdr::curr::{DecoratedSignature, SignatureHint, Uint256};
+        use stellar_xdr::{DecoratedSignature, SignatureHint, Uint256};
 
         let secret = SecretKey::generate();
         let pubkey_bytes = *secret.public_key().as_bytes();
         let payload = b"test payload data";
 
-        let signed_payload = stellar_xdr::curr::SignerKeyEd25519SignedPayload {
+        let signed_payload = stellar_xdr::SignerKeyEd25519SignedPayload {
             ed25519: Uint256(pubkey_bytes),
             payload: payload.as_slice().try_into().unwrap(),
         };
@@ -465,21 +465,21 @@ mod tests {
 
         let bad_sig = DecoratedSignature {
             hint: SignatureHint(xor_hint),
-            signature: stellar_xdr::curr::Signature(vec![0xDE; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0xDE; 64].try_into().unwrap()),
         };
         assert!(!verify_ed25519_signed_payload(&bad_sig, &signed_payload));
     }
 
     #[test]
     fn test_verify_ed25519_signed_payload_invalid_key() {
-        use stellar_xdr::curr::{DecoratedSignature, SignatureHint, Uint256};
+        use stellar_xdr::{DecoratedSignature, SignatureHint, Uint256};
 
         // Use y=2 which is not on curve
         let mut invalid_key = [0u8; 32];
         invalid_key[0] = 2;
         let payload = b"test payload";
 
-        let signed_payload = stellar_xdr::curr::SignerKeyEd25519SignedPayload {
+        let signed_payload = stellar_xdr::SignerKeyEd25519SignedPayload {
             ed25519: Uint256(invalid_key),
             payload: payload.as_slice().try_into().unwrap(),
         };
@@ -507,20 +507,20 @@ mod tests {
 
         let sig = DecoratedSignature {
             hint: SignatureHint(xor_hint),
-            signature: stellar_xdr::curr::Signature(vec![0xAB; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0xAB; 64].try_into().unwrap()),
         };
         assert!(!verify_ed25519_signed_payload(&sig, &signed_payload));
     }
 
     #[test]
     fn test_verify_ed25519_signed_payload_malformed_signature_length() {
-        use stellar_xdr::curr::{DecoratedSignature, SignatureHint, Uint256};
+        use stellar_xdr::{DecoratedSignature, SignatureHint, Uint256};
 
         let secret = SecretKey::generate();
         let pubkey_bytes = *secret.public_key().as_bytes();
         let payload = b"test payload";
 
-        let signed_payload = stellar_xdr::curr::SignerKeyEd25519SignedPayload {
+        let signed_payload = stellar_xdr::SignerKeyEd25519SignedPayload {
             ed25519: Uint256(pubkey_bytes),
             payload: payload.as_slice().try_into().unwrap(),
         };
@@ -549,14 +549,14 @@ mod tests {
         // Too short (32 bytes instead of 64)
         let short_sig = DecoratedSignature {
             hint: SignatureHint(xor_hint),
-            signature: stellar_xdr::curr::Signature(vec![0xAB; 32].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0xAB; 32].try_into().unwrap()),
         };
         assert!(!verify_ed25519_signed_payload(&short_sig, &signed_payload));
 
         // Empty signature
         let empty_sig = DecoratedSignature {
             hint: SignatureHint(xor_hint),
-            signature: stellar_xdr::curr::Signature(vec![].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![].try_into().unwrap()),
         };
         assert!(!verify_ed25519_signed_payload(&empty_sig, &signed_payload));
     }

--- a/crates/db/src/database/history.rs
+++ b/crates/db/src/database/history.rs
@@ -1,6 +1,6 @@
 //! High-level database methods for history and RPC retention data.
 
-use stellar_xdr::curr::{TransactionHistoryEntry, TransactionHistoryResultEntry};
+use stellar_xdr::{TransactionHistoryEntry, TransactionHistoryResultEntry};
 
 use crate::{pool::Database, queries, Result};
 

--- a/crates/db/src/database/mod.rs
+++ b/crates/db/src/database/mod.rs
@@ -150,7 +150,7 @@ impl Database {
     /// Returns the ledger header for a given sequence number.
     ///
     /// Returns `None` if the ledger is not found.
-    pub fn get_ledger_header(&self, seq: u32) -> Result<Option<stellar_xdr::curr::LedgerHeader>> {
+    pub fn get_ledger_header(&self, seq: u32) -> Result<Option<stellar_xdr::LedgerHeader>> {
         self.with_connection(|conn| {
             use queries::LedgerQueries;
             conn.load_ledger_header(seq)

--- a/crates/db/src/database/scp.rs
+++ b/crates/db/src/database/scp.rs
@@ -1,6 +1,6 @@
 //! High-level database methods for SCP and bucket-list persistence.
 
-use stellar_xdr::curr::{ScpEnvelope, ScpQuorumSet};
+use stellar_xdr::{ScpEnvelope, ScpQuorumSet};
 
 use crate::{pool::Database, queries, Result};
 

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -47,7 +47,7 @@ pub enum DbError {
     /// Occurs when reading or writing Stellar XDR-encoded data to/from
     /// the database. This can indicate data corruption or version mismatch.
     #[error("XDR error: {0}")]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     /// Requested data was not found.
     ///

--- a/crates/db/src/queries/events.rs
+++ b/crates/db/src/queries/events.rs
@@ -4,7 +4,7 @@
 //! used by the `getEvents` RPC endpoint.
 
 use rusqlite::{params, Connection};
-use stellar_xdr::curr::ContractEventType;
+use stellar_xdr::ContractEventType;
 
 use super::{install_query_budget, is_query_interrupted};
 use crate::error::DbError;

--- a/crates/db/src/queries/history.rs
+++ b/crates/db/src/queries/history.rs
@@ -11,7 +11,7 @@
 
 use henyey_common::xdr_stream::XdrOutputStream;
 use rusqlite::{params, Connection, OptionalExtension};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Limits, ReadXdr, TransactionHistoryEntry, TransactionHistoryResultEntry, WriteXdr,
 };
 
@@ -514,7 +514,7 @@ impl HistoryQueries for Connection {
 mod tests {
     use super::*;
     use rusqlite::Connection;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, TransactionHistoryEntryExt, TransactionHistoryResultEntryExt, TransactionResultSet,
         TransactionSet, VecM,
     };

--- a/crates/db/src/queries/ledger.rs
+++ b/crates/db/src/queries/ledger.rs
@@ -7,7 +7,7 @@
 use henyey_common::xdr_stream::XdrOutputStream;
 use henyey_common::Hash256;
 use rusqlite::{params, Connection, OptionalExtension};
-use stellar_xdr::curr::{LedgerHeader, LedgerHeaderHistoryEntry, Limits, ReadXdr};
+use stellar_xdr::{LedgerHeader, LedgerHeaderHistoryEntry, Limits, ReadXdr};
 
 use crate::error::DbError;
 
@@ -222,9 +222,9 @@ impl LedgerQueries for Connection {
             let hash_bytes = Hash256::from_hex(&hash_hex)
                 .map_err(|e| DbError::Integrity(format!("Invalid ledger hash: {}", e)))?;
             let entry = LedgerHeaderHistoryEntry {
-                hash: stellar_xdr::curr::Hash(hash_bytes.0),
+                hash: stellar_xdr::Hash(hash_bytes.0),
                 header,
-                ext: stellar_xdr::curr::LedgerHeaderHistoryEntryExt::V0,
+                ext: stellar_xdr::LedgerHeaderHistoryEntryExt::V0,
             };
             stream
                 .write_one(&entry)
@@ -321,7 +321,7 @@ impl LedgerQueries for Connection {
 mod tests {
     use super::*;
     use rusqlite::Connection;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, WriteXdr,
     };
 

--- a/crates/db/src/queries/scp.rs
+++ b/crates/db/src/queries/scp.rs
@@ -15,7 +15,7 @@
 use henyey_common::xdr_stream::XdrOutputStream;
 use henyey_common::Hash256;
 use rusqlite::{params, Connection, OptionalExtension};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, LedgerScpMessages, Limits, NodeId, PublicKey, ReadXdr, ScpEnvelope, ScpHistoryEntry,
     ScpHistoryEntryV0, ScpQuorumSet, Uint256, WriteXdr,
 };
@@ -279,10 +279,10 @@ impl ScpQueries for Connection {
 /// Extract the quorum set hash from an SCP envelope's statement.
 fn scp_envelope_quorum_set_hash(envelope: &ScpEnvelope) -> Hash256 {
     let hash = match &envelope.statement.pledges {
-        stellar_xdr::curr::ScpStatementPledges::Nominate(nom) => &nom.quorum_set_hash,
-        stellar_xdr::curr::ScpStatementPledges::Prepare(prep) => &prep.quorum_set_hash,
-        stellar_xdr::curr::ScpStatementPledges::Confirm(conf) => &conf.quorum_set_hash,
-        stellar_xdr::curr::ScpStatementPledges::Externalize(ext) => &ext.commit_quorum_set_hash,
+        stellar_xdr::ScpStatementPledges::Nominate(nom) => &nom.quorum_set_hash,
+        stellar_xdr::ScpStatementPledges::Prepare(prep) => &prep.quorum_set_hash,
+        stellar_xdr::ScpStatementPledges::Confirm(conf) => &conf.quorum_set_hash,
+        stellar_xdr::ScpStatementPledges::Externalize(ext) => &ext.commit_quorum_set_hash,
     };
     Hash256::from_bytes(hash.0)
 }
@@ -606,7 +606,7 @@ fn referenced_tx_set_hashes_from_state_json(state_json: &str) -> Result<Vec<Hash
 /// `Vec<Value>` (in Nominate); each `Value` decodes into a `StellarValue`
 /// whose `tx_set_hash` is the referenced hash.
 fn extract_tx_set_hashes_from_envelope(envelope: &ScpEnvelope) -> Vec<Hash> {
-    use stellar_xdr::curr::{ScpStatementPledges, StellarValue, Value as XdrValue};
+    use stellar_xdr::{ScpStatementPledges, StellarValue, Value as XdrValue};
 
     fn from_value(value: &XdrValue) -> Option<Hash> {
         let sv = StellarValue::from_xdr(value.as_slice(), Limits::none()).ok()?;
@@ -807,28 +807,26 @@ mod tests {
     fn persisted_state_json_referencing(tx_set_hash: &Hash) -> String {
         // Construct a NOMINATE envelope referencing `tx_set_hash` via a
         // StellarValue.
-        let stellar_value = stellar_xdr::curr::StellarValue {
+        let stellar_value = stellar_xdr::StellarValue {
             tx_set_hash: tx_set_hash.clone(),
-            close_time: stellar_xdr::curr::TimePoint(0),
+            close_time: stellar_xdr::TimePoint(0),
             upgrades: vec![].try_into().unwrap(),
-            ext: stellar_xdr::curr::StellarValueExt::Basic,
+            ext: stellar_xdr::StellarValueExt::Basic,
         };
         let value_xdr = stellar_value.to_xdr(Limits::none()).unwrap();
         let envelope = ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
+            statement: stellar_xdr::ScpStatement {
                 node_id: NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
                 slot_index: 100,
-                pledges: stellar_xdr::curr::ScpStatementPledges::Nominate(
-                    stellar_xdr::curr::ScpNomination {
-                        quorum_set_hash: Hash([0u8; 32]),
-                        votes: vec![stellar_xdr::curr::Value(value_xdr.try_into().unwrap())]
-                            .try_into()
-                            .unwrap(),
-                        accepted: vec![].try_into().unwrap(),
-                    },
-                ),
+                pledges: stellar_xdr::ScpStatementPledges::Nominate(stellar_xdr::ScpNomination {
+                    quorum_set_hash: Hash([0u8; 32]),
+                    votes: vec![stellar_xdr::Value(value_xdr.try_into().unwrap())]
+                        .try_into()
+                        .unwrap(),
+                    accepted: vec![].try_into().unwrap(),
+                }),
             },
-            signature: stellar_xdr::curr::Signature::default(),
+            signature: stellar_xdr::Signature::default(),
         };
         let env_xdr: Vec<u8> = envelope.to_xdr(Limits::none()).unwrap();
         // Match the herder's PersistedSlotState JSON shape: serde_json renders
@@ -919,13 +917,13 @@ mod tests {
         let node_id = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
         let qset_hash = Hash([0u8; 32]);
         let envelope = ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
+            statement: stellar_xdr::ScpStatement {
                 node_id: node_id.clone(),
                 slot_index: 100,
-                pledges: stellar_xdr::curr::ScpStatementPledges::Prepare(
-                    stellar_xdr::curr::ScpStatementPrepare {
+                pledges: stellar_xdr::ScpStatementPledges::Prepare(
+                    stellar_xdr::ScpStatementPrepare {
                         quorum_set_hash: qset_hash.clone(),
-                        ballot: stellar_xdr::curr::ScpBallot {
+                        ballot: stellar_xdr::ScpBallot {
                             counter: 1,
                             value: vec![].try_into().unwrap(),
                         },
@@ -936,7 +934,7 @@ mod tests {
                     },
                 ),
             },
-            signature: stellar_xdr::curr::Signature::default(),
+            signature: stellar_xdr::Signature::default(),
         };
         conn.store_scp_history(100, &[envelope]).unwrap();
 
@@ -983,13 +981,13 @@ mod tests {
             let node_id = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([seq as u8; 32])));
             let qset_hash = Hash([seq as u8; 32]);
             let envelope = ScpEnvelope {
-                statement: stellar_xdr::curr::ScpStatement {
+                statement: stellar_xdr::ScpStatement {
                     node_id: node_id.clone(),
                     slot_index: seq as u64,
-                    pledges: stellar_xdr::curr::ScpStatementPledges::Prepare(
-                        stellar_xdr::curr::ScpStatementPrepare {
+                    pledges: stellar_xdr::ScpStatementPledges::Prepare(
+                        stellar_xdr::ScpStatementPrepare {
                             quorum_set_hash: qset_hash.clone(),
-                            ballot: stellar_xdr::curr::ScpBallot {
+                            ballot: stellar_xdr::ScpBallot {
                                 counter: 1,
                                 value: vec![].try_into().unwrap(),
                             },
@@ -1000,7 +998,7 @@ mod tests {
                         },
                     ),
                 },
-                signature: stellar_xdr::curr::Signature::default(),
+                signature: stellar_xdr::Signature::default(),
             };
             conn.store_scp_history(seq, &[envelope]).unwrap();
 
@@ -1081,13 +1079,13 @@ mod tests {
             for validator in 0..3u8 {
                 let node_id = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([validator; 32])));
                 envelopes.push(ScpEnvelope {
-                    statement: stellar_xdr::curr::ScpStatement {
+                    statement: stellar_xdr::ScpStatement {
                         node_id,
                         slot_index: seq as u64,
-                        pledges: stellar_xdr::curr::ScpStatementPledges::Prepare(
-                            stellar_xdr::curr::ScpStatementPrepare {
+                        pledges: stellar_xdr::ScpStatementPledges::Prepare(
+                            stellar_xdr::ScpStatementPrepare {
                                 quorum_set_hash: Hash([0u8; 32]),
-                                ballot: stellar_xdr::curr::ScpBallot {
+                                ballot: stellar_xdr::ScpBallot {
                                     counter: 1,
                                     value: vec![].try_into().unwrap(),
                                 },
@@ -1098,7 +1096,7 @@ mod tests {
                             },
                         ),
                     },
-                    signature: stellar_xdr::curr::Signature::default(),
+                    signature: stellar_xdr::Signature::default(),
                 });
             }
             conn.store_scp_history(seq, &envelopes).unwrap();
@@ -1126,13 +1124,13 @@ mod tests {
             // Create a simple test envelope
             let node_id = NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([seq as u8; 32])));
             let envelope = ScpEnvelope {
-                statement: stellar_xdr::curr::ScpStatement {
+                statement: stellar_xdr::ScpStatement {
                     node_id: node_id.clone(),
                     slot_index: seq as u64,
-                    pledges: stellar_xdr::curr::ScpStatementPledges::Prepare(
-                        stellar_xdr::curr::ScpStatementPrepare {
+                    pledges: stellar_xdr::ScpStatementPledges::Prepare(
+                        stellar_xdr::ScpStatementPrepare {
                             quorum_set_hash: Hash([0u8; 32]),
-                            ballot: stellar_xdr::curr::ScpBallot {
+                            ballot: stellar_xdr::ScpBallot {
                                 counter: 1,
                                 value: vec![].try_into().unwrap(),
                             },
@@ -1143,7 +1141,7 @@ mod tests {
                         },
                     ),
                 },
-                signature: stellar_xdr::curr::Signature::default(),
+                signature: stellar_xdr::Signature::default(),
             };
             conn.store_scp_history(seq, &[envelope]).unwrap();
 

--- a/crates/db/src/scp_persistence.rs
+++ b/crates/db/src/scp_persistence.rs
@@ -15,7 +15,7 @@
 //! let manager = ScpPersistenceManager::new(Box::new(persistence));
 //! ```
 
-use stellar_xdr::curr::Hash;
+use stellar_xdr::Hash;
 use tracing::debug;
 
 use crate::error::DbError;

--- a/crates/henyey/src/bin/header_compare.rs
+++ b/crates/henyey/src/bin/header_compare.rs
@@ -31,7 +31,7 @@ use henyey_common::Hash256;
 use henyey_history::HistoryArchive;
 use henyey_ledger::compute_header_hash;
 use std::path::PathBuf;
-use stellar_xdr::curr::{LedgerHeader, TransactionHistoryResultEntry, WriteXdr};
+use stellar_xdr::{LedgerHeader, TransactionHistoryResultEntry, WriteXdr};
 
 /// CLI arguments for the header comparison tool.
 #[derive(Parser)]
@@ -260,8 +260,8 @@ fn compare_present_entries(
 
     let count = local_results.len().min(archive_results.len());
     for i in 0..count {
-        let local_bytes = local_results[i].to_xdr(stellar_xdr::curr::Limits::none())?;
-        let archive_bytes = archive_results[i].to_xdr(stellar_xdr::curr::Limits::none())?;
+        let local_bytes = local_results[i].to_xdr(stellar_xdr::Limits::none())?;
+        let archive_bytes = archive_results[i].to_xdr(stellar_xdr::Limits::none())?;
         if local_bytes != archive_bytes {
             diffs.push(format!(
                 "tx[{}] mismatch: local fee={} result={:?} | archive fee={} result={:?}",
@@ -281,7 +281,7 @@ fn compare_present_entries(
 fn print_tx_result_hash(label: &str, entry: &TransactionHistoryResultEntry) {
     let bytes = entry
         .tx_result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .unwrap_or_default();
     let hash = Hash256::hash(&bytes);
     println!("  {} hash: {}", label, hash.to_hex());
@@ -290,7 +290,7 @@ fn print_tx_result_hash(label: &str, entry: &TransactionHistoryResultEntry) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, TransactionResult, TransactionResultExt, TransactionResultPair,
         TransactionResultResult, TransactionResultSet, VecM,
     };
@@ -302,7 +302,7 @@ mod tests {
             tx_result_set: TransactionResultSet {
                 results: VecM::default(),
             },
-            ext: stellar_xdr::curr::TransactionHistoryResultEntryExt::V0,
+            ext: stellar_xdr::TransactionHistoryResultEntryExt::V0,
         }
     }
 
@@ -321,7 +321,7 @@ mod tests {
             tx_result_set: TransactionResultSet {
                 results: vec![pair].try_into().unwrap(),
             },
-            ext: stellar_xdr::curr::TransactionHistoryResultEntryExt::V0,
+            ext: stellar_xdr::TransactionHistoryResultEntryExt::V0,
         }
     }
 

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -123,7 +123,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
-use stellar_xdr::curr::WriteXdr;
+use stellar_xdr::WriteXdr;
 
 use henyey_app::{
     logging, run_catchup, run_node, App, AppConfig, CatchupMode as CatchupModeInternal,
@@ -2512,7 +2512,7 @@ fn cmd_offline_info(config: AppConfig) -> anyhow::Result<()> {
     use henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION;
     use henyey_db::queries::StateQueries;
     use std::time::{SystemTime, UNIX_EPOCH};
-    use stellar_xdr::curr::LedgerHeaderExt;
+    use stellar_xdr::LedgerHeaderExt;
 
     let db_path = &config.database.path;
 
@@ -2845,7 +2845,7 @@ async fn verify_single_checkpoint(
 
                 match result_entry
                     .tx_result_set
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                 {
                     Ok(bytes) => {
                         if let Err(e) = verify::verify_tx_result_set(header, &bytes) {
@@ -3035,7 +3035,7 @@ async fn cmd_debug_bucket_entry(
     use henyey_common::Hash256;
     use henyey_history::is_checkpoint_ledger;
     use std::sync::Arc;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, LedgerEntryData, LedgerKey, LedgerKeyAccount, PublicKey, Uint256,
     };
 
@@ -3282,7 +3282,7 @@ async fn cmd_dump_ledger(
 ) -> anyhow::Result<()> {
     use henyey_bucket::BucketManager;
     use std::io::Write;
-    use stellar_xdr::curr::LedgerEntryType;
+    use stellar_xdr::LedgerEntryType;
 
     // Parse entry type filter if provided
     let type_filter: Option<LedgerEntryType> = if let Some(ref type_str) = filter.entry_type {
@@ -3630,7 +3630,7 @@ async fn cmd_verify_checkpoints(
 
     // Collect verified checkpoint hashes
     let mut verified_checkpoints: Vec<serde_json::Value> = Vec::new();
-    let mut prev_header: Option<stellar_xdr::curr::LedgerHeader> = None;
+    let mut prev_header: Option<stellar_xdr::LedgerHeader> = None;
     let mut verified_count = 0;
     let mut error_count = 0;
 
@@ -3657,7 +3657,7 @@ async fn cmd_verify_checkpoints(
                     continue;
                 }
 
-                let headers: Vec<stellar_xdr::curr::LedgerHeader> = history_entries
+                let headers: Vec<stellar_xdr::LedgerHeader> = history_entries
                     .iter()
                     .map(|entry| entry.header.clone())
                     .collect();

--- a/crates/henyey/src/publish_history.rs
+++ b/crates/henyey/src/publish_history.rs
@@ -188,10 +188,10 @@ pub(crate) async fn cmd_publish_history(config: AppConfig, force: bool) -> anyho
                 .get_ledger_header(seq)?
                 .ok_or_else(|| anyhow::anyhow!("Missing ledger header {}", seq))?;
             let hash = compute_header_hash(&header)?;
-            headers.push(stellar_xdr::curr::LedgerHeaderHistoryEntry {
+            headers.push(stellar_xdr::LedgerHeaderHistoryEntry {
                 header,
-                hash: stellar_xdr::curr::Hash(hash.0),
-                ext: stellar_xdr::curr::LedgerHeaderHistoryEntryExt::V0,
+                hash: stellar_xdr::Hash(hash.0),
+                ext: stellar_xdr::LedgerHeaderHistoryEntryExt::V0,
             });
 
             let tx_entry = db.get_tx_history_entry(seq)?;
@@ -365,9 +365,9 @@ fn build_scp_history_entries(
     db: &henyey_db::Database,
     start_ledger: u32,
     checkpoint: u32,
-) -> anyhow::Result<Vec<stellar_xdr::curr::ScpHistoryEntry>> {
+) -> anyhow::Result<Vec<stellar_xdr::ScpHistoryEntry>> {
     use std::collections::HashSet;
-    use stellar_xdr::curr::{LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0};
+    use stellar_xdr::{LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0};
 
     let mut entries = Vec::new();
     for seq in start_ledger..=checkpoint {
@@ -430,7 +430,7 @@ fn write_root_has(
 fn write_scp_history_file(
     base_dir: &std::path::Path,
     checkpoint: u32,
-    entries: &[stellar_xdr::curr::ScpHistoryEntry],
+    entries: &[stellar_xdr::ScpHistoryEntry],
 ) -> anyhow::Result<()> {
     use henyey_history::paths::checkpoint_path;
 
@@ -455,7 +455,7 @@ struct CommandArchiveTarget {
 mod tests {
     use super::*;
     use std::io::Read;
-    use stellar_xdr::curr::ReadXdr;
+    use stellar_xdr::ReadXdr;
 
     /// Regression test for #2097: CLI publish staging must use `<bucket_dir>/tmp/`,
     /// not the system temp directory.
@@ -465,7 +465,7 @@ mod tests {
             BucketListQueries, HistoryQueries, LedgerQueries, PublishQueueQueries, StateQueries,
         };
         use henyey_db::schema::state_keys;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, Limits, StellarValue, StellarValueExt,
             TransactionHistoryEntry, TransactionHistoryEntryExt, TransactionHistoryResultEntry,
             TransactionHistoryResultEntryExt, TransactionResultSet, TransactionSet, VecM, WriteXdr,
@@ -524,7 +524,7 @@ mod tests {
                     previous_ledger_hash: Hash(previous_header_hash.0),
                     scp_value: StellarValue {
                         tx_set_hash: Hash(tx_hash.0),
-                        close_time: stellar_xdr::curr::TimePoint(seq as u64),
+                        close_time: stellar_xdr::TimePoint(seq as u64),
                         upgrades: VecM::default(),
                         ext: StellarValueExt::Basic,
                     },
@@ -635,11 +635,11 @@ mod tests {
         use tempfile::TempDir;
 
         let tmp = TempDir::new().unwrap();
-        let entry = stellar_xdr::curr::ScpHistoryEntry::V0(stellar_xdr::curr::ScpHistoryEntryV0 {
-            quorum_sets: stellar_xdr::curr::VecM::default(),
-            ledger_messages: stellar_xdr::curr::LedgerScpMessages {
+        let entry = stellar_xdr::ScpHistoryEntry::V0(stellar_xdr::ScpHistoryEntryV0 {
+            quorum_sets: stellar_xdr::VecM::default(),
+            ledger_messages: stellar_xdr::LedgerScpMessages {
                 ledger_seq: 63,
-                messages: stellar_xdr::curr::VecM::default(),
+                messages: stellar_xdr::VecM::default(),
             },
         });
 
@@ -658,11 +658,9 @@ mod tests {
         let payload_len = (mark & 0x7fff_ffff) as usize;
         assert_eq!(payload_len, bytes.len() - 4);
 
-        let parsed = stellar_xdr::curr::ScpHistoryEntry::from_xdr(
-            &bytes[4..],
-            stellar_xdr::curr::Limits::none(),
-        )
-        .unwrap();
+        let parsed =
+            stellar_xdr::ScpHistoryEntry::from_xdr(&bytes[4..], stellar_xdr::Limits::none())
+                .unwrap();
         assert_eq!(parsed, entry);
     }
 
@@ -671,11 +669,11 @@ mod tests {
         use tempfile::TempDir;
 
         let tmp = TempDir::new().unwrap();
-        let entry = stellar_xdr::curr::ScpHistoryEntry::V0(stellar_xdr::curr::ScpHistoryEntryV0 {
-            quorum_sets: stellar_xdr::curr::VecM::default(),
-            ledger_messages: stellar_xdr::curr::LedgerScpMessages {
+        let entry = stellar_xdr::ScpHistoryEntry::V0(stellar_xdr::ScpHistoryEntryV0 {
+            quorum_sets: stellar_xdr::VecM::default(),
+            ledger_messages: stellar_xdr::LedgerScpMessages {
                 ledger_seq: 63,
-                messages: stellar_xdr::curr::VecM::default(),
+                messages: stellar_xdr::VecM::default(),
             },
         });
 

--- a/crates/henyey/src/quorum_intersection.rs
+++ b/crates/henyey/src/quorum_intersection.rs
@@ -29,7 +29,7 @@ use henyey_scp::quorum_intersection::{
     check_intersection, find_unsatisfiable_node, IntersectionResult,
 };
 use serde::Deserialize;
-use stellar_xdr::curr::{NodeId, ScpQuorumSet};
+use stellar_xdr::{NodeId, ScpQuorumSet};
 
 /// JSON representation of the network configuration for quorum intersection analysis.
 #[derive(Debug, Deserialize)]
@@ -120,7 +120,7 @@ pub(crate) fn check_quorum_intersection_from_json(path: &Path) -> anyhow::Result
 
 /// Converts a node ID to its hexadecimal representation for display.
 fn node_id_to_hex(node: &NodeId) -> String {
-    use stellar_xdr::curr::PublicKey;
+    use stellar_xdr::PublicKey;
     match node.0 {
         PublicKey::PublicKeyTypeEd25519(ref key) => hex::encode(key.0),
     }

--- a/crates/henyey/src/settings_upgrade.rs
+++ b/crates/henyey/src/settings_upgrade.rs
@@ -14,7 +14,7 @@
 //! hex tx hash. The final line is always the base64 `ConfigUpgradeSetKey`.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ConfigUpgradeSet, ConfigUpgradeSetKey, ContractDataDurability, ContractExecutable, ContractId,
     ContractIdPreimage, ContractIdPreimageFromAddress, CreateContractArgs, DecoratedSignature,
     Hash, HashIdPreimage, HashIdPreimageContractId, HostFunction, InvokeContractArgs,
@@ -124,8 +124,8 @@ fn get_wasm_restore_tx(
         fee,
         resource_fee,
         single_operation(OperationBody::RestoreFootprint(
-            stellar_xdr::curr::RestoreFootprintOp {
-                ext: stellar_xdr::curr::ExtensionPoint::V0,
+            stellar_xdr::RestoreFootprintOp {
+                ext: stellar_xdr::ExtensionPoint::V0,
             },
         )),
         resources,
@@ -160,7 +160,7 @@ fn get_upload_tx(public_key: &Uint256, seq_num: i64) -> (TransactionEnvelope, Le
         fee,
         resource_fee,
         single_operation(OperationBody::InvokeHostFunction(
-            stellar_xdr::curr::InvokeHostFunctionOp {
+            stellar_xdr::InvokeHostFunctionOp {
                 host_function: HostFunction::UploadContractWasm(wasm.try_into().unwrap()),
                 auth: VecM::default(),
             },
@@ -212,8 +212,8 @@ fn get_create_tx_with_salt(
 
     // Build contract ID preimage
     let id_preimage = ContractIdPreimage::Address(ContractIdPreimageFromAddress {
-        address: ScAddress::Account(stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(public_key.clone()),
+        address: ScAddress::Account(stellar_xdr::AccountId(
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(public_key.clone()),
         )),
         salt,
     });
@@ -225,9 +225,7 @@ fn get_create_tx_with_salt(
         contract_id_preimage: id_preimage.clone(),
     });
 
-    let full_preimage_bytes = full_preimage
-        .to_xdr(stellar_xdr::curr::Limits::none())
-        .unwrap();
+    let full_preimage_bytes = full_preimage.to_xdr(stellar_xdr::Limits::none()).unwrap();
     let contract_id = Hash(sha256(&full_preimage_bytes).0);
 
     // Build create contract operation and auth entry (both need id_preimage + executable)
@@ -271,7 +269,7 @@ fn get_create_tx_with_salt(
         fee,
         resource_fee,
         single_operation(OperationBody::InvokeHostFunction(
-            stellar_xdr::curr::InvokeHostFunctionOp {
+            stellar_xdr::InvokeHostFunctionOp {
                 host_function: HostFunction::CreateContract(create_args),
                 auth: vec![auth].try_into().unwrap(),
             },
@@ -297,16 +295,14 @@ fn get_invoke_tx(
     seq_num: i64,
     add_resource_fee: i64,
 ) -> (TransactionEnvelope, ConfigUpgradeSetKey) {
-    let upgrade_set_bytes = upgrade_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
-        .unwrap();
+    let upgrade_set_bytes = upgrade_set.to_xdr(stellar_xdr::Limits::none()).unwrap();
 
     // Build invoke contract args
     let addr = ScAddress::Contract(ContractId(deployment.contract_id.clone()));
 
     let function_name = ScSymbol("write".try_into().unwrap());
 
-    let args_val = ScVal::Bytes(stellar_xdr::curr::ScBytes(
+    let args_val = ScVal::Bytes(stellar_xdr::ScBytes(
         upgrade_set_bytes.clone().try_into().unwrap(),
     ));
 
@@ -318,9 +314,9 @@ fn get_invoke_tx(
 
     // Build the upgrade data ledger key
     let upgrade_hash = sha256(&upgrade_set_bytes);
-    let upgrade_hash_val = ScVal::Bytes(stellar_xdr::curr::ScBytes(
+    let upgrade_hash_val = ScVal::Bytes(stellar_xdr::ScBytes(
         Hash(upgrade_hash.0)
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .unwrap()
             .try_into()
             .unwrap(),
@@ -356,7 +352,7 @@ fn get_invoke_tx(
         fee,
         resource_fee,
         single_operation(OperationBody::InvokeHostFunction(
-            stellar_xdr::curr::InvokeHostFunctionOp {
+            stellar_xdr::InvokeHostFunctionOp {
                 host_function: HostFunction::InvokeContract(invoke_args),
                 auth: VecM::default(),
             },
@@ -387,7 +383,7 @@ fn compute_tx_hash(
         _ => panic!("Expected ENVELOPE_TYPE_TX"),
     };
 
-    let payload_bytes = payload.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+    let payload_bytes = payload.to_xdr(stellar_xdr::Limits::none()).unwrap();
     sha256(&payload_bytes)
 }
 
@@ -408,7 +404,7 @@ fn sign_tx(
 
     let decorated = DecoratedSignature {
         hint,
-        signature: stellar_xdr::curr::Signature(signature.as_bytes().to_vec().try_into().unwrap()),
+        signature: stellar_xdr::Signature(signature.as_bytes().to_vec().try_into().unwrap()),
     };
 
     match envelope {
@@ -439,7 +435,7 @@ pub(crate) fn run(params: &SettingsUpgradeParams<'_>) -> anyhow::Result<()> {
     let xdr_bytes = BASE64
         .decode(params.xdr_base64)
         .map_err(|e| anyhow::anyhow!("Failed to decode base64 XDR: {}", e))?;
-    let upgrade_set = ConfigUpgradeSet::from_xdr(&xdr_bytes, stellar_xdr::curr::Limits::none())
+    let upgrade_set = ConfigUpgradeSet::from_xdr(&xdr_bytes, stellar_xdr::Limits::none())
         .map_err(|e| anyhow::anyhow!("Failed to decode ConfigUpgradeSet XDR: {}", e))?;
 
     // Parse public key from StrKey
@@ -486,7 +482,7 @@ pub(crate) fn run(params: &SettingsUpgradeParams<'_>) -> anyhow::Result<()> {
 
         for tx in txs {
             let tx_hash = sign_tx(tx, &secret_key, params.network_passphrase);
-            let tx_bytes = tx.to_xdr(stellar_xdr::curr::Limits::none())?;
+            let tx_bytes = tx.to_xdr(stellar_xdr::Limits::none())?;
             println!("{}", BASE64.encode(&tx_bytes));
             println!("{}", hex::encode(tx_hash.0));
         }
@@ -504,7 +500,7 @@ pub(crate) fn run(params: &SettingsUpgradeParams<'_>) -> anyhow::Result<()> {
 
         for (i, label) in labels.iter().enumerate() {
             eprintln!("{}", label);
-            let tx_bytes = txs[i].to_xdr(stellar_xdr::curr::Limits::none())?;
+            let tx_bytes = txs[i].to_xdr(stellar_xdr::Limits::none())?;
             println!("{}", BASE64.encode(&tx_bytes));
             let tx_hash = compute_tx_hash(txs[i], params.network_passphrase);
             println!("{}", hex::encode(tx_hash.0));
@@ -512,7 +508,7 @@ pub(crate) fn run(params: &SettingsUpgradeParams<'_>) -> anyhow::Result<()> {
     }
 
     // Always output the ConfigUpgradeSetKey as the last line
-    let key_bytes = upgrade_set_key.to_xdr(stellar_xdr::curr::Limits::none())?;
+    let key_bytes = upgrade_set_key.to_xdr(stellar_xdr::Limits::none())?;
     println!("{}", BASE64.encode(&key_bytes));
 
     Ok(())

--- a/crates/henyey/src/verify_execution/diffs.rs
+++ b/crates/henyey/src/verify_execution/diffs.rs
@@ -7,9 +7,9 @@
 /// Returns a short description of a TransactionEnvelope for diagnostics:
 /// (op_types_csv, declared_fee, soroban_resource_fee, soroban_resources_summary).
 pub(super) fn describe_envelope(
-    env: Option<&stellar_xdr::curr::TransactionEnvelope>,
+    env: Option<&stellar_xdr::TransactionEnvelope>,
 ) -> (String, i64, i64, String) {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Operation, OperationBody, SorobanTransactionData, TransactionEnvelope, TransactionExt,
     };
     fn describe_op(op: &Operation) -> &'static str {
@@ -44,7 +44,7 @@ pub(super) fn describe_envelope(
         }
     }
     fn summarize_resources(data: &SorobanTransactionData) -> String {
-        use stellar_xdr::curr::SorobanTransactionDataExt;
+        use stellar_xdr::SorobanTransactionDataExt;
         let r = &data.resources;
         let archived = match &data.ext {
             SorobanTransactionDataExt::V1(ext) => ext.archived_soroban_entries.len(),
@@ -81,7 +81,7 @@ pub(super) fn describe_envelope(
         }
         TransactionEnvelope::TxFeeBump(fb) => {
             let (inner_ops_str, inner_sb_fee, inner_sb_summary) = match &fb.tx.inner_tx {
-                stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+                stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                     let ops_str = inner
                         .tx
                         .operations
@@ -112,13 +112,13 @@ pub(super) fn describe_envelope(
 /// "operation byte-write resources exceeds amount specified") — critical
 /// for #2503 hash-mismatch divergence diagnosis.
 pub(super) fn extract_diagnostic_event_summary(
-    meta: Option<&stellar_xdr::curr::TransactionMeta>,
+    meta: Option<&stellar_xdr::TransactionMeta>,
 ) -> String {
-    use stellar_xdr::curr::{ScVal, TransactionMeta};
+    use stellar_xdr::{ScVal, TransactionMeta};
     let Some(meta) = meta else {
         return String::new();
     };
-    let events: &[stellar_xdr::curr::DiagnosticEvent] = match meta {
+    let events: &[stellar_xdr::DiagnosticEvent] = match meta {
         TransactionMeta::V3(m) => m
             .soroban_meta
             .as_ref()
@@ -130,7 +130,7 @@ pub(super) fn extract_diagnostic_event_summary(
     let mut summaries = Vec::new();
     for event in events {
         let body = match &event.event.body {
-            stellar_xdr::curr::ContractEventBody::V0(b) => b,
+            stellar_xdr::ContractEventBody::V0(b) => b,
         };
         let mut parts: Vec<String> = Vec::new();
         for topic in body.topics.as_slice() {
@@ -176,41 +176,38 @@ pub(super) fn extract_diagnostic_event_summary(
 
 /// Build a per-tx state-changes summary string mirroring what henyey logs from
 /// manager.rs::commit on hash mismatch. Format: "phase:type:size:hash16 | …"
-pub(super) fn summarize_cdp_meta_changes(
-    meta: Option<&stellar_xdr::curr::TransactionMeta>,
-) -> String {
+pub(super) fn summarize_cdp_meta_changes(meta: Option<&stellar_xdr::TransactionMeta>) -> String {
     use sha2::{Digest, Sha256};
-    use stellar_xdr::curr::{LedgerEntryChange, LedgerEntryData, TransactionMeta, WriteXdr};
+    use stellar_xdr::{LedgerEntryChange, LedgerEntryData, TransactionMeta, WriteXdr};
     let Some(meta) = meta else {
         return String::new();
     };
     let mut parts: Vec<String> = Vec::new();
-    let walk =
-        |changes: &stellar_xdr::curr::LedgerEntryChanges, parts: &mut Vec<String>, phase: &str| {
-            for change in changes.iter() {
-                let entry = match change {
-                    LedgerEntryChange::Created(e) => e,
-                    LedgerEntryChange::Updated(e) => e,
-                    LedgerEntryChange::Restored(e) => e,
-                    _ => continue,
-                };
-                if matches!(entry.data, LedgerEntryData::Ttl(_)) {
-                    continue;
-                }
-                let data_bytes = entry
-                    .data
-                    .to_xdr(stellar_xdr::curr::Limits::none())
-                    .unwrap_or_default();
-                let data_hash = format!("{:x}", Sha256::digest(&data_bytes));
-                parts.push(format!(
-                    "{}:t{:?}:{}:{}",
-                    phase,
-                    std::mem::discriminant(&entry.data),
-                    data_bytes.len(),
-                    &data_hash[..16],
-                ));
+    let walk = |changes: &stellar_xdr::LedgerEntryChanges, parts: &mut Vec<String>, phase: &str| {
+        for change in changes.iter() {
+            let entry = match change {
+                LedgerEntryChange::Created(e) => e,
+                LedgerEntryChange::Updated(e) => e,
+                LedgerEntryChange::Restored(e) => e,
+                _ => continue,
+            };
+            if matches!(entry.data, LedgerEntryData::Ttl(_)) {
+                continue;
             }
-        };
+            let data_bytes = entry
+                .data
+                .to_xdr(stellar_xdr::Limits::none())
+                .unwrap_or_default();
+            let data_hash = format!("{:x}", Sha256::digest(&data_bytes));
+            parts.push(format!(
+                "{}:t{:?}:{}:{}",
+                phase,
+                std::mem::discriminant(&entry.data),
+                data_bytes.len(),
+                &data_hash[..16],
+            ));
+        }
+    };
     match meta {
         TransactionMeta::V3(m) => {
             walk(&m.tx_changes_before, &mut parts, "before");
@@ -250,8 +247,8 @@ pub(super) fn summarize_cdp_meta_changes(
 /// across a transaction's tx_apply_processing change groups. Mirrors the
 /// stellar-core write_bytes accounting (which excludes TTL entries) for
 /// side-by-side comparison with henyey's `total_write_bytes`.
-pub(super) fn summarize_cdp_meta(meta: Option<&stellar_xdr::curr::TransactionMeta>) -> (u32, u64) {
-    use stellar_xdr::curr::{LedgerEntryChange, LedgerEntryData, WriteXdr};
+pub(super) fn summarize_cdp_meta(meta: Option<&stellar_xdr::TransactionMeta>) -> (u32, u64) {
+    use stellar_xdr::{LedgerEntryChange, LedgerEntryData, WriteXdr};
     let Some(meta) = meta else {
         return (0, 0);
     };
@@ -268,7 +265,7 @@ pub(super) fn summarize_cdp_meta(meta: Option<&stellar_xdr::curr::TransactionMet
                 continue;
             }
             count += 1;
-            if let Ok(bytes) = entry.to_xdr(stellar_xdr::curr::Limits::none()) {
+            if let Ok(bytes) = entry.to_xdr(stellar_xdr::Limits::none()) {
                 total_bytes += bytes.len() as u64;
             }
         }
@@ -279,10 +276,8 @@ pub(super) fn summarize_cdp_meta(meta: Option<&stellar_xdr::curr::TransactionMet
 /// Returns a CSV summary of operation result discriminants for a transaction
 /// result, e.g. "InvokeHostFunction:Trapped". Used to diagnose tx-level
 /// success/fail divergence by exposing per-op outcomes.
-pub(super) fn describe_op_results(r: &stellar_xdr::curr::TransactionResultResult) -> String {
-    use stellar_xdr::curr::{
-        InnerTransactionResultResult, OperationResult, TransactionResultResult,
-    };
+pub(super) fn describe_op_results(r: &stellar_xdr::TransactionResultResult) -> String {
+    use stellar_xdr::{InnerTransactionResultResult, OperationResult, TransactionResultResult};
     fn one_op(op: &OperationResult) -> String {
         // Print the full Debug repr (without payload values) so that
         // success/failure variants of inner result types like
@@ -322,8 +317,8 @@ pub(super) fn describe_op_results(r: &stellar_xdr::curr::TransactionResultResult
 }
 
 /// Returns a human-readable name for a `TransactionResultResult` variant.
-pub(super) fn tx_result_code_name(r: &stellar_xdr::curr::TransactionResultResult) -> String {
-    use stellar_xdr::curr::TransactionResultResult;
+pub(super) fn tx_result_code_name(r: &stellar_xdr::TransactionResultResult) -> String {
+    use stellar_xdr::TransactionResultResult;
     match r {
         TransactionResultResult::TxSuccess(_) => "txSuccess".to_string(),
         TransactionResultResult::TxFailed(_) => "txFailed".to_string(),
@@ -335,16 +330,16 @@ pub(super) fn tx_result_code_name(r: &stellar_xdr::curr::TransactionResultResult
 
 /// Prints pairwise differences between two operation result slices.
 pub(super) fn print_op_diffs(
-    our_ops: &[stellar_xdr::curr::OperationResult],
-    cdp_ops: &[stellar_xdr::curr::OperationResult],
+    our_ops: &[stellar_xdr::OperationResult],
+    cdp_ops: &[stellar_xdr::OperationResult],
 ) {
-    use stellar_xdr::curr::WriteXdr;
+    use stellar_xdr::WriteXdr;
     for (j, (our_op, cdp_op)) in our_ops.iter().zip(cdp_ops.iter()).enumerate() {
         let our_op_xdr = our_op
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .unwrap_or_default();
         let cdp_op_xdr = cdp_op
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .unwrap_or_default();
         if our_op_xdr != cdp_op_xdr {
             println!("          Op {} differs:", j);
@@ -355,7 +350,7 @@ pub(super) fn print_op_diffs(
 }
 
 /// Prints all operations from a result slice with a label.
-pub(super) fn print_all_ops(label: &str, ops: &[stellar_xdr::curr::OperationResult]) {
+pub(super) fn print_all_ops(label: &str, ops: &[stellar_xdr::OperationResult]) {
     println!("        {} ops ({}):", label, ops.len());
     for (j, op) in ops.iter().enumerate() {
         println!("          Op {}: {:?}", j, op);
@@ -364,8 +359,8 @@ pub(super) fn print_all_ops(label: &str, ops: &[stellar_xdr::curr::OperationResu
 
 /// Prints an exhaustive field-by-field comparison of two ledger headers.
 pub(super) fn print_header_field_diffs(
-    h: &stellar_xdr::curr::LedgerHeader,
-    c: &stellar_xdr::curr::LedgerHeader,
+    h: &stellar_xdr::LedgerHeader,
+    c: &stellar_xdr::LedgerHeader,
     bucket_levels: &[(henyey_common::Hash256, henyey_common::Hash256)],
 ) {
     use henyey_common::Hash256;
@@ -499,10 +494,10 @@ pub(super) fn print_header_field_diffs(
 
 /// Compare fee bump inner results from both sides and print differences.
 pub(super) fn print_fee_bump_inner_diffs(
-    our_result: &stellar_xdr::curr::TransactionResultResult,
-    cdp_result: &stellar_xdr::curr::TransactionResultResult,
+    our_result: &stellar_xdr::TransactionResultResult,
+    cdp_result: &stellar_xdr::TransactionResultResult,
 ) {
-    use stellar_xdr::curr::{InnerTransactionResultResult, TransactionResultResult};
+    use stellar_xdr::{InnerTransactionResultResult, TransactionResultResult};
 
     match (our_result, cdp_result) {
         (
@@ -592,10 +587,10 @@ pub(super) fn print_fee_bump_inner_diffs(
 /// Shows ordering differences, then does a TX-by-TX XDR comparison with
 /// detailed operation-level diffs for all result variant combinations.
 pub(super) fn print_tx_result_diffs(
-    our_results: &[stellar_xdr::curr::TransactionResultPair],
-    cdp_results: &[stellar_xdr::curr::TransactionResultPair],
+    our_results: &[stellar_xdr::TransactionResultPair],
+    cdp_results: &[stellar_xdr::TransactionResultPair],
 ) {
-    use stellar_xdr::curr::{TransactionResultResult, WriteXdr};
+    use stellar_xdr::{TransactionResultResult, WriteXdr};
     println!(
         "    TX count: ours={} CDP={}",
         our_results.len(),
@@ -628,11 +623,11 @@ pub(super) fn print_tx_result_diffs(
     for (i, (our_tx, cdp_tx)) in our_results.iter().zip(cdp_results.iter()).enumerate() {
         let our_xdr = our_tx
             .result
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .unwrap_or_default();
         let cdp_xdr = cdp_tx
             .result
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .unwrap_or_default();
 
         if our_xdr != cdp_xdr {
@@ -729,25 +724,25 @@ pub(super) fn print_tx_result_diffs(
 /// Mapping preserved exactly: `Created→creates`; `Updated` and `Restored→updates`;
 /// `Removed→deletes`; `State` ignored. Callers accumulate (`+=`) the returned
 /// tuple — the counts fold across all change-groups and tx_metas.
-fn count_changes(changes: &[stellar_xdr::curr::LedgerEntryChange]) -> (u32, u32, u32) {
+fn count_changes(changes: &[stellar_xdr::LedgerEntryChange]) -> (u32, u32, u32) {
     let mut creates = 0u32;
     let mut updates = 0u32;
     let mut deletes = 0u32;
     for change in changes {
         match change {
-            stellar_xdr::curr::LedgerEntryChange::Created(_) => creates += 1,
-            stellar_xdr::curr::LedgerEntryChange::Updated(_) => updates += 1,
-            stellar_xdr::curr::LedgerEntryChange::Removed(_) => deletes += 1,
-            stellar_xdr::curr::LedgerEntryChange::Restored(_) => updates += 1,
-            stellar_xdr::curr::LedgerEntryChange::State(_) => {}
+            stellar_xdr::LedgerEntryChange::Created(_) => creates += 1,
+            stellar_xdr::LedgerEntryChange::Updated(_) => updates += 1,
+            stellar_xdr::LedgerEntryChange::Removed(_) => deletes += 1,
+            stellar_xdr::LedgerEntryChange::Restored(_) => updates += 1,
+            stellar_xdr::LedgerEntryChange::State(_) => {}
         }
     }
     (creates, updates, deletes)
 }
 
 pub(super) fn cdp_change_counts(
-    tx_metas: &[stellar_xdr::curr::TransactionMeta],
-    upgrade_metas: &[stellar_xdr::curr::UpgradeEntryMeta],
+    tx_metas: &[stellar_xdr::TransactionMeta],
+    upgrade_metas: &[stellar_xdr::UpgradeEntryMeta],
 ) -> (u32, u32, u32, u32, u32) {
     let mut cdp_creates = 0u32;
     let mut cdp_updates = 0u32;
@@ -768,8 +763,8 @@ pub(super) fn cdp_change_counts(
     for um in upgrade_metas {
         for change in um.changes.iter() {
             match change {
-                stellar_xdr::curr::LedgerEntryChange::Created(_) => upgrade_creates += 1,
-                stellar_xdr::curr::LedgerEntryChange::Updated(_) => upgrade_updates += 1,
+                stellar_xdr::LedgerEntryChange::Created(_) => upgrade_creates += 1,
+                stellar_xdr::LedgerEntryChange::Updated(_) => upgrade_updates += 1,
                 _ => {}
             }
         }
@@ -788,23 +783,23 @@ pub(super) fn cdp_change_counts(
 ///
 /// Verbatim move of the `if !cdp_upgrade_metas.is_empty()` block from
 /// `run::print_eviction_and_entry_diagnostics`.
-pub(super) fn print_cdp_upgrade_entries(upgrade_metas: &[stellar_xdr::curr::UpgradeEntryMeta]) {
+pub(super) fn print_cdp_upgrade_entries(upgrade_metas: &[stellar_xdr::UpgradeEntryMeta]) {
     if !upgrade_metas.is_empty() {
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
         println!("    CDP upgrade entries (expected):");
         for (ui, um) in upgrade_metas.iter().enumerate() {
             for change in um.changes.iter() {
                 match change {
-                    stellar_xdr::curr::LedgerEntryChange::Updated(entry) => {
+                    stellar_xdr::LedgerEntryChange::Updated(entry) => {
                         let key_str = match &entry.data {
-                            stellar_xdr::curr::LedgerEntryData::ConfigSetting(cs) => {
+                            stellar_xdr::LedgerEntryData::ConfigSetting(cs) => {
                                 format!("ConfigSetting({:?})", cs.discriminant())
                             }
                             other => format!("{:?}", std::mem::discriminant(other)),
                         };
                         let xdr_bytes = entry
-                            .to_xdr(stellar_xdr::curr::Limits::none())
+                            .to_xdr(stellar_xdr::Limits::none())
                             .unwrap_or_default();
                         let xdr_size = xdr_bytes.len();
                         let hash = {
@@ -816,15 +811,15 @@ pub(super) fn print_cdp_upgrade_entries(upgrade_metas: &[stellar_xdr::curr::Upgr
                         println!("      upgrade[{}] Updated: key={}, last_modified={}, xdr_size={}, xdr_hash={}",
                         ui, key_str, entry.last_modified_ledger_seq, xdr_size, hash);
                     }
-                    stellar_xdr::curr::LedgerEntryChange::Created(entry) => {
+                    stellar_xdr::LedgerEntryChange::Created(entry) => {
                         let key_str = match &entry.data {
-                            stellar_xdr::curr::LedgerEntryData::ConfigSetting(cs) => {
+                            stellar_xdr::LedgerEntryData::ConfigSetting(cs) => {
                                 format!("ConfigSetting({:?})", cs.discriminant())
                             }
                             other => format!("{:?}", std::mem::discriminant(other)),
                         };
                         let xdr_bytes = entry
-                            .to_xdr(stellar_xdr::curr::Limits::none())
+                            .to_xdr(stellar_xdr::Limits::none())
                             .unwrap_or_default();
                         let xdr_size = xdr_bytes.len();
                         let hash = {
@@ -836,9 +831,9 @@ pub(super) fn print_cdp_upgrade_entries(upgrade_metas: &[stellar_xdr::curr::Upgr
                         println!("      upgrade[{}] Created: key={}, last_modified={}, xdr_size={}, xdr_hash={}",
                         ui, key_str, entry.last_modified_ledger_seq, xdr_size, hash);
                     }
-                    stellar_xdr::curr::LedgerEntryChange::State(entry) => {
+                    stellar_xdr::LedgerEntryChange::State(entry) => {
                         let key_str = match &entry.data {
-                            stellar_xdr::curr::LedgerEntryData::ConfigSetting(cs) => {
+                            stellar_xdr::LedgerEntryData::ConfigSetting(cs) => {
                                 format!("ConfigSetting({:?})", cs.discriminant())
                             }
                             other => format!("{:?}", std::mem::discriminant(other)),
@@ -859,29 +854,29 @@ pub(super) fn print_cdp_upgrade_entries(upgrade_metas: &[stellar_xdr::curr::Upgr
 /// printing. Includes ALL change sources: `fee_processing`,
 /// `tx_apply_processing`, and `post_tx_apply_fee_processing` (V2 only).
 pub(super) fn coalesce_cdp_final_entries(
-    lcm: &stellar_xdr::curr::LedgerCloseMeta,
-) -> std::collections::HashMap<Vec<u8>, stellar_xdr::curr::LedgerEntry> {
-    use stellar_xdr::curr::WriteXdr;
+    lcm: &stellar_xdr::LedgerCloseMeta,
+) -> std::collections::HashMap<Vec<u8>, stellar_xdr::LedgerEntry> {
+    use stellar_xdr::WriteXdr;
     // Coalesce: keep last Updated entry per key
     // Include ALL change sources: fee_processing, tx_apply_processing, and post_tx_apply_fee_processing
-    let mut final_entries: std::collections::HashMap<Vec<u8>, stellar_xdr::curr::LedgerEntry> =
+    let mut final_entries: std::collections::HashMap<Vec<u8>, stellar_xdr::LedgerEntry> =
         std::collections::HashMap::new();
     // Helper to process a slice of changes into the coalesced map
     let coalesce_changes =
-        |changes: &[stellar_xdr::curr::LedgerEntryChange],
-         map: &mut std::collections::HashMap<Vec<u8>, stellar_xdr::curr::LedgerEntry>| {
+        |changes: &[stellar_xdr::LedgerEntryChange],
+         map: &mut std::collections::HashMap<Vec<u8>, stellar_xdr::LedgerEntry>| {
             for change in changes {
                 match change {
-                    stellar_xdr::curr::LedgerEntryChange::Updated(entry)
-                    | stellar_xdr::curr::LedgerEntryChange::Created(entry)
-                    | stellar_xdr::curr::LedgerEntryChange::Restored(entry) => {
+                    stellar_xdr::LedgerEntryChange::Updated(entry)
+                    | stellar_xdr::LedgerEntryChange::Created(entry)
+                    | stellar_xdr::LedgerEntryChange::Restored(entry) => {
                         let key = henyey_common::entry_to_key(entry);
-                        if let Ok(kb) = key.to_xdr(stellar_xdr::curr::Limits::none()) {
+                        if let Ok(kb) = key.to_xdr(stellar_xdr::Limits::none()) {
                             map.insert(kb, entry.clone());
                         }
                     }
-                    stellar_xdr::curr::LedgerEntryChange::Removed(key) => {
-                        if let Ok(kb) = key.to_xdr(stellar_xdr::curr::Limits::none()) {
+                    stellar_xdr::LedgerEntryChange::Removed(key) => {
+                        if let Ok(kb) = key.to_xdr(stellar_xdr::Limits::none()) {
                             map.remove(&kb);
                         }
                     }
@@ -890,29 +885,29 @@ pub(super) fn coalesce_cdp_final_entries(
             }
         };
     let coalesce_tx_meta =
-        |meta: &stellar_xdr::curr::TransactionMeta,
-         map: &mut std::collections::HashMap<Vec<u8>, stellar_xdr::curr::LedgerEntry>| {
+        |meta: &stellar_xdr::TransactionMeta,
+         map: &mut std::collections::HashMap<Vec<u8>, stellar_xdr::LedgerEntry>| {
             henyey_common::meta_walk::for_each_change_group(meta, |changes| {
                 coalesce_changes(changes, map);
             });
         };
     // Process ALL change sources from LCM tx_processing
     match &lcm {
-        stellar_xdr::curr::LedgerCloseMeta::V0(v0) => {
+        stellar_xdr::LedgerCloseMeta::V0(v0) => {
             for tp in v0.tx_processing.iter() {
                 coalesce_changes(&tp.fee_processing, &mut final_entries);
                 coalesce_tx_meta(&tp.tx_apply_processing, &mut final_entries);
                 // V0 TransactionResultMeta has no post_tx_apply_fee_processing
             }
         }
-        stellar_xdr::curr::LedgerCloseMeta::V1(v1) => {
+        stellar_xdr::LedgerCloseMeta::V1(v1) => {
             for tp in v1.tx_processing.iter() {
                 coalesce_changes(&tp.fee_processing, &mut final_entries);
                 coalesce_tx_meta(&tp.tx_apply_processing, &mut final_entries);
                 // V1 TransactionResultMeta has no post_tx_apply_fee_processing
             }
         }
-        stellar_xdr::curr::LedgerCloseMeta::V2(v2) => {
+        stellar_xdr::LedgerCloseMeta::V2(v2) => {
             for tp in v2.tx_processing.iter() {
                 coalesce_changes(&tp.fee_processing, &mut final_entries);
                 coalesce_tx_meta(&tp.tx_apply_processing, &mut final_entries);
@@ -924,15 +919,12 @@ pub(super) fn coalesce_cdp_final_entries(
 }
 
 /// Prints readable offer-entry diff details for a CDP/ours offer mismatch.
-fn print_offer_diff_detail(
-    cdp_o: &stellar_xdr::curr::OfferEntry,
-    our_o: &stellar_xdr::curr::OfferEntry,
-) {
+fn print_offer_diff_detail(cdp_o: &stellar_xdr::OfferEntry, our_o: &stellar_xdr::OfferEntry) {
     println!(
         "      CDP  offer: seller={:?} amount={} price={}/{}",
         hex::encode(
             &{
-                let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref pk) = cdp_o.seller_id.0;
+                let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref pk) = cdp_o.seller_id.0;
                 pk.0
             }[..8]
         ),
@@ -944,7 +936,7 @@ fn print_offer_diff_detail(
         "      Ours offer: seller={:?} amount={} price={}/{}",
         hex::encode(
             &{
-                let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref pk) = our_o.seller_id.0;
+                let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref pk) = our_o.seller_id.0;
                 pk.0
             }[..8]
         ),
@@ -955,21 +947,18 @@ fn print_offer_diff_detail(
 }
 
 /// Prints readable account-entry diff details for a CDP/ours account mismatch.
-fn print_account_diff_detail(
-    cdp_a: &stellar_xdr::curr::AccountEntry,
-    our_a: &stellar_xdr::curr::AccountEntry,
-) {
+fn print_account_diff_detail(cdp_a: &stellar_xdr::AccountEntry, our_a: &stellar_xdr::AccountEntry) {
     let cdp_pk = {
-        let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref pk) = cdp_a.account_id.0;
+        let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref pk) = cdp_a.account_id.0;
         hex::encode(&pk.0[..16])
     };
     // Extract sponsorship counts from extensions
-    let get_ext = |a: &stellar_xdr::curr::AccountEntry| -> (u32, u32, u32) {
+    let get_ext = |a: &stellar_xdr::AccountEntry| -> (u32, u32, u32) {
         match &a.ext {
-            stellar_xdr::curr::AccountEntryExt::V0 => (0, 0, 0),
-            stellar_xdr::curr::AccountEntryExt::V1(v1) => match &v1.ext {
-                stellar_xdr::curr::AccountEntryExtensionV1Ext::V0 => (0, 0, 0),
-                stellar_xdr::curr::AccountEntryExtensionV1Ext::V2(v2) => (
+            stellar_xdr::AccountEntryExt::V0 => (0, 0, 0),
+            stellar_xdr::AccountEntryExt::V1(v1) => match &v1.ext {
+                stellar_xdr::AccountEntryExtensionV1Ext::V0 => (0, 0, 0),
+                stellar_xdr::AccountEntryExtensionV1Ext::V2(v2) => (
                     v2.num_sponsoring,
                     v2.num_sponsored,
                     v2.signer_sponsoring_i_ds.len() as u32,
@@ -1011,8 +1000,8 @@ fn print_account_diff_detail(
 
 /// Prints readable trustline-entry diff details for a CDP/ours trustline mismatch.
 fn print_trustline_diff_detail(
-    cdp_t: &stellar_xdr::curr::TrustLineEntry,
-    our_t: &stellar_xdr::curr::TrustLineEntry,
+    cdp_t: &stellar_xdr::TrustLineEntry,
+    our_t: &stellar_xdr::TrustLineEntry,
 ) {
     println!(
         "      CDP  trustline: balance={} asset={:?}",
@@ -1026,13 +1015,11 @@ fn print_trustline_diff_detail(
 
 /// Prints readable liquidity-pool-entry diff details for a CDP/ours pool mismatch.
 fn print_pool_diff_detail(
-    cdp_p: &stellar_xdr::curr::LiquidityPoolEntry,
-    our_p: &stellar_xdr::curr::LiquidityPoolEntry,
+    cdp_p: &stellar_xdr::LiquidityPoolEntry,
+    our_p: &stellar_xdr::LiquidityPoolEntry,
 ) {
-    let stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(ref cdp_cp) =
-        cdp_p.body;
-    let stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(ref our_cp) =
-        our_p.body;
+    let stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(ref cdp_cp) = cdp_p.body;
+    let stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(ref our_cp) = our_p.body;
     println!(
         "      CDP  pool: reserve_a={} reserve_b={}",
         cdp_cp.reserve_a, cdp_cp.reserve_b
@@ -1045,14 +1032,14 @@ fn print_pool_diff_detail(
 
 /// Formats a short key description for a CDP entry that is truly missing from
 /// our state. Returns the string; the caller emits the `println!`.
-fn format_missing_entry_key(data: &stellar_xdr::curr::LedgerEntryData) -> String {
+fn format_missing_entry_key(data: &stellar_xdr::LedgerEntryData) -> String {
     match data {
-        stellar_xdr::curr::LedgerEntryData::Account(a) => {
-            let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref pk) = a.account_id.0;
+        stellar_xdr::LedgerEntryData::Account(a) => {
+            let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref pk) = a.account_id.0;
             format!("Account({})", hex::encode(&pk.0[..8]))
         }
-        stellar_xdr::curr::LedgerEntryData::Trustline(t) => {
-            let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref pk) = t.account_id.0;
+        stellar_xdr::LedgerEntryData::Trustline(t) => {
+            let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref pk) = t.account_id.0;
             format!(
                 "Trustline(acct={}, asset={:?}, balance={})",
                 hex::encode(&pk.0[..8]),
@@ -1060,9 +1047,8 @@ fn format_missing_entry_key(data: &stellar_xdr::curr::LedgerEntryData) -> String
                 t.balance
             )
         }
-        stellar_xdr::curr::LedgerEntryData::LiquidityPool(p) => {
-            let stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(ref cp) =
-                p.body;
+        stellar_xdr::LedgerEntryData::LiquidityPool(p) => {
+            let stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(ref cp) = p.body;
             format!("Pool(ra={}, rb={})", cp.reserve_a, cp.reserve_b)
         }
         other => format!("{:?}", std::mem::discriminant(other)),
@@ -1078,11 +1064,11 @@ fn format_missing_entry_key(data: &stellar_xdr::curr::LedgerEntryData) -> String
 /// and the `offer_store_lock()` `MutexGuard` scopes stay inside this helper.
 pub(super) fn print_cdp_entry_comparison(
     ctx: &super::VerifyContext,
-    result_header: &stellar_xdr::curr::LedgerHeader,
-    final_entries: &std::collections::HashMap<Vec<u8>, stellar_xdr::curr::LedgerEntry>,
+    result_header: &stellar_xdr::LedgerHeader,
+    final_entries: &std::collections::HashMap<Vec<u8>, stellar_xdr::LedgerEntry>,
 ) {
     use sha2::{Digest, Sha256};
-    use stellar_xdr::curr::WriteXdr;
+    use stellar_xdr::WriteXdr;
     // Compare CDP entries with our bucket list state
     let bl = ctx.ledger_manager.bucket_list();
     let bl_snapshot = henyey_bucket::BucketListSnapshot::new(&bl, result_header.clone());
@@ -1090,13 +1076,12 @@ pub(super) fn print_cdp_entry_comparison(
     let mut diffs = 0;
     let mut missing = 0;
     for (key_bytes, cdp_entry) in final_entries.iter() {
-        use stellar_xdr::curr::ReadXdr;
-        if let Ok(key) = stellar_xdr::curr::LedgerKey::from_xdr(
-            key_bytes.as_slice(),
-            stellar_xdr::curr::Limits::none(),
-        ) {
+        use stellar_xdr::ReadXdr;
+        if let Ok(key) =
+            stellar_xdr::LedgerKey::from_xdr(key_bytes.as_slice(), stellar_xdr::Limits::none())
+        {
             let cdp_xdr = cdp_entry
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap_or_default();
             let cdp_hash = {
                 let mut h = Sha256::new();
@@ -1106,7 +1091,7 @@ pub(super) fn print_cdp_entry_comparison(
             match bl_snapshot.get(&key) {
                 Some(our_entry) => {
                     let our_xdr = our_entry
-                        .to_xdr(stellar_xdr::curr::Limits::none())
+                        .to_xdr(stellar_xdr::Limits::none())
                         .unwrap_or_default();
                     let our_hash = {
                         let mut h = Sha256::new();
@@ -1135,29 +1120,29 @@ pub(super) fn print_cdp_entry_comparison(
                         );
                         // For offers, show readable details
                         if let (
-                            stellar_xdr::curr::LedgerEntryData::Offer(cdp_o),
-                            stellar_xdr::curr::LedgerEntryData::Offer(our_o),
+                            stellar_xdr::LedgerEntryData::Offer(cdp_o),
+                            stellar_xdr::LedgerEntryData::Offer(our_o),
                         ) = (&cdp_entry.data, &our_entry.data)
                         {
                             print_offer_diff_detail(cdp_o, our_o);
                         }
                         if let (
-                            stellar_xdr::curr::LedgerEntryData::Account(cdp_a),
-                            stellar_xdr::curr::LedgerEntryData::Account(our_a),
+                            stellar_xdr::LedgerEntryData::Account(cdp_a),
+                            stellar_xdr::LedgerEntryData::Account(our_a),
                         ) = (&cdp_entry.data, &our_entry.data)
                         {
                             print_account_diff_detail(cdp_a, our_a);
                         }
                         if let (
-                            stellar_xdr::curr::LedgerEntryData::Trustline(cdp_t),
-                            stellar_xdr::curr::LedgerEntryData::Trustline(our_t),
+                            stellar_xdr::LedgerEntryData::Trustline(cdp_t),
+                            stellar_xdr::LedgerEntryData::Trustline(our_t),
                         ) = (&cdp_entry.data, &our_entry.data)
                         {
                             print_trustline_diff_detail(cdp_t, our_t);
                         }
                         if let (
-                            stellar_xdr::curr::LedgerEntryData::LiquidityPool(cdp_p),
-                            stellar_xdr::curr::LedgerEntryData::LiquidityPool(our_p),
+                            stellar_xdr::LedgerEntryData::LiquidityPool(cdp_p),
+                            stellar_xdr::LedgerEntryData::LiquidityPool(our_p),
                         ) = (&cdp_entry.data, &our_entry.data)
                         {
                             print_pool_diff_detail(cdp_p, our_p);
@@ -1170,15 +1155,14 @@ pub(super) fn print_cdp_entry_comparison(
                 None => {
                     // For offers, try the offer_store instead of bucket list snapshot
                     // (offers are not indexed in bucket list snapshot)
-                    if let stellar_xdr::curr::LedgerEntryData::Offer(ref cdp_offer) = cdp_entry.data
-                    {
+                    if let stellar_xdr::LedgerEntryData::Offer(ref cdp_offer) = cdp_entry.data {
                         let offer_store = ctx.ledger_manager.offer_store_lock();
                         if let Some(our_entry) = offer_store
                             .get_ledger_entry_by_id(cdp_offer.offer_id)
                             .as_ref()
                         {
                             let our_xdr = our_entry
-                                .to_xdr(stellar_xdr::curr::Limits::none())
+                                .to_xdr(stellar_xdr::Limits::none())
                                 .unwrap_or_default();
                             let our_hash = {
                                 let mut h = Sha256::new();
@@ -1187,13 +1171,12 @@ pub(super) fn print_cdp_entry_comparison(
                             };
                             if our_hash != cdp_hash {
                                 diffs += 1;
-                                if let stellar_xdr::curr::LedgerEntryData::Offer(ref our_offer) =
+                                if let stellar_xdr::LedgerEntryData::Offer(ref our_offer) =
                                     our_entry.data
                                 {
                                     let cdp_seller = {
-                                        let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                                            ref pk,
-                                        ) = cdp_offer.seller_id.0;
+                                        let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref pk) =
+                                            cdp_offer.seller_id.0;
                                         hex::encode(&pk.0[..8])
                                     };
                                     println!(
@@ -1221,7 +1204,7 @@ pub(super) fn print_cdp_entry_comparison(
                             // Offer is truly missing from our state
                             missing += 1;
                             let cdp_seller = {
-                                let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref pk) =
+                                let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref pk) =
                                     cdp_offer.seller_id.0;
                                 hex::encode(&pk.0)
                             };
@@ -1257,7 +1240,7 @@ pub(super) fn print_cdp_entry_comparison(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, ExtensionPoint, GeneralizedTransactionSet, Hash,
         LedgerCloseMeta, LedgerCloseMetaExt, LedgerCloseMetaV2, LedgerEntry, LedgerEntryChange,
         LedgerEntryData, LedgerEntryExt, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntry,
@@ -1411,7 +1394,7 @@ mod tests {
 
     fn entry_key_bytes(entry: &LedgerEntry) -> Vec<u8> {
         henyey_common::entry_to_key(entry)
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .unwrap()
     }
 

--- a/crates/henyey/src/verify_execution/run.rs
+++ b/crates/henyey/src/verify_execution/run.rs
@@ -194,7 +194,7 @@ async fn verify_single_ledger(
     ctx: &mut VerifyContext,
     stats: &mut VerifyStats,
     prev_ledger_hash: &mut Hash256,
-    header_entry: &stellar_xdr::curr::LedgerHeaderHistoryEntry,
+    header_entry: &stellar_xdr::LedgerHeaderHistoryEntry,
 ) -> anyhow::Result<()> {
     let header = &header_entry.header;
     let seq = header.ledger_seq;
@@ -335,8 +335,8 @@ fn log_close_ledger_failure_diag(
     ctx: &VerifyContext,
     seq: u32,
     verified_header_hash: Hash256,
-    cdp_header: &stellar_xdr::curr::LedgerHeader,
-    lcm: &stellar_xdr::curr::LedgerCloseMeta,
+    cdp_header: &stellar_xdr::LedgerHeader,
+    lcm: &stellar_xdr::LedgerCloseMeta,
 ) {
     tracing::warn!(
         target: "hash_mismatch_debug",
@@ -361,7 +361,7 @@ fn log_close_ledger_failure_diag(
     // CRITICAL: cdp envelopes (from tx_set, canonical order) and
     // tx_processing (apply order) are NOT aligned by index. We MUST
     // align by tx hash via extract_transaction_processing.
-    let network_id = stellar_xdr::curr::Hash(*ctx.ledger_manager.network_id().0.as_bytes());
+    let network_id = stellar_xdr::Hash(*ctx.ledger_manager.network_id().0.as_bytes());
     let cdp_processing = henyey_history::cdp::extract_transaction_processing(lcm, &network_id);
     for (i, info) in cdp_processing.iter().enumerate() {
         let (op_types, declared_fee, soroban_resource_fee, soroban_resources) =
@@ -400,17 +400,17 @@ fn log_close_ledger_failure_diag(
 fn print_mismatch_details(
     ctx: &VerifyContext,
     seq: u32,
-    our_header: &stellar_xdr::curr::LedgerHeader,
+    our_header: &stellar_xdr::LedgerHeader,
     our_header_hash: Hash256,
     expected_header_hash: Hash256,
     our_tx_result_hash: Hash256,
     expected_tx_result_hash: Hash256,
     header_matches: bool,
     tx_result_matches: bool,
-    our_tx_results: &[stellar_xdr::curr::TransactionResultPair],
-    cdp_tx_results: &[stellar_xdr::curr::TransactionResultPair],
-    cdp_header: &stellar_xdr::curr::LedgerHeader,
-    lcm: &stellar_xdr::curr::LedgerCloseMeta,
+    our_tx_results: &[stellar_xdr::TransactionResultPair],
+    cdp_tx_results: &[stellar_xdr::TransactionResultPair],
+    cdp_header: &stellar_xdr::LedgerHeader,
+    lcm: &stellar_xdr::LedgerCloseMeta,
 ) {
     println!();
     println!("  Ledger {}: MISMATCH", seq);
@@ -591,8 +591,8 @@ pub(super) fn print_summary(stats: &mut VerifyStats, elapsed: Duration) {
 /// the divergence is likely in bucket list state (eviction, upgrades, etc.).
 fn print_eviction_and_entry_diagnostics(
     ctx: &VerifyContext,
-    lcm: &stellar_xdr::curr::LedgerCloseMeta,
-    result_header: &stellar_xdr::curr::LedgerHeader,
+    lcm: &stellar_xdr::LedgerCloseMeta,
+    result_header: &stellar_xdr::LedgerHeader,
 ) {
     let cdp_evicted_keys = henyey_history::cdp::extract_evicted_keys(lcm);
     let tx_metas = henyey_history::cdp::extract_transaction_metas(lcm);

--- a/crates/herder/src/dead_node_tracker.rs
+++ b/crates/herder/src/dead_node_tracker.rs
@@ -41,7 +41,7 @@
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
-use stellar_xdr::curr::NodeId;
+use stellar_xdr::NodeId;
 
 /// Interval for checking dead nodes (15 minutes, matching stellar-core).
 pub const CHECK_FOR_DEAD_NODES_MINUTES: u64 = 15;
@@ -201,14 +201,12 @@ impl DeadNodeTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::PublicKey;
+    use stellar_xdr::PublicKey;
 
     fn make_node_id(n: u8) -> NodeId {
         let mut bytes = [0u8; 32];
         bytes[0] = n;
-        NodeId(PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-            bytes,
-        )))
+        NodeId(PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)))
     }
 
     #[test]

--- a/crates/herder/src/externalize_lag.rs
+++ b/crates/herder/src/externalize_lag.rs
@@ -24,7 +24,7 @@ use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use henyey_scp::SlotIndex;
-use stellar_xdr::curr::{NodeId, ScpQuorumSet};
+use stellar_xdr::{NodeId, ScpQuorumSet};
 
 /// Maximum number of lag samples retained per node.
 const MAX_LAG_SAMPLES: usize = 128;
@@ -201,10 +201,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::PublicKey;
+    use stellar_xdr::PublicKey;
 
     fn make_node(byte: u8) -> NodeId {
-        NodeId(PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
+        NodeId(PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(
             [byte; 32],
         )))
     }

--- a/crates/herder/src/fetching_envelopes.rs
+++ b/crates/herder/src/fetching_envelopes.rs
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use stellar_xdr::curr::{Hash, Limits, ReadXdr, ScpEnvelope, ScpQuorumSet};
+use stellar_xdr::{Hash, Limits, ReadXdr, ScpEnvelope, ScpQuorumSet};
 use tracing::{debug, trace};
 
 /// Callback type for requesting items from peers.
@@ -1088,7 +1088,7 @@ impl FetchingEnvelopes {
     /// Parity: stellar-core rejects envelopes containing non-signed StellarValues
     /// in both nomination (votes/accepted) and ballot statements.
     fn check_stellar_value_signed(envelope: &ScpEnvelope) -> bool {
-        use stellar_xdr::curr::{ScpStatementPledges, StellarValue, StellarValueExt};
+        use stellar_xdr::{ScpStatementPledges, StellarValue, StellarValueExt};
 
         let values: Vec<&[u8]> = match &envelope.statement.pledges {
             ScpStatementPledges::Nominate(nom) => {
@@ -1136,7 +1136,7 @@ impl FetchingEnvelopes {
     /// from ALL statement types including NOMINATE (votes + accepted). Previously
     /// NOMINATE returned None, bypassing tx_set fetch gating (#1117).
     fn extract_tx_set_hashes(envelope: &ScpEnvelope) -> Vec<Hash256> {
-        use stellar_xdr::curr::StellarValue;
+        use stellar_xdr::StellarValue;
 
         henyey_scp::Slot::get_statement_values(&envelope.statement)
             .into_iter()
@@ -1147,7 +1147,7 @@ impl FetchingEnvelopes {
 
     /// Extract QuorumSet hash from an envelope.
     fn extract_quorum_set_hash(envelope: &ScpEnvelope) -> Option<Hash256> {
-        use stellar_xdr::curr::ScpStatementPledges;
+        use stellar_xdr::ScpStatementPledges;
 
         let hash = match &envelope.statement.pledges {
             ScpStatementPledges::Nominate(nom) => Some(&nom.quorum_set_hash),
@@ -1168,7 +1168,7 @@ impl FetchingEnvelopes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         NodeId as XdrNodeId, PublicKey, ScpNomination, ScpStatement, ScpStatementPledges,
         Signature, Uint256, Value, WriteXdr,
     };
@@ -1480,7 +1480,7 @@ mod tests {
     // =========================================================================
 
     fn make_basic_stellar_value() -> Vec<u8> {
-        use stellar_xdr::curr::{StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr};
+        use stellar_xdr::{StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr};
         let sv = StellarValue {
             tx_set_hash: Hash([0u8; 32]),
             close_time: TimePoint(12345),
@@ -1491,7 +1491,7 @@ mod tests {
     }
 
     fn make_signed_stellar_value_bytes() -> Vec<u8> {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             LedgerCloseValueSignature, StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr,
         };
         let sv = StellarValue {
@@ -1500,14 +1500,14 @@ mod tests {
             upgrades: VecM::default(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id: XdrNodeId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]))),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }),
         };
         sv.to_xdr(Limits::none()).unwrap()
     }
 
     fn make_envelope_with_nomination_values(slot: SlotIndex, values: Vec<Vec<u8>>) -> ScpEnvelope {
-        use stellar_xdr::curr::Value;
+        use stellar_xdr::Value;
         let node_id = XdrNodeId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
         let votes: Vec<Value> = values
             .into_iter()
@@ -1720,32 +1720,28 @@ mod tests {
     /// different StellarValues that also need the STELLAR_VALUE_SIGNED check.
     #[test]
     fn test_audit_xh3_prepare_validates_prepared_and_prepared_prime() {
-        use stellar_xdr::curr::{
-            ScpBallot, ScpStatementPrepare, StellarValue, StellarValueExt, Value,
-        };
+        use stellar_xdr::{ScpBallot, ScpStatementPrepare, StellarValue, StellarValueExt, Value};
 
         // Create a signed StellarValue for the main ballot
         let signed_sv = StellarValue {
             tx_set_hash: Hash([1u8; 32]),
-            close_time: stellar_xdr::curr::TimePoint(1000),
+            close_time: stellar_xdr::TimePoint(1000),
             upgrades: vec![].try_into().unwrap(),
-            ext: StellarValueExt::Signed(stellar_xdr::curr::LedgerCloseValueSignature {
+            ext: StellarValueExt::Signed(stellar_xdr::LedgerCloseValueSignature {
                 node_id: XdrNodeId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]))),
                 signature: Signature(vec![0u8; 64].try_into().unwrap()),
             }),
         };
-        let signed_bytes = signed_sv.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+        let signed_bytes = signed_sv.to_xdr(stellar_xdr::Limits::none()).unwrap();
 
         // Create an unsigned (Basic) StellarValue for the prepared ballot
         let unsigned_sv = StellarValue {
             tx_set_hash: Hash([2u8; 32]),
-            close_time: stellar_xdr::curr::TimePoint(999),
+            close_time: stellar_xdr::TimePoint(999),
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Basic,
         };
-        let unsigned_bytes = unsigned_sv
-            .to_xdr(stellar_xdr::curr::Limits::none())
-            .unwrap();
+        let unsigned_bytes = unsigned_sv.to_xdr(stellar_xdr::Limits::none()).unwrap();
 
         let node_id = XdrNodeId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
 
@@ -1781,7 +1777,7 @@ mod tests {
 
     /// Helper to create a signed StellarValue for test envelopes.
     fn make_test_stellar_value(tx_set_hash: [u8; 32]) -> Value {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             LedgerCloseValueSignature, StellarValue, StellarValueExt, TimePoint, WriteXdr,
         };
 
@@ -1874,7 +1870,7 @@ mod tests {
 
     /// Build a signed StellarValue referencing a specific tx_set_hash.
     fn make_signed_stellar_value_with_hash(tx_set_hash: Hash256) -> Vec<u8> {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             LedgerCloseValueSignature, StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr,
         };
         let sv = StellarValue {
@@ -1883,7 +1879,7 @@ mod tests {
             upgrades: VecM::default(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id: XdrNodeId(PublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]))),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }),
         };
         sv.to_xdr(Limits::none()).unwrap()

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -56,7 +56,7 @@ use henyey_common::{Hash256, NetworkId};
 use henyey_crypto::{PublicKey, SecretKey};
 use henyey_ledger::LedgerManager;
 use henyey_scp::{SlotIndex, SCP};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     EnvelopeType, LedgerCloseValueSignature, LedgerHeader, LedgerUpgrade, Limits, NodeId, ReadXdr,
     ScpEnvelope, ScpQuorumSet, ScpStatementPledges, Signature as XdrSignature, StellarValue,
     StellarValueExt, TimePoint, TransactionEnvelope, Uint256, UpgradeType, Value, WriteXdr,
@@ -354,7 +354,7 @@ pub struct HerderConfig {
     pub max_tx_set_size: usize,
 
     /// Protocol upgrades this validator proposes to include in nominations.
-    pub proposed_upgrades: Vec<stellar_xdr::curr::LedgerUpgrade>,
+    pub proposed_upgrades: Vec<stellar_xdr::LedgerUpgrade>,
 
     /// Maximum supported protocol version for upgrade validation.
     pub max_protocol_version: u32,
@@ -701,9 +701,9 @@ impl Herder {
             );
             for v in quorum_set.validators.iter() {
                 let key_hex = match &v.0 {
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                        stellar_xdr::curr::Uint256(bytes),
-                    ) => hex::encode(bytes),
+                    stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => {
+                        hex::encode(bytes)
+                    }
                 };
                 info!(validator = %key_hex, "Quorum set validator");
             }
@@ -839,15 +839,13 @@ impl Herder {
                     }
                     let _guard = Guard(&manager_for_thread);
 
-                    use stellar_xdr::curr::{Limits, WriteXdr};
+                    use stellar_xdr::{Limits, WriteXdr};
 
                     let envelopes = scp.get_latest_messages_send(slot);
 
-                    let mut tx_sets: Vec<(stellar_xdr::curr::Hash, Vec<u8>)> = Vec::new();
-                    let mut quorum_sets: Vec<(
-                        stellar_xdr::curr::Hash,
-                        stellar_xdr::curr::ScpQuorumSet,
-                    )> = Vec::new();
+                    let mut tx_sets: Vec<(stellar_xdr::Hash, Vec<u8>)> = Vec::new();
+                    let mut quorum_sets: Vec<(stellar_xdr::Hash, stellar_xdr::ScpQuorumSet)> =
+                        Vec::new();
 
                     for envelope in &envelopes {
                         for hash in crate::persistence::get_tx_set_hashes(envelope) {
@@ -1022,7 +1020,7 @@ impl Herder {
     pub fn test_inject_externalizing_envelope(
         &self,
         slot: u64,
-        envelope: stellar_xdr::curr::ScpEnvelope,
+        envelope: stellar_xdr::ScpEnvelope,
     ) {
         self.scp.test_inject_externalizing_envelope(slot, envelope);
     }
@@ -1034,8 +1032,8 @@ impl Herder {
     #[doc(hidden)]
     pub fn test_store_quorum_set(
         &self,
-        node_id: &stellar_xdr::curr::NodeId,
-        qset: stellar_xdr::curr::ScpQuorumSet,
+        node_id: &stellar_xdr::NodeId,
+        qset: stellar_xdr::ScpQuorumSet,
     ) {
         self.scp_driver.test_store_quorum_set(node_id, qset);
     }
@@ -1363,10 +1361,10 @@ impl Herder {
     }
 
     /// Return the set of node IDs from the local quorum set (if configured).
-    pub fn local_quorum_nodes(&self) -> std::collections::HashSet<stellar_xdr::curr::NodeId> {
+    pub fn local_quorum_nodes(&self) -> std::collections::HashSet<stellar_xdr::NodeId> {
         fn collect_nodes(
-            quorum_set: &stellar_xdr::curr::ScpQuorumSet,
-            acc: &mut std::collections::HashSet<stellar_xdr::curr::NodeId>,
+            quorum_set: &stellar_xdr::ScpQuorumSet,
+            acc: &mut std::collections::HashSet<stellar_xdr::NodeId>,
         ) {
             for validator in quorum_set.validators.iter() {
                 acc.insert(validator.clone());
@@ -1767,7 +1765,7 @@ impl Herder {
 
         // Check all values in the envelope based on statement type
         // Returns true if ANY value passes (conservative / permissive)
-        use stellar_xdr::curr::ScpStatementPledges;
+        use stellar_xdr::ScpStatementPledges;
         match &envelope.statement.pledges {
             ScpStatementPledges::Nominate(nom) => {
                 nom.accepted.iter().any(|v| check_value(v))
@@ -2111,8 +2109,7 @@ impl Herder {
         // validated helper so malformed EXTERNALIZE values cannot trigger
         // fetch side effects.
         let lcl = self.ledger_manager.current_ledger_seq() as u64;
-        if let stellar_xdr::curr::ScpStatementPledges::Externalize(_) = &envelope.statement.pledges
-        {
+        if let stellar_xdr::ScpStatementPledges::Externalize(_) = &envelope.statement.pledges {
             if let Ok(hashes) = crate::herder_utils::get_validated_tx_set_hashes(&envelope) {
                 for tx_set_hash in hashes {
                     if slot > lcl {
@@ -2194,7 +2191,7 @@ impl Herder {
         let slot = envelope.statement.slot_index;
         let is_externalize = matches!(
             envelope.statement.pledges,
-            stellar_xdr::curr::ScpStatementPledges::Externalize(_)
+            stellar_xdr::ScpStatementPledges::Externalize(_)
         );
 
         debug!(
@@ -3169,8 +3166,8 @@ impl Herder {
             max_tx_set_size: parts.header.max_tx_set_size,
             base_reserve: parts.header.base_reserve,
             flags: match &parts.header.ext {
-                stellar_xdr::curr::LedgerHeaderExt::V0 => 0,
-                stellar_xdr::curr::LedgerHeaderExt::V1(ext) => ext.flags,
+                stellar_xdr::LedgerHeaderExt::V0 => 0,
+                stellar_xdr::LedgerHeaderExt::V1(ext) => ext.flags,
             },
             max_soroban_tx_set_size: parts.max_soroban_tx_set_size,
         };
@@ -3458,8 +3455,8 @@ impl Herder {
             // build path uses the same ledger state as self-validation (#2319).
             let network_id = NetworkId(self.scp_driver.network_id());
             let ledger_flags = match &header.ext {
-                stellar_xdr::curr::LedgerHeaderExt::V0 => 0u32,
-                stellar_xdr::curr::LedgerHeaderExt::V1(v1) => v1.flags,
+                stellar_xdr::LedgerHeaderExt::V0 => 0u32,
+                stellar_xdr::LedgerHeaderExt::V1(v1) => v1.flags,
             };
             let mut validation_ctx = crate::tx_set_utils::TxSetValidationContext::new(
                 header.ledger_seq,
@@ -3686,7 +3683,7 @@ impl Herder {
         close_time: u64,
         upgrades: Vec<UpgradeType>,
     ) -> std::result::Result<StellarValue, HerderError> {
-        let xdr_tx_set_hash = stellar_xdr::curr::Hash(tx_set_hash.0);
+        let xdr_tx_set_hash = stellar_xdr::Hash(tx_set_hash.0);
         let xdr_close_time = TimePoint(close_time);
         let secret_key = self
             .secret_key
@@ -3705,7 +3702,7 @@ impl Herder {
         sign_data.extend_from_slice(&encode_xdr(&xdr_tx_set_hash, "tx set hash")?);
         sign_data.extend_from_slice(&encode_xdr(&xdr_close_time, "close time")?);
         let sig = secret_key.sign(&sign_data);
-        let node_id = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+        let node_id = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
             *secret_key.public_key().as_bytes(),
         )));
 
@@ -3762,7 +3759,7 @@ impl Herder {
     /// queue.
     ///
     /// Matches stellar-core `Herder::sourceAccountPending(AccountID const&)`.
-    pub fn source_account_pending(&self, account_id: &stellar_xdr::curr::AccountId) -> bool {
+    pub fn source_account_pending(&self, account_id: &stellar_xdr::AccountId) -> bool {
         let key = account_key_from_account_id(account_id);
         self.tx_queue
             .pending_accounts()
@@ -4701,7 +4698,7 @@ mod tests {
     use crate::tx_queue::TransactionSet;
     use henyey_crypto::SecretKey;
     use henyey_scp::hash_quorum_set;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         EnvelopeType, LedgerCloseValueSignature, LedgerUpgrade, Limits, NodeId as XdrNodeId,
         ReadXdr, ScpBallot, ScpNomination, ScpStatement, ScpStatementExternalize,
         ScpStatementPledges, ScpStatementPrepare, Signature as XdrSignature, StellarValue,
@@ -4753,7 +4750,7 @@ mod tests {
         let tx_set_hash = *tx_set.hash();
         herder.scp_driver.cache_tx_set(tx_set);
 
-        let xdr_tx_set_hash = stellar_xdr::curr::Hash(tx_set_hash.0);
+        let xdr_tx_set_hash = stellar_xdr::Hash(tx_set_hash.0);
         let close_time = TimePoint(1);
 
         // Sign: (networkID, ENVELOPE_TYPE_SCPVALUE, txSetHash, closeTime)
@@ -4764,8 +4761,8 @@ mod tests {
         sign_data.extend_from_slice(&close_time.to_xdr(Limits::none()).expect("xdr"));
         let sig = secret_key.sign(&sign_data);
 
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*secret_key.public_key().as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*secret_key.public_key().as_bytes()),
         ));
 
         let stellar_value = StellarValue {
@@ -4774,9 +4771,7 @@ mod tests {
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id,
-                signature: stellar_xdr::curr::Signature(
-                    sig.0.to_vec().try_into().unwrap_or_default(),
-                ),
+                signature: stellar_xdr::Signature(sig.0.to_vec().try_into().unwrap_or_default()),
             }),
         };
         let value_bytes = stellar_value.to_xdr(Limits::none()).unwrap();
@@ -4808,8 +4803,8 @@ mod tests {
         let secret = SecretKey::from_seed(&[1u8; 32]);
         let public = secret.public_key();
 
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*public.as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
         ));
 
         // Include a vote with a valid close time so the envelope passes
@@ -4824,7 +4819,7 @@ mod tests {
             node_id: node_id.clone(),
             slot_index: slot,
             pledges: ScpStatementPledges::Nominate(ScpNomination {
-                quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 votes: vec![vote].try_into().unwrap(),
                 accepted: vec![].try_into().unwrap(),
             }),
@@ -4847,8 +4842,8 @@ mod tests {
     }
 
     fn make_test_envelope(slot: u64) -> ScpEnvelope {
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([0u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([0u8; 32]),
         ));
 
         ScpEnvelope {
@@ -4856,7 +4851,7 @@ mod tests {
                 node_id,
                 slot_index: slot,
                 pledges: ScpStatementPledges::Nominate(ScpNomination {
-                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                     votes: vec![].try_into().unwrap(),
                     accepted: vec![].try_into().unwrap(),
                 }),
@@ -5279,12 +5274,12 @@ mod tests {
     }
 
     fn make_minimal_tx_envelope() -> TransactionEnvelope {
-        use stellar_xdr::curr::{Memo, TransactionV0, TransactionV0Envelope, TransactionV0Ext};
+        use stellar_xdr::{Memo, TransactionV0, TransactionV0Envelope, TransactionV0Ext};
         TransactionEnvelope::TxV0(TransactionV0Envelope {
             tx: TransactionV0 {
-                source_account_ed25519: stellar_xdr::curr::Uint256([0u8; 32]),
+                source_account_ed25519: stellar_xdr::Uint256([0u8; 32]),
                 fee: 100,
-                seq_num: stellar_xdr::curr::SequenceNumber(1),
+                seq_num: stellar_xdr::SequenceNumber(1),
                 time_bounds: None,
                 memo: Memo::None,
                 operations: vec![].try_into().unwrap(),
@@ -5318,7 +5313,7 @@ mod tests {
     /// must return TryAgainLater (stellar-core HerderImpl.cpp:627-645).
     #[test]
     fn test_receive_transaction_cross_type_conflict_returns_try_again_later() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             CreateAccountOp, DecoratedSignature, HostFunction, InvokeContractArgs,
             InvokeHostFunctionOp, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
             PublicKey, ScAddress, ScSymbol, SequenceNumber, SignatureHint, StringM, Transaction,
@@ -5339,9 +5334,9 @@ mod tests {
             operations: vec![Operation {
                 source_account: None,
                 body: OperationBody::CreateAccount(CreateAccountOp {
-                    destination: stellar_xdr::curr::AccountId(PublicKey::PublicKeyTypeEd25519(
-                        Uint256([255u8; 32]),
-                    )),
+                    destination: stellar_xdr::AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+                        [255u8; 32],
+                    ))),
                     starting_balance: 1000000000,
                 }),
             }]
@@ -5368,7 +5363,7 @@ mod tests {
         let host_function = HostFunction::InvokeContract(InvokeContractArgs {
             contract_address: ScAddress::default(),
             function_name,
-            args: VecM::<stellar_xdr::curr::ScVal>::default(),
+            args: VecM::<stellar_xdr::ScVal>::default(),
         });
         let soroban_tx = Transaction {
             source_account: MuxedAccount::Ed25519(Uint256([42u8; 32])),
@@ -5530,12 +5525,12 @@ mod tests {
     /// Create a StellarValue with a given close time and encode to Value.
     fn make_value_with_close_time(close_time: u64) -> Value {
         let sv = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            tx_set_hash: stellar_xdr::Hash([0u8; 32]),
             close_time: TimePoint(close_time),
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
-                node_id: XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                    stellar_xdr::curr::Uint256([0u8; 32]),
+                node_id: XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0u8; 32]),
                 )),
                 signature: XdrSignature(vec![0u8; 64].try_into().unwrap()),
             }),
@@ -5545,8 +5540,8 @@ mod tests {
 
     /// Create a nomination envelope with a specific close time in its voted values.
     fn make_nomination_envelope_with_close_time(slot: u64, close_time: u64) -> ScpEnvelope {
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
         let value = make_value_with_close_time(close_time);
 
@@ -5555,7 +5550,7 @@ mod tests {
                 node_id,
                 slot_index: slot,
                 pledges: ScpStatementPledges::Nominate(ScpNomination {
-                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                     votes: vec![value].try_into().unwrap(),
                     accepted: vec![].try_into().unwrap(),
                 }),
@@ -6002,10 +5997,10 @@ mod tests {
         let config = HerderConfig {
             is_validator: true,
             node_public_key: public,
-            local_quorum_set: Some(stellar_xdr::curr::ScpQuorumSet {
+            local_quorum_set: Some(stellar_xdr::ScpQuorumSet {
                 threshold: 1,
-                validators: vec![stellar_xdr::curr::NodeId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
+                validators: vec![stellar_xdr::NodeId(
+                    stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(
                         *public.as_bytes(),
                     )),
                 )]
@@ -6106,18 +6101,15 @@ mod tests {
         let seed = [7u8; 32];
         let secret = SecretKey::from_seed(&seed);
         let public = secret.public_key();
-        let local_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*public.as_bytes()),
-            ));
-        let fake_peer1 =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256([1u8; 32]),
-            ));
-        let fake_peer2 =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256([2u8; 32]),
-            ));
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
+        let fake_peer1 = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
+        ));
+        let fake_peer2 = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([2u8; 32]),
+        ));
 
         let quorum_set = ScpQuorumSet {
             threshold: 2,
@@ -6194,7 +6186,7 @@ mod tests {
     /// without a cross-module visibility change.
     fn make_lm_at_seq_for_stale_test(ledger_seq: u32) -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -6257,10 +6249,9 @@ mod tests {
         let seed = [42u8; 32];
         let secret = SecretKey::from_seed(&seed);
         let public = secret.public_key();
-        let local_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*public.as_bytes()),
-            ));
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
             validators: vec![local_node_id].try_into().unwrap(),
@@ -6498,7 +6489,7 @@ mod tests {
         // With lcl_close_time = u64::MAX - 100, close_time = u64::MAX - 99,
         // which is always > now + MAX_TIME_SLIP_SECONDS → gate rejects.
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let lm_config = LedgerManagerConfig {
@@ -6593,10 +6584,9 @@ mod tests {
         let seed = [43u8; 32];
         let secret = SecretKey::from_seed(&seed);
         let public = secret.public_key();
-        let local_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*public.as_bytes()),
-            ));
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
             validators: vec![local_node_id].try_into().unwrap(),
@@ -6638,7 +6628,7 @@ mod tests {
         close_time: u64,
     ) -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -6692,10 +6682,9 @@ mod tests {
         let seed = [50u8; 32];
         let secret = SecretKey::from_seed(&seed);
         let public = secret.public_key();
-        let local_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*public.as_bytes()),
-            ));
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
             validators: vec![local_node_id].try_into().unwrap(),
@@ -6747,10 +6736,9 @@ mod tests {
         let seed = [51u8; 32];
         let secret = SecretKey::from_seed(&seed);
         let public = secret.public_key();
-        let local_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*public.as_bytes()),
-            ));
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
             validators: vec![local_node_id].try_into().unwrap(),
@@ -6937,10 +6925,9 @@ mod tests {
         let seed = [70u8; 32];
         let secret = SecretKey::from_seed(&seed);
         let public = secret.public_key();
-        let local_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*public.as_bytes()),
-            ));
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
             validators: vec![local_node_id].try_into().unwrap(),
@@ -7040,10 +7027,9 @@ mod tests {
         let seed = [44u8; 32];
         let secret = SecretKey::from_seed(&seed);
         let public = secret.public_key();
-        let local_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*public.as_bytes()),
-            ));
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
             validators: vec![local_node_id].try_into().unwrap(),
@@ -7148,8 +7134,8 @@ mod tests {
     /// with a properly signed StellarValue (STELLAR_VALUE_SIGNED).
     fn make_signed_externalize_from(slot: u64, herder: &Herder, secret: &SecretKey) -> ScpEnvelope {
         let public = secret.public_key();
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*public.as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
         ));
 
         // Use the value helper that caches the tx set and signs properly
@@ -7161,7 +7147,7 @@ mod tests {
             pledges: ScpStatementPledges::Externalize(ScpStatementExternalize {
                 commit: ScpBallot { counter: 1, value },
                 n_h: 1,
-                commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
             }),
         };
 
@@ -7777,13 +7763,13 @@ mod tests {
     /// for that quorum set get unblocked.
     #[test]
     fn test_audit_004_store_quorum_set_unblocks_fetching_envelopes() {
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let herder = make_test_herder();
 
         // Build a sane quorum set with one validator.
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
@@ -7847,7 +7833,7 @@ mod tests {
     /// and permanently strand the envelope).
     #[test]
     fn test_audit_104_qset_missing_routes_through_fetching() {
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let local_secret = SecretKey::from_seed(&[7u8; 32]);
         let local_public = local_secret.public_key();
@@ -7945,7 +7931,7 @@ mod tests {
     /// drains them via spawn_blocking.
     #[test]
     fn test_issue_1907_process_scp_envelope_does_not_drain_ready_inline() {
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let local_secret = SecretKey::from_seed(&[7u8; 32]);
         let local_public = local_secret.public_key();
@@ -8222,13 +8208,13 @@ mod tests {
     /// store_quorum_set().
     #[test]
     fn test_audit_104_store_quorum_set_drains_ready() {
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let herder = make_test_herder();
 
         // Build a sane quorum set
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
@@ -8302,7 +8288,7 @@ mod tests {
     async fn test_issue_1773_receive_tx_set_frees_event_loop_during_drain() {
         use std::sync::atomic::{AtomicU64, Ordering};
         use std::sync::Arc;
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let herder = Arc::new(make_test_herder());
 
@@ -8314,8 +8300,8 @@ mod tests {
         // processed-set dedup does not short-circuit the drain loop;
         // the `counter` field in ScpBallot provides that uniqueness.
         const BACKLOG: usize = 400;
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([42u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([42u8; 32]),
         ));
         let mut envelopes = Vec::with_capacity(BACKLOG);
         for i in 0..BACKLOG {
@@ -8414,13 +8400,13 @@ mod tests {
     async fn test_issue_1907_quorum_set_drain_frees_event_loop() {
         use std::sync::atomic::{AtomicU64, Ordering};
         use std::sync::Arc;
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let herder = Arc::new(make_test_herder());
 
         // Build a sane quorum set
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([42u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([42u8; 32]),
         ));
         let quorum_set = ScpQuorumSet {
             threshold: 1,
@@ -8513,15 +8499,15 @@ mod tests {
     /// `process_ready_fetching_envelopes()` call should drain them.
     #[test]
     fn test_issue_1922_cache_tx_set_does_not_drain_inline() {
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let herder = make_test_herder();
 
         let tx_set = TransactionSet::new(Hash256::ZERO, Vec::new());
 
         // Synthesise 10 ready envelopes for slot 1.
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([42u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([42u8; 32]),
         ));
         let mut envelopes = Vec::with_capacity(10);
         for i in 0..10 {
@@ -8581,7 +8567,7 @@ mod tests {
     async fn test_issue_1922_cache_tx_set_and_drain_frees_event_loop() {
         use std::sync::atomic::{AtomicU64, Ordering};
         use std::sync::Arc;
-        use stellar_xdr::curr::Hash as XdrHash;
+        use stellar_xdr::Hash as XdrHash;
 
         let herder = Arc::new(make_test_herder());
 
@@ -8589,8 +8575,8 @@ mod tests {
 
         // Synthesise 400 ready envelopes for slot 1.
         const BACKLOG: usize = 400;
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([42u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([42u8; 32]),
         ));
         let mut envelopes = Vec::with_capacity(BACKLOG);
         for i in 0..BACKLOG {
@@ -8852,7 +8838,7 @@ mod tests {
         herder: &Herder,
         secret_key: &SecretKey,
     ) -> Value {
-        let xdr_tx_set_hash = stellar_xdr::curr::Hash(tx_set_hash.0);
+        let xdr_tx_set_hash = stellar_xdr::Hash(tx_set_hash.0);
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -8867,8 +8853,8 @@ mod tests {
         sign_data.extend_from_slice(&close_time.to_xdr(Limits::none()).unwrap());
         let sig = secret_key.sign(&sign_data);
 
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*secret_key.public_key().as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*secret_key.public_key().as_bytes()),
         ));
 
         let stellar_value = StellarValue {
@@ -8877,9 +8863,7 @@ mod tests {
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id,
-                signature: stellar_xdr::curr::Signature(
-                    sig.0.to_vec().try_into().unwrap_or_default(),
-                ),
+                signature: stellar_xdr::Signature(sig.0.to_vec().try_into().unwrap_or_default()),
             }),
         };
         Value(
@@ -9064,8 +9048,8 @@ mod tests {
         // Peer that will send the EXTERNALIZE.
         let peer_secret = SecretKey::from_seed(&[2u8; 32]);
         let peer_public = peer_secret.public_key();
-        let peer_node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*peer_public.as_bytes()),
+        let peer_node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*peer_public.as_bytes()),
         ));
 
         // Set tracking: consensus_index = 1 (next slot to close).
@@ -9089,7 +9073,7 @@ mod tests {
                 pledges: ScpStatementPledges::Externalize(ScpStatementExternalize {
                     commit: ScpBallot { counter: 1, value },
                     n_h: 1,
-                    commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 }),
             },
             // Envelope signature not verified by SCP (bypassed in this test).
@@ -9175,8 +9159,8 @@ mod tests {
         // Peer that will send the EXTERNALIZE.
         let peer_secret = SecretKey::from_seed(&[2u8; 32]);
         let peer_public = peer_secret.public_key();
-        let peer_node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*peer_public.as_bytes()),
+        let peer_node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*peer_public.as_bytes()),
         ));
 
         // Set tracking: consensus_index = 1 (next slot to close).
@@ -9207,7 +9191,7 @@ mod tests {
                 pledges: ScpStatementPledges::Externalize(ScpStatementExternalize {
                     commit: ScpBallot { counter: 1, value },
                     n_h: 1,
-                    commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 }),
             },
             // Envelope signature not verified by SCP (bypassed in this test).
@@ -9283,8 +9267,8 @@ mod tests {
 
     fn make_persist_envelope_with_tx_set_hash(
         slot: u64,
-        tx_set_hash: stellar_xdr::curr::Hash,
-    ) -> stellar_xdr::curr::ScpEnvelope {
+        tx_set_hash: stellar_xdr::Hash,
+    ) -> stellar_xdr::ScpEnvelope {
         let stellar_value = StellarValue {
             tx_set_hash,
             close_time: TimePoint(0),
@@ -9292,14 +9276,14 @@ mod tests {
             ext: StellarValueExt::Basic,
         };
         let value = stellar_value.to_xdr(Limits::none()).unwrap();
-        stellar_xdr::curr::ScpEnvelope {
+        stellar_xdr::ScpEnvelope {
             statement: ScpStatement {
-                node_id: XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                    stellar_xdr::curr::Uint256([0u8; 32]),
+                node_id: XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0u8; 32]),
                 )),
                 slot_index: slot,
                 pledges: ScpStatementPledges::Nominate(ScpNomination {
-                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                     votes: vec![Value(value.try_into().unwrap())].try_into().unwrap(),
                     accepted: vec![].try_into().unwrap(),
                 }),
@@ -9324,8 +9308,8 @@ mod tests {
             "first install should succeed"
         );
 
-        let referenced_hash = stellar_xdr::curr::Hash([1u8; 32]);
-        let orphan_hash = stellar_xdr::curr::Hash([2u8; 32]);
+        let referenced_hash = stellar_xdr::Hash([1u8; 32]);
+        let orphan_hash = stellar_xdr::Hash([2u8; 32]);
 
         // Drive setup through the public manager API: persist an envelope
         // referencing `referenced_hash`, but pass BOTH tx sets through so the
@@ -9488,10 +9472,10 @@ mod tests {
 
         // Inject an orphan tx set directly via the manager (not referenced
         // by any persisted envelope).
-        let orphan_hash = stellar_xdr::curr::Hash([0xAAu8; 32]);
+        let orphan_hash = stellar_xdr::Hash([0xAAu8; 32]);
         let orphan_env = make_persist_envelope_with_tx_set_hash(
             999_999,
-            stellar_xdr::curr::Hash([0xBBu8; 32]), // some unrelated hash
+            stellar_xdr::Hash([0xBBu8; 32]), // some unrelated hash
         );
         manager
             .persist_scp_state(
@@ -9525,7 +9509,7 @@ mod inv_h2_lcl_guard_tests {
 
     fn make_lm_at_seq(ledger_seq: u32) -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -9967,13 +9951,13 @@ mod inv_h2_lcl_guard_tests {
 #[cfg(test)]
 mod closing_gate_tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ScpNomination, ScpStatement, ScpStatementPledges, Signature as XdrSignature,
     };
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -10028,16 +10012,15 @@ mod closing_gate_tests {
     }
 
     fn make_test_envelope(slot: u64) -> ScpEnvelope {
-        let node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256([0u8; 32]),
-            ));
+        let node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([0u8; 32]),
+        ));
         ScpEnvelope {
             statement: ScpStatement {
                 node_id,
                 slot_index: slot,
                 pledges: ScpStatementPledges::Nominate(ScpNomination {
-                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                     votes: vec![].try_into().unwrap(),
                     accepted: vec![].try_into().unwrap(),
                 }),
@@ -10241,7 +10224,7 @@ mod set_state_tests {
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -10478,7 +10461,7 @@ mod scp_pipeline_tests {
         Verdict, VerifiedEnvelope, VerifierState,
     };
     use henyey_crypto::SecretKey;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         NodeId as XdrNodeId, ScpNomination, ScpStatement, ScpStatementPledges,
         Signature as XdrSignature,
     };
@@ -10496,15 +10479,15 @@ mod scp_pipeline_tests {
     }
 
     fn make_unsigned_envelope(slot: u64, node_seed: u8) -> ScpEnvelope {
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([node_seed; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([node_seed; 32]),
         ));
         ScpEnvelope {
             statement: ScpStatement {
                 node_id,
                 slot_index: slot,
                 pledges: ScpStatementPledges::Nominate(ScpNomination {
-                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                     votes: vec![].try_into().unwrap(),
                     accepted: vec![].try_into().unwrap(),
                 }),
@@ -10552,14 +10535,14 @@ mod scp_pipeline_tests {
         herder: &Herder,
         secret: &SecretKey,
     ) -> ScpEnvelope {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             LedgerCloseValueSignature, Limits, NodeId as XdrNodeId, ScpNomination, ScpStatement,
             ScpStatementPledges, Signature as XdrSignature, StellarValue, StellarValueExt,
             TimePoint, Value, WriteXdr,
         };
         let public = secret.public_key();
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*public.as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
         ));
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -10567,11 +10550,11 @@ mod scp_pipeline_tests {
             .as_secs();
 
         // Build a signed StellarValue so check_envelope_close_time accepts it.
-        let tx_set_hash = stellar_xdr::curr::Hash([0u8; 32]);
+        let tx_set_hash = stellar_xdr::Hash([0u8; 32]);
         let close_time = TimePoint(now);
         let mut sign_data = herder.scp_driver.network_id().0.to_vec();
         sign_data.extend_from_slice(
-            &stellar_xdr::curr::EnvelopeType::Scpvalue
+            &stellar_xdr::EnvelopeType::Scpvalue
                 .to_xdr(Limits::none())
                 .unwrap(),
         );
@@ -10584,7 +10567,7 @@ mod scp_pipeline_tests {
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id: node_id.clone(),
-                signature: stellar_xdr::curr::Signature(
+                signature: stellar_xdr::Signature(
                     value_sig.0.to_vec().try_into().unwrap_or_default(),
                 ),
             }),
@@ -10595,7 +10578,7 @@ mod scp_pipeline_tests {
             node_id,
             slot_index: slot,
             pledges: ScpStatementPledges::Nominate(ScpNomination {
-                quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 votes: vec![vote].try_into().unwrap(),
                 accepted: vec![].try_into().unwrap(),
             }),
@@ -10960,7 +10943,7 @@ mod scp_pipeline_tests {
 
     fn make_ledger_manager_at_seq(ledger_seq: u32) -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -11130,14 +11113,14 @@ mod scp_pipeline_tests {
 #[cfg(test)]
 mod advance_tracking_slot_tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, NodeId as XdrNodeId, PublicKey, ScpEnvelope, ScpNomination, ScpStatement,
         ScpStatementPledges, Uint256,
     };
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -11204,7 +11187,7 @@ mod advance_tracking_slot_tests {
                     accepted: vec![].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
         }
     }
 
@@ -11403,7 +11386,7 @@ mod advance_tracking_slot_tests {
     async fn test_nomination_value_uses_single_snapshot() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::LedgerManagerConfig;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             CreateAccountOp, DecoratedSignature, Hash, LedgerHeader, LedgerHeaderExt, Memo,
             MuxedAccount, Operation, OperationBody, Preconditions, SequenceNumber, SignatureHint,
             StellarValue, StellarValueExt, TimePoint, Transaction, TransactionEnvelope,
@@ -11412,10 +11395,9 @@ mod advance_tracking_slot_tests {
 
         fn make_synthetic_envelope(seed: u8) -> TransactionEnvelope {
             let source = MuxedAccount::Ed25519(Uint256([seed; 32]));
-            let dest =
-                stellar_xdr::curr::AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                    Uint256([seed.wrapping_add(128); 32]),
-                ));
+            let dest = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                Uint256([seed.wrapping_add(128); 32]),
+            ));
             let tx = Transaction {
                 source_account: source,
                 fee: 200,
@@ -11437,7 +11419,7 @@ mod advance_tracking_slot_tests {
                 tx,
                 signatures: vec![DecoratedSignature {
                     hint: SignatureHint([0u8; 4]),
-                    signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                    signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
                 }]
                 .try_into()
                 .unwrap(),
@@ -11449,7 +11431,7 @@ mod advance_tracking_slot_tests {
         let secret_for_herder = henyey_crypto::SecretKey::from_seed(&seed);
         let public = secret_for_herder.public_key();
         let node_id = super::node_id_from_public_key(&public);
-        let quorum_set = stellar_xdr::curr::ScpQuorumSet {
+        let quorum_set = stellar_xdr::ScpQuorumSet {
             threshold: 1,
             validators: vec![node_id].try_into().unwrap(),
             inner_sets: vec![].try_into().unwrap(),
@@ -11574,9 +11556,7 @@ mod advance_tracking_slot_tests {
     /// Build a v24 `LedgerHeader` with a non-zero `max_tx_set_size`. Mirrors
     /// the header shape used by `test_nomination_value_uses_single_snapshot`.
     fn v24_header() -> LedgerHeader {
-        use stellar_xdr::curr::{
-            Hash, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
-        };
+        use stellar_xdr::{Hash, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM};
         LedgerHeader {
             ledger_version: 24,
             previous_ledger_hash: Hash([0u8; 32]),
@@ -11610,7 +11590,7 @@ mod advance_tracking_slot_tests {
     /// is an empty `TransactionPhase::V0`. The hash is computed from the XDR
     /// encoding so that `prepare_for_apply` accepts the recomputed hash.
     fn empty_n_phase_generalized_tx_set(n_phases: usize) -> TransactionSet {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, TransactionPhase, TransactionSetV1, VecM,
         };
         let phases: VecM<TransactionPhase> = (0..n_phases)
@@ -11796,16 +11776,16 @@ mod advance_tracking_slot_tests {
     // ── Cross-phase duplicate-source test helpers ────────────────────────
 
     /// Classic `CreateAccount` envelope (same shape as `tx_set.rs` tests).
-    fn make_classic_envelope(seed: u8, fee: u32) -> stellar_xdr::curr::TransactionEnvelope {
-        use stellar_xdr::curr::{
+    fn make_classic_envelope(seed: u8, fee: u32) -> stellar_xdr::TransactionEnvelope {
+        use stellar_xdr::{
             CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
             Preconditions, SequenceNumber, SignatureHint, Transaction, TransactionEnvelope,
             TransactionExt, TransactionV1Envelope, Uint256,
         };
         let source = MuxedAccount::Ed25519(Uint256([seed; 32]));
-        let dest = stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([seed.wrapping_add(1); 32])),
-        );
+        let dest = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            [seed.wrapping_add(1); 32],
+        )));
         TransactionEnvelope::Tx(TransactionV1Envelope {
             tx: Transaction {
                 source_account: source,
@@ -11826,7 +11806,7 @@ mod advance_tracking_slot_tests {
             },
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -11834,11 +11814,8 @@ mod advance_tracking_slot_tests {
     }
 
     /// Soroban `InvokeHostFunction` envelope (same shape as `tx_set.rs` tests).
-    fn make_soroban_envelope_for_phase(
-        seed: u8,
-        fee: u32,
-    ) -> stellar_xdr::curr::TransactionEnvelope {
-        use stellar_xdr::curr::{
+    fn make_soroban_envelope_for_phase(seed: u8, fee: u32) -> stellar_xdr::TransactionEnvelope {
+        use stellar_xdr::{
             ContractDataDurability, ContractId, DecoratedSignature, Hash, HostFunction,
             InvokeContractArgs, InvokeHostFunctionOp, LedgerFootprint, LedgerKey,
             LedgerKeyContractData, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
@@ -11888,7 +11865,7 @@ mod advance_tracking_slot_tests {
             },
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -11898,7 +11875,7 @@ mod advance_tracking_slot_tests {
     /// Build a 2-phase generalized tx set: V0 classic + V1 parallel Soroban.
     /// `classic_seed` and `soroban_seed` control the source-account ED25519 key.
     fn make_two_phase_tx_set(classic_seed: u8, soroban_seed: u8) -> TransactionSet {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DependentTxCluster, GeneralizedTransactionSet, Hash, ParallelTxExecutionStage,
             TransactionPhase, TransactionSetV1, TxSetComponent,
             TxSetComponentTxsMaybeDiscountedFee,
@@ -12036,7 +12013,7 @@ mod advance_tracking_slot_tests {
         use crate::tx_set_utils::TxSetValidationContext;
         use henyey_common::NetworkId;
         use std::time::Duration;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountId, DecoratedSignature, Hash, LedgerHeader, LedgerHeaderExt, Memo, MuxedAccount,
             Operation, OperationBody, Preconditions, PublicKey, SequenceNumber, SignatureHint,
             StellarValue, StellarValueExt, TimePoint, Transaction, TransactionEnvelope,
@@ -12065,7 +12042,7 @@ mod advance_tracking_slot_tests {
             memo: Memo::None,
             operations: vec![Operation {
                 source_account: None,
-                body: OperationBody::CreateAccount(stellar_xdr::curr::CreateAccountOp {
+                body: OperationBody::CreateAccount(stellar_xdr::CreateAccountOp {
                     destination: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([255u8; 32]))),
                     starting_balance: 1_000_000_000,
                 }),
@@ -12078,7 +12055,7 @@ mod advance_tracking_slot_tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -12213,7 +12190,7 @@ mod advance_tracking_slot_tests {
     async fn test_build_nomination_value_self_check_passes_on_v24() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::LedgerManagerConfig;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
 
@@ -12222,7 +12199,7 @@ mod advance_tracking_slot_tests {
         let secret_for_herder = henyey_crypto::SecretKey::from_seed(&seed);
         let public = secret_for_herder.public_key();
         let node_id = super::node_id_from_public_key(&public);
-        let quorum_set = stellar_xdr::curr::ScpQuorumSet {
+        let quorum_set = stellar_xdr::ScpQuorumSet {
             threshold: 1,
             validators: vec![node_id].try_into().unwrap(),
             inner_sets: vec![].try_into().unwrap(),
@@ -12299,11 +12276,9 @@ mod advance_tracking_slot_tests {
         // Decode the StellarValue to extract the tx_set_hash and verify the
         // tx set was actually cached (caching only happens after the
         // self-validation gate accepts it).
-        let stellar_value = stellar_xdr::curr::StellarValue::from_xdr(
-            &value.0[..],
-            stellar_xdr::curr::Limits::none(),
-        )
-        .expect("decode StellarValue");
+        let stellar_value =
+            stellar_xdr::StellarValue::from_xdr(&value.0[..], stellar_xdr::Limits::none())
+                .expect("decode StellarValue");
         let tx_set_hash = Hash256::from_bytes(stellar_value.tx_set_hash.0);
         assert!(
             herder.scp_driver().has_tx_set(&tx_set_hash),
@@ -12432,7 +12407,7 @@ mod quorum_health_tests {
     use crate::tx_queue::TransactionSet;
     use henyey_crypto::SecretKey;
     use henyey_scp::hash_quorum_set;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         EnvelopeType, LedgerCloseValueSignature, Limits, NodeId as XdrNodeId, ScpBallot,
         ScpStatement, ScpStatementExternalize, ScpStatementPledges, ScpStatementPrepare,
         Signature as XdrSignature, StellarValue, StellarValueExt, TimePoint, Value, WriteXdr,
@@ -12440,7 +12415,7 @@ mod quorum_health_tests {
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{Hash, LedgerHeader, LedgerHeaderExt, VecM};
+        use stellar_xdr::{Hash, LedgerHeader, LedgerHeaderExt, VecM};
         let config = LedgerManagerConfig {
             validate_bucket_hash: false,
             ..Default::default()
@@ -12527,7 +12502,7 @@ mod quorum_health_tests {
         // Register each peer's quorum set so that is_statement_sane can
         // resolve the quorum_set_hash in PREPARE/CONFIRM envelopes.
         for key in &keys[1..] {
-            let peer_node_id = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            let peer_node_id = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
                 *key.public_key().as_bytes(),
             )));
             herder.store_quorum_set(&peer_node_id, quorum_set.clone());
@@ -12544,7 +12519,7 @@ mod quorum_health_tests {
         let tx_set_hash = *tx_set.hash();
         herder.scp_driver.cache_tx_set(tx_set);
 
-        let xdr_tx_set_hash = stellar_xdr::curr::Hash(tx_set_hash.0);
+        let xdr_tx_set_hash = stellar_xdr::Hash(tx_set_hash.0);
         let close_time = TimePoint(1);
 
         let network_id = herder.scp_driver.network_id();
@@ -12554,8 +12529,8 @@ mod quorum_health_tests {
         sign_data.extend_from_slice(&close_time.to_xdr(Limits::none()).unwrap());
         let sig = signer.sign(&sign_data);
 
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*signer.public_key().as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*signer.public_key().as_bytes()),
         ));
 
         let stellar_value = StellarValue {
@@ -12578,7 +12553,7 @@ mod quorum_health_tests {
         slot: u64,
         pledges: ScpStatementPledges,
     ) -> ScpEnvelope {
-        let node_id = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+        let node_id = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
             *secret_key.public_key().as_bytes(),
         )));
         ScpEnvelope {
@@ -12598,14 +12573,14 @@ mod quorum_health_tests {
                 value: value.clone(),
             },
             n_h: u32::MAX,
-            commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
         })
     }
 
     fn prepare_pledges(value: &Value, quorum_set: &ScpQuorumSet) -> ScpStatementPledges {
         let qs_hash = hash_quorum_set(quorum_set);
         ScpStatementPledges::Prepare(ScpStatementPrepare {
-            quorum_set_hash: stellar_xdr::curr::Hash(qs_hash.0),
+            quorum_set_hash: stellar_xdr::Hash(qs_hash.0),
             ballot: ScpBallot {
                 counter: 1,
                 value: value.clone(),
@@ -12830,7 +12805,7 @@ mod quorum_health_tests {
         );
 
         for key in &keys[1..] {
-            let peer_node_id = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            let peer_node_id = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
                 *key.public_key().as_bytes(),
             )));
             herder.store_quorum_set(&peer_node_id, quorum_set.clone());
@@ -12943,7 +12918,7 @@ mod quorum_health_tests {
         let node_ids: Vec<NodeId> = keys
             .iter()
             .map(|k| {
-                NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+                NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
                     *k.public_key().as_bytes(),
                 )))
             })
@@ -12999,9 +12974,9 @@ mod quorum_health_tests {
                 key[..4].copy_from_slice(&idx.to_le_bytes());
                 key
             };
-            let churn_node_id = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                Uint256(churn_key),
-            ));
+            let churn_node_id = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+                churn_key,
+            )));
 
             // Each churn node gets a sane single-node qset (threshold=1,
             // validators=[self]). Unique validator field → unique hash.
@@ -13106,7 +13081,7 @@ mod quorum_intersection_deadlock_tests {
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -13190,7 +13165,7 @@ mod quorum_intersection_deadlock_tests {
 
         // Expand the transitive quorum tracker with all peers.
         for key in keys.iter().skip(1) {
-            let peer_node_id = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            let peer_node_id = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
                 *key.public_key().as_bytes(),
             )));
             herder.store_quorum_set(&peer_node_id, quorum_set.clone());
@@ -13326,7 +13301,7 @@ mod quorum_intersection_deadlock_tests {
 mod dynamic_close_time_tests {
     use super::*;
     use henyey_ledger::{LedgerManager, LedgerManagerConfig, SorobanNetworkInfo};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
     };
 
@@ -13564,7 +13539,7 @@ mod previous_value_tests {
     use crate::tx_queue::TransactionSet;
     use henyey_crypto::SecretKey;
     use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         EnvelopeType, Hash, LedgerCloseValueSignature, LedgerHeader, LedgerHeaderExt, Limits,
         NodeId as XdrNodeId, ScpBallot, ScpStatement, ScpStatementExternalize, ScpStatementPledges,
         Signature as XdrSignature, StellarValue, StellarValueExt, TimePoint, Value, VecM, WriteXdr,
@@ -13715,8 +13690,8 @@ mod previous_value_tests {
         sign_data.extend_from_slice(&ct.to_xdr(Limits::none()).unwrap());
         let sig = secret.sign(&sign_data);
 
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*secret.public_key().as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*secret.public_key().as_bytes()),
         ));
 
         let stellar_value = StellarValue {
@@ -13725,9 +13700,7 @@ mod previous_value_tests {
             upgrades: VecM::default(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id,
-                signature: stellar_xdr::curr::Signature(
-                    sig.0.to_vec().try_into().unwrap_or_default(),
-                ),
+                signature: stellar_xdr::Signature(sig.0.to_vec().try_into().unwrap_or_default()),
             }),
         };
         Value(
@@ -13749,8 +13722,8 @@ mod previous_value_tests {
         secret: &SecretKey,
         value: Value,
     ) -> ScpEnvelope {
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*secret.public_key().as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*secret.public_key().as_bytes()),
         ));
 
         let statement = ScpStatement {
@@ -13909,7 +13882,7 @@ mod previous_value_tests {
 mod required_lm_behavioral_tests {
     use super::*;
     use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
     };
 
@@ -14098,7 +14071,7 @@ mod required_lm_behavioral_tests {
 mod fetching_envelopes_routing_tests {
     use super::*;
     use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash as XdrHash, LedgerHeader, LedgerHeaderExt, NodeId as XdrNodeId, ScpBallot,
         ScpEnvelope, ScpStatement, ScpStatementPledges, ScpStatementPrepare,
         Signature as XdrSignature, StellarValue, StellarValueExt, TimePoint, Value, VecM,
@@ -14155,8 +14128,8 @@ mod fetching_envelopes_routing_tests {
     /// Helper: make a simple test envelope for FetchingEnvelopes tests.
     /// Uses a Prepare statement with a unique counter for hash uniqueness.
     fn make_fetching_test_envelope(slot: u64, counter: u32) -> ScpEnvelope {
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([42u8; 32]),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([42u8; 32]),
         ));
         let ballot = ScpBallot {
             counter,
@@ -14167,7 +14140,7 @@ mod fetching_envelopes_routing_tests {
                 node_id,
                 slot_index: slot,
                 pledges: ScpStatementPledges::Prepare(ScpStatementPrepare {
-                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                     ballot,
                     prepared: None,
                     prepared_prime: None,

--- a/crates/herder/src/herder_utils.rs
+++ b/crates/herder/src/herder_utils.rs
@@ -9,7 +9,7 @@
 
 use henyey_common::Hash256;
 use henyey_scp::Slot;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Limits, NodeId, ReadXdr, ScpEnvelope, ScpStatement, StellarValue, StellarValueExt,
 };
 
@@ -30,7 +30,7 @@ use stellar_xdr::curr::{
 /// # Example
 ///
 /// ```ignore
-/// use stellar_xdr::curr::ScpStatement;
+/// use stellar_xdr::ScpStatement;
 /// use henyey_herder::get_stellar_values;
 ///
 /// let values = get_stellar_values(&statement);
@@ -62,7 +62,7 @@ pub fn get_stellar_values(statement: &ScpStatement) -> Vec<StellarValue> {
 /// # Example
 ///
 /// ```ignore
-/// use stellar_xdr::curr::ScpEnvelope;
+/// use stellar_xdr::ScpEnvelope;
 /// use henyey_herder::get_tx_set_hashes_from_envelope;
 ///
 /// let hashes = get_tx_set_hashes_from_envelope(&envelope);
@@ -131,7 +131,7 @@ pub fn get_validated_tx_set_hashes(envelope: &ScpEnvelope) -> Result<Vec<Hash256
 /// # Example
 ///
 /// ```ignore
-/// use stellar_xdr::curr::NodeId;
+/// use stellar_xdr::NodeId;
 /// use henyey_herder::to_short_string;
 ///
 /// let short = to_short_string(&node_id);
@@ -139,7 +139,7 @@ pub fn get_validated_tx_set_hashes(envelope: &ScpEnvelope) -> Result<Vec<Hash256
 /// ```
 pub fn to_short_string(node_id: &NodeId) -> String {
     match &node_id.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => {
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => {
             // Convert to hex and take first 5 characters
             let hex = hex::encode(key.0);
             hex.chars().take(5).collect()
@@ -163,7 +163,7 @@ pub fn to_short_strkey(node_id: &NodeId) -> String {
     use stellar_strkey::ed25519::PublicKey as StrPublicKey;
 
     match &node_id.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => {
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => {
             let strkey = StrPublicKey(key.0).to_string();
             strkey.chars().take(5).collect()
         }
@@ -193,7 +193,7 @@ pub(crate) async fn sleep_until_or_forever(instant: Option<tokio::time::Instant>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         LedgerCloseValueSignature, Limits, ScpBallot, ScpNomination, ScpStatement,
         ScpStatementExternalize, ScpStatementPledges, Signature as XdrSignature, StellarValue,
         StellarValueExt, TimePoint, Uint256, Value, WriteXdr,
@@ -201,7 +201,7 @@ mod tests {
 
     fn make_test_stellar_value(tx_set_hash: [u8; 32], close_time: u64) -> StellarValue {
         StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash),
             close_time: TimePoint(close_time),
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -211,9 +211,7 @@ mod tests {
     fn make_test_node_id(seed: u8) -> NodeId {
         let mut key = [0u8; 32];
         key[0] = seed;
-        NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
-            key,
-        )))
+        NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(key)))
     }
 
     fn encode_value(sv: &StellarValue) -> Value {
@@ -230,7 +228,7 @@ mod tests {
             node_id: make_test_node_id(1),
             slot_index: 1,
             pledges: ScpStatementPledges::Nominate(ScpNomination {
-                quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 votes: vec![encode_value(&sv1)].try_into().unwrap(),
                 accepted: vec![encode_value(&sv2)].try_into().unwrap(),
             }),
@@ -257,7 +255,7 @@ mod tests {
                     value: encode_value(&sv),
                 },
                 n_h: 1,
-                commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
             }),
         };
 
@@ -281,10 +279,10 @@ mod tests {
                         value: encode_value(&sv),
                     },
                     n_h: 1,
-                    commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
         };
 
         let hashes = get_tx_set_hashes_from_envelope(&envelope);
@@ -317,7 +315,7 @@ mod tests {
             node_id: make_test_node_id(1),
             slot_index: 1,
             pledges: ScpStatementPledges::Nominate(ScpNomination {
-                quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 votes: vec![Value(vec![1, 2, 3].try_into().unwrap())]
                     .try_into()
                     .unwrap(),
@@ -336,11 +334,11 @@ mod tests {
 
     fn make_signed_stellar_value(tx_set_hash: [u8; 32], close_time: u64) -> StellarValue {
         StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash),
             close_time: TimePoint(close_time),
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
-                node_id: NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+                node_id: NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
                     [0u8; 32],
                 ))),
                 signature: XdrSignature(vec![0u8; 64].try_into().unwrap()),
@@ -362,10 +360,10 @@ mod tests {
                         value: encode_value(&sv),
                     },
                     n_h: 1,
-                    commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
         };
 
         let result = get_validated_tx_set_hashes(&envelope);
@@ -390,10 +388,10 @@ mod tests {
                         value: encode_value(&sv),
                     },
                     n_h: 1,
-                    commit_quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
         };
 
         let result = get_validated_tx_set_hashes(&envelope);
@@ -408,14 +406,14 @@ mod tests {
                 node_id: make_test_node_id(1),
                 slot_index: 1,
                 pledges: ScpStatementPledges::Nominate(ScpNomination {
-                    quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                    quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                     votes: vec![Value(vec![1, 2, 3].try_into().unwrap())]
                         .try_into()
                         .unwrap(),
                     accepted: vec![].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
         };
 
         let result = get_validated_tx_set_hashes(&envelope);
@@ -433,7 +431,7 @@ mod tests {
             node_id: make_test_node_id(1),
             slot_index: 1,
             pledges: ScpStatementPledges::Nominate(ScpNomination {
-                quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
                 votes: vec![encode_value(&signed_sv), encode_value(&basic_sv)]
                     .try_into()
                     .unwrap(),

--- a/crates/herder/src/json_api.rs
+++ b/crates/herder/src/json_api.rs
@@ -14,7 +14,7 @@
 //! - `PendingEnvelopes::getJsonInfo()`
 
 use serde::{Deserialize, Serialize};
-use stellar_xdr::curr::NodeId;
+use stellar_xdr::NodeId;
 
 /// Complete Herder JSON info response.
 ///
@@ -249,7 +249,7 @@ pub fn format_node_id(node_id: &NodeId, full_keys: bool) -> String {
     use stellar_strkey::ed25519::PublicKey as StrPublicKey;
 
     match &node_id.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => {
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => {
             let strkey = StrPublicKey(key.0).to_string();
             if full_keys {
                 strkey
@@ -461,14 +461,12 @@ impl QuorumJsonInfoBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::Uint256;
+    use stellar_xdr::Uint256;
 
     fn make_test_node_id(seed: u8) -> NodeId {
         let mut key = [0u8; 32];
         key[0] = seed;
-        NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
-            key,
-        )))
+        NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(key)))
     }
 
     #[test]

--- a/crates/herder/src/ledger_close_data.rs
+++ b/crates/herder/src/ledger_close_data.rs
@@ -9,10 +9,10 @@
 //! validation for replay and verification.
 
 use henyey_common::Hash256;
-use stellar_xdr::curr::{Limits, ReadXdr, StellarValue, StoredDebugTransactionSet};
+use stellar_xdr::{Limits, ReadXdr, StellarValue, StoredDebugTransactionSet};
 
 #[cfg(feature = "test-utils")]
-use stellar_xdr::curr::TransactionResultSet;
+use stellar_xdr::TransactionResultSet;
 
 use crate::tx_queue::TransactionSet;
 
@@ -36,7 +36,7 @@ use crate::tx_queue::TransactionSet;
 ///
 /// ```ignore
 /// use henyey_herder::{LedgerCloseData, TransactionSet};
-/// use stellar_xdr::curr::StellarValue;
+/// use stellar_xdr::StellarValue;
 ///
 /// let tx_set = TransactionSet::new(prev_hash, transactions);
 /// let stellar_value = /* ... */;
@@ -159,7 +159,7 @@ impl LedgerCloseData {
     }
 
     /// Get the upgrades from the StellarValue.
-    pub fn upgrades(&self) -> &[stellar_xdr::curr::UpgradeType] {
+    pub fn upgrades(&self) -> &[stellar_xdr::UpgradeType] {
         &self.value.upgrades
     }
 
@@ -235,8 +235,8 @@ pub enum LedgerCloseDataError {
     XdrError(String),
 }
 
-impl From<stellar_xdr::curr::Error> for LedgerCloseDataError {
-    fn from(e: stellar_xdr::curr::Error) -> Self {
+impl From<stellar_xdr::Error> for LedgerCloseDataError {
+    fn from(e: stellar_xdr::Error) -> Self {
         LedgerCloseDataError::XdrError(e.to_string())
     }
 }
@@ -255,9 +255,9 @@ impl From<stellar_xdr::curr::Error> for LedgerCloseDataError {
 /// A string representation of the StellarValue.
 pub fn stellar_value_to_string<F>(sv: &StellarValue, short_node_id: Option<F>) -> String
 where
-    F: Fn(&stellar_xdr::curr::NodeId) -> String,
+    F: Fn(&stellar_xdr::NodeId) -> String,
 {
-    use stellar_xdr::curr::{LedgerUpgrade, StellarValueExt};
+    use stellar_xdr::{LedgerUpgrade, StellarValueExt};
 
     let mut res = String::from("[");
 
@@ -303,8 +303,8 @@ where
 }
 
 /// Convert a LedgerUpgrade to a human-readable string.
-fn upgrade_to_string(upgrade: &stellar_xdr::curr::LedgerUpgrade) -> String {
-    use stellar_xdr::curr::LedgerUpgrade;
+fn upgrade_to_string(upgrade: &stellar_xdr::LedgerUpgrade) -> String {
+    use stellar_xdr::LedgerUpgrade;
 
     match upgrade {
         LedgerUpgrade::Version(v) => format!("version={}", v),
@@ -325,7 +325,7 @@ fn upgrade_to_string(upgrade: &stellar_xdr::curr::LedgerUpgrade) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{Hash, Limits, StellarValueExt, TimePoint, UpgradeType, WriteXdr};
+    use stellar_xdr::{Hash, Limits, StellarValueExt, TimePoint, UpgradeType, WriteXdr};
 
     fn make_test_value(tx_set_hash: [u8; 32], close_time: u64) -> StellarValue {
         StellarValue {
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn test_stellar_value_to_string_basic() {
         let value = make_test_value([0xABu8; 32], 12345);
-        let s = stellar_value_to_string::<fn(&stellar_xdr::curr::NodeId) -> String>(&value, None);
+        let s = stellar_value_to_string::<fn(&stellar_xdr::NodeId) -> String>(&value, None);
 
         assert!(s.contains("txH: "));
         assert!(s.contains("ct: 12345"));
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_stellar_value_to_string_with_upgrades() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
 
         let upgrade = LedgerUpgrade::Version(25);
         let upgrade_bytes = upgrade.to_xdr(Limits::none()).unwrap();
@@ -391,13 +391,13 @@ mod tests {
             ext: StellarValueExt::Basic,
         };
 
-        let s = stellar_value_to_string::<fn(&stellar_xdr::curr::NodeId) -> String>(&value, None);
+        let s = stellar_value_to_string::<fn(&stellar_xdr::NodeId) -> String>(&value, None);
         assert!(s.contains("version=25"));
     }
 
     #[test]
     fn test_upgrade_to_string() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
 
         assert_eq!(upgrade_to_string(&LedgerUpgrade::Version(25)), "version=25");
         assert_eq!(

--- a/crates/herder/src/lib.rs
+++ b/crates/herder/src/lib.rs
@@ -221,7 +221,7 @@ pub type Result<T> = std::result::Result<T, HerderError>;
 #[derive(Debug)]
 pub struct PendingTransaction {
     /// The transaction envelope containing the transaction and signatures.
-    pub envelope: stellar_xdr::curr::TransactionEnvelope,
+    pub envelope: stellar_xdr::TransactionEnvelope,
     /// When this transaction was first received from the network.
     pub received_at: std::time::Instant,
     /// Number of times this transaction has been seen/broadcast.
@@ -267,14 +267,14 @@ pub trait HerderCallback: Send + Sync {
         ledger_seq: u32,
         tx_set: TransactionSet,
         close_time: u64,
-        upgrades: Vec<stellar_xdr::curr::UpgradeType>,
-        stellar_value_ext: stellar_xdr::curr::StellarValueExt,
+        upgrades: Vec<stellar_xdr::UpgradeType>,
+        stellar_value_ext: stellar_xdr::StellarValueExt,
     ) -> Result<henyey_common::Hash256>;
 
     /// Called when an SCP message should be broadcast to the network.
     ///
     /// The implementer should relay this envelope to connected peers.
-    async fn broadcast_scp_message(&self, envelope: stellar_xdr::curr::ScpEnvelope);
+    async fn broadcast_scp_message(&self, envelope: stellar_xdr::ScpEnvelope);
 }
 
 #[cfg(test)]
@@ -291,7 +291,7 @@ mod tests {
 
     fn make_default_lm() -> std::sync::Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {

--- a/crates/herder/src/parallel_tx_set_builder.rs
+++ b/crates/herder/src/parallel_tx_set_builder.rs
@@ -20,7 +20,7 @@ use henyey_common::types::Hash256;
 use henyey_tx::envelope_utils::envelope_soroban_data;
 use henyey_tx::tx_set_xdr::{empty_soroban_phase, soroban_phase_with_stages};
 use henyey_tx::{FeeRate, InclusionFee};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     DependentTxCluster, GeneralizedTransactionSet, Hash, LedgerKey, Limits,
     ParallelTxExecutionStage, TransactionEnvelope, TransactionPhase, TransactionSetV1,
     TxSetComponent, TxSetComponentTxsMaybeDiscountedFee, VecM, WriteXdr,
@@ -931,7 +931,7 @@ fn to_hashed_stages(stages: Vec<Vec<Vec<TransactionEnvelope>>>) -> Vec<Vec<Vec<H
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         HostFunction, InvokeContractArgs, InvokeHostFunctionOp, LedgerFootprint, LedgerKey,
         LedgerKeyContractData, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
         ScAddress, ScVal, SorobanResources, SorobanTransactionData, SorobanTransactionDataExt,
@@ -966,10 +966,10 @@ mod tests {
             source_account: None,
             body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
                 host_function: HostFunction::InvokeContract(InvokeContractArgs {
-                    contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(
-                        stellar_xdr::curr::Hash([seed; 32]),
+                    contract_address: ScAddress::Contract(stellar_xdr::ContractId(
+                        stellar_xdr::Hash([seed; 32]),
                     )),
-                    function_name: stellar_xdr::curr::ScSymbol("test".try_into().unwrap()),
+                    function_name: stellar_xdr::ScSymbol("test".try_into().unwrap()),
                     args: Default::default(),
                 }),
                 auth: Default::default(),
@@ -978,7 +978,7 @@ mod tests {
         let tx = Transaction {
             source_account: source,
             fee: 1000,
-            seq_num: stellar_xdr::curr::SequenceNumber(seq),
+            seq_num: stellar_xdr::SequenceNumber(seq),
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![invoke_op].try_into().unwrap(),
@@ -1012,11 +1012,9 @@ mod tests {
     /// Create a contract data ledger key with a unique identifier.
     fn contract_key(id: u8) -> LedgerKey {
         LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(
-                [id; 32],
-            ))),
+            contract: ScAddress::Contract(stellar_xdr::ContractId(stellar_xdr::Hash([id; 32]))),
             key: ScVal::U32(id as u32),
-            durability: stellar_xdr::curr::ContractDataDurability::Persistent,
+            durability: stellar_xdr::ContractDataDurability::Persistent,
         })
     }
 
@@ -1215,7 +1213,7 @@ mod tests {
     /// the normal tx (800/1=800 rate) beats the fee-bumped tx (1000/2=500 rate).
     #[test]
     fn test_fee_bump_soroban_uses_per_op_rate() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -1261,7 +1259,7 @@ mod tests {
     /// count from a fee-bump Soroban envelope as `TransactionFrame::soroban_data`.
     #[test]
     fn test_fee_bump_instruction_extraction_matches_frame() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -1641,7 +1639,7 @@ mod tests {
         outer_fee: i64,
         resource_fee: i64,
     ) -> TransactionEnvelope {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -1743,7 +1741,7 @@ mod tests {
 #[cfg(test)]
 mod stages_to_xdr_phase_tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         HostFunction, InvokeContractArgs, InvokeHostFunctionOp, LedgerFootprint, LedgerKey,
         LedgerKeyContractData, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
         ScAddress, ScVal, SorobanResources, SorobanTransactionData, SorobanTransactionDataExt,
@@ -1775,10 +1773,10 @@ mod stages_to_xdr_phase_tests {
             source_account: None,
             body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
                 host_function: HostFunction::InvokeContract(InvokeContractArgs {
-                    contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(
-                        stellar_xdr::curr::Hash([seed; 32]),
+                    contract_address: ScAddress::Contract(stellar_xdr::ContractId(
+                        stellar_xdr::Hash([seed; 32]),
                     )),
-                    function_name: stellar_xdr::curr::ScSymbol("test".try_into().unwrap()),
+                    function_name: stellar_xdr::ScSymbol("test".try_into().unwrap()),
                     args: Default::default(),
                 }),
                 auth: Default::default(),
@@ -1787,7 +1785,7 @@ mod stages_to_xdr_phase_tests {
         let tx = Transaction {
             source_account: source,
             fee: 1000,
-            seq_num: stellar_xdr::curr::SequenceNumber(seq),
+            seq_num: stellar_xdr::SequenceNumber(seq),
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![invoke_op].try_into().unwrap(),
@@ -1801,11 +1799,9 @@ mod stages_to_xdr_phase_tests {
 
     fn contract_key(id: u8) -> LedgerKey {
         LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(
-                [id; 32],
-            ))),
+            contract: ScAddress::Contract(stellar_xdr::ContractId(stellar_xdr::Hash([id; 32]))),
             key: ScVal::U32(id as u32),
-            durability: stellar_xdr::curr::ContractDataDurability::Persistent,
+            durability: stellar_xdr::ContractDataDurability::Persistent,
         })
     }
 
@@ -1982,8 +1978,8 @@ mod stages_to_xdr_phase_tests {
         let phase2 = stages_to_xdr_phase(to_hashed_stages(stages2), Some(100));
 
         // Both phases should produce the same XDR
-        let xdr1 = phase1.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
-        let xdr2 = phase2.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+        let xdr1 = phase1.to_xdr(stellar_xdr::Limits::none()).unwrap();
+        let xdr2 = phase2.to_xdr(stellar_xdr::Limits::none()).unwrap();
         assert_eq!(xdr1, xdr2, "stages_to_xdr_phase should be idempotent");
     }
 
@@ -2195,7 +2191,7 @@ mod stages_to_xdr_phase_tests {
 #[cfg(test)]
 mod stellar_core_parity_tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractDataDurability, HostFunction, InvokeContractArgs, InvokeHostFunctionOp,
         LedgerFootprint, LedgerKey, LedgerKeyContractData, Memo, MuxedAccount, Operation,
         OperationBody, Preconditions, ScAddress, ScVal, SorobanResources, SorobanTransactionData,
@@ -2217,9 +2213,7 @@ mod stellar_core_parity_tests {
             ContractDataDurability::Temporary
         };
         LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(
-                [0u8; 32],
-            ))),
+            contract: ScAddress::Contract(stellar_xdr::ContractId(stellar_xdr::Hash([0u8; 32]))),
             key: ScVal::I32(id),
             durability,
         })
@@ -2269,10 +2263,10 @@ mod stellar_core_parity_tests {
             source_account: None,
             body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
                 host_function: HostFunction::InvokeContract(InvokeContractArgs {
-                    contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(
-                        stellar_xdr::curr::Hash(source_bytes),
+                    contract_address: ScAddress::Contract(stellar_xdr::ContractId(
+                        stellar_xdr::Hash(source_bytes),
                     )),
-                    function_name: stellar_xdr::curr::ScSymbol("test".try_into().unwrap()),
+                    function_name: stellar_xdr::ScSymbol("test".try_into().unwrap()),
                     args: Default::default(),
                 }),
                 auth: Default::default(),
@@ -2283,7 +2277,7 @@ mod stellar_core_parity_tests {
         let tx = Transaction {
             source_account: source,
             fee: inclusion_fee as u32,
-            seq_num: stellar_xdr::curr::SequenceNumber(1),
+            seq_num: stellar_xdr::SequenceNumber(1),
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![invoke_op].try_into().unwrap(),
@@ -2910,7 +2904,7 @@ mod stellar_core_parity_tests {
     /// handle fee-bump envelopes (not just `TransactionEnvelope::Tx`).
     #[test]
     fn test_extract_helpers_fee_bump_envelope() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx, Limits, WriteXdr,
         };
@@ -3040,7 +3034,7 @@ mod stellar_core_parity_tests {
         use rand::rngs::StdRng;
         use rand::{Rng, SeedableRng};
         use std::collections::HashSet;
-        use stellar_xdr::curr::{Limits, ReadXdr, WriteXdr};
+        use stellar_xdr::{Limits, ReadXdr, WriteXdr};
 
         for iter in 0..10u64 {
             let seed = 42 + iter;
@@ -3232,7 +3226,7 @@ mod stellar_core_parity_tests {
             4,
         );
 
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen_set;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen_set;
         let soroban_phase = &v1.phases[1];
         match soroban_phase {
             TransactionPhase::V1(parallel) => {

--- a/crates/herder/src/pending.rs
+++ b/crates/herder/src/pending.rs
@@ -38,7 +38,7 @@ use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use stellar_xdr::curr::ScpEnvelope;
+use stellar_xdr::ScpEnvelope;
 
 /// Per-slot envelope safety cap. Henyey-specific defense-in-depth.
 ///
@@ -606,7 +606,7 @@ impl Default for PendingEnvelopes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, NodeId as XdrNodeId, PublicKey, ScpEnvelope, ScpNomination, ScpStatement,
         ScpStatementPledges, Uint256,
     };
@@ -625,7 +625,7 @@ mod tests {
                     accepted: vec![].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
         }
     }
 
@@ -725,7 +725,7 @@ mod tests {
                     accepted: vec![].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
         }
     }
 

--- a/crates/herder/src/persistence.rs
+++ b/crates/herder/src/persistence.rs
@@ -30,7 +30,7 @@
 //! latest SCP state is durable. This enables recovery to the last externalized slot.
 
 use serde::{Deserialize, Serialize};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, Limits, ReadXdr, ScpEnvelope, ScpQuorumSet, ScpStatementPledges, StellarValue, Value,
     WriteXdr,
 };
@@ -658,7 +658,7 @@ pub struct RestoredScpState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     pub(crate) fn make_test_envelope(slot: u64) -> ScpEnvelope {
         ScpEnvelope {

--- a/crates/herder/src/quorum_intersection_state.rs
+++ b/crates/herder/src/quorum_intersection_state.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use henyey_common::Hash256;
-use stellar_xdr::curr::NodeId;
+use stellar_xdr::NodeId;
 
 /// Result of a completed quorum intersection analysis.
 #[derive(Debug, Clone)]

--- a/crates/herder/src/quorum_set_tracker.rs
+++ b/crates/herder/src/quorum_set_tracker.rs
@@ -14,7 +14,7 @@ use std::sync::{Mutex, RwLock};
 use henyey_common::Hash256;
 use henyey_crypto::RandomEvictionCache;
 use henyey_scp::hash_quorum_set;
-use stellar_xdr::curr::{NodeId, PublicKey, ScpQuorumSet};
+use stellar_xdr::{NodeId, PublicKey, ScpQuorumSet};
 use tracing::{debug, info, trace};
 
 use super::scp_driver::PendingQuorumSet;
@@ -305,7 +305,7 @@ impl QuorumSetTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{ScpQuorumSet, Uint256, VecM};
+    use stellar_xdr::{ScpQuorumSet, Uint256, VecM};
 
     fn make_node_id(seed: u8) -> NodeId {
         NodeId(PublicKey::PublicKeyTypeEd25519(Uint256([seed; 32])))

--- a/crates/herder/src/quorum_tracker.rs
+++ b/crates/herder/src/quorum_tracker.rs
@@ -59,7 +59,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 use henyey_scp::{is_quorum, is_v_blocking, SlotIndex};
-use stellar_xdr::curr::{NodeId, ScpQuorumSet};
+use stellar_xdr::{NodeId, ScpQuorumSet};
 
 /// Tracks quorum participation over recent slots.
 ///
@@ -399,7 +399,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{PublicKey, Uint256};
+    use stellar_xdr::{PublicKey, Uint256};
 
     fn make_node_id(seed: u8) -> NodeId {
         let mut bytes = [0u8; 32];

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -57,7 +57,7 @@ use henyey_common::{Hash256, NetworkId};
 use henyey_crypto::{PublicKey, SecretKey, Signature};
 use henyey_ledger::LedgerManager;
 use henyey_scp::{SCPDriver, SlotIndex, ValidationLevel};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     EnvelopeType, LedgerUpgrade, NodeId, ReadXdr, ScpBallot, ScpEnvelope, ScpQuorumSet,
     ScpStatement, StellarValue, StellarValueExt, Value, WriteXdr,
 };
@@ -76,7 +76,7 @@ fn describe_stellar_value_ext(ext: &StellarValueExt) -> String {
         StellarValueExt::Basic => "Basic".to_string(),
         StellarValueExt::Signed(sig) => {
             let node_id_bytes = match &sig.node_id.0 {
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => key.0,
+                stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => key.0,
             };
             format!(
                 "Signed(node_id={}, sig_len={})",
@@ -693,7 +693,7 @@ impl ScpDriver {
     /// `get_quorum_set_by_hash()` can find it.
     #[cfg(feature = "test-support")]
     #[doc(hidden)]
-    pub fn test_store_quorum_set(&self, node_id: &stellar_xdr::curr::NodeId, qset: ScpQuorumSet) {
+    pub fn test_store_quorum_set(&self, node_id: &stellar_xdr::NodeId, qset: ScpQuorumSet) {
         self.qset_tracker.store(node_id, qset);
     }
 
@@ -1213,8 +1213,8 @@ impl ScpDriver {
     /// Returns the captured `now` instant so callers can reuse it for timing consistency.
     pub fn record_self_externalize_event(&self, slot: SlotIndex) -> std::time::Instant {
         let now = std::time::Instant::now();
-        let self_node = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*self.config.node_id.as_bytes()),
+        let self_node = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*self.config.node_id.as_bytes()),
         ));
         self.externalize_lag
             .write()
@@ -1495,7 +1495,7 @@ impl ScpDriver {
         nomination: bool,
     ) -> ValueValidation {
         // Decode the StellarValue
-        let stellar_value = match StellarValue::from_xdr(value, stellar_xdr::curr::Limits::none()) {
+        let stellar_value = match StellarValue::from_xdr(value, stellar_xdr::Limits::none()) {
             Ok(v) => v,
             Err(e) => {
                 debug!("Failed to decode StellarValue: {}", e);
@@ -1678,16 +1678,14 @@ impl ScpDriver {
     fn check_upgrade_ordering(stellar_value: &StellarValue) -> bool {
         let mut last_upgrade_order = None;
         for upgrade in stellar_value.upgrades.iter() {
-            let upgrade = match LedgerUpgrade::from_xdr(
-                upgrade.0.as_slice(),
-                stellar_xdr::curr::Limits::none(),
-            ) {
-                Ok(upgrade) => upgrade,
-                Err(_) => {
-                    debug!("Invalid ledger upgrade encountered");
-                    return false;
-                }
-            };
+            let upgrade =
+                match LedgerUpgrade::from_xdr(upgrade.0.as_slice(), stellar_xdr::Limits::none()) {
+                    Ok(upgrade) => upgrade,
+                    Err(_) => {
+                        debug!("Invalid ledger upgrade encountered");
+                        return false;
+                    }
+                };
             let order = Self::upgrade_type_order(&upgrade);
             if last_upgrade_order.is_some_and(|prev| order <= prev) {
                 debug!("Invalid ledger upgrade encountered");
@@ -1704,30 +1702,27 @@ impl ScpDriver {
     fn verify_stellar_value_signature(
         &self,
         node_id: &NodeId,
-        signature: &stellar_xdr::curr::Signature,
-        tx_set_hash: &stellar_xdr::curr::Hash,
-        close_time: stellar_xdr::curr::TimePoint,
+        signature: &stellar_xdr::Signature,
+        tx_set_hash: &stellar_xdr::Hash,
+        close_time: stellar_xdr::TimePoint,
     ) -> bool {
         let pubkey_bytes = match &node_id.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                bytes,
-            )) => bytes,
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => bytes,
         };
 
         // Build signed data: (networkID, ENVELOPE_TYPE_SCPVALUE, txSetHash, closeTime)
         let mut data = self.network_id.0.to_vec();
-        if let Ok(env_type_bytes) = EnvelopeType::Scpvalue.to_xdr(stellar_xdr::curr::Limits::none())
-        {
+        if let Ok(env_type_bytes) = EnvelopeType::Scpvalue.to_xdr(stellar_xdr::Limits::none()) {
             data.extend_from_slice(&env_type_bytes);
         } else {
             return false;
         }
-        if let Ok(hash_bytes) = tx_set_hash.to_xdr(stellar_xdr::curr::Limits::none()) {
+        if let Ok(hash_bytes) = tx_set_hash.to_xdr(stellar_xdr::Limits::none()) {
             data.extend_from_slice(&hash_bytes);
         } else {
             return false;
         }
-        if let Ok(time_bytes) = close_time.to_xdr(stellar_xdr::curr::Limits::none()) {
+        if let Ok(time_bytes) = close_time.to_xdr(stellar_xdr::Limits::none()) {
             data.extend_from_slice(&time_bytes);
         } else {
             return false;
@@ -1755,11 +1750,10 @@ impl ScpDriver {
         }
 
         // Decode the StellarValue
-        let mut stellar_value =
-            match StellarValue::from_xdr(value, stellar_xdr::curr::Limits::none()) {
-                Ok(v) => v,
-                Err(_) => return None,
-            };
+        let mut stellar_value = match StellarValue::from_xdr(value, stellar_xdr::Limits::none()) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
 
         // Parity: only extract if fully validated against local state
         // (does NOT check STELLAR_VALUE_SIGNED or signature)
@@ -1782,10 +1776,9 @@ impl ScpDriver {
         let lcl_close_time = lcl_header.scp_value.close_time.0;
         let mut valid_upgrades = Vec::new();
         for upgrade_bytes in stellar_value.upgrades.iter() {
-            if let Ok(upgrade) = LedgerUpgrade::from_xdr(
-                upgrade_bytes.0.as_slice(),
-                stellar_xdr::curr::Limits::none(),
-            ) {
+            if let Ok(upgrade) =
+                LedgerUpgrade::from_xdr(upgrade_bytes.0.as_slice(), stellar_xdr::Limits::none())
+            {
                 if self.is_upgrade_valid(&upgrade, current_version, lcl_close_time, true) {
                     valid_upgrades.push(upgrade_bytes.clone());
                 }
@@ -1799,7 +1792,7 @@ impl ScpDriver {
                 .expect("valid_upgrades is subset of input which is already bounded");
             // Re-encode
             stellar_value
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .ok()
                 .map(|bytes| {
                     Value(
@@ -1854,7 +1847,7 @@ impl ScpDriver {
         for upgrade_bytes in stellar_value.upgrades.iter() {
             let upgrade = match LedgerUpgrade::from_xdr(
                 upgrade_bytes.0.as_slice(),
-                stellar_xdr::curr::Limits::none(),
+                stellar_xdr::Limits::none(),
             ) {
                 Ok(u) => u,
                 Err(_) => return false,
@@ -1993,7 +1986,7 @@ impl ScpDriver {
 
         for &v in &sorted_values {
             // Step 1: Parse candidate value (stellar-core line 682-688).
-            let sv = StellarValue::from_xdr(v, stellar_xdr::curr::Limits::none())
+            let sv = StellarValue::from_xdr(v, stellar_xdr::Limits::none())
                 .expect("BUG: cannot parse candidate value in combineCandidates");
 
             // Step 2: XOR hash (stellar-core line 690).
@@ -2007,7 +2000,7 @@ impl ScpDriver {
             for upgrade_bytes in sv.upgrades.iter() {
                 let upgrade = LedgerUpgrade::from_xdr(
                     upgrade_bytes.0.as_slice(),
-                    stellar_xdr::curr::Limits::none(),
+                    stellar_xdr::Limits::none(),
                 )
                 .expect("BUG: cannot parse upgrade in validated candidate");
                 let order = Self::upgrade_type_order(&upgrade);
@@ -2123,13 +2116,13 @@ impl ScpDriver {
         // Parity: stellar-core uses xdr_to_opaque (throws on failure) at
         // HerderSCPDriver.cpp:810 and does not bound-check the upgrade count
         // (would crash on XDR serialization if >6).
-        let upgrade_bytes: Vec<stellar_xdr::curr::UpgradeType> = merged_upgrades
+        let upgrade_bytes: Vec<stellar_xdr::UpgradeType> = merged_upgrades
             .values()
             .map(|upgrade| {
                 let bytes = upgrade
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                     .expect("BUG: failed to re-encode LedgerUpgrade");
-                stellar_xdr::curr::UpgradeType(
+                stellar_xdr::UpgradeType(
                     bytes
                         .try_into()
                         .expect("BUG: encoded upgrade exceeds UpgradeType byte limit"),
@@ -2147,7 +2140,7 @@ impl ScpDriver {
         });
 
         let xdr_bytes = result
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("BUG: failed to encode combined StellarValue");
         Value(
             xdr_bytes
@@ -2305,17 +2298,17 @@ impl ScpDriver {
     /// Iterate over all transactions in a phase, yielding each envelope
     /// together with the component's optional base fee.
     fn phase_txs_with_base_fee(
-        phase: &stellar_xdr::curr::TransactionPhase,
-    ) -> Vec<(&stellar_xdr::curr::TransactionEnvelope, Option<i64>)> {
+        phase: &stellar_xdr::TransactionPhase,
+    ) -> Vec<(&stellar_xdr::TransactionEnvelope, Option<i64>)> {
         match phase {
-            stellar_xdr::curr::TransactionPhase::V0(components) => components
+            stellar_xdr::TransactionPhase::V0(components) => components
                 .iter()
                 .flat_map(|comp| {
-                    let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) = comp;
+                    let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) = comp;
                     c.txs.iter().map(move |tx| (tx, c.base_fee))
                 })
                 .collect(),
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => parallel
+            stellar_xdr::TransactionPhase::V1(parallel) => parallel
                 .execution_stages
                 .iter()
                 .flat_map(|stage| stage.iter())
@@ -2340,7 +2333,7 @@ impl ScpDriver {
                 .map(|env| crate::tx_set_utils::envelope_fee(env).as_i64())
                 .fold(0i64, i64::saturating_add);
         };
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = gen;
 
         let mut total = 0i64;
         for phase in set_v1.phases.iter() {
@@ -2355,7 +2348,7 @@ impl ScpDriver {
     /// Compute applying-time fee for a single transaction.
     ///
     /// Matches stellar-core `TransactionFrame::getFee(lh, baseFee, applying=true)`.
-    fn tx_applying_fee(env: &stellar_xdr::curr::TransactionEnvelope, base_fee: Option<i64>) -> i64 {
+    fn tx_applying_fee(env: &stellar_xdr::TransactionEnvelope, base_fee: Option<i64>) -> i64 {
         let full_fee = crate::tx_set_utils::envelope_fee(env);
         let Some(bf) = base_fee else {
             return full_fee.as_i64();
@@ -2370,7 +2363,7 @@ impl ScpDriver {
     }
 
     /// Get number of operations from a transaction envelope.
-    fn envelope_num_ops(env: &stellar_xdr::curr::TransactionEnvelope) -> usize {
+    fn envelope_num_ops(env: &stellar_xdr::TransactionEnvelope) -> usize {
         crate::tx_set_utils::envelope_num_ops(env)
     }
 
@@ -2417,7 +2410,7 @@ impl ScpDriver {
     pub fn build_signed_bytes(network_id: &Hash256, envelope: &ScpEnvelope) -> Result<Vec<u8>> {
         let statement_bytes = envelope
             .statement
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .map_err(|e| HerderError::Internal(format!("Failed to encode statement: {}", e)))?;
         let mut data = Vec::with_capacity(32 + 4 + statement_bytes.len());
         data.extend_from_slice(&network_id.0);
@@ -2431,12 +2424,10 @@ impl ScpDriver {
     pub fn verify_signed_bytes(
         data: &[u8],
         node_id: &NodeId,
-        sig: &stellar_xdr::curr::Signature,
+        sig: &stellar_xdr::Signature,
     ) -> Result<()> {
         let pubkey_bytes = match &node_id.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                bytes,
-            )) => bytes,
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => bytes,
         };
 
         let sig_bytes: [u8; 64] = sig
@@ -2497,7 +2488,7 @@ impl ScpDriver {
 
         // Parse the StellarValue and extract stellar_value_ext for logging
         let (tx_set_hash, close_time, stellar_value_ext_desc) =
-            if let Ok(sv) = StellarValue::from_xdr(&value, stellar_xdr::curr::Limits::none()) {
+            if let Ok(sv) = StellarValue::from_xdr(&value, stellar_xdr::Limits::none()) {
                 let ext_desc = describe_stellar_value_ext(&sv.ext);
                 (
                     Some(Hash256::from_bytes(sv.tx_set_hash.0)),
@@ -2515,7 +2506,7 @@ impl ScpDriver {
                 if old.value != value {
                     // Parse old value's stellar_value_ext for comparison
                     let old_ext_desc = if let Ok(old_sv) =
-                        StellarValue::from_xdr(&old.value, stellar_xdr::curr::Limits::none())
+                        StellarValue::from_xdr(&old.value, stellar_xdr::Limits::none())
                     {
                         describe_stellar_value_ext(&old_sv.ext)
                     } else {
@@ -2875,12 +2866,12 @@ impl ScpDriver {
     }
 
     /// Store a quorum set for a node.
-    pub fn store_quorum_set(&self, node_id: &stellar_xdr::curr::NodeId, quorum_set: ScpQuorumSet) {
+    pub fn store_quorum_set(&self, node_id: &stellar_xdr::NodeId, quorum_set: ScpQuorumSet) {
         self.qset_tracker.store(node_id, quorum_set);
     }
 
     /// Get a quorum set for a node.
-    pub fn get_quorum_set(&self, node_id: &stellar_xdr::curr::NodeId) -> Option<ScpQuorumSet> {
+    pub fn get_quorum_set(&self, node_id: &stellar_xdr::NodeId) -> Option<ScpQuorumSet> {
         self.qset_tracker.get_by_node(node_id)
     }
 
@@ -2915,7 +2906,7 @@ mod manual_close_tests {
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -2989,23 +2980,19 @@ mod manual_close_tests {
         });
 
         // Calling emit should NOT invoke the sender when suppress_scp is true.
-        let dummy_env = stellar_xdr::curr::ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
-                node_id: stellar_xdr::curr::NodeId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                        [0; 32],
-                    )),
-                ),
+        let dummy_env = stellar_xdr::ScpEnvelope {
+            statement: stellar_xdr::ScpStatement {
+                node_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0; 32]),
+                )),
                 slot_index: 1,
-                pledges: stellar_xdr::curr::ScpStatementPledges::Nominate(
-                    stellar_xdr::curr::ScpNomination {
-                        quorum_set_hash: stellar_xdr::curr::Hash([0; 32]),
-                        votes: vec![].try_into().unwrap(),
-                        accepted: vec![].try_into().unwrap(),
-                    },
-                ),
+                pledges: stellar_xdr::ScpStatementPledges::Nominate(stellar_xdr::ScpNomination {
+                    quorum_set_hash: stellar_xdr::Hash([0; 32]),
+                    votes: vec![].try_into().unwrap(),
+                    accepted: vec![].try_into().unwrap(),
+                }),
             },
-            signature: stellar_xdr::curr::Signature::default(),
+            signature: stellar_xdr::Signature::default(),
         };
         driver.emit(dummy_env);
         assert_eq!(call_count.load(Ordering::SeqCst), 0);
@@ -3041,23 +3028,19 @@ mod manual_close_tests {
             count_clone.fetch_add(1, Ordering::SeqCst);
         });
 
-        let dummy_env = stellar_xdr::curr::ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
-                node_id: stellar_xdr::curr::NodeId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                        [0; 32],
-                    )),
-                ),
+        let dummy_env = stellar_xdr::ScpEnvelope {
+            statement: stellar_xdr::ScpStatement {
+                node_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0; 32]),
+                )),
                 slot_index: 1,
-                pledges: stellar_xdr::curr::ScpStatementPledges::Nominate(
-                    stellar_xdr::curr::ScpNomination {
-                        quorum_set_hash: stellar_xdr::curr::Hash([0; 32]),
-                        votes: vec![].try_into().unwrap(),
-                        accepted: vec![].try_into().unwrap(),
-                    },
-                ),
+                pledges: stellar_xdr::ScpStatementPledges::Nominate(stellar_xdr::ScpNomination {
+                    quorum_set_hash: stellar_xdr::Hash([0; 32]),
+                    votes: vec![].try_into().unwrap(),
+                    accepted: vec![].try_into().unwrap(),
+                }),
             },
-            signature: stellar_xdr::curr::Signature::default(),
+            signature: stellar_xdr::Signature::default(),
         };
         driver.emit(dummy_env);
         assert_eq!(
@@ -3094,23 +3077,19 @@ mod manual_close_tests {
             count_clone.fetch_add(1, Ordering::SeqCst);
         });
 
-        let dummy_env = stellar_xdr::curr::ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
-                node_id: stellar_xdr::curr::NodeId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                        [0; 32],
-                    )),
-                ),
+        let dummy_env = stellar_xdr::ScpEnvelope {
+            statement: stellar_xdr::ScpStatement {
+                node_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0; 32]),
+                )),
                 slot_index: 1,
-                pledges: stellar_xdr::curr::ScpStatementPledges::Nominate(
-                    stellar_xdr::curr::ScpNomination {
-                        quorum_set_hash: stellar_xdr::curr::Hash([0; 32]),
-                        votes: vec![].try_into().unwrap(),
-                        accepted: vec![].try_into().unwrap(),
-                    },
-                ),
+                pledges: stellar_xdr::ScpStatementPledges::Nominate(stellar_xdr::ScpNomination {
+                    quorum_set_hash: stellar_xdr::Hash([0; 32]),
+                    votes: vec![].try_into().unwrap(),
+                    accepted: vec![].try_into().unwrap(),
+                }),
             },
-            signature: stellar_xdr::curr::Signature::default(),
+            signature: stellar_xdr::Signature::default(),
         };
         driver.emit(dummy_env);
         assert_eq!(call_count.load(Ordering::SeqCst), 1);
@@ -3140,7 +3119,7 @@ mod cache_tests {
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -3308,10 +3287,8 @@ mod cache_tests {
         let node_id = PublicKey::from_bytes(&[9u8; 32]).expect("node id");
         let quorum_set = ScpQuorumSet {
             threshold: 1,
-            validators: vec![stellar_xdr::curr::NodeId(
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                    [1u8; 32],
-                )),
+            validators: vec![stellar_xdr::NodeId(
+                stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256([1u8; 32])),
             )]
             .try_into()
             .unwrap(),
@@ -3333,10 +3310,9 @@ mod cache_tests {
         );
 
         // Create a test node_id for the request
-        let sender_node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256([2u8; 32]),
-            ));
+        let sender_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([2u8; 32]),
+        ));
 
         let known_hash = hash_quorum_set(&quorum_set);
         assert!(!driver.request_quorum_set(known_hash, sender_node_id.clone()));
@@ -3568,13 +3544,13 @@ mod cache_tests {
         secret: &henyey_crypto::SecretKey,
         tx_set_hash: [u8; 32],
         close_time: u64,
-    ) -> stellar_xdr::curr::Value {
-        use stellar_xdr::curr::{
+    ) -> stellar_xdr::Value {
+        use stellar_xdr::{
             EnvelopeType, LedgerCloseValueSignature, Limits, NodeId as XdrNodeId, StellarValue,
             StellarValueExt, TimePoint, WriteXdr,
         };
 
-        let xdr_tx_set_hash = stellar_xdr::curr::Hash(tx_set_hash);
+        let xdr_tx_set_hash = stellar_xdr::Hash(tx_set_hash);
         let ct = TimePoint(close_time);
 
         // Sign: (networkID, ENVELOPE_TYPE_SCPVALUE, txSetHash, closeTime)
@@ -3584,8 +3560,8 @@ mod cache_tests {
         sign_data.extend_from_slice(&ct.to_xdr(Limits::none()).unwrap());
         let sig = secret.sign(&sign_data);
 
-        let node_id = XdrNodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*secret.public_key().as_bytes()),
+        let node_id = XdrNodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*secret.public_key().as_bytes()),
         ));
 
         let sv = StellarValue {
@@ -3594,12 +3570,10 @@ mod cache_tests {
             upgrades: vec![].try_into().unwrap(),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id,
-                signature: stellar_xdr::curr::Signature(
-                    sig.0.to_vec().try_into().unwrap_or_default(),
-                ),
+                signature: stellar_xdr::Signature(sig.0.to_vec().try_into().unwrap_or_default()),
             }),
         };
-        stellar_xdr::curr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap())
+        stellar_xdr::Value(sv.to_xdr(Limits::none()).unwrap().try_into().unwrap())
     }
 
     #[test]
@@ -3970,7 +3944,7 @@ impl SCPDriver for HerderScpCallback {
         self.driver.emit(envelope.clone());
     }
 
-    fn get_quorum_set(&self, node_id: &stellar_xdr::curr::NodeId) -> Option<ScpQuorumSet> {
+    fn get_quorum_set(&self, node_id: &stellar_xdr::NodeId) -> Option<ScpQuorumSet> {
         self.driver.get_quorum_set(node_id)
     }
 
@@ -3994,11 +3968,11 @@ impl SCPDriver for HerderScpCallback {
             .record_externalized(slot_index, value.clone(), Some(now));
     }
 
-    fn ballot_did_prepare(&self, _slot_index: u64, _ballot: &stellar_xdr::curr::ScpBallot) {
+    fn ballot_did_prepare(&self, _slot_index: u64, _ballot: &stellar_xdr::ScpBallot) {
         // Logging only
     }
 
-    fn ballot_did_confirm(&self, _slot_index: u64, _ballot: &stellar_xdr::curr::ScpBallot) {
+    fn ballot_did_confirm(&self, _slot_index: u64, _ballot: &stellar_xdr::ScpBallot) {
         // Logging only
     }
 
@@ -4098,7 +4072,7 @@ impl SCPDriver for HerderScpCallback {
     fn sign_envelope(&self, envelope: &mut ScpEnvelope) {
         if let Some(sig) = self.driver.sign_envelope(&envelope.statement) {
             envelope.signature =
-                stellar_xdr::curr::Signature(sig.0.to_vec().try_into().unwrap_or_default());
+                stellar_xdr::Signature(sig.0.to_vec().try_into().unwrap_or_default());
             self.driver.scp_metrics.inc_envelope_sign();
         }
     }
@@ -4109,7 +4083,7 @@ impl SCPDriver for HerderScpCallback {
 
     /// Parity: check if a value contains protocol upgrades.
     fn has_upgrades(&self, value: &Value) -> bool {
-        if let Ok(sv) = StellarValue::from_xdr(value, stellar_xdr::curr::Limits::none()) {
+        if let Ok(sv) = StellarValue::from_xdr(value, stellar_xdr::Limits::none()) {
             !sv.upgrades.is_empty()
         } else {
             false
@@ -4118,9 +4092,9 @@ impl SCPDriver for HerderScpCallback {
 
     /// Parity: strip all upgrades from a value.
     fn strip_all_upgrades(&self, value: &Value) -> Option<Value> {
-        let mut sv = StellarValue::from_xdr(value, stellar_xdr::curr::Limits::none()).ok()?;
+        let mut sv = StellarValue::from_xdr(value, stellar_xdr::Limits::none()).ok()?;
         sv.upgrades = Vec::new().try_into().ok()?;
-        sv.to_xdr(stellar_xdr::curr::Limits::none())
+        sv.to_xdr(stellar_xdr::Limits::none())
             .ok()
             .map(|bytes| Value(bytes.try_into().unwrap_or_default()))
     }
@@ -4140,7 +4114,7 @@ impl SCPDriver for HerderScpCallback {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         LedgerCloseValueSignature, Limits, StellarValue, StellarValueExt, TimePoint, UpgradeType,
         VecM,
     };
@@ -4151,7 +4125,7 @@ mod tests {
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{Hash, LedgerHeader, LedgerHeaderExt};
+        use stellar_xdr::{Hash, LedgerHeader, LedgerHeaderExt};
         let config = LedgerManagerConfig {
             validate_bucket_hash: false,
             ..Default::default()
@@ -4262,7 +4236,7 @@ mod tests {
 
     /// Create a properly SIGNED StellarValue using the given secret key and network ID.
     fn make_signed_stellar_value(
-        tx_set_hash: stellar_xdr::curr::Hash,
+        tx_set_hash: stellar_xdr::Hash,
         close_time: u64,
         upgrades: Vec<UpgradeType>,
         secret_key: &SecretKey,
@@ -4276,10 +4250,9 @@ mod tests {
         sign_data.extend_from_slice(&close_time.to_xdr(Limits::none()).expect("xdr"));
         let sig = secret_key.sign(&sign_data);
 
-        let node_id =
-            stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256(*secret_key.public_key().as_bytes()),
-            ));
+        let node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*secret_key.public_key().as_bytes()),
+        ));
 
         StellarValue {
             tx_set_hash,
@@ -4289,9 +4262,7 @@ mod tests {
                 .expect("test: upgrades must fit in VecM<UpgradeType, 6>"),
             ext: StellarValueExt::Signed(LedgerCloseValueSignature {
                 node_id,
-                signature: stellar_xdr::curr::Signature(
-                    sig.0.to_vec().try_into().unwrap_or_default(),
-                ),
+                signature: stellar_xdr::Signature(sig.0.to_vec().try_into().unwrap_or_default()),
             }),
         }
     }
@@ -4690,8 +4661,8 @@ mod tests {
     #[test]
     fn test_first_to_self_externalize_lag_peer_first() {
         let driver = make_test_driver();
-        let peer_node = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let peer_node = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
 
         driver.record_slot_activity(100);
@@ -4749,8 +4720,8 @@ mod tests {
     #[test]
     fn test_first_to_self_externalize_lag_duplicate_externalization() {
         let driver = make_test_driver();
-        let peer_node = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let peer_node = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
 
         driver.record_slot_activity(100);
@@ -4774,8 +4745,8 @@ mod tests {
     #[test]
     fn test_first_to_self_externalize_lag_cleanup() {
         let driver = make_test_driver();
-        let peer_node = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let peer_node = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
 
         // Record externalize event for slot 100.
@@ -4805,8 +4776,8 @@ mod tests {
         // Create the driver outside the local recorder scope — driver setup
         // does not emit histograms.
         let driver = make_test_driver();
-        let peer_node = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([1u8; 32]),
+        let peer_node = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([1u8; 32]),
         ));
 
         let recorder = PrometheusBuilder::new().build_recorder();
@@ -4899,7 +4870,7 @@ mod tests {
         driver.cache_tx_set(tx_set);
 
         let sv = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash.0),
+            tx_set_hash: stellar_xdr::Hash(hash.0),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -4936,7 +4907,7 @@ mod tests {
 
         let invalid_upgrade = UpgradeType(vec![0u8; 1].try_into().unwrap());
         let sv = make_signed_stellar_value(
-            stellar_xdr::curr::Hash(tx_set_hash.0),
+            stellar_xdr::Hash(tx_set_hash.0),
             now,
             vec![invalid_upgrade],
             &secret_key,
@@ -4964,7 +4935,7 @@ mod tests {
             .as_secs();
 
         let sv = make_signed_stellar_value(
-            stellar_xdr::curr::Hash(tx_set_hash.0),
+            stellar_xdr::Hash(tx_set_hash.0),
             now,
             vec![],
             &secret_key,
@@ -4990,7 +4961,7 @@ mod tests {
         // LCL close_time is 0. A value with close_time=0 (not strictly
         // greater) must be rejected at slot 1 (current ledger = LCL+1).
         let sv = make_signed_stellar_value(
-            stellar_xdr::curr::Hash(tx_set_hash.0),
+            stellar_xdr::Hash(tx_set_hash.0),
             0, // same as LCL close_time
             vec![],
             &secret_key,
@@ -5029,7 +5000,7 @@ mod tests {
         ];
 
         let sv = make_signed_stellar_value(
-            stellar_xdr::curr::Hash(tx_set_hash.0),
+            stellar_xdr::Hash(tx_set_hash.0),
             now,
             upgrades,
             &secret_key,
@@ -5063,7 +5034,7 @@ mod tests {
 
         // Create a value with Basic ext (no signature)
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -5092,7 +5063,7 @@ mod tests {
 
         // Create a signed value but tamper with the signature
         let mut sv = make_signed_stellar_value(
-            stellar_xdr::curr::Hash(tx_set_hash.0),
+            stellar_xdr::Hash(tx_set_hash.0),
             now,
             vec![],
             &secret_key,
@@ -5128,7 +5099,7 @@ mod tests {
             .as_secs();
 
         let sv = make_signed_stellar_value(
-            stellar_xdr::curr::Hash(tx_set_hash.0),
+            stellar_xdr::Hash(tx_set_hash.0),
             now,
             vec![],
             &secret_key,
@@ -5150,7 +5121,7 @@ mod tests {
 
         let data = b"test message";
         let sig_bytes = secret.sign(data);
-        let sig = stellar_xdr::curr::Signature(sig_bytes.as_bytes().to_vec().try_into().unwrap());
+        let sig = stellar_xdr::Signature(sig_bytes.as_bytes().to_vec().try_into().unwrap());
 
         assert!(ScpDriver::verify_signed_bytes(data, &node_id, &sig).is_ok());
     }
@@ -5163,7 +5134,7 @@ mod tests {
 
         let data = b"test message";
         let wrong_sig = [0u8; 64];
-        let sig = stellar_xdr::curr::Signature(wrong_sig.to_vec().try_into().unwrap());
+        let sig = stellar_xdr::Signature(wrong_sig.to_vec().try_into().unwrap());
 
         let err = ScpDriver::verify_signed_bytes(data, &node_id, &sig).unwrap_err();
         assert!(
@@ -5180,12 +5151,12 @@ mod tests {
         // y=2 is not on the ed25519 curve
         let mut bad_key = [0u8; 32];
         bad_key[0] = 2;
-        let node_id = NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(bad_key),
+        let node_id = NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(bad_key),
         ));
 
         let data = b"test message";
-        let sig = stellar_xdr::curr::Signature([0u8; 64].to_vec().try_into().unwrap());
+        let sig = stellar_xdr::Signature([0u8; 64].to_vec().try_into().unwrap());
 
         let err = ScpDriver::verify_signed_bytes(data, &node_id, &sig).unwrap_err();
         assert!(
@@ -5202,7 +5173,7 @@ mod tests {
 
         let data = b"test message";
         // Too short signature
-        let sig = stellar_xdr::curr::Signature(vec![0u8; 32].try_into().unwrap());
+        let sig = stellar_xdr::Signature(vec![0u8; 32].try_into().unwrap());
 
         let err = ScpDriver::verify_signed_bytes(data, &node_id, &sig).unwrap_err();
         assert!(
@@ -5225,7 +5196,7 @@ mod tests {
 
         // Value with missing tx set (MaybeValid from local state check)
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([1u8; 32]),
+            tx_set_hash: stellar_xdr::Hash([1u8; 32]),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -5281,7 +5252,7 @@ mod tests {
         ];
 
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(now),
             upgrades: upgrades.try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -5344,7 +5315,7 @@ mod tests {
         ];
 
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(now),
             upgrades: upgrades.try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -5406,7 +5377,7 @@ mod tests {
         ];
 
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(now),
             upgrades: upgrades.try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -5476,7 +5447,7 @@ mod tests {
         ];
 
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(now),
             upgrades: upgrades.try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -5509,7 +5480,7 @@ mod tests {
     /// an unset OnceLock would skip validation entirely (fail-open).
     #[test]
     fn test_default_upgrades_rejects_nominations() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
 
         let driver = make_test_driver();
 
@@ -5561,7 +5532,7 @@ mod tests {
         ];
 
         let stellar_value = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
             close_time: TimePoint(now),
             upgrades: upgrades.try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -5598,7 +5569,7 @@ mod tests {
             .to_xdr(Limits::none())
             .expect("xdr");
         let sv1 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_1.0),
+            tx_set_hash: stellar_xdr::Hash(hash_1.0),
             close_time: TimePoint(now),
             upgrades: vec![UpgradeType(version.try_into().unwrap())]
                 .try_into()
@@ -5611,7 +5582,7 @@ mod tests {
             .to_xdr(Limits::none())
             .expect("xdr");
         let sv2 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_2.0),
+            tx_set_hash: stellar_xdr::Hash(hash_2.0),
             close_time: TimePoint(now),
             upgrades: vec![UpgradeType(base_fee.try_into().unwrap())]
                 .try_into()
@@ -5654,7 +5625,7 @@ mod tests {
             .to_xdr(Limits::none())
             .expect("xdr");
         let sv1 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_1.0),
+            tx_set_hash: stellar_xdr::Hash(hash_1.0),
             close_time: TimePoint(now),
             upgrades: vec![UpgradeType(v24.try_into().unwrap())]
                 .try_into()
@@ -5667,7 +5638,7 @@ mod tests {
             .to_xdr(Limits::none())
             .expect("xdr");
         let sv2 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_2.0),
+            tx_set_hash: stellar_xdr::Hash(hash_2.0),
             close_time: TimePoint(now),
             upgrades: vec![UpgradeType(v25.try_into().unwrap())]
                 .try_into()
@@ -5702,7 +5673,7 @@ mod tests {
 
         // Value without upgrades
         let sv_no_upgrades = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([1u8; 32]),
+            tx_set_hash: stellar_xdr::Hash([1u8; 32]),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -5715,7 +5686,7 @@ mod tests {
             .to_xdr(Limits::none())
             .expect("xdr");
         let sv_with_upgrades = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([1u8; 32]),
+            tx_set_hash: stellar_xdr::Hash([1u8; 32]),
             close_time: TimePoint(now),
             upgrades: vec![UpgradeType(version.try_into().unwrap())]
                 .try_into()
@@ -6029,7 +6000,7 @@ mod tests {
         driver.cache_tx_set(tx_set);
 
         let sv = make_signed_stellar_value(
-            stellar_xdr::curr::Hash(tx_set_hash.0),
+            stellar_xdr::Hash(tx_set_hash.0),
             now,
             vec![],
             &secret_key,
@@ -6045,16 +6016,16 @@ mod tests {
     // Phase 2A: is_tx_set_well_formed tests
     // =========================================================================
 
-    fn make_simple_tx(seed: u8) -> stellar_xdr::curr::TransactionEnvelope {
-        use stellar_xdr::curr::{
+    fn make_simple_tx(seed: u8) -> stellar_xdr::TransactionEnvelope {
+        use stellar_xdr::{
             CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
             Preconditions, SequenceNumber, SignatureHint, Transaction, TransactionEnvelope,
             TransactionExt, TransactionV1Envelope, Uint256,
         };
         let source = MuxedAccount::Ed25519(Uint256([seed; 32]));
-        let dest = stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([seed.wrapping_add(1); 32])),
-        );
+        let dest = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            [seed.wrapping_add(1); 32],
+        )));
         let tx = Transaction {
             source_account: source,
             fee: 100,
@@ -6076,7 +6047,7 @@ mod tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -6099,7 +6070,7 @@ mod tests {
     #[test]
     fn test_is_tx_set_well_formed_sorted() {
         // Create txs and sort them by hash
-        let mut txs: Vec<stellar_xdr::curr::TransactionEnvelope> =
+        let mut txs: Vec<stellar_xdr::TransactionEnvelope> =
             (1..=5).map(|i| make_simple_tx(i)).collect();
         txs.sort_by(|a, b| {
             let ha = Hash256::hash_xdr(a);
@@ -6114,7 +6085,7 @@ mod tests {
     #[test]
     fn test_is_tx_set_well_formed_unsorted() {
         // Create txs sorted by hash, then swap first two to make unsorted
-        let mut txs: Vec<stellar_xdr::curr::TransactionEnvelope> =
+        let mut txs: Vec<stellar_xdr::TransactionEnvelope> =
             (1..=5).map(|i| make_simple_tx(i)).collect();
         txs.sort_by(|a, b| {
             let ha = Hash256::hash_xdr(a);
@@ -6148,7 +6119,7 @@ mod tests {
     /// The is_tx_set_well_formed check only applies to legacy tx sets.
     #[test]
     fn test_audit_013_generalized_tx_set_not_rejected_by_global_sort() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, ParallelTxsComponent, TransactionPhase,
             TransactionSetV1, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
         };
@@ -6324,7 +6295,7 @@ mod tests {
         let upgrade_type = UpgradeType(upgrade_bytes.try_into().unwrap());
 
         let sv = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([0; 32]),
+            tx_set_hash: stellar_xdr::Hash([0; 32]),
             close_time: TimePoint(1500),
             upgrades: vec![upgrade_type].try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -6353,7 +6324,7 @@ mod tests {
     fn test_audit_023_config_upgrade_nonexistent_key_rejected() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ConfigUpgradeSetKey, ContractId, Hash, LedgerHeader, LedgerHeaderExt, StellarValueExt,
             TimePoint, VecM,
         };
@@ -6412,7 +6383,7 @@ mod tests {
         let upgrade_type = UpgradeType(upgrade_bytes.try_into().unwrap());
 
         let sv = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([0; 32]),
+            tx_set_hash: stellar_xdr::Hash([0; 32]),
             close_time: TimePoint(0),
             upgrades: vec![upgrade_type].try_into().unwrap(),
             ext: StellarValueExt::Basic,
@@ -6432,7 +6403,7 @@ mod tests {
     /// not found, and non-Config upgrades are unaffected.
     #[test]
     fn test_audit_023_is_valid_upgrade_for_apply_config_with_default_lm() {
-        use stellar_xdr::curr::{ConfigUpgradeSetKey, ContractId, Hash};
+        use stellar_xdr::{ConfigUpgradeSetKey, ContractId, Hash};
 
         let lm = make_default_lm();
 
@@ -6533,7 +6504,7 @@ mod tests {
             .as_secs();
 
         // Create a signed StellarValue referencing a tx_set_hash NOT in cache
-        let uncached_hash = stellar_xdr::curr::Hash([0xAB; 32]);
+        let uncached_hash = stellar_xdr::Hash([0xAB; 32]);
         let sv =
             make_signed_stellar_value(uncached_hash, now, vec![], &secret_key, &driver.network_id);
 
@@ -6570,13 +6541,13 @@ mod tests {
         let tx_set_b = TransactionSet::new(lcl_hash, vec![]);
 
         let sv_a = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_a.hash().0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_a.hash().0),
             close_time: TimePoint(1_700_000_000),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
         };
         let sv_b = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_b.hash().0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_b.hash().0),
             close_time: TimePoint(1_700_000_000),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -6603,7 +6574,7 @@ mod tests {
     fn test_audit_260_upgrades_from_stale_lcl_included() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, LedgerUpgrade, Limits, StellarValue,
             StellarValueExt, TimePoint, UpgradeType, VecM,
         };
@@ -6666,7 +6637,7 @@ mod tests {
         let now = 1_700_000_000u64;
 
         let sv_valid = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_valid.0),
+            tx_set_hash: stellar_xdr::Hash(hash_valid.0),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -6676,7 +6647,7 @@ mod tests {
             .to_xdr(Limits::none())
             .expect("xdr");
         let sv_stale = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_stale.0),
+            tx_set_hash: stellar_xdr::Hash(hash_stale.0),
             close_time: TimePoint(now),
             upgrades: vec![UpgradeType(version_upgrade.try_into().unwrap())]
                 .try_into()
@@ -6716,7 +6687,7 @@ mod tests {
     fn test_audit_260_hash_includes_all_candidates() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, Limits, StellarValue, StellarValueExt, TimePoint,
             VecM,
         };
@@ -6783,19 +6754,19 @@ mod tests {
         let now = 1_700_000_000u64;
 
         let sv_a = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_a.0),
+            tx_set_hash: stellar_xdr::Hash(hash_a.0),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
         };
         let sv_b = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_b.0),
+            tx_set_hash: stellar_xdr::Hash(hash_b.0),
             close_time: TimePoint(now + 1), // different close_time to ensure different SV hash
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
         };
         let sv_stale = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_stale.0),
+            tx_set_hash: stellar_xdr::Hash(hash_stale.0),
             close_time: TimePoint(now + 2),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -6864,7 +6835,7 @@ mod tests {
     fn test_combine_candidates_returns_empty_when_single_candidate_stale() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
 
@@ -6918,7 +6889,7 @@ mod tests {
         driver.cache_tx_set(tx_set_stale);
 
         let sv_stale = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_stale.0),
+            tx_set_hash: stellar_xdr::Hash(hash_stale.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -6943,7 +6914,7 @@ mod tests {
     fn test_combine_candidates_returns_empty_when_all_candidates_stale() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
 
@@ -7003,13 +6974,13 @@ mod tests {
 
         let now = 1_700_000_000u64;
         let sv_1 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_1.0),
+            tx_set_hash: stellar_xdr::Hash(hash_1.0),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
         };
         let sv_2 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_2.0),
+            tx_set_hash: stellar_xdr::Hash(hash_2.0),
             close_time: TimePoint(now + 1),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -7037,7 +7008,7 @@ mod tests {
     fn test_combine_candidates_empty_return_maps_to_none_via_wrapper() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
 
@@ -7091,7 +7062,7 @@ mod tests {
         driver.cache_tx_set(tx_set_stale);
 
         let sv_stale = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash_stale.0),
+            tx_set_hash: stellar_xdr::Hash(hash_stale.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -7313,7 +7284,7 @@ mod tests {
     fn test_audit_264_fee_balance_check_in_scp_validation() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountEntryExt, AccountId, Asset, BucketListType, DecoratedSignature,
             Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerHeader, LedgerHeaderExt,
             Memo, MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions, PublicKey,
@@ -7321,7 +7292,7 @@ mod tests {
             StellarValueExt, Thresholds, TimePoint, Transaction, TransactionEnvelope,
             TransactionExt, TransactionV1Envelope, Uint256,
         };
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, ParallelTxsComponent, TransactionPhase, TransactionSetV1,
             TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
         };
@@ -7338,7 +7309,7 @@ mod tests {
             num_sub_entries: 0,
             inflation_dest: None,
             flags: 0,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([1, 1, 1, 1]),
             signers: VecM::default(),
             ext: AccountEntryExt::V0,
@@ -7472,7 +7443,7 @@ mod tests {
     #[test]
     fn test_audit_264_default_ledger_manager_permissive() {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, ParallelTxsComponent, TransactionPhase,
             TransactionSetV1,
         };
@@ -7483,7 +7454,7 @@ mod tests {
             ..Default::default()
         };
         let lm = LedgerManager::new("Test Network".to_string(), lm_config);
-        let header = stellar_xdr::curr::LedgerHeader {
+        let header = stellar_xdr::LedgerHeader {
             ledger_version: 0,
             previous_ledger_hash: Hash([0u8; 32]),
             scp_value: StellarValue {
@@ -7508,7 +7479,7 @@ mod tests {
                 Hash([0u8; 32]),
                 Hash([0u8; 32]),
             ],
-            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            ext: stellar_xdr::LedgerHeaderExt::V0,
         };
         let header_hash = henyey_ledger::compute_header_hash(&header).expect("hash");
         lm.initialize(
@@ -7548,7 +7519,7 @@ mod tests {
     /// fatal false→true panic in store_valid.
     #[test]
     fn test_check_and_cache_tx_set_valid_reuses_cached_false_without_revalidation() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, ParallelTxsComponent, TransactionPhase,
             TransactionSetV1,
         };
@@ -7615,7 +7586,7 @@ mod tests {
             .to_xdr(Limits::none())
             .unwrap();
         let sv1 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash.0),
+            tx_set_hash: stellar_xdr::Hash(hash.0),
             close_time: TimePoint(now),
             upgrades: vec![
                 UpgradeType(u1.try_into().unwrap()),
@@ -7632,14 +7603,14 @@ mod tests {
             .to_xdr(Limits::none())
             .unwrap();
         let u5 = LedgerUpgrade::Flags(1).to_xdr(Limits::none()).unwrap();
-        let u6 = LedgerUpgrade::Config(stellar_xdr::curr::ConfigUpgradeSetKey {
-            contract_id: stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash([0u8; 32])),
-            content_hash: stellar_xdr::curr::Hash([1u8; 32]),
+        let u6 = LedgerUpgrade::Config(stellar_xdr::ConfigUpgradeSetKey {
+            contract_id: stellar_xdr::ContractId(stellar_xdr::Hash([0u8; 32])),
+            content_hash: stellar_xdr::Hash([1u8; 32]),
         })
         .to_xdr(Limits::none())
         .unwrap();
         let sv2 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash.0),
+            tx_set_hash: stellar_xdr::Hash(hash.0),
             close_time: TimePoint(now),
             upgrades: vec![
                 UpgradeType(u4.try_into().unwrap()),
@@ -7688,7 +7659,7 @@ mod tests {
             .to_xdr(Limits::none())
             .unwrap();
         let sv1 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash.0),
+            tx_set_hash: stellar_xdr::Hash(hash.0),
             close_time: TimePoint(now),
             upgrades: vec![
                 UpgradeType(u1.try_into().unwrap()),
@@ -7703,9 +7674,9 @@ mod tests {
 
         // Candidate 2: FLAGS, CONFIG, MAX_SOROBAN_TX_SET_SIZE (3 more = 7 total)
         let u5 = LedgerUpgrade::Flags(1).to_xdr(Limits::none()).unwrap();
-        let u6 = LedgerUpgrade::Config(stellar_xdr::curr::ConfigUpgradeSetKey {
-            contract_id: stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash([0u8; 32])),
-            content_hash: stellar_xdr::curr::Hash([1u8; 32]),
+        let u6 = LedgerUpgrade::Config(stellar_xdr::ConfigUpgradeSetKey {
+            contract_id: stellar_xdr::ContractId(stellar_xdr::Hash([0u8; 32])),
+            content_hash: stellar_xdr::Hash([1u8; 32]),
         })
         .to_xdr(Limits::none())
         .unwrap();
@@ -7713,7 +7684,7 @@ mod tests {
             .to_xdr(Limits::none())
             .unwrap();
         let sv2 = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash.0),
+            tx_set_hash: stellar_xdr::Hash(hash.0),
             close_time: TimePoint(now),
             upgrades: vec![
                 UpgradeType(u5.try_into().unwrap()),
@@ -7750,7 +7721,7 @@ mod tests {
 
         // One valid candidate
         let sv = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash.0),
+            tx_set_hash: stellar_xdr::Hash(hash.0),
             close_time: TimePoint(now),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -7784,7 +7755,7 @@ mod tests {
         let valid_upgrade = LedgerUpgrade::Version(25).to_xdr(Limits::none()).unwrap();
         let malformed_bytes: Vec<u8> = vec![0xFF, 0xFE, 0xFD];
         let sv = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(hash.0),
+            tx_set_hash: stellar_xdr::Hash(hash.0),
             close_time: TimePoint(now),
             upgrades: vec![
                 UpgradeType(valid_upgrade.try_into().unwrap()),
@@ -7809,7 +7780,7 @@ mod tests {
     fn test_combine_candidates_panics_on_prepare_for_apply_failure_before_lcl_filter() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use henyey_ledger::{compute_header_hash, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, LedgerHeader, LedgerHeaderExt, StellarValue,
             StellarValueExt, TimePoint, TransactionPhase, TransactionSetV1, TxSetComponent,
             TxSetComponentTxsMaybeDiscountedFee, VecM,
@@ -7909,13 +7880,13 @@ mod tests {
         driver.cache_tx_set(valid_tx_set);
 
         let sv_bad = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(bad_hash.0),
+            tx_set_hash: stellar_xdr::Hash(bad_hash.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
         };
         let sv_valid = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(valid_hash.0),
+            tx_set_hash: stellar_xdr::Hash(valid_hash.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -7942,7 +7913,7 @@ mod tests {
         let uncached_hash = Hash256::from_bytes([0xAA; 32]);
         let malformed_bytes: Vec<u8> = vec![0xFF, 0xFE, 0xFD];
         let sv_bad = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(uncached_hash.0),
+            tx_set_hash: stellar_xdr::Hash(uncached_hash.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: vec![UpgradeType(malformed_bytes.try_into().unwrap())]
                 .try_into()
@@ -7956,7 +7927,7 @@ mod tests {
         driver.cache_tx_set(valid_tx_set);
 
         let sv_valid = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(valid_hash.0),
+            tx_set_hash: stellar_xdr::Hash(valid_hash.0),
             close_time: TimePoint(1_700_000_000),
             upgrades: VecM::default(),
             ext: StellarValueExt::Basic,
@@ -7983,7 +7954,7 @@ mod tests {
 
         // Candidate A: valid StellarValue XDR with a malformed upgrade.
         let sv_a = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([0x11; 32]),
+            tx_set_hash: stellar_xdr::Hash([0x11; 32]),
             close_time: TimePoint(1_700_000_000),
             upgrades: vec![UpgradeType(vec![0xFF, 0xFE, 0xFD].try_into().unwrap())]
                 .try_into()
@@ -8024,7 +7995,7 @@ mod tests {
         // Candidate A: valid StellarValue with a malformed upgrade.
         // Its raw bytes will be LOWER than candidate B's.
         let sv_a = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([0x01; 32]),
+            tx_set_hash: stellar_xdr::Hash([0x01; 32]),
             close_time: TimePoint(1_000_000_000),
             upgrades: vec![UpgradeType(vec![0xFF, 0xFE, 0xFD].try_into().unwrap())]
                 .try_into()
@@ -8036,7 +8007,7 @@ mod tests {
         // Candidate B: valid StellarValue with a malformed upgrade.
         // Its raw bytes will be HIGHER than candidate A's (tx_set_hash 0x99 > 0x01).
         let sv_b = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([0x99; 32]),
+            tx_set_hash: stellar_xdr::Hash([0x99; 32]),
             close_time: TimePoint(2_000_000_000),
             upgrades: vec![UpgradeType(vec![0xAA, 0xBB, 0xCC].try_into().unwrap())]
                 .try_into()
@@ -8072,7 +8043,7 @@ mod tests {
         // Candidate A (canonically first — low raw bytes): valid StellarValue
         // with a malformed upgrade.
         let sv_a = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash([0x01; 32]),
+            tx_set_hash: stellar_xdr::Hash([0x01; 32]),
             close_time: TimePoint(1_000_000_000),
             upgrades: vec![UpgradeType(vec![0xFF, 0xFE, 0xFD].try_into().unwrap())]
                 .try_into()
@@ -8099,7 +8070,7 @@ mod tests {
 mod compare_tx_sets_tests {
     use super::*;
     use crate::tx_queue::TransactionSet;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         GeneralizedTransactionSet, Hash, Limits, ParallelTxsComponent, TransactionPhase,
         TransactionSetV1, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
     };
@@ -8118,7 +8089,7 @@ mod compare_tx_sets_tests {
 
     fn make_default_lm() -> Arc<henyey_ledger::LedgerManager> {
         use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
         let config = LedgerManagerConfig {
@@ -8177,16 +8148,16 @@ mod compare_tx_sets_tests {
     }
 
     /// Create a simple transaction with a given fee and operation count.
-    fn make_tx(seed: u8, fee: u32, ops: usize) -> stellar_xdr::curr::TransactionEnvelope {
-        use stellar_xdr::curr::{
+    fn make_tx(seed: u8, fee: u32, ops: usize) -> stellar_xdr::TransactionEnvelope {
+        use stellar_xdr::{
             CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
             Preconditions, SequenceNumber, SignatureHint, Transaction, TransactionEnvelope,
             TransactionExt, TransactionV1Envelope, Uint256,
         };
         let source = MuxedAccount::Ed25519(Uint256([seed; 32]));
-        let dest = stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([seed.wrapping_add(1); 32])),
-        );
+        let dest = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            [seed.wrapping_add(1); 32],
+        )));
         let operations: Vec<Operation> = (0..ops)
             .map(|_| Operation {
                 source_account: None,
@@ -8209,7 +8180,7 @@ mod compare_tx_sets_tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -8256,12 +8227,8 @@ mod compare_tx_sets_tests {
 
     /// Create a Soroban-like transaction with a given fee and resource fee.
     /// inclusion_fee = fee - resource_fee.
-    fn make_soroban_tx(
-        seed: u8,
-        fee: u32,
-        resource_fee: i64,
-    ) -> stellar_xdr::curr::TransactionEnvelope {
-        use stellar_xdr::curr::{
+    fn make_soroban_tx(seed: u8, fee: u32, resource_fee: i64) -> stellar_xdr::TransactionEnvelope {
+        use stellar_xdr::{
             AccountId, DecoratedSignature, HostFunction, InvokeContractArgs, InvokeHostFunctionOp,
             LedgerFootprint, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
             PublicKey, ScAddress, ScVal, SequenceNumber, SignatureHint, SorobanResources,
@@ -8269,7 +8236,7 @@ mod compare_tx_sets_tests {
             TransactionExt, TransactionV1Envelope, Uint256, VecM,
         };
         let source = MuxedAccount::Ed25519(Uint256([seed; 32]));
-        let function_name = stellar_xdr::curr::ScSymbol("test".try_into().unwrap());
+        let function_name = stellar_xdr::ScSymbol("test".try_into().unwrap());
         let operations = vec![Operation {
             source_account: None,
             body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
@@ -8308,7 +8275,7 @@ mod compare_tx_sets_tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -8316,7 +8283,7 @@ mod compare_tx_sets_tests {
     }
 
     fn make_generalized_tx_set(
-        tx: stellar_xdr::curr::TransactionEnvelope,
+        tx: stellar_xdr::TransactionEnvelope,
         base_fee: i64,
     ) -> TransactionSet {
         let component =
@@ -8517,7 +8484,7 @@ mod compare_tx_sets_tests {
     #[test]
     #[should_panic(expected = "missing from cache in combineCandidates")]
     fn test_combine_candidates_panics_instead_of_filtering_missing_high_priority_candidate() {
-        use stellar_xdr::curr::{StellarValue, StellarValueExt, TimePoint};
+        use stellar_xdr::{StellarValue, StellarValueExt, TimePoint};
 
         let driver = make_driver();
         let lcl_hash = driver.ledger_manager.current_header_hash();
@@ -8528,13 +8495,13 @@ mod compare_tx_sets_tests {
         let tx_set_b = TransactionSet::new(lcl_hash, vec![make_tx(2, 100, 1)]);
 
         let sv_a = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_a.hash().0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_a.hash().0),
             close_time: TimePoint(1_700_000_000),
             upgrades: Default::default(),
             ext: StellarValueExt::Basic,
         };
         let sv_b = StellarValue {
-            tx_set_hash: stellar_xdr::curr::Hash(tx_set_b.hash().0),
+            tx_set_hash: stellar_xdr::Hash(tx_set_b.hash().0),
             close_time: TimePoint(1_700_000_000),
             upgrades: Default::default(),
             ext: StellarValueExt::Basic,
@@ -8751,21 +8718,17 @@ mod compare_tx_sets_tests {
 
     /// Helper: create a fee-bump transaction with an i64 outer fee.
     /// Enables near-i64::MAX fee values for saturation tests.
-    fn make_fee_bump_tx(
-        seed: u8,
-        outer_fee: i64,
-        ops: usize,
-    ) -> stellar_xdr::curr::TransactionEnvelope {
-        use stellar_xdr::curr::{
+    fn make_fee_bump_tx(seed: u8, outer_fee: i64, ops: usize) -> stellar_xdr::TransactionEnvelope {
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx, MuxedAccount, Uint256,
         };
         let inner = make_tx(seed, 1000, ops);
         let inner_env = match inner {
-            stellar_xdr::curr::TransactionEnvelope::Tx(env) => env,
+            stellar_xdr::TransactionEnvelope::Tx(env) => env,
             _ => panic!("expected Tx envelope"),
         };
-        stellar_xdr::curr::TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
+        stellar_xdr::TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
             tx: FeeBumpTransaction {
                 fee_source: MuxedAccount::Ed25519(Uint256([seed; 32])),
                 fee: outer_fee,
@@ -8811,7 +8774,7 @@ mod compare_tx_sets_tests {
 
     #[test]
     fn test_tx_set_total_fees_generalized_saturation() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             GeneralizedTransactionSet, Hash, TransactionPhase, TransactionSetV1, TxSetComponent,
             TxSetComponentTxsMaybeDiscountedFee,
         };
@@ -8936,7 +8899,7 @@ mod compare_tx_sets_tests {
     /// produce different composites — making SCP ballot convergence impossible.
     #[test]
     fn test_combine_candidates_order_independent() {
-        use stellar_xdr::curr::{StellarValue, StellarValueExt, TimePoint, WriteXdr};
+        use stellar_xdr::{StellarValue, StellarValueExt, TimePoint, WriteXdr};
 
         let driver = make_driver();
         let lcl_hash = driver.ledger_manager.current_header_hash();
@@ -8962,13 +8925,13 @@ mod compare_tx_sets_tests {
         };
 
         let val_a = Value(
-            sv_a.to_xdr(stellar_xdr::curr::Limits::none())
+            sv_a.to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
         );
         let val_b = Value(
-            sv_b.to_xdr(stellar_xdr::curr::Limits::none())
+            sv_b.to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -9105,8 +9068,8 @@ mod validator_weight_config_tests {
     fn make_node_id(seed: u8) -> NodeId {
         let mut bytes = [0u8; 32];
         bytes[0] = seed;
-        NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(bytes),
+        NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(bytes),
         ))
     }
 

--- a/crates/herder/src/scp_verify.rs
+++ b/crates/herder/src/scp_verify.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use henyey_common::Hash256;
-use stellar_xdr::curr::ScpEnvelope;
+use stellar_xdr::ScpEnvelope;
 
 use crate::error::HerderError;
 use crate::scp_driver::ScpDriver;
@@ -658,7 +658,7 @@ mod tests {
     }
 
     fn dummy_envelope() -> ScpEnvelope {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             NodeId, PublicKey as XdrPublicKey, ScpBallot, ScpStatement, ScpStatementPledges,
             ScpStatementPrepare, Signature, Uint256, Value,
         };
@@ -666,7 +666,7 @@ mod tests {
         let node_id = NodeId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32])));
         let value = Value(vec![].try_into().unwrap());
         let pledges = ScpStatementPledges::Prepare(ScpStatementPrepare {
-            quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
             ballot: ScpBallot {
                 counter: 1,
                 value: value.clone(),

--- a/crates/herder/src/surge_pricing.rs
+++ b/crates/herder/src/surge_pricing.rs
@@ -58,7 +58,7 @@ use henyey_tx::envelope_utils::{
     envelope_operation_count, has_dex_operations_envelope, is_soroban_envelope,
     resources_from_envelope,
 };
-use stellar_xdr::curr::TransactionEnvelope;
+use stellar_xdr::TransactionEnvelope;
 
 use crate::tx_queue::QueuedTransaction;
 use henyey_tx::FeeRate;
@@ -866,7 +866,7 @@ mod tests {
     #[should_panic(expected = "erase: resources exceed lane current count")]
     fn test_erase_panics_when_resources_exceed_lane_count() {
         use crate::tx_queue::QueuedTransaction;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
             SequenceNumber, Signature, SignatureHint, Transaction, TransactionEnvelope,
             TransactionV1Envelope, Uint256,
@@ -888,7 +888,7 @@ mod tests {
             }]
             .try_into()
             .unwrap(),
-            ext: stellar_xdr::curr::TransactionExt::V0,
+            ext: stellar_xdr::TransactionExt::V0,
         };
         let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
             tx,

--- a/crates/herder/src/tx_queue/arb_flood_damping.rs
+++ b/crates/herder/src/tx_queue/arb_flood_damping.rs
@@ -12,7 +12,7 @@ use henyey_ledger::offer::AssetPair;
 use rand::distributions::Distribution;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use stellar_xdr::curr::{Asset, Operation, OperationBody};
+use stellar_xdr::{Asset, Operation, OperationBody};
 
 // ---------------------------------------------------------------------------
 // Loop detection
@@ -126,7 +126,7 @@ struct AssetKey(Vec<u8>);
 
 impl AssetKey {
     fn from(asset: &Asset) -> Self {
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
         Self(
             asset
                 .to_xdr(Limits::none())
@@ -378,16 +378,16 @@ impl Distribution<u32> for GeometricDistribution {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AlphaNum4, AssetCode4, PathPaymentStrictReceiveOp, PathPaymentStrictSendOp, Uint256, VecM,
     };
 
     fn make_asset(code: &[u8; 4]) -> Asset {
         Asset::CreditAlphanum4(AlphaNum4 {
             asset_code: AssetCode4(*code),
-            issuer: stellar_xdr::curr::AccountId(
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32])),
-            ),
+            issuer: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+                [0u8; 32],
+            ))),
         })
     }
 
@@ -401,7 +401,7 @@ mod tests {
             body: OperationBody::PathPaymentStrictReceive(PathPaymentStrictReceiveOp {
                 send_asset: send,
                 send_max: 1_000_000,
-                destination: stellar_xdr::curr::MuxedAccount::Ed25519(Uint256([0u8; 32])),
+                destination: stellar_xdr::MuxedAccount::Ed25519(Uint256([0u8; 32])),
                 dest_asset: dest,
                 dest_amount: 1,
                 path: path.try_into().unwrap_or_else(|_| VecM::default()),
@@ -415,7 +415,7 @@ mod tests {
             body: OperationBody::PathPaymentStrictSend(PathPaymentStrictSendOp {
                 send_asset: send,
                 send_amount: 1_000_000,
-                destination: stellar_xdr::curr::MuxedAccount::Ed25519(Uint256([0u8; 32])),
+                destination: stellar_xdr::MuxedAccount::Ed25519(Uint256([0u8; 32])),
                 dest_asset: dest,
                 dest_min: 1,
                 path: path.try_into().unwrap_or_else(|_| VecM::default()),

--- a/crates/herder/src/tx_queue/flood_queue.rs
+++ b/crates/herder/src/tx_queue/flood_queue.rs
@@ -132,7 +132,7 @@ mod tests {
     use henyey_common::Hash256;
     use std::sync::Arc;
     use std::time::Instant;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
         Preconditions, SequenceNumber, Signature as XdrSignature, SignatureHint, Transaction,
         TransactionEnvelope, TransactionExt, TransactionV1Envelope, Uint256,
@@ -143,9 +143,9 @@ mod tests {
         let operations = vec![Operation {
             source_account: None,
             body: OperationBody::CreateAccount(CreateAccountOp {
-                destination: stellar_xdr::curr::AccountId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([255u8; 32])),
-                ),
+                destination: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    Uint256([255u8; 32]),
+                )),
                 starting_balance: 1_000_000_000,
             }),
         }];

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -53,8 +53,8 @@ use henyey_common::{
     any_greater, xdr_to_bytes, Hash256, NetworkId, Resource, ResourceType, NUM_SOROBAN_TX_RESOURCES,
 };
 use henyey_crypto::Sha256Hasher;
-use stellar_xdr::curr::WriteXdr;
-use stellar_xdr::curr::{
+use stellar_xdr::WriteXdr;
+use stellar_xdr::{
     AccountEntry, AccountId, DecoratedSignature, FeeBumpTransactionInnerTx,
     GeneralizedTransactionSet, Limits, OperationType, Preconditions, SignerKey,
     TransactionEnvelope, TransactionPhase, TxSetComponent,
@@ -1155,16 +1155,14 @@ fn build_eviction_exclusion(
 }
 
 /// Get the source account (inner for fee-bump) as a MuxedAccount.
-fn source_account_from_envelope(envelope: &TransactionEnvelope) -> stellar_xdr::curr::MuxedAccount {
+fn source_account_from_envelope(envelope: &TransactionEnvelope) -> stellar_xdr::MuxedAccount {
     match envelope {
         TransactionEnvelope::TxV0(env) => {
-            stellar_xdr::curr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone())
+            stellar_xdr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone())
         }
         TransactionEnvelope::Tx(env) => env.tx.source_account.clone(),
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
-                inner.tx.source_account.clone()
-            }
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.source_account.clone(),
         },
     }
 }
@@ -1186,7 +1184,7 @@ fn account_id_from_envelope(envelope: &TransactionEnvelope) -> AccountId {
 fn fee_source_key(envelope: &TransactionEnvelope) -> Vec<u8> {
     let fee_source = match envelope {
         TransactionEnvelope::TxV0(env) => {
-            stellar_xdr::curr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone())
+            stellar_xdr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone())
         }
         TransactionEnvelope::Tx(env) => env.tx.source_account.clone(),
         TransactionEnvelope::TxFeeBump(env) => env.tx.fee_source.clone(),
@@ -1200,11 +1198,11 @@ use henyey_tx::envelope_utils::is_fee_bump_envelope;
 
 /// Convert an XDR-encoded account key back to AccountId.
 fn account_id_from_fee_source_key(key: &[u8]) -> AccountId {
-    use stellar_xdr::curr::ReadXdr;
+    use stellar_xdr::ReadXdr;
     AccountId::from_xdr(key, Limits::none()).unwrap_or({
         // Fallback to a zero account ID if decoding fails
-        AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([0; 32]),
+        AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([0; 32]),
         ))
     })
 }
@@ -1654,7 +1652,7 @@ impl TransactionQueue {
         // Queue admission only: validate host function pairing.
         // stellar-core enforces this at queue admission but not tx-set checkValid.
         if frame.is_soroban() && !frame.validate_host_fn() {
-            return Err(stellar_xdr::curr::TransactionResultCode::TxSorobanInvalid);
+            return Err(stellar_xdr::TransactionResultCode::TxSorobanInvalid);
         }
 
         // Build ledger context once for bounds and signature validation.
@@ -1734,7 +1732,7 @@ impl TransactionQueue {
                 if henyey_tx::is_op_supported(&op_type, ctx.protocol_version, ctx.ledger_flags)
                     .is_err()
                 {
-                    return Err(stellar_xdr::curr::TransactionResultCode::TxFailed);
+                    return Err(stellar_xdr::TransactionResultCode::TxFailed);
                 }
                 let effective_source = match &op.source_account {
                     Some(muxed) => henyey_tx::muxed_to_account_id(muxed),
@@ -1747,7 +1745,7 @@ impl TransactionQueue {
                 )
                 .is_err()
                 {
-                    return Err(stellar_xdr::curr::TransactionResultCode::TxFailed);
+                    return Err(stellar_xdr::TransactionResultCode::TxFailed);
                 }
             }
         }
@@ -1761,7 +1759,7 @@ impl TransactionQueue {
     /// Parity: stellar-core `TransactionFrame::checkSorobanResources()`.
     fn check_soroban_resources(
         &self,
-        env: &stellar_xdr::curr::TransactionEnvelope,
+        env: &stellar_xdr::TransactionEnvelope,
     ) -> std::result::Result<(), String> {
         let ctx = self.validation_context.read();
         let Some(ref limits) = ctx.soroban_limits else {
@@ -1958,7 +1956,7 @@ impl TransactionQueue {
         &self,
         lane_config: &dyn SurgePricingLaneConfig,
         lane_fees: &mut Vec<Option<FeeRate>>,
-        envelope: &stellar_xdr::curr::TransactionEnvelope,
+        envelope: &stellar_xdr::TransactionEnvelope,
         queued: &QueuedTransaction,
     ) -> bool {
         let lane = lane_config.get_lane(envelope);
@@ -3417,10 +3415,7 @@ fn has_ed25519_signature(
         .any(|sig| henyey_tx::verify_signature_with_raw_key(tx_hash, sig, key_bytes))
 }
 
-fn has_hashx_signature(
-    signatures: &[DecoratedSignature],
-    key: &stellar_xdr::curr::Uint256,
-) -> bool {
+fn has_hashx_signature(signatures: &[DecoratedSignature], key: &stellar_xdr::Uint256) -> bool {
     signatures.iter().any(|sig| {
         if sig.signature.0.len() != 32 {
             return false;
@@ -3437,7 +3432,7 @@ fn has_hashx_signature(
 fn has_signed_payload_signature(
     _tx_hash: &Hash256,
     signatures: &[DecoratedSignature],
-    payload: &stellar_xdr::curr::SignerKeyEd25519SignedPayload,
+    payload: &stellar_xdr::SignerKeyEd25519SignedPayload,
 ) -> bool {
     signatures
         .iter()
@@ -3456,7 +3451,7 @@ mod tests {
     use henyey_common::NetworkId;
     use henyey_common::{Resource, ResourceType, NUM_SOROBAN_TX_RESOURCES};
     use henyey_crypto::{sign_hash, SecretKey};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, AlphaNum4, Asset, AssetCode4, ContractExecutable, ContractIdPreimage,
         ContractIdPreimageFromAddress, CreateAccountOp, CreateContractArgs, DecoratedSignature,
         Duration, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
@@ -3649,14 +3644,14 @@ mod tests {
             TransactionEnvelope::TxV0(tx) => tx.tx.seq_num.0,
             TransactionEnvelope::Tx(tx) => tx.tx.seq_num.0,
             TransactionEnvelope::TxFeeBump(tx) => match &tx.tx.inner_tx {
-                stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
+                stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
             },
         }
     }
 
     fn envelope_size(envelope: &TransactionEnvelope) -> usize {
         envelope
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .map(|bytes| bytes.len())
             .unwrap_or(0)
     }
@@ -3675,7 +3670,7 @@ mod tests {
                 env.tx.source_account = source;
             }
             TransactionEnvelope::TxFeeBump(env) => match &mut env.tx.inner_tx {
-                stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+                stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                     inner.tx.source_account = source;
                 }
             },
@@ -4062,15 +4057,15 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 100);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         assert_eq!(v1.phases.len(), 2);
 
         match &v1.phases[0] {
-            stellar_xdr::curr::TransactionPhase::V0(components) => {
+            stellar_xdr::TransactionPhase::V0(components) => {
                 let txs: Vec<_> = components
                     .iter()
                     .flat_map(|component| match component {
-                        stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) => {
+                        stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) => {
                             comp.txs.to_vec()
                         }
                     })
@@ -4086,7 +4081,7 @@ mod tests {
         }
 
         match &v1.phases[1] {
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+            stellar_xdr::TransactionPhase::V1(parallel) => {
                 let mut txs = Vec::new();
                 for stage in parallel.execution_stages.iter() {
                     for cluster in stage.iter() {
@@ -4132,10 +4127,10 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         let base_fee = match &v1.phases[0] {
-            stellar_xdr::curr::TransactionPhase::V0(components) => {
-                let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) =
+            stellar_xdr::TransactionPhase::V0(components) => {
+                let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) =
                     &components[0];
                 comp.base_fee
             }
@@ -4155,9 +4150,9 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         let base_fee = match &v1.phases[1] {
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => parallel.base_fee,
+            stellar_xdr::TransactionPhase::V1(parallel) => parallel.base_fee,
             _ => None,
         };
 
@@ -4178,11 +4173,11 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
 
         let txs = match &v1.phases[0] {
-            stellar_xdr::curr::TransactionPhase::V0(components) => {
-                let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) =
+            stellar_xdr::TransactionPhase::V0(components) => {
+                let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) =
                     &components[0];
                 comp.txs.to_vec()
             }
@@ -4208,11 +4203,11 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
 
         let mut txs = Vec::new();
         match &v1.phases[1] {
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+            stellar_xdr::TransactionPhase::V1(parallel) => {
                 for stage in parallel.execution_stages.iter() {
                     for cluster in stage.iter() {
                         txs.extend(cluster.0.iter().cloned());
@@ -4270,12 +4265,10 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 100);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         let base_fee = match &v1.phases[0] {
-            stellar_xdr::curr::TransactionPhase::V0(components) => match &components[0] {
-                stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) => {
-                    comp.base_fee
-                }
+            stellar_xdr::TransactionPhase::V0(components) => match &components[0] {
+                stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) => comp.base_fee,
             },
             _ => None,
         };
@@ -4663,10 +4656,10 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(tx_set) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(tx_set) = gen;
         let phases = &tx_set.phases;
         let components = match &phases[0] {
-            stellar_xdr::curr::TransactionPhase::V0(components) => components,
+            stellar_xdr::TransactionPhase::V0(components) => components,
             _ => panic!("expected classic phase"),
         };
         assert_eq!(components.len(), 2);
@@ -4674,7 +4667,7 @@ mod tests {
         let mut base_fees = Vec::new();
         let mut tx_counts = Vec::new();
         for comp in components.iter() {
-            let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) = comp;
+            let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) = comp;
             base_fees.push(comp.base_fee);
             tx_counts.push(comp.txs.len());
         }
@@ -4975,16 +4968,16 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 200);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         let components = match &v1.phases[0] {
-            stellar_xdr::curr::TransactionPhase::V0(comps) => comps,
+            stellar_xdr::TransactionPhase::V0(comps) => comps,
             _ => panic!("expected classic phase"),
         };
 
         let mut has_dex_fee = false;
         let mut has_classic_fee = false;
         for comp in components.iter() {
-            let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) = comp;
+            let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) = comp;
             match comp.base_fee {
                 Some(500) => has_dex_fee = true,
                 Some(fee) if fee == base_fee => has_classic_fee = true,
@@ -5085,9 +5078,9 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         let base_fee = match &v1.phases[1] {
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => parallel.base_fee,
+            stellar_xdr::TransactionPhase::V1(parallel) => parallel.base_fee,
             _ => None,
         };
         assert_eq!(base_fee, Some(8000));
@@ -5116,9 +5109,9 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         let parallel = match &v1.phases[1] {
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => parallel,
+            stellar_xdr::TransactionPhase::V1(parallel) => parallel,
             _ => panic!("expected Soroban V1 phase"),
         };
 
@@ -5890,7 +5883,7 @@ mod tests {
 
     #[test]
     fn test_extra_signer_signed_payload_satisfied() {
-        use stellar_xdr::curr::SignerKeyEd25519SignedPayload;
+        use stellar_xdr::SignerKeyEd25519SignedPayload;
 
         let queue = TransactionQueue::with_defaults();
 
@@ -5972,7 +5965,7 @@ mod tests {
     #[test]
     fn test_extra_signer_signed_payload_wrong_key_rejected() {
         use henyey_tx::TxResultCode;
-        use stellar_xdr::curr::SignerKeyEd25519SignedPayload;
+        use stellar_xdr::SignerKeyEd25519SignedPayload;
 
         let queue = TransactionQueue::with_defaults();
 
@@ -6058,7 +6051,7 @@ mod tests {
     #[test]
     fn test_extra_signer_signed_payload_bad_signature_rejected() {
         use henyey_tx::TxResultCode;
-        use stellar_xdr::curr::SignerKeyEd25519SignedPayload;
+        use stellar_xdr::SignerKeyEd25519SignedPayload;
 
         let queue = TransactionQueue::with_defaults();
 
@@ -6144,7 +6137,7 @@ mod tests {
     #[test]
     fn test_extra_signer_signed_payload_empty_payload_rejected() {
         use henyey_tx::TxResultCode;
-        use stellar_xdr::curr::SignerKeyEd25519SignedPayload;
+        use stellar_xdr::SignerKeyEd25519SignedPayload;
 
         let queue = TransactionQueue::with_defaults();
 
@@ -6251,7 +6244,7 @@ mod tests {
     #[test]
     fn test_audit_093_queue_rejects_expiring_tx() {
         use henyey_tx::TxResultCode;
-        use stellar_xdr::curr::TimeBounds;
+        use stellar_xdr::TimeBounds;
 
         let lcl_close_time: u64 = 1_700_000_000;
         let expected_close_secs: u64 = 5;
@@ -6292,8 +6285,8 @@ mod tests {
             fee: 200,
             seq_num: SequenceNumber(1),
             cond: Preconditions::Time(TimeBounds {
-                min_time: stellar_xdr::curr::TimePoint(0),
-                max_time: stellar_xdr::curr::TimePoint(max_time),
+                min_time: stellar_xdr::TimePoint(0),
+                max_time: stellar_xdr::TimePoint(max_time),
             }),
             memo: Memo::None,
             operations: operations.try_into().unwrap(),
@@ -6325,7 +6318,7 @@ mod tests {
     #[test]
     fn test_queue_already_expired_tx_returns_too_late() {
         use henyey_tx::TxResultCode;
-        use stellar_xdr::curr::TimeBounds;
+        use stellar_xdr::TimeBounds;
 
         let lcl_close_time: u64 = 1_700_000_000;
         let config = TxQueueConfig {
@@ -6362,8 +6355,8 @@ mod tests {
             fee: 200,
             seq_num: SequenceNumber(1),
             cond: Preconditions::Time(TimeBounds {
-                min_time: stellar_xdr::curr::TimePoint(0),
-                max_time: stellar_xdr::curr::TimePoint(max_time),
+                min_time: stellar_xdr::TimePoint(0),
+                max_time: stellar_xdr::TimePoint(max_time),
             }),
             memo: Memo::None,
             operations: operations.try_into().unwrap(),
@@ -6394,7 +6387,7 @@ mod tests {
     #[test]
     fn test_queue_uses_dynamic_expected_close_time() {
         use henyey_tx::TxResultCode;
-        use stellar_xdr::curr::TimeBounds;
+        use stellar_xdr::TimeBounds;
 
         // Use current wall-clock time so drift ≈ 0.
         let lcl_close_time: u64 = std::time::SystemTime::now()
@@ -6439,8 +6432,8 @@ mod tests {
             fee: 200,
             seq_num: SequenceNumber(1),
             cond: Preconditions::Time(TimeBounds {
-                min_time: stellar_xdr::curr::TimePoint(0),
-                max_time: stellar_xdr::curr::TimePoint(max_time),
+                min_time: stellar_xdr::TimePoint(0),
+                max_time: stellar_xdr::TimePoint(max_time),
             }),
             memo: Memo::None,
             operations: operations.try_into().unwrap(),
@@ -7306,7 +7299,7 @@ mod tests {
 
     /// Helper for AUDIT-214 (#2103) tests: count txs in a phase.
     fn audit_214_phase_tx_count(phase: &TransactionPhase) -> usize {
-        use stellar_xdr::curr::TxSetComponent;
+        use stellar_xdr::TxSetComponent;
         match phase {
             TransactionPhase::V0(components) => components
                 .iter()
@@ -7335,7 +7328,7 @@ mod tests {
         read_only_entries: usize,
         read_write_entries: usize,
     ) -> TransactionEnvelope {
-        use stellar_xdr::curr::LedgerKey;
+        use stellar_xdr::LedgerKey;
         let source = MuxedAccount::Ed25519(Uint256([50u8; 32]));
         let host_function = HostFunction::InvokeContract(InvokeContractArgs {
             contract_address: ScAddress::default(),
@@ -7353,14 +7346,14 @@ mod tests {
         // Build footprint with specified entry counts
         let read_only: Vec<LedgerKey> = (0..read_only_entries)
             .map(|i| {
-                LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+                LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                     account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([i as u8; 32]))),
                 })
             })
             .collect();
         let read_write: Vec<LedgerKey> = (0..read_write_entries)
             .map(|i| {
-                LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+                LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                     account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
                         [(i + 100) as u8; 32],
                     ))),
@@ -7983,9 +7976,9 @@ mod tests {
 
         let _set = queue.build_generalized_tx_set(Hash256::ZERO, 10);
         let gen = _set.generalized_tx_set().unwrap().clone();
-        let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = gen;
+        let stellar_xdr::GeneralizedTransactionSet::V1(v1) = gen;
         let parallel = match &v1.phases[1] {
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => parallel,
+            stellar_xdr::TransactionPhase::V1(parallel) => parallel,
             _ => panic!("expected Soroban V1 phase"),
         };
 
@@ -8411,7 +8404,7 @@ mod tests {
 #[cfg(test)]
 mod pending_depth_tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
         Preconditions, SequenceNumber, SignatureHint, Transaction, TransactionEnvelope,
         TransactionExt, TransactionV1Envelope, Uint256,
@@ -8424,8 +8417,8 @@ mod pending_depth_tests {
                 source_account: None,
                 body: OperationBody::CreateAccount(CreateAccountOp {
                     // Use destination [255; 32] so it differs from any test source
-                    destination: stellar_xdr::curr::AccountId(
-                        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([255u8; 32])),
+                    destination: stellar_xdr::AccountId(
+                        stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256([255u8; 32])),
                     ),
                     starting_balance: 1_000_000_000,
                 }),
@@ -8444,7 +8437,7 @@ mod pending_depth_tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -8706,7 +8699,7 @@ mod snapshot_providers_tests {
         let source = MuxedAccount::Ed25519(Uint256([source_seed; 32]));
         let operations: Vec<Operation> = vec![Operation {
             source_account: None,
-            body: OperationBody::CreateAccount(stellar_xdr::curr::CreateAccountOp {
+            body: OperationBody::CreateAccount(stellar_xdr::CreateAccountOp {
                 destination: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([255u8; 32]))),
                 starting_balance: 1_000_000_000,
             }),
@@ -8724,14 +8717,14 @@ mod snapshot_providers_tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
         })
     }
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
         PublicKey, SequenceNumber, SignatureHint, Transaction, TransactionEnvelope, TransactionExt,
         TransactionV1Envelope, Uint256,
@@ -8819,7 +8812,7 @@ mod snapshot_providers_tests {
 mod resource_limit_parity_tests {
     use super::*;
     use henyey_common::{Resource, ResourceType};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractDataDurability, GeneralizedTransactionSet, HostFunction, InvokeContractArgs,
         InvokeHostFunctionOp, LedgerFootprint, LedgerKey, LedgerKeyContractData, Memo,
         MuxedAccount, Operation, OperationBody, Preconditions, ScAddress, ScVal, SorobanResources,
@@ -8843,9 +8836,7 @@ mod resource_limit_parity_tests {
             ContractDataDurability::Temporary
         };
         LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(
-                [0u8; 32],
-            ))),
+            contract: ScAddress::Contract(stellar_xdr::ContractId(stellar_xdr::Hash([0u8; 32]))),
             key: ScVal::I32(id),
             durability,
         })
@@ -8896,10 +8887,10 @@ mod resource_limit_parity_tests {
             source_account: None,
             body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
                 host_function: HostFunction::InvokeContract(InvokeContractArgs {
-                    contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(
-                        stellar_xdr::curr::Hash(source_bytes),
+                    contract_address: ScAddress::Contract(stellar_xdr::ContractId(
+                        stellar_xdr::Hash(source_bytes),
                     )),
-                    function_name: stellar_xdr::curr::ScSymbol("test".try_into().unwrap()),
+                    function_name: stellar_xdr::ScSymbol("test".try_into().unwrap()),
                     args: Default::default(),
                 }),
                 auth: Default::default(),
@@ -8910,7 +8901,7 @@ mod resource_limit_parity_tests {
         let tx = Transaction {
             source_account: source,
             fee: inclusion_fee as u32,
-            seq_num: stellar_xdr::curr::SequenceNumber(1),
+            seq_num: stellar_xdr::SequenceNumber(1),
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![invoke_op].try_into().unwrap(),
@@ -8983,13 +8974,13 @@ mod resource_limit_parity_tests {
     /// Returns (num_stages, clusters_per_stage, txs_per_cluster) for uniform shapes.
     fn extract_soroban_phase(
         gen_tx_set: &GeneralizedTransactionSet,
-    ) -> &stellar_xdr::curr::ParallelTxsComponent {
+    ) -> &stellar_xdr::ParallelTxsComponent {
         match gen_tx_set {
             GeneralizedTransactionSet::V1(v1) => {
                 // Phase 1 is the Soroban phase
                 let phase = &v1.phases[1];
                 match phase {
-                    stellar_xdr::curr::TransactionPhase::V1(component) => component,
+                    stellar_xdr::TransactionPhase::V1(component) => component,
                     _ => panic!("expected V1 soroban phase"),
                 }
             }
@@ -9257,10 +9248,7 @@ mod resource_limit_parity_tests {
             let mut id = 0u32;
             let sample_tx =
                 make_resource_limit_tx(&mut id, 1_000_000, &[0, 1], &[2, 3], 100, 1_000, 100);
-            let tx_size = sample_tx
-                .to_xdr(stellar_xdr::curr::Limits::none())
-                .unwrap()
-                .len() as i64;
+            let tx_size = sample_tx.to_xdr(stellar_xdr::Limits::none()).unwrap().len() as i64;
 
             let mut limits = default_soroban_limits();
             limits.set_val(ResourceType::TxByteSize, 11 * tx_size - 1);
@@ -9324,7 +9312,7 @@ mod resource_limit_parity_tests {
 mod eviction_queue_tests {
     use super::*;
     use henyey_common::types::Hash256;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_test_envelope(fee: u32, ops: usize) -> TransactionEnvelope {
         let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));
@@ -9367,7 +9355,7 @@ mod eviction_queue_tests {
                 env.tx.source_account = source;
             }
             TransactionEnvelope::TxFeeBump(env) => match &mut env.tx.inner_tx {
-                stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+                stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                     inner.tx.source_account = source;
                 }
             },
@@ -10048,7 +10036,7 @@ mod fee_rate_tests {
     }
 
     fn make_dummy_envelope(fee: u32, ops: u32) -> TransactionEnvelope {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         let mut operations = Vec::new();
         for _ in 0..ops {
             operations.push(Operation {
@@ -10079,7 +10067,7 @@ mod fee_rate_tests {
 #[cfg(test)]
 mod broadcast_visitor_tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_test_envelope(fee: u32, ops: usize) -> TransactionEnvelope {
         let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));

--- a/crates/herder/src/tx_queue/selection.rs
+++ b/crates/herder/src/tx_queue/selection.rs
@@ -139,7 +139,7 @@ impl TransactionQueue {
         override_fee_provider: Option<&dyn FeeBalanceProvider>,
         override_account_provider: Option<&dyn AccountProvider>,
     ) -> TransactionSet {
-        use stellar_xdr::curr::GeneralizedTransactionSet;
+        use stellar_xdr::GeneralizedTransactionSet;
 
         // Derive base_fee, protocol_version, and validation context from the
         // build context. For Nomination, these come from the snapshot header.
@@ -254,8 +254,8 @@ impl TransactionQueue {
         let (soroban_phase, _soroban_base_fee) =
             build_soroban_phase_with_base_fee(soroban_txs, soroban_limited, base_fee, &self.config);
 
-        let gen_tx_set = GeneralizedTransactionSet::V1(stellar_xdr::curr::TransactionSetV1 {
-            previous_ledger_hash: stellar_xdr::curr::Hash(previous_ledger_hash.0),
+        let gen_tx_set = GeneralizedTransactionSet::V1(stellar_xdr::TransactionSetV1 {
+            previous_ledger_hash: stellar_xdr::Hash(previous_ledger_hash.0),
             phases: vec![classic_phase, soroban_phase]
                 .try_into()
                 .unwrap_or_default(),
@@ -568,7 +568,7 @@ impl TransactionQueue {
 /// selection, `base_fee` must be `None` regardless of surge-pricing state.
 /// In stellar-core (`TxSetFrame.cpp:286-290`), `baseFee` is set only when
 /// `inclusionFeeMap` is non-empty (i.e., at least one tx survived).
-fn empty_soroban_phase_pair() -> (stellar_xdr::curr::TransactionPhase, Option<i64>) {
+fn empty_soroban_phase_pair() -> (stellar_xdr::TransactionPhase, Option<i64>) {
     (henyey_tx::tx_set_xdr::empty_soroban_phase(), None)
 }
 
@@ -584,8 +584,8 @@ fn build_soroban_phase_with_base_fee(
     soroban_limited: bool,
     ledger_base_fee: i64,
     config: &super::TxQueueConfig,
-) -> (stellar_xdr::curr::TransactionPhase, Option<i64>) {
-    use stellar_xdr::curr::{DependentTxCluster, ParallelTxExecutionStage, TransactionEnvelope};
+) -> (stellar_xdr::TransactionPhase, Option<i64>) {
+    use stellar_xdr::{DependentTxCluster, ParallelTxExecutionStage, TransactionEnvelope};
 
     if soroban_txs.is_empty() {
         return empty_soroban_phase_pair();
@@ -681,10 +681,8 @@ fn build_classic_phase(
     dex_limited: bool,
     base_fee: i64,
     has_dex_lane: bool,
-) -> stellar_xdr::curr::TransactionPhase {
-    use stellar_xdr::curr::{
-        TransactionPhase, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
-    };
+) -> stellar_xdr::TransactionPhase {
+    use stellar_xdr::{TransactionPhase, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee};
 
     let mut classic_components: Vec<TxSetComponent> = Vec::new();
     if !classic_txs.is_empty() {

--- a/crates/herder/src/tx_queue/tx_set.rs
+++ b/crates/herder/src/tx_queue/tx_set.rs
@@ -199,15 +199,15 @@ impl TransactionSet {
             TxSetBody::Generalized(gen) => {
                 let GeneralizedTransactionSet::V1(v1) = gen;
                 let iter = v1.phases.iter().flat_map(|phase| match phase {
-                    stellar_xdr::curr::TransactionPhase::V0(components) => {
+                    stellar_xdr::TransactionPhase::V0(components) => {
                         let iter = components.iter().flat_map(|comp| match comp {
-                            stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(
-                                c,
-                            ) => c.txs.iter(),
+                            stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) => {
+                                c.txs.iter()
+                            }
                         });
                         Box::new(iter) as Box<dyn Iterator<Item = &TransactionEnvelope>>
                     }
-                    stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+                    stellar_xdr::TransactionPhase::V1(parallel) => {
                         let iter = parallel
                             .execution_stages
                             .iter()
@@ -229,16 +229,18 @@ impl TransactionSet {
                 let mut count = 0;
                 for phase in v1.phases.iter() {
                     match phase {
-                        stellar_xdr::curr::TransactionPhase::V0(components) => {
+                        stellar_xdr::TransactionPhase::V0(components) => {
                             for comp in components.iter() {
                                 match comp {
-                                    stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) => {
+                                    stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(
+                                        c,
+                                    ) => {
                                         count += c.txs.len();
                                     }
                                 }
                             }
                         }
-                        stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+                        stellar_xdr::TransactionPhase::V1(parallel) => {
                             for stage in parallel.execution_stages.iter() {
                                 for cluster in stage.iter() {
                                     count += cluster.0.len();
@@ -271,8 +273,8 @@ impl TransactionSet {
                 previous_ledger_hash,
                 transactions,
             } => {
-                let xdr_set = stellar_xdr::curr::TransactionSet {
-                    previous_ledger_hash: stellar_xdr::curr::Hash(previous_ledger_hash.0),
+                let xdr_set = stellar_xdr::TransactionSet {
+                    previous_ledger_hash: stellar_xdr::Hash(previous_ledger_hash.0),
                     txs: transactions.try_into().unwrap_or_default(),
                 };
                 henyey_ledger::TransactionSetVariant::Classic(xdr_set)
@@ -297,7 +299,7 @@ impl TransactionSet {
     ///   ONLY for peer flooding, NOT for consensus validation (which expects
     ///   2-phase sets from selection.rs).
     pub fn to_generalized_tx_set(&self) -> Option<GeneralizedTransactionSet> {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionPhase, TransactionSetV1, TxSetComponent, TxSetComponentTxsMaybeDiscountedFee,
         };
 
@@ -315,7 +317,7 @@ impl TransactionSet {
                 );
                 let phase = TransactionPhase::V0(vec![component].try_into().ok()?);
                 Some(GeneralizedTransactionSet::V1(TransactionSetV1 {
-                    previous_ledger_hash: stellar_xdr::curr::Hash(previous_ledger_hash.0),
+                    previous_ledger_hash: stellar_xdr::Hash(previous_ledger_hash.0),
                     phases: vec![phase].try_into().ok()?,
                 }))
             }
@@ -361,8 +363,8 @@ impl TransactionSet {
     }
 
     /// Convert to StoredTransactionSet XDR for persistence.
-    pub fn to_xdr_stored_set(&self) -> stellar_xdr::curr::StoredTransactionSet {
-        use stellar_xdr::curr::StoredTransactionSet;
+    pub fn to_xdr_stored_set(&self) -> stellar_xdr::StoredTransactionSet {
+        use stellar_xdr::StoredTransactionSet;
 
         match &self.body {
             TxSetBody::Generalized(gen) => StoredTransactionSet::V1(gen.clone()),
@@ -370,8 +372,8 @@ impl TransactionSet {
                 previous_ledger_hash,
                 transactions,
             } => {
-                let legacy = stellar_xdr::curr::TransactionSet {
-                    previous_ledger_hash: stellar_xdr::curr::Hash(previous_ledger_hash.0),
+                let legacy = stellar_xdr::TransactionSet {
+                    previous_ledger_hash: stellar_xdr::Hash(previous_ledger_hash.0),
                     txs: transactions.clone().try_into().unwrap_or_default(),
                 };
                 StoredTransactionSet::V0(legacy)
@@ -381,9 +383,9 @@ impl TransactionSet {
 
     /// Create from StoredTransactionSet XDR.
     pub fn from_xdr_stored_set(
-        stored: &stellar_xdr::curr::StoredTransactionSet,
+        stored: &stellar_xdr::StoredTransactionSet,
     ) -> std::result::Result<Self, String> {
-        use stellar_xdr::curr::StoredTransactionSet;
+        use stellar_xdr::StoredTransactionSet;
 
         match stored {
             StoredTransactionSet::V0(legacy) => {
@@ -529,7 +531,7 @@ impl PreparedTransactionSet {
     #[allow(clippy::too_many_arguments)]
     pub fn check_valid(
         &self,
-        lcl_header: &stellar_xdr::curr::LedgerHeader,
+        lcl_header: &stellar_xdr::LedgerHeader,
         lcl_hash: &henyey_common::Hash256,
         close_time_offset: u64,
         network_id: NetworkId,
@@ -716,7 +718,7 @@ fn validate_sequential_phase_xdr_structure(
 
 /// Validate the structure of a parallel (V1) phase component.
 fn validate_parallel_component(
-    parallel: &stellar_xdr::curr::ParallelTxsComponent,
+    parallel: &stellar_xdr::ParallelTxsComponent,
 ) -> std::result::Result<(), TxSetStructureError> {
     // Reject negative base fees (parity: TxSetFrame.cpp:1480)
     if let Some(fee) = parallel.base_fee {
@@ -795,10 +797,10 @@ fn validate_tx_fee(env: &TransactionEnvelope) -> std::result::Result<(), String>
                 return Err("Soroban transaction uses TxV0 envelope".to_string());
             }
             TransactionEnvelope::Tx(e) => match &e.tx.ext {
-                stellar_xdr::curr::TransactionExt::V0 => {
+                stellar_xdr::TransactionExt::V0 => {
                     return Err("Soroban transaction missing SorobanTransactionData".to_string());
                 }
-                stellar_xdr::curr::TransactionExt::V1(data) => {
+                stellar_xdr::TransactionExt::V1(data) => {
                     let resource_fee = data.resource_fee;
                     if resource_fee < 0 || resource_fee > MAX_RESOURCE_FEE {
                         return Err(format!(
@@ -810,13 +812,13 @@ fn validate_tx_fee(env: &TransactionEnvelope) -> std::result::Result<(), String>
             },
             TransactionEnvelope::TxFeeBump(e) => match &e.tx.inner_tx {
                 FeeBumpTransactionInnerTx::Tx(inner) => match &inner.tx.ext {
-                    stellar_xdr::curr::TransactionExt::V0 => {
+                    stellar_xdr::TransactionExt::V0 => {
                         return Err(
                             "Soroban fee-bump inner transaction missing SorobanTransactionData"
                                 .to_string(),
                         );
                     }
-                    stellar_xdr::curr::TransactionExt::V1(data) => {
+                    stellar_xdr::TransactionExt::V1(data) => {
                         let resource_fee = data.resource_fee;
                         if resource_fee < 0 || resource_fee > MAX_RESOURCE_FEE {
                             return Err(format!(
@@ -891,16 +893,16 @@ fn extract_transactions_from_generalized(
 
     for phase in v1.phases.iter() {
         match phase {
-            stellar_xdr::curr::TransactionPhase::V0(components) => {
+            stellar_xdr::TransactionPhase::V0(components) => {
                 for component in components.iter() {
                     match component {
-                        stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) => {
+                        stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) => {
                             transactions.extend(comp.txs.iter().cloned());
                         }
                     }
                 }
             }
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+            stellar_xdr::TransactionPhase::V1(parallel) => {
                 // V1 phase has execution_stages, which contains parallel stages
                 for stage in parallel.execution_stages.iter() {
                     for cluster in stage.iter() {
@@ -992,7 +994,7 @@ fn summary_generalized_tx_set(gen: &GeneralizedTransactionSet) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractDataDurability, ContractId, CreateAccountOp, DecoratedSignature,
         DependentTxCluster, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
         FeeBumpTransactionInnerTx, GeneralizedTransactionSet, Hash, HostFunction,
@@ -1007,9 +1009,9 @@ mod tests {
 
     fn make_tx_envelope(seed: u8, fee: u32) -> TransactionEnvelope {
         let source = MuxedAccount::Ed25519(Uint256([seed; 32]));
-        let dest = stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([seed.wrapping_add(1); 32])),
-        );
+        let dest = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            [seed.wrapping_add(1); 32],
+        )));
         let tx = Transaction {
             source_account: source,
             fee,
@@ -1031,7 +1033,7 @@ mod tests {
             tx,
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -1058,7 +1060,7 @@ mod tests {
             },
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -1247,7 +1249,7 @@ mod tests {
 
     fn make_gen_tx_set(phases: Vec<TransactionPhase>) -> GeneralizedTransactionSet {
         GeneralizedTransactionSet::V1(TransactionSetV1 {
-            previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
             phases: phases.try_into().unwrap(),
         })
     }
@@ -1595,7 +1597,7 @@ mod tests {
             },
             signatures: vec![DecoratedSignature {
                 hint: SignatureHint([0u8; 4]),
-                signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+                signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
             }]
             .try_into()
             .unwrap(),
@@ -1616,7 +1618,7 @@ mod tests {
                 time_bounds: None,
                 memo: Memo::None,
                 operations: vec![invoke_host_fn_op()].try_into().unwrap(),
-                ext: stellar_xdr::curr::TransactionV0Ext::V0,
+                ext: stellar_xdr::TransactionV0Ext::V0,
             },
             signatures: vec![].try_into().unwrap(),
         });
@@ -1844,7 +1846,7 @@ mod tests {
     /// Uses V22 because V23+ requires parallel Soroban phases (V1).
     #[test]
     fn test_check_valid_accepts_empty_generalized_on_v22() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
 
@@ -1907,7 +1909,7 @@ mod tests {
     /// Generalized set on protocol < V20 must be rejected by check_valid.
     #[test]
     fn test_check_valid_rejects_generalized_on_pre_v20() {
-        use stellar_xdr::curr::{LedgerHeader, LedgerHeaderExt};
+        use stellar_xdr::{LedgerHeader, LedgerHeaderExt};
 
         let gen = make_gen_tx_set(vec![
             TransactionPhase::V0(vec![].try_into().unwrap()),
@@ -1943,7 +1945,7 @@ mod tests {
     /// Legacy set on protocol >= V20 must be rejected by check_valid.
     #[test]
     fn test_check_valid_rejects_legacy_on_v20_plus() {
-        use stellar_xdr::curr::{LedgerHeader, LedgerHeaderExt};
+        use stellar_xdr::{LedgerHeader, LedgerHeaderExt};
 
         let mut txs = vec![make_tx_envelope(1, 100)];
         sort_txs_by_hash(&mut txs);
@@ -1975,7 +1977,7 @@ mod tests {
     /// by prepare_for_apply).
     #[test]
     fn test_check_valid_accepts_legacy_on_pre_v20() {
-        use stellar_xdr::curr::{LedgerHeader, LedgerHeaderExt};
+        use stellar_xdr::{LedgerHeader, LedgerHeaderExt};
 
         let mut txs = vec![make_tx_envelope(1, 100)];
         sort_txs_by_hash(&mut txs);
@@ -2088,7 +2090,7 @@ mod tests {
 
     #[test]
     fn test_from_wire_legacy_matches_from_xdr_stored_set() {
-        use stellar_xdr::curr::StoredTransactionSet;
+        use stellar_xdr::StoredTransactionSet;
 
         // Create unsorted transactions
         let tx_a = make_tx_envelope(10, 500);
@@ -2101,7 +2103,7 @@ mod tests {
         let from_wire = TransactionSet::from_wire_legacy(prev_hash, wire_order.clone());
 
         // Build via from_xdr_stored_set (V0 legacy path)
-        let stored_set = StoredTransactionSet::V0(stellar_xdr::curr::TransactionSet {
+        let stored_set = StoredTransactionSet::V0(stellar_xdr::TransactionSet {
             previous_ledger_hash: Hash(prev_hash.0),
             txs: wire_order.try_into().unwrap(),
         });

--- a/crates/herder/src/tx_queue_limiter.rs
+++ b/crates/herder/src/tx_queue_limiter.rs
@@ -504,7 +504,7 @@ mod tests {
     use super::*;
     use henyey_common::Hash256;
     use std::sync::Arc;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
         SequenceNumber, Signature, SignatureHint, Transaction, TransactionEnvelope,
         TransactionV1Envelope, Uint256,
@@ -526,7 +526,7 @@ mod tests {
             cond: Preconditions::None,
             memo: Memo::None,
             operations: operations.try_into().unwrap(),
-            ext: stellar_xdr::curr::TransactionExt::V0,
+            ext: stellar_xdr::TransactionExt::V0,
         };
 
         let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {

--- a/crates/herder/src/tx_set_utils.rs
+++ b/crates/herder/src/tx_set_utils.rs
@@ -21,7 +21,7 @@ use henyey_tx::{
     muxed_to_account_id, validate_basic, LedgerContext, OperationTypeExt, SignatureChecker,
     TransactionFrame,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountId, GeneralizedTransactionSet, LedgerHeader, Preconditions, SignerKey,
     TransactionEnvelope, TransactionPhase, TxSetComponent,
 };
@@ -125,13 +125,13 @@ pub(crate) fn envelope_inclusion_fee(env: &TransactionEnvelope) -> henyey_tx::In
     let resource_fee = match env {
         TransactionEnvelope::TxV0(_) => 0,
         TransactionEnvelope::Tx(env) => match &env.tx.ext {
-            stellar_xdr::curr::TransactionExt::V0 => 0,
-            stellar_xdr::curr::TransactionExt::V1(data) => data.resource_fee,
+            stellar_xdr::TransactionExt::V0 => 0,
+            stellar_xdr::TransactionExt::V1(data) => data.resource_fee,
         },
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => match &inner.tx.ext {
-                stellar_xdr::curr::TransactionExt::V0 => 0,
-                stellar_xdr::curr::TransactionExt::V1(data) => data.resource_fee,
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => match &inner.tx.ext {
+                stellar_xdr::TransactionExt::V0 => 0,
+                stellar_xdr::TransactionExt::V1(data) => data.resource_fee,
             },
         },
     };
@@ -789,8 +789,8 @@ fn validate_ops_auth(
                     );
                     return false;
                 }
-                let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref key) = op_source_id.0;
-                let signers = vec![stellar_xdr::curr::Signer {
+                let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref key) = op_source_id.0;
+                let signers = vec![stellar_xdr::Signer {
                     key: SignerKey::Ed25519(key.clone()),
                     weight: 1,
                 }];
@@ -824,10 +824,10 @@ fn validate_extra_signers(frame: &TransactionFrame, checker: &mut SignatureCheck
         return true;
     }
 
-    let signers: Vec<stellar_xdr::curr::Signer> = cond
+    let signers: Vec<stellar_xdr::Signer> = cond
         .extra_signers
         .iter()
-        .map(|key| stellar_xdr::curr::Signer {
+        .map(|key| stellar_xdr::Signer {
             key: key.clone(),
             weight: 1,
         })
@@ -1745,7 +1745,7 @@ pub(crate) fn check_valid_soroban(
 /// A read-only key in one cluster must not appear as read-write in another cluster,
 /// and a read-write key in one cluster must not appear in any other cluster's footprint.
 fn check_stage_footprint_conflicts(
-    stage: &stellar_xdr::curr::ParallelTxExecutionStage,
+    stage: &stellar_xdr::ParallelTxExecutionStage,
 ) -> TxSetValidationResult {
     let mut stage_read_only_keys: HashSet<Vec<u8>> = HashSet::new();
     let mut stage_read_write_keys: HashSet<Vec<u8>> = HashSet::new();
@@ -1784,7 +1784,7 @@ fn check_stage_footprint_conflicts(
 }
 
 /// Serialize a LedgerKey to bytes for use as a hash set key.
-fn key_to_bytes(key: &stellar_xdr::curr::LedgerKey) -> Vec<u8> {
+fn key_to_bytes(key: &stellar_xdr::LedgerKey) -> Vec<u8> {
     henyey_common::xdr_stream::xdr_to_bytes(key)
 }
 
@@ -1822,7 +1822,7 @@ fn source_account_ed25519(env: &TransactionEnvelope) -> [u8; 32] {
         TransactionEnvelope::TxV0(e) => e.tx.source_account_ed25519.0,
         TransactionEnvelope::Tx(e) => henyey_tx::muxed_to_ed25519(&e.tx.source_account).0,
         TransactionEnvelope::TxFeeBump(e) => match &e.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                 henyey_tx::muxed_to_ed25519(&inner.tx.source_account).0
             }
         },
@@ -1912,7 +1912,7 @@ pub(crate) fn check_tx_set_valid(
 
     // Build validation context for per-TX checks
     let ledger_flags = match &lcl_header.ext {
-        stellar_xdr::curr::LedgerHeaderExt::V1(ext) => ext.flags,
+        stellar_xdr::LedgerHeaderExt::V1(ext) => ext.flags,
         _ => 0,
     };
     let mut ctx = TxSetValidationContext::new(
@@ -2017,7 +2017,7 @@ mod tests {
     use super::*;
     use crate::tx_queue::FeeBalanceProvider;
     use henyey_common::NetworkId;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, Asset, DecoratedSignature, LedgerBounds, Memo, MuxedAccount, Operation,
         OperationBody, PaymentOp, Preconditions, PreconditionsV2, PublicKey, SequenceNumber,
         Signature as XdrSignature, SignatureHint, TimeBounds, TimePoint, Transaction,
@@ -2069,14 +2069,14 @@ mod tests {
             let account = AccountEntry {
                 account_id: account_id.clone(),
                 balance: 10_000_000,
-                seq_num: stellar_xdr::curr::SequenceNumber(seq_num),
+                seq_num: stellar_xdr::SequenceNumber(seq_num),
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
-                thresholds: stellar_xdr::curr::Thresholds([1, 1, 1, 1]), // master=1, low=1, med=1, high=1
-                signers: stellar_xdr::curr::VecM::default(),
-                ext: stellar_xdr::curr::AccountEntryExt::V0,
+                home_domain: stellar_xdr::String32::default(),
+                thresholds: stellar_xdr::Thresholds([1, 1, 1, 1]), // master=1, low=1, med=1, high=1
+                signers: stellar_xdr::VecM::default(),
+                ext: stellar_xdr::AccountEntryExt::V0,
             };
             self.accounts.insert(account_id, account);
         }
@@ -2222,7 +2222,7 @@ mod tests {
             time_bounds: None,
             ledger_bounds: Some(ledger_bounds),
             min_seq_num: None,
-            min_seq_age: stellar_xdr::curr::Duration(0),
+            min_seq_age: stellar_xdr::Duration(0),
             min_seq_ledger_gap: 0,
             extra_signers: VecM::default(),
         });
@@ -2819,7 +2819,7 @@ mod tests {
         txs: Vec<TransactionEnvelope>,
         base_fee: Option<i64>,
     ) -> TransactionPhase {
-        use stellar_xdr::curr::{TxSetComponent, TxSetComponentTxsMaybeDiscountedFee};
+        use stellar_xdr::{TxSetComponent, TxSetComponentTxsMaybeDiscountedFee};
         TransactionPhase::V0(
             vec![TxSetComponent::TxsetCompTxsMaybeDiscountedFee(
                 TxSetComponentTxsMaybeDiscountedFee {
@@ -2868,7 +2868,7 @@ mod tests {
 
     #[test]
     fn test_check_fee_map_negative_parallel_base_fee_rejected() {
-        use stellar_xdr::curr::ParallelTxsComponent;
+        use stellar_xdr::ParallelTxsComponent;
         // Defense-in-depth: negative base_fee is also rejected during
         // deserialization in stellar-core.
         let phase = TransactionPhase::V1(ParallelTxsComponent {
@@ -2922,7 +2922,7 @@ mod tests {
 
     #[test]
     fn test_check_fee_map_v1_none_base_fee_low_tx_fee_skipped() {
-        use stellar_xdr::curr::ParallelTxsComponent;
+        use stellar_xdr::ParallelTxsComponent;
         // AUDIT-268: V1/parallel path — same as above for V1 arm.
         // base_fee=None, tx fee=50 < lcl_base_fee=100 → must pass.
         let tx = make_valid_envelope(50, 1);
@@ -2950,7 +2950,7 @@ mod tests {
 
     #[test]
     fn test_check_fee_map_v1_some_base_fee_tx_too_low() {
-        use stellar_xdr::curr::ParallelTxsComponent;
+        use stellar_xdr::ParallelTxsComponent;
         // V1/parallel with base_fee=Some(100), lcl_base_fee=100.
         // TX fee=50, 1 op → inclusion_fee = 50 < 100 → invalid.
         let tx = make_valid_envelope(50, 1);
@@ -3082,7 +3082,7 @@ mod tests {
         let phase_with_low_base_fee = make_v0_phase_with_fee(vec![tx], Some(50));
         let soroban_phase = make_v0_phase_with_fee(vec![], Some(100));
 
-        use stellar_xdr::curr::{Hash, TransactionSetV1};
+        use stellar_xdr::{Hash, TransactionSetV1};
         let gen_tx_set = GeneralizedTransactionSet::V1(TransactionSetV1 {
             previous_ledger_hash: Hash([0u8; 32]),
             phases: vec![phase_with_low_base_fee, soroban_phase]
@@ -3166,7 +3166,7 @@ mod tests {
 
     #[test]
     fn test_check_tx_set_valid_wrong_phase_count() {
-        use stellar_xdr::curr::{Hash, TransactionSetV1};
+        use stellar_xdr::{Hash, TransactionSetV1};
         // Create a tx set with only 1 phase (should be 2)
         let phase = TransactionPhase::V0(vec![].try_into().unwrap());
         let gen_tx_set = GeneralizedTransactionSet::V1(TransactionSetV1 {
@@ -3194,7 +3194,7 @@ mod tests {
 
     #[test]
     fn test_check_tx_set_valid_generalized_txset_mismatch() {
-        use stellar_xdr::curr::{Hash, TransactionSetV1};
+        use stellar_xdr::{Hash, TransactionSetV1};
         let gen_tx_set = GeneralizedTransactionSet::V1(TransactionSetV1 {
             previous_ledger_hash: Hash([0u8; 32]),
             phases: vec![
@@ -3230,7 +3230,7 @@ mod tests {
     /// does not match the LCL hash.
     #[test]
     fn test_check_tx_set_valid_previous_ledger_hash_mismatch() {
-        use stellar_xdr::curr::{Hash, TransactionSetV1};
+        use stellar_xdr::{Hash, TransactionSetV1};
 
         let gen_tx_set = GeneralizedTransactionSet::V1(TransactionSetV1 {
             previous_ledger_hash: Hash([0u8; 32]),
@@ -3399,7 +3399,7 @@ mod tests {
 
     #[test]
     fn test_check_valid_classic_rejects_parallel_phase() {
-        use stellar_xdr::curr::ParallelTxsComponent;
+        use stellar_xdr::ParallelTxsComponent;
         // Intentionally invalid: parallel phase where classic is expected
         let phase = TransactionPhase::V1(ParallelTxsComponent {
             base_fee: Some(100),
@@ -3417,10 +3417,10 @@ mod tests {
         instructions: u32,
         read_bytes: u32,
         write_bytes: u32,
-        read_only_keys: Vec<stellar_xdr::curr::LedgerKey>,
-        read_write_keys: Vec<stellar_xdr::curr::LedgerKey>,
+        read_only_keys: Vec<stellar_xdr::LedgerKey>,
+        read_write_keys: Vec<stellar_xdr::LedgerKey>,
     ) -> TransactionEnvelope {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             InvokeHostFunctionOp, LedgerFootprint, SorobanResources, SorobanTransactionData,
             SorobanTransactionDataExt,
         };
@@ -3429,12 +3429,12 @@ mod tests {
         let op = Operation {
             source_account: None,
             body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-                host_function: stellar_xdr::curr::HostFunction::InvokeContract(
-                    stellar_xdr::curr::InvokeContractArgs {
-                        contract_address: stellar_xdr::curr::ScAddress::Contract(
-                            stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash([0u8; 32])),
+                host_function: stellar_xdr::HostFunction::InvokeContract(
+                    stellar_xdr::InvokeContractArgs {
+                        contract_address: stellar_xdr::ScAddress::Contract(
+                            stellar_xdr::ContractId(stellar_xdr::Hash([0u8; 32])),
                         ),
-                        function_name: stellar_xdr::curr::ScSymbol("test".try_into().unwrap()),
+                        function_name: stellar_xdr::ScSymbol("test".try_into().unwrap()),
                         args: vec![].try_into().unwrap(),
                     },
                 ),
@@ -3465,7 +3465,7 @@ mod tests {
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![op].try_into().unwrap(),
-            ext: stellar_xdr::curr::TransactionExt::V1(soroban_data),
+            ext: stellar_xdr::TransactionExt::V1(soroban_data),
         };
 
         TransactionEnvelope::Tx(TransactionV1Envelope {
@@ -3494,7 +3494,7 @@ mod tests {
     }
 
     fn make_soroban_lcl_header(protocol: u32) -> LedgerHeader {
-        use stellar_xdr::curr::{Hash, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint};
+        use stellar_xdr::{Hash, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint};
         LedgerHeader {
             ledger_version: protocol,
             previous_ledger_hash: Hash([0u8; 32]),
@@ -3547,7 +3547,7 @@ mod tests {
 
     #[test]
     fn test_check_valid_soroban_parallel_mismatch_protocol_22() {
-        use stellar_xdr::curr::ParallelTxsComponent;
+        use stellar_xdr::ParallelTxsComponent;
         let info = make_soroban_network_info();
         let header = make_soroban_lcl_header(22);
         // Intentionally invalid: parallel phase on protocol 22 (pre-parallel)
@@ -3576,7 +3576,7 @@ mod tests {
 
     #[test]
     fn test_check_valid_soroban_parallel_too_many_clusters() {
-        use stellar_xdr::curr::{DependentTxCluster, ParallelTxExecutionStage};
+        use stellar_xdr::{DependentTxCluster, ParallelTxExecutionStage};
         let mut info = make_soroban_network_info();
         info.ledger_max_dependent_tx_clusters = 2; // Only allow 2 clusters per stage
         let header = make_soroban_lcl_header(23);
@@ -3606,7 +3606,7 @@ mod tests {
 
     #[test]
     fn test_check_valid_soroban_parallel_sequential_instruction_limit() {
-        use stellar_xdr::curr::{DependentTxCluster, ParallelTxExecutionStage};
+        use stellar_xdr::{DependentTxCluster, ParallelTxExecutionStage};
         let mut info = make_soroban_network_info();
         info.ledger_max_instructions = 1_000;
         info.ledger_max_dependent_tx_clusters = 10;
@@ -3639,7 +3639,7 @@ mod tests {
 
     #[test]
     fn test_check_valid_soroban_parallel_rw_conflict() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DependentTxCluster, LedgerKey, LedgerKeyAccount, ParallelTxExecutionStage,
         };
         let mut info = make_soroban_network_info();
@@ -3675,7 +3675,7 @@ mod tests {
 
     #[test]
     fn test_check_valid_soroban_parallel_no_conflict_different_keys() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DependentTxCluster, LedgerKey, LedgerKeyAccount, ParallelTxExecutionStage,
         };
         let mut info = make_soroban_network_info();
@@ -4073,7 +4073,7 @@ mod tests {
             TransactionEnvelope::Tx(e) => e,
             _ => panic!("expected V1 envelope"),
         };
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -4135,7 +4135,7 @@ mod tests {
         classic_txs: Vec<TransactionEnvelope>,
         soroban_txs: Vec<TransactionEnvelope>,
     ) -> GeneralizedTransactionSet {
-        use stellar_xdr::curr::{Hash, TransactionSetV1};
+        use stellar_xdr::{Hash, TransactionSetV1};
 
         let classic_phase = make_v0_phase_with_fee(classic_txs, Some(100));
         let soroban_phase = make_v0_phase_with_fee(soroban_txs, Some(100));
@@ -4273,7 +4273,7 @@ mod tests {
         let phase_with_low_base_fee = make_v0_phase_with_fee(vec![tx.clone()], Some(50));
         let soroban_phase = make_v0_phase_with_fee(vec![], Some(100));
 
-        use stellar_xdr::curr::{Hash, TransactionSetV1};
+        use stellar_xdr::{Hash, TransactionSetV1};
         let gen_tx_set = GeneralizedTransactionSet::V1(TransactionSetV1 {
             previous_ledger_hash: Hash([0u8; 32]),
             phases: vec![phase_with_low_base_fee, soroban_phase]
@@ -4316,7 +4316,7 @@ mod tests {
         let tx = make_soroban_envelope(2_000_000, 100, 100, vec![], vec![]);
         let soroban_phase = make_v0_phase_with_fee(vec![tx], Some(100));
 
-        use stellar_xdr::curr::{Hash, TransactionSetV1};
+        use stellar_xdr::{Hash, TransactionSetV1};
         let gen_tx_set = GeneralizedTransactionSet::V1(TransactionSetV1 {
             previous_ledger_hash: Hash([0u8; 32]),
             phases: vec![classic_phase, soroban_phase].try_into().unwrap(),
@@ -4514,7 +4514,7 @@ mod tests {
         inner_seq: i64,
         bumped_fee: i64,
     ) -> TransactionEnvelope {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -4586,11 +4586,11 @@ mod tests {
             source_account: source,
             fee,
             seq_num: SequenceNumber(seq),
-            cond: Preconditions::V2(stellar_xdr::curr::PreconditionsV2 {
+            cond: Preconditions::V2(stellar_xdr::PreconditionsV2 {
                 time_bounds: None,
                 ledger_bounds: None,
                 min_seq_num: None,
-                min_seq_age: stellar_xdr::curr::Duration(0),
+                min_seq_age: stellar_xdr::Duration(0),
                 min_seq_ledger_gap: 0,
                 extra_signers: extra_signer_keys.try_into().unwrap(),
             }),
@@ -4767,7 +4767,7 @@ mod tests {
     /// re-validation, tx-set validation MUST catch invalid outer signatures.
     #[test]
     fn test_validate_fee_bump_invalid_outer_signature_rejected() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -4896,7 +4896,7 @@ mod tests {
     /// on the inner transaction.
     #[test]
     fn test_validate_fee_bump_extra_inner_signature_rejected() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -5058,7 +5058,7 @@ mod tests {
         bumped_fee: i64,
         seq: i64,
     ) -> TransactionEnvelope {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -5335,13 +5335,11 @@ mod tests {
 
     /// Build a FrozenKeyConfig that freezes the account with the given ed25519 key.
     fn frozen_config_for_account(key_bytes: [u8; 32]) -> henyey_tx::frozen_keys::FrozenKeyConfig {
-        use stellar_xdr::curr::{
-            AccountId, LedgerKey, LedgerKeyAccount, PublicKey, Uint256, WriteXdr,
-        };
+        use stellar_xdr::{AccountId, LedgerKey, LedgerKeyAccount, PublicKey, Uint256, WriteXdr};
         let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(key_bytes)));
         let ledger_key = LedgerKey::Account(LedgerKeyAccount { account_id });
         let key_xdr = ledger_key
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("encode ledger key");
         henyey_tx::frozen_keys::FrozenKeyConfig::new(vec![key_xdr], vec![])
     }
@@ -5367,7 +5365,7 @@ mod tests {
 
     #[test]
     fn test_frozen_source_bypass_hash_passes() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountId, Hash, LedgerKey, LedgerKeyAccount, PublicKey, Uint256, WriteXdr,
         };
 
@@ -5376,7 +5374,7 @@ mod tests {
             account_id: account_id.clone(),
         });
         let key_xdr = ledger_key
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("encode ledger key");
 
         // Compute the tx hash used for bypass checking
@@ -5412,7 +5410,7 @@ mod tests {
 
     #[test]
     fn test_frozen_non_source_account_passes() {
-        use stellar_xdr::curr::{AccountId, PublicKey, Uint256};
+        use stellar_xdr::{AccountId, PublicKey, Uint256};
 
         let mut ctx = test_context();
         // Freeze a different account (not the source in make_valid_envelope)

--- a/crates/herder/src/upgrades.rs
+++ b/crates/herder/src/upgrades.rs
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use stellar_xdr::curr::{ConfigUpgradeSetKey, LedgerUpgrade, ReadXdr, UpgradeType};
+use stellar_xdr::{ConfigUpgradeSetKey, LedgerUpgrade, ReadXdr, UpgradeType};
 
 /// Default expiration time for pending upgrades (15 minutes, matching stellar-core
 /// Upgrades::DEFAULT_UPGRADE_EXPIRATION_MINUTES).
@@ -216,8 +216,8 @@ impl ConfigUpgradeSetKeyJson {
         ch.copy_from_slice(&content_hash);
 
         Ok(ConfigUpgradeSetKey {
-            contract_id: stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(cid)),
-            content_hash: stellar_xdr::curr::Hash(ch),
+            contract_id: stellar_xdr::ContractId(stellar_xdr::Hash(cid)),
+            content_hash: stellar_xdr::Hash(ch),
         })
     }
 }
@@ -559,7 +559,7 @@ impl Upgrades {
         // Remove individual applied upgrades
         for upgrade_bytes in applied_upgrades {
             let Ok(upgrade) =
-                LedgerUpgrade::from_xdr(&upgrade_bytes.0, stellar_xdr::curr::Limits::none())
+                LedgerUpgrade::from_xdr(&upgrade_bytes.0, stellar_xdr::Limits::none())
             else {
                 continue;
             };
@@ -650,8 +650,7 @@ pub fn is_valid_for_apply(
     current_version: u32,
     max_protocol_version: u32,
 ) -> (UpgradeValidity, Option<LedgerUpgrade>) {
-    let upgrade = match LedgerUpgrade::from_xdr(&upgrade_bytes.0, stellar_xdr::curr::Limits::none())
-    {
+    let upgrade = match LedgerUpgrade::from_xdr(&upgrade_bytes.0, stellar_xdr::Limits::none()) {
         Ok(u) => u,
         Err(_) => return (UpgradeValidity::XdrInvalid, None),
     };
@@ -704,7 +703,7 @@ pub fn upgrade_to_string(upgrade: &LedgerUpgrade) -> String {
 ///
 /// Returns None if the XDR cannot be deserialized.
 pub fn parse_upgrade(upgrade_bytes: &UpgradeType) -> Option<LedgerUpgrade> {
-    LedgerUpgrade::from_xdr(&upgrade_bytes.0, stellar_xdr::curr::Limits::none()).ok()
+    LedgerUpgrade::from_xdr(&upgrade_bytes.0, stellar_xdr::Limits::none()).ok()
 }
 
 #[cfg(test)]
@@ -858,12 +857,12 @@ mod tests {
 
     #[test]
     fn test_is_valid_for_apply_version() {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         let upgrade = LedgerUpgrade::Version(24);
         let bytes = UpgradeType(
             upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -884,13 +883,13 @@ mod tests {
 
     #[test]
     fn test_is_valid_for_apply_base_fee() {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         // Valid fee
         let upgrade = LedgerUpgrade::BaseFee(100);
         let bytes = UpgradeType(
             upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -902,7 +901,7 @@ mod tests {
         let upgrade = LedgerUpgrade::BaseFee(0);
         let bytes = UpgradeType(
             upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -913,13 +912,13 @@ mod tests {
 
     #[test]
     fn test_is_valid_for_apply_flags() {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         // Valid flags on protocol 18+
         let upgrade = LedgerUpgrade::Flags(0x3);
         let bytes = UpgradeType(
             upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -935,7 +934,7 @@ mod tests {
         let upgrade = LedgerUpgrade::Flags(0x100);
         let bytes = UpgradeType(
             upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -946,12 +945,12 @@ mod tests {
 
     #[test]
     fn test_is_valid_for_apply_soroban() {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         let upgrade = LedgerUpgrade::MaxSorobanTxSetSize(100);
         let bytes = UpgradeType(
             upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -979,12 +978,12 @@ mod tests {
     /// demanded) would make it fail.
     #[test]
     fn test_numeric_upgrade_zero_accepted_matches_core() {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         fn encode(upgrade: LedgerUpgrade) -> UpgradeType {
             UpgradeType(
                 upgrade
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                     .unwrap()
                     .try_into()
                     .unwrap(),
@@ -1076,7 +1075,7 @@ mod tests {
 
     #[test]
     fn test_remove_upgrades_applied() {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         let mut params = UpgradeParameters::new(1000);
         params.protocol_version = Some(24);
@@ -1088,7 +1087,7 @@ mod tests {
         let applied_upgrade = LedgerUpgrade::Version(24);
         let applied_bytes = UpgradeType(
             applied_upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -1102,12 +1101,12 @@ mod tests {
 
     #[test]
     fn test_parse_upgrade() {
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
 
         let upgrade = LedgerUpgrade::Version(24);
         let bytes = UpgradeType(
             upgrade
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -1120,8 +1119,8 @@ mod tests {
     #[test]
     fn test_config_upgrade_set_key_json() {
         let key = ConfigUpgradeSetKey {
-            contract_id: stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash([1u8; 32])),
-            content_hash: stellar_xdr::curr::Hash([2u8; 32]),
+            contract_id: stellar_xdr::ContractId(stellar_xdr::Hash([1u8; 32])),
+            content_hash: stellar_xdr::Hash([2u8; 32]),
         };
 
         let json = ConfigUpgradeSetKeyJson::from_xdr(&key);
@@ -1368,8 +1367,8 @@ mod tests {
 
         // Propose upgrade with a DIFFERENT key K2
         let different_key = ConfigUpgradeSetKey {
-            contract_id: stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash([3u8; 32])),
-            content_hash: stellar_xdr::curr::Hash([4u8; 32]),
+            contract_id: stellar_xdr::ContractId(stellar_xdr::Hash([3u8; 32])),
+            content_hash: stellar_xdr::Hash([4u8; 32]),
         };
         let upgrade = LedgerUpgrade::Config(different_key);
 
@@ -1389,15 +1388,15 @@ mod tests {
     /// matching current CONFIG_SETTING entries. Returns `(ctx, key)` where
     /// `key` is the `ConfigUpgradeSetKey` suitable for `UpgradeParameters`.
     fn build_config_upgrade_context(
-        upgrade_set: &stellar_xdr::curr::ConfigUpgradeSet,
-        current_settings: &[stellar_xdr::curr::ConfigSettingEntry],
+        upgrade_set: &stellar_xdr::ConfigUpgradeSet,
+        current_settings: &[stellar_xdr::ConfigSettingEntry],
         protocol_version: u32,
         ledger_seq: u32,
     ) -> (ConfigUpgradeContext, ConfigUpgradeSetKey) {
         use henyey_common::Hash256;
         use henyey_ledger::{SnapshotBuilder, SnapshotHandle};
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // Compute the content hash from the XDR-encoded upgrade set.
         let upgrade_xdr = upgrade_set.to_xdr(Limits::none()).unwrap();
@@ -1421,7 +1420,7 @@ mod tests {
         let data_entry = LedgerEntry {
             last_modified_ledger_seq: ledger_seq,
             data: LedgerEntryData::ContractData(ContractDataEntry {
-                ext: stellar_xdr::curr::ExtensionPoint::V0,
+                ext: stellar_xdr::ExtensionPoint::V0,
                 contract: ScAddress::Contract(ContractId(contract_id.clone())),
                 key: ScVal::Bytes(content_hash_bytes.to_vec().try_into().unwrap()),
                 durability: ContractDataDurability::Temporary,
@@ -1481,7 +1480,7 @@ mod tests {
     #[test]
     fn test_create_upgrades_for_config_with_context_needed() {
         use base64::{engine::general_purpose::STANDARD, Engine};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let proposed = ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
             ledger_max_instructions: 200_000_000, // differs
@@ -1545,7 +1544,7 @@ mod tests {
     #[test]
     fn test_create_upgrades_for_config_with_context_not_needed() {
         use base64::{engine::general_purpose::STANDARD, Engine};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // Proposed and current are identical — upgrade not needed.
         let setting = ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
@@ -1599,10 +1598,10 @@ mod tests {
     #[test]
     fn test_from_snapshot_propagates_get_entry_error() {
         use henyey_ledger::{EntryLookupFn, LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let key = ConfigUpgradeSetKey {
-            contract_id: stellar_xdr::curr::ContractId(Hash([1u8; 32])),
+            contract_id: stellar_xdr::ContractId(Hash([1u8; 32])),
             content_hash: Hash([2u8; 32]),
         };
 
@@ -1787,7 +1786,7 @@ mod tests {
     #[test]
     fn test_scheduled_config_variant_nominate() {
         use base64::{engine::general_purpose::STANDARD, Engine};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let proposed = ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
             ledger_max_instructions: 200_000_000, // differs from current

--- a/crates/herder/tests/persistence_race.rs
+++ b/crates/herder/tests/persistence_race.rs
@@ -28,7 +28,7 @@ use henyey_herder::{
     get_tx_set_hashes, PersistedSlotState, ScpPersistenceManager, ScpStatePersistence,
     SqliteScpPersistence,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, Limits, NodeId, PublicKey, ScpEnvelope, ScpNomination, ScpStatement, ScpStatementPledges,
     Signature, StellarValue, StellarValueExt, TimePoint, Uint256, Value, WriteXdr,
 };

--- a/crates/herder/tests/scp_envelope_pipeline_order.rs
+++ b/crates/herder/tests/scp_envelope_pipeline_order.rs
@@ -25,7 +25,7 @@ use henyey_crypto::SecretKey;
 use henyey_herder::scp_verify::PostVerifyReason;
 use henyey_herder::{EnvelopeState, Herder, HerderConfig, TimerManagerHandle};
 use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash as XdrHash, LedgerCloseValueSignature, Limits, NodeId as XdrNodeId,
     PublicKey as XdrPublicKey, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement,
     ScpStatementPledges, Signature as XdrSignature, StellarValue, StellarValueExt, TimePoint,
@@ -48,7 +48,7 @@ const PEER_SEED: [u8; 32] = [9u8; 32];
 // ---------------------------------------------------------------------------
 
 fn make_default_lm() -> Arc<LedgerManager> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, StellarValue as XdrStellarValue,
         StellarValueExt as XdrStellarValueExt, TimePoint as XdrTimePoint, VecM,
     };

--- a/crates/herder/tests/scp_envelope_relay.rs
+++ b/crates/herder/tests/scp_envelope_relay.rs
@@ -29,7 +29,7 @@ use henyey_crypto::SecretKey;
 use henyey_herder::scp_verify::PostVerifyReason;
 use henyey_herder::{EnvelopeState, Herder, HerderConfig, TimerManagerHandle};
 use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash as XdrHash, LedgerCloseValueSignature, Limits, NodeId as XdrNodeId,
     PublicKey as XdrPublicKey, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement,
     ScpStatementPledges, Signature as XdrSignature, StellarValue, StellarValueExt, TimePoint,
@@ -54,7 +54,7 @@ const PEER_SEED: [u8; 32] = [9u8; 32];
 // ---------------------------------------------------------------------------
 
 fn make_default_lm() -> Arc<LedgerManager> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, StellarValue as XdrStellarValue,
         StellarValueExt as XdrStellarValueExt, TimePoint as XdrTimePoint, VecM,
     };

--- a/crates/herder/tests/scp_split_equivalence.rs
+++ b/crates/herder/tests/scp_split_equivalence.rs
@@ -39,7 +39,7 @@ use henyey_crypto::SecretKey;
 use henyey_herder::scp_verify::{self, PostVerifyReason, PreFilter};
 use henyey_herder::{EnvelopeState, Herder, HerderConfig, TimerManagerHandle};
 use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash as XdrHash, LedgerCloseValueSignature, Limits, NodeId as XdrNodeId,
     PublicKey as XdrPublicKey, ScpBallot, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement,
     ScpStatementExternalize, ScpStatementPledges, ScpStatementPrepare, Signature as XdrSignature,
@@ -51,7 +51,7 @@ use stellar_xdr::curr::{
 // ---------------------------------------------------------------------------
 
 fn make_default_lm() -> Arc<LedgerManager> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, StellarValue as XdrStellarValue,
         StellarValueExt as XdrStellarValueExt, TimePoint as XdrTimePoint, VecM,
     };

--- a/crates/herder/tests/scp_stage_attribution.rs
+++ b/crates/herder/tests/scp_stage_attribution.rs
@@ -35,7 +35,7 @@ use henyey_herder::scp_verify::{
 };
 use henyey_herder::{Herder, HerderConfig, HerderState, TimerManagerHandle};
 use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash as XdrHash, LedgerCloseValueSignature, Limits, NodeId as XdrNodeId,
     PublicKey as XdrPublicKey, ScpBallot, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement,
     ScpStatementExternalize, ScpStatementPledges, ScpStatementPrepare, Signature as XdrSignature,
@@ -47,7 +47,7 @@ use stellar_xdr::curr::{
 // ---------------------------------------------------------------------------
 
 fn make_default_lm() -> Arc<LedgerManager> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, StellarValue as XdrStellarValue,
         StellarValueExt as XdrStellarValueExt, TimePoint as XdrTimePoint, VecM,
     };

--- a/crates/herder/tests/tx_queue.rs
+++ b/crates/herder/tests/tx_queue.rs
@@ -1,7 +1,7 @@
 use henyey_common::{Hash256, Resource, ResourceType, NUM_SOROBAN_TX_RESOURCES};
 use henyey_herder::{TransactionQueue, TxQueueConfig};
 use henyey_tx::muxed_to_account_id;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, AlphaNum4, Asset, AssetCode4, CreateAccountOp, DecoratedSignature, HostFunction,
     InvokeContractArgs, InvokeHostFunctionOp, LedgerFootprint, ManageSellOfferOp, Memo,
     MuxedAccount, Operation, OperationBody, Preconditions, Price, PublicKey, ScAddress, ScSymbol,
@@ -147,7 +147,7 @@ fn set_source(envelope: &mut TransactionEnvelope, seed: u8) {
             env.tx.source_account = source;
         }
         TransactionEnvelope::TxFeeBump(env) => match &mut env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                 inner.tx.source_account = source;
             }
         },
@@ -163,7 +163,7 @@ fn set_seq(envelope: &mut TransactionEnvelope, seq: i64) {
             env.tx.seq_num = SequenceNumber(seq);
         }
         TransactionEnvelope::TxFeeBump(env) => match &mut env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                 inner.tx.seq_num = SequenceNumber(seq);
             }
         },
@@ -173,13 +173,11 @@ fn set_seq(envelope: &mut TransactionEnvelope, seq: i64) {
 fn account_key_from_envelope(envelope: &TransactionEnvelope) -> Vec<u8> {
     let source = match envelope {
         TransactionEnvelope::TxV0(env) => {
-            stellar_xdr::curr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone())
+            stellar_xdr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone())
         }
         TransactionEnvelope::Tx(env) => env.tx.source_account.clone(),
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
-                inner.tx.source_account.clone()
-            }
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.source_account.clone(),
         },
     };
     let account_id = muxed_to_account_id(&source);
@@ -313,7 +311,7 @@ fn test_sequence_gap_blocks_following() {
             TransactionEnvelope::Tx(env) => env.tx.seq_num.0,
             TransactionEnvelope::TxV0(env) => env.tx.seq_num.0,
             TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-                stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
+                stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
             },
         })
         .collect();
@@ -371,7 +369,7 @@ fn test_starting_sequence_excludes_prior() {
             TransactionEnvelope::Tx(env) => env.tx.seq_num.0,
             TransactionEnvelope::TxV0(env) => env.tx.seq_num.0,
             TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-                stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
+                stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
             },
         })
         .collect();

--- a/crates/herder/tests/txset_mixed_equivalence.rs
+++ b/crates/herder/tests/txset_mixed_equivalence.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 
 use henyey_common::{Hash256, NetworkId};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, AlphaNum4, Asset, AssetCode4, CreateAccountOp, GeneralizedTransactionSet,
     InvokeContractArgs, InvokeHostFunctionOp, ManageSellOfferOp, MuxedAccount, Operation,
     OperationBody, Price, PublicKey, ScAddress, ScSymbol, ScVal, SequenceNumber, SorobanResources,
@@ -35,8 +35,8 @@ fn make_classic_payment(fee: u32) -> TransactionEnvelope {
         source_account: source,
         fee,
         seq_num: SequenceNumber(1),
-        cond: stellar_xdr::curr::Preconditions::None,
-        memo: stellar_xdr::curr::Memo::None,
+        cond: stellar_xdr::Preconditions::None,
+        memo: stellar_xdr::Memo::None,
         operations: vec![op].try_into().unwrap(),
         ext: TransactionExt::V0,
     };
@@ -67,8 +67,8 @@ fn make_dex_tx(fee: u32) -> TransactionEnvelope {
         source_account: source,
         fee,
         seq_num: SequenceNumber(1),
-        cond: stellar_xdr::curr::Preconditions::None,
-        memo: stellar_xdr::curr::Memo::None,
+        cond: stellar_xdr::Preconditions::None,
+        memo: stellar_xdr::Memo::None,
         operations: vec![op].try_into().unwrap(),
         ext: TransactionExt::V0,
     };
@@ -95,8 +95,8 @@ fn make_multi_op_classic(fee: u32, ops: usize) -> TransactionEnvelope {
         source_account: source,
         fee,
         seq_num: SequenceNumber(1),
-        cond: stellar_xdr::curr::Preconditions::None,
-        memo: stellar_xdr::curr::Memo::None,
+        cond: stellar_xdr::Preconditions::None,
+        memo: stellar_xdr::Memo::None,
         operations: operations.try_into().unwrap(),
         ext: TransactionExt::V0,
     };
@@ -111,7 +111,7 @@ fn make_soroban_tx(fee: u32, instructions: u32) -> TransactionEnvelope {
     let op = Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            host_function: stellar_xdr::curr::HostFunction::InvokeContract(InvokeContractArgs {
+            host_function: stellar_xdr::HostFunction::InvokeContract(InvokeContractArgs {
                 contract_address: ScAddress::default(),
                 function_name: ScSymbol(
                     StringM::<32>::try_from("test".to_string()).expect("symbol"),
@@ -122,7 +122,7 @@ fn make_soroban_tx(fee: u32, instructions: u32) -> TransactionEnvelope {
         }),
     };
     let resources = SorobanResources {
-        footprint: stellar_xdr::curr::LedgerFootprint {
+        footprint: stellar_xdr::LedgerFootprint {
             read_only: VecM::default(),
             read_write: VecM::default(),
         },
@@ -134,8 +134,8 @@ fn make_soroban_tx(fee: u32, instructions: u32) -> TransactionEnvelope {
         source_account: source,
         fee,
         seq_num: SequenceNumber(1),
-        cond: stellar_xdr::curr::Preconditions::None,
-        memo: stellar_xdr::curr::Memo::None,
+        cond: stellar_xdr::Preconditions::None,
+        memo: stellar_xdr::Memo::None,
         operations: vec![op].try_into().unwrap(),
         ext: TransactionExt::V1(SorobanTransactionData {
             ext: SorobanTransactionDataExt::V0,
@@ -159,7 +159,7 @@ fn set_source(envelope: &mut TransactionEnvelope, seed: u8) {
             env.tx.source_account = source;
         }
         TransactionEnvelope::TxFeeBump(env) => match &mut env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                 inner.tx.source_account = source;
             }
         },
@@ -195,8 +195,7 @@ fn flatten_gen_tx_set(gen: &GeneralizedTransactionSet) -> Vec<TransactionEnvelop
 }
 
 fn xdr_bytes(gen: &GeneralizedTransactionSet) -> Vec<u8> {
-    gen.to_xdr(stellar_xdr::curr::Limits::none())
-        .expect("XDR encode")
+    gen.to_xdr(stellar_xdr::Limits::none()).expect("XDR encode")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/herder/tests/txset_summary.rs
+++ b/crates/herder/tests/txset_summary.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use henyey_common::{Hash256, NetworkId};
 use henyey_tx::TransactionFrame;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, AlphaNum4, Asset, AssetCode4, CreateAccountOp, InvokeContractArgs,
     InvokeHostFunctionOp, LedgerFootprint, ManageSellOfferOp, MuxedAccount, Operation,
     OperationBody, Price, PublicKey, ScAddress, ScSymbol, ScVal, SequenceNumber, SorobanResources,
@@ -47,8 +47,8 @@ fn make_classic_payment(fee: u32) -> TransactionEnvelope {
         source_account: source,
         fee,
         seq_num: SequenceNumber(1),
-        cond: stellar_xdr::curr::Preconditions::None,
-        memo: stellar_xdr::curr::Memo::None,
+        cond: stellar_xdr::Preconditions::None,
+        memo: stellar_xdr::Memo::None,
         operations: vec![op].try_into().unwrap(),
         ext: TransactionExt::V0,
     };
@@ -79,8 +79,8 @@ fn make_classic_dex(fee: u32) -> TransactionEnvelope {
         source_account: source,
         fee,
         seq_num: SequenceNumber(1),
-        cond: stellar_xdr::curr::Preconditions::None,
-        memo: stellar_xdr::curr::Memo::None,
+        cond: stellar_xdr::Preconditions::None,
+        memo: stellar_xdr::Memo::None,
         operations: vec![op].try_into().unwrap(),
         ext: TransactionExt::V0,
     };
@@ -95,7 +95,7 @@ fn make_soroban_tx(total_fee: u32, resource_fee: i64) -> TransactionEnvelope {
     let op = Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            host_function: stellar_xdr::curr::HostFunction::InvokeContract(InvokeContractArgs {
+            host_function: stellar_xdr::HostFunction::InvokeContract(InvokeContractArgs {
                 contract_address: ScAddress::default(),
                 function_name: ScSymbol(
                     StringM::<32>::try_from("test".to_string()).expect("symbol"),
@@ -107,17 +107,17 @@ fn make_soroban_tx(total_fee: u32, resource_fee: i64) -> TransactionEnvelope {
     };
     let footprint = LedgerFootprint {
         read_only: vec![
-            stellar_xdr::curr::LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            stellar_xdr::LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([6u8; 32]))),
             }),
-            stellar_xdr::curr::LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            stellar_xdr::LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([7u8; 32]))),
             }),
         ]
         .try_into()
         .unwrap(),
-        read_write: vec![stellar_xdr::curr::LedgerKey::Account(
-            stellar_xdr::curr::LedgerKeyAccount {
+        read_write: vec![stellar_xdr::LedgerKey::Account(
+            stellar_xdr::LedgerKeyAccount {
                 account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([8u8; 32]))),
             },
         )]
@@ -134,8 +134,8 @@ fn make_soroban_tx(total_fee: u32, resource_fee: i64) -> TransactionEnvelope {
         source_account: source,
         fee: total_fee,
         seq_num: SequenceNumber(1),
-        cond: stellar_xdr::curr::Preconditions::None,
-        memo: stellar_xdr::curr::Memo::None,
+        cond: stellar_xdr::Preconditions::None,
+        memo: stellar_xdr::Memo::None,
         operations: vec![op].try_into().unwrap(),
         ext: TransactionExt::V1(SorobanTransactionData {
             ext: SorobanTransactionDataExt::V0,
@@ -151,13 +151,13 @@ fn make_soroban_tx(total_fee: u32, resource_fee: i64) -> TransactionEnvelope {
 
 fn summary_for_set(
     txs: &[TransactionEnvelope],
-    gen: &stellar_xdr::curr::GeneralizedTransactionSet,
+    gen: &stellar_xdr::GeneralizedTransactionSet,
 ) -> TxSetSummary {
     let mut base_fee_map: HashMap<Hash256, Option<i64>> = HashMap::new();
     let mut soroban_base_fee = None;
 
-    let stellar_xdr::curr::GeneralizedTransactionSet::V1(tx_set) = gen;
-    if let stellar_xdr::curr::TransactionPhase::V0(components) = &tx_set.phases[0] {
+    let stellar_xdr::GeneralizedTransactionSet::V1(tx_set) = gen;
+    if let stellar_xdr::TransactionPhase::V0(components) = &tx_set.phases[0] {
         for component in components.iter() {
             let TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) = component;
             for tx in comp.txs.iter() {
@@ -166,7 +166,7 @@ fn summary_for_set(
         }
     }
     match &tx_set.phases[1] {
-        stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+        stellar_xdr::TransactionPhase::V1(parallel) => {
             soroban_base_fee = parallel.base_fee;
             for stage in parallel.execution_stages.iter() {
                 for cluster in stage.iter() {
@@ -176,7 +176,7 @@ fn summary_for_set(
                 }
             }
         }
-        stellar_xdr::curr::TransactionPhase::V0(components) => {
+        stellar_xdr::TransactionPhase::V0(components) => {
             if let Some(component) = components.first() {
                 let TxSetComponent::TxsetCompTxsMaybeDiscountedFee(comp) = component;
                 soroban_base_fee = comp.base_fee;
@@ -234,7 +234,7 @@ fn summary_for_set(
             disk_read_entries += resources.get_val(henyey_common::ResourceType::ReadLedgerEntries);
             write_entries += resources.get_val(henyey_common::ResourceType::WriteLedgerEntries);
             tx_size_bytes += tx
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .map(|b| b.len() as i64)
                 .unwrap_or(0);
         } else {

--- a/crates/history/src/archive.rs
+++ b/crates/history/src/archive.rs
@@ -6,7 +6,7 @@
 
 use henyey_common::Hash256;
 use reqwest::Client;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeaderHistoryEntry, ScpHistoryEntry, TransactionHistoryEntry,
     TransactionHistoryResultEntry,
 };
@@ -349,7 +349,7 @@ impl HistoryArchive {
     pub async fn fetch_ledger_header_with_hash(
         &self,
         seq: u32,
-    ) -> Result<(stellar_xdr::curr::LedgerHeader, Hash256), HistoryError> {
+    ) -> Result<(stellar_xdr::LedgerHeader, Hash256), HistoryError> {
         let headers = self.fetch_ledger_headers(seq).await?;
 
         for entry in headers {

--- a/crates/history/src/catchup/buckets.rs
+++ b/crates/history/src/catchup/buckets.rs
@@ -696,7 +696,7 @@ mod tests {
     use super::*;
     use crate::archive_state::HASBucketNext;
     use henyey_bucket::{BucketEntry, HOT_ARCHIVE_BUCKET_LIST_LEVELS};
-    use stellar_xdr::curr::{BucketMetadata, BucketMetadataExt};
+    use stellar_xdr::{BucketMetadata, BucketMetadataExt};
 
     fn meta_entry(version: u32) -> BucketEntry {
         BucketEntry::Metaentry(BucketMetadata {
@@ -928,7 +928,7 @@ mod tests {
     use crate::archive_state::HistoryArchiveState;
     use henyey_bucket::BucketManager;
     use henyey_db::Database;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, LedgerEntry, LedgerEntryData, LedgerEntryExt,
         PublicKey, SequenceNumber, String32, Thresholds, Uint256,
     };
@@ -1053,7 +1053,7 @@ mod tests {
     /// fix.
     #[tokio::test]
     async fn test_apply_buckets_full_header_hash_identical_across_fan_out() {
-        use stellar_xdr::curr::{Hash, LedgerHeader};
+        use stellar_xdr::{Hash, LedgerHeader};
 
         // Six distinct non-empty live levels so unbounded fan-out overlaps
         // multiple concurrent restore workers (maximizes any ordering

--- a/crates/history/src/catchup/download.rs
+++ b/crates/history/src/catchup/download.rs
@@ -12,7 +12,7 @@ use henyey_common::Hash256;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeader, LedgerHeaderHistoryEntry, ScpHistoryEntry, TransactionHistoryEntry,
     TransactionHistoryResultEntry,
 };

--- a/crates/history/src/catchup/mod.rs
+++ b/crates/history/src/catchup/mod.rs
@@ -68,8 +68,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use henyey_ledger::{LedgerManager, TransactionSetVariant};
-use stellar_xdr::curr::LedgerCloseMeta;
-use stellar_xdr::curr::{
+use stellar_xdr::LedgerCloseMeta;
+use stellar_xdr::{
     ExtensionPoint, GeneralizedTransactionSet, Hash, LedgerCloseMetaExt, LedgerCloseMetaExtV1,
     LedgerCloseMetaV2, LedgerHeader, LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt,
     ScpHistoryEntry, TransactionHistoryEntry, TransactionHistoryResultEntry, TransactionResultPair,
@@ -79,7 +79,7 @@ use tracing::{debug, info};
 
 /// Extract a `TransactionSetVariant` from a `TransactionHistoryEntry`.
 pub(crate) fn tx_set_from_history_entry(entry: &TransactionHistoryEntry) -> TransactionSetVariant {
-    use stellar_xdr::curr::TransactionHistoryEntryExt;
+    use stellar_xdr::TransactionHistoryEntryExt;
     match &entry.ext {
         TransactionHistoryEntryExt::V0 => TransactionSetVariant::Classic(entry.tx_set.clone()),
         TransactionHistoryEntryExt::V1(set) => TransactionSetVariant::Generalized(set.clone()),
@@ -1143,7 +1143,7 @@ impl CatchupManager {
             if let Some(header) = header_map.get(&entry.ledger_seq) {
                 let xdr = entry
                     .tx_result_set
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                     .map_err(|e| {
                         HistoryError::CatchupFailed(format!(
                             "failed to encode tx result set: {}",
@@ -1383,7 +1383,7 @@ pub(crate) fn make_empty_tx_set(lcl: &LclContext) -> TransactionSetVariant {
     use henyey_common::protocol::{
         protocol_version_starts_from, ProtocolVersion, PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION,
     };
-    use stellar_xdr::curr::{TransactionPhase, TransactionSet, VecM};
+    use stellar_xdr::{TransactionPhase, TransactionSet, VecM};
 
     let previous_ledger_hash = lcl.lcl_hash().clone();
     let lcl_protocol_version = lcl.protocol_version();
@@ -1515,7 +1515,7 @@ impl CatchupManagerBuilder {
             emit_classic_events: false,
             backfill_stellar_asset_events: false,
             run_eviction: true,
-            eviction_settings: stellar_xdr::curr::StateArchivalSettings::default(),
+            eviction_settings: stellar_xdr::StateArchivalSettings::default(),
             wait_for_publish: false,
         };
 
@@ -1677,11 +1677,11 @@ mod tests {
         let header = LedgerHeader {
             ledger_version: 20,
             previous_ledger_hash: Hash([0u8; 32]),
-            scp_value: stellar_xdr::curr::StellarValue {
+            scp_value: stellar_xdr::StellarValue {
                 tx_set_hash: Hash([0u8; 32]),
-                close_time: stellar_xdr::curr::TimePoint(0),
-                upgrades: stellar_xdr::curr::VecM::default(),
-                ext: stellar_xdr::curr::StellarValueExt::Basic,
+                close_time: stellar_xdr::TimePoint(0),
+                upgrades: stellar_xdr::VecM::default(),
+                ext: stellar_xdr::StellarValueExt::Basic,
             },
             tx_set_result_hash: Hash([0u8; 32]),
             bucket_list_hash: Hash([0u8; 32]),
@@ -1694,7 +1694,7 @@ mod tests {
             base_reserve: 5000000,
             max_tx_set_size: 100,
             skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
-            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            ext: stellar_xdr::LedgerHeaderExt::V0,
         };
         let entry = LedgerHeaderHistoryEntry {
             hash: Hash([1u8; 32]),

--- a/crates/history/src/catchup/persist.rs
+++ b/crates/history/src/catchup/persist.rs
@@ -5,7 +5,7 @@ use henyey_bucket::BucketList;
 use henyey_common::{Hash256, NetworkId};
 
 use henyey_tx::TransactionFrame;
-use stellar_xdr::curr::{LedgerHeader, ScpHistoryEntry, WriteXdr};
+use stellar_xdr::{LedgerHeader, ScpHistoryEntry, WriteXdr};
 use tracing::warn;
 
 use super::{CatchupManager, LedgerData};
@@ -27,7 +27,7 @@ impl CatchupManager {
 
                 for data in ledger_data {
                     let header = data.header();
-                    let header_xdr = header.to_xdr(stellar_xdr::curr::Limits::none())?;
+                    let header_xdr = header.to_xdr(stellar_xdr::Limits::none())?;
                     conn.store_ledger_header(header, &header_xdr)?;
 
                     // Only store tx/result entries for Present data.
@@ -58,12 +58,12 @@ impl CatchupManager {
                             .map_err(|e| DbError::Integrity(e.to_string()))?;
                         let tx_id = tx_hash.to_hex();
 
-                        let tx_body = tx.to_xdr(stellar_xdr::curr::Limits::none())?;
-                        let tx_result_xdr = tx_result.to_xdr(stellar_xdr::curr::Limits::none())?;
+                        let tx_body = tx.to_xdr(stellar_xdr::Limits::none())?;
+                        let tx_result_xdr = tx_result.to_xdr(stellar_xdr::Limits::none())?;
 
                         // Compute status from result code
                         let status = {
-                            use stellar_xdr::curr::TransactionResultCode;
+                            use stellar_xdr::TransactionResultCode;
                             let code = tx_result.result.result.discriminant();
                             if code == TransactionResultCode::TxSuccess
                                 || code == TransactionResultCode::TxFeeBumpInnerSuccess
@@ -158,7 +158,7 @@ impl CatchupManager {
         self.db
             .with_connection(|conn| {
                 use henyey_db::queries::LedgerQueries;
-                let header_xdr = header.to_xdr(stellar_xdr::curr::Limits::none())?;
+                let header_xdr = header.to_xdr(stellar_xdr::Limits::none())?;
                 conn.store_ledger_header(header, &header_xdr)?;
                 Ok(())
             })
@@ -175,9 +175,9 @@ impl CatchupManager {
     /// `getLedgers`) see entries for the replayed range. The streaming callback
     /// (if configured) writes the meta to the fd:3 pipe for captive core
     /// consumers like stellar-rpc and horizon.
-    pub(super) fn emit_meta(&self, ledger_seq: u32, meta: stellar_xdr::curr::LedgerCloseMeta) {
+    pub(super) fn emit_meta(&self, ledger_seq: u32, meta: stellar_xdr::LedgerCloseMeta) {
         // Persist to SQLite first (to_xdr borrows &self on meta, no clone needed).
-        match meta.to_xdr(stellar_xdr::curr::Limits::none()) {
+        match meta.to_xdr(stellar_xdr::Limits::none()) {
             Ok(meta_xdr) => {
                 if let Err(err) = self.db.store_ledger_close_meta(ledger_seq, &meta_xdr) {
                     warn!(
@@ -210,7 +210,7 @@ mod tests {
     use henyey_bucket::BucketManager;
     use henyey_common::protocol::LclContext;
     use henyey_db::Database;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, Memo, MuxedAccount, Preconditions, SequenceNumber, Transaction,
         TransactionEnvelope, TransactionExt, TransactionHistoryEntry, TransactionHistoryEntryExt,
         TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResult,
@@ -415,7 +415,7 @@ mod tests {
     #[test]
     fn test_make_empty_tx_set_v20_sequential() {
         use henyey_ledger::TransactionSetVariant;
-        use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase};
+        use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase};
 
         let lcl = LclContext::new(20, henyey_common::Hash256([7u8; 32]));
         let tx_set = make_empty_tx_set(&lcl);
@@ -440,7 +440,7 @@ mod tests {
     #[test]
     fn test_make_empty_tx_set_v22_sequential() {
         use henyey_ledger::TransactionSetVariant;
-        use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase};
+        use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase};
 
         let lcl = LclContext::new(22, henyey_common::Hash256([5u8; 32]));
         let tx_set = make_empty_tx_set(&lcl);
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn test_make_empty_tx_set_v23_parallel() {
         use henyey_ledger::TransactionSetVariant;
-        use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase};
+        use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase};
 
         let lcl = LclContext::new(23, henyey_common::Hash256([9u8; 32]));
         let tx_set = make_empty_tx_set(&lcl);
@@ -722,11 +722,11 @@ mod tests {
             ledger_seq,
             ledger_version: current_protocol,
             previous_ledger_hash,
-            scp_value: stellar_xdr::curr::StellarValue {
-                tx_set_hash: stellar_xdr::curr::Hash(tx_set_hash.0),
-                close_time: stellar_xdr::curr::TimePoint(0),
+            scp_value: stellar_xdr::StellarValue {
+                tx_set_hash: stellar_xdr::Hash(tx_set_hash.0),
+                close_time: stellar_xdr::TimePoint(0),
                 upgrades: Default::default(),
-                ext: stellar_xdr::curr::StellarValueExt::Basic,
+                ext: stellar_xdr::StellarValueExt::Basic,
             },
             ..Default::default()
         }
@@ -776,7 +776,7 @@ mod tests {
         // Steady state: LCL at 20, current at 20. Generalized V0+V0.
         use crate::verify::verify_tx_set;
         use henyey_ledger::TransactionSetVariant;
-        use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase};
+        use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase};
 
         let header = make_header_with_empty_tx_set_hash(200, 20, 20);
         let lcl = LclContext::new(20, henyey_common::Hash256(header.previous_ledger_hash.0));
@@ -798,7 +798,7 @@ mod tests {
         // Protocol boundary: LCL at 22 (Generalized V0+V0), current upgrades to 23.
         use crate::verify::verify_tx_set;
         use henyey_ledger::TransactionSetVariant;
-        use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase};
+        use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase};
 
         let header = make_header_with_empty_tx_set_hash(300, 23, 22);
         let lcl = LclContext::new(22, henyey_common::Hash256(header.previous_ledger_hash.0));
@@ -824,7 +824,7 @@ mod tests {
         // Steady state: LCL at 23, current at 23. Generalized V0+V1 (parallel).
         use crate::verify::verify_tx_set;
         use henyey_ledger::TransactionSetVariant;
-        use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase};
+        use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase};
 
         let header = make_header_with_empty_tx_set_hash(400, 23, 23);
         let lcl = LclContext::new(23, henyey_common::Hash256(header.previous_ledger_hash.0));
@@ -930,11 +930,11 @@ mod tests {
             ledger_seq: 2,
             ledger_version: 23,
             previous_ledger_hash: prev_hash,
-            scp_value: stellar_xdr::curr::StellarValue {
-                tx_set_hash: stellar_xdr::curr::Hash(hash_v23.0),
-                close_time: stellar_xdr::curr::TimePoint(0),
+            scp_value: stellar_xdr::StellarValue {
+                tx_set_hash: stellar_xdr::Hash(hash_v23.0),
+                close_time: stellar_xdr::TimePoint(0),
                 upgrades: Default::default(),
-                ext: stellar_xdr::curr::StellarValueExt::Basic,
+                ext: stellar_xdr::StellarValueExt::Basic,
             },
             ..Default::default()
         };

--- a/crates/history/src/catchup/replay.rs
+++ b/crates/history/src/catchup/replay.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use henyey_common::protocol::LclContext;
 use henyey_common::Hash256;
 use henyey_ledger::{HeaderSnapshot, LedgerCloseData, LedgerManager};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeader, LedgerHeaderHistoryEntry, LedgerUpgrade, Limits, ReadXdr, WriteXdr,
 };
 use tracing::{debug, info, warn};
@@ -351,7 +351,7 @@ impl CatchupManager {
             // unused. Use a zero placeholder rather than recomputing the header
             // hash for a synthetic entry that we discard immediately.
             let virtual_entry = LedgerHeaderHistoryEntry {
-                hash: stellar_xdr::curr::Hash([0; 32]),
+                hash: stellar_xdr::Hash([0; 32]),
                 header,
                 ext: Default::default(),
             };
@@ -442,7 +442,7 @@ impl CatchupManager {
             if let Some(result_entry) = data.tx_result_entry() {
                 let xdr = result_entry
                     .tx_result_set
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                     .map_err(|e| {
                         HistoryError::CatchupFailed(format!(
                             "Failed to serialize tx result set for ledger {}: {}",
@@ -876,10 +876,10 @@ mod tests {
     /// hash, and `lcl_prev_hash` is what the LCL header's
     /// `previous_ledger_hash` field carries (i.e. the hash of LCL-1).
     fn make_test_lcl(lcl_seq: u32, lcl_hash: Hash256, lcl_prev_hash: Hash256) -> HeaderSnapshot {
-        use stellar_xdr::curr::LedgerHeader;
+        use stellar_xdr::LedgerHeader;
         let mut header = LedgerHeader::default();
         header.ledger_seq = lcl_seq;
-        header.previous_ledger_hash = stellar_xdr::curr::Hash(lcl_prev_hash.0);
+        header.previous_ledger_hash = stellar_xdr::Hash(lcl_prev_hash.0);
         HeaderSnapshot {
             header,
             hash: lcl_hash,
@@ -894,13 +894,13 @@ mod tests {
         seq: u32,
         entry_hash: Hash256,
         entry_prev: Hash256,
-    ) -> stellar_xdr::curr::LedgerHeaderHistoryEntry {
-        use stellar_xdr::curr::{LedgerHeader, LedgerHeaderHistoryEntry};
+    ) -> stellar_xdr::LedgerHeaderHistoryEntry {
+        use stellar_xdr::{LedgerHeader, LedgerHeaderHistoryEntry};
         let mut header = LedgerHeader::default();
         header.ledger_seq = seq;
-        header.previous_ledger_hash = stellar_xdr::curr::Hash(entry_prev.0);
+        header.previous_ledger_hash = stellar_xdr::Hash(entry_prev.0);
         LedgerHeaderHistoryEntry {
-            hash: stellar_xdr::curr::Hash(entry_hash.0),
+            hash: stellar_xdr::Hash(entry_hash.0),
             header,
             ext: Default::default(),
         }
@@ -1133,11 +1133,11 @@ mod tests {
     /// out of `verify_knit_to_lcl` later.
     fn make_apply_ledger_data(seq: u32, prev_hash: Hash256) -> LedgerData {
         use henyey_common::protocol::LclContext;
-        use stellar_xdr::curr::LedgerHeader;
+        use stellar_xdr::LedgerHeader;
 
         let mut header = LedgerHeader::default();
         header.ledger_seq = seq;
-        header.previous_ledger_hash = stellar_xdr::curr::Hash(prev_hash.0);
+        header.previous_ledger_hash = stellar_xdr::Hash(prev_hash.0);
 
         let lcl = LclContext::new(0, prev_hash);
         LedgerData::new(header, None, None, &lcl).expect("valid LedgerData")
@@ -1331,7 +1331,7 @@ mod tests {
     /// After fix: the error propagates, halting replay.
     #[test]
     fn test_audit_yh2_tx_set_mismatch_is_error() {
-        use stellar_xdr::curr::{Hash, LedgerHeader, StellarValue, TransactionSet};
+        use stellar_xdr::{Hash, LedgerHeader, StellarValue, TransactionSet};
 
         // Create a header with a specific tx_set_hash
         let mut header = LedgerHeader::default();
@@ -1360,7 +1360,7 @@ mod tests {
     /// [AUDIT-YH2] verify_tx_result_set must return a fatal error for mismatched result hashes.
     #[test]
     fn test_audit_yh2_tx_result_set_mismatch_is_error() {
-        use stellar_xdr::curr::{Hash, LedgerHeader};
+        use stellar_xdr::{Hash, LedgerHeader};
 
         let mut header = LedgerHeader::default();
         header.ledger_seq = 100;
@@ -1451,7 +1451,7 @@ mod tests {
     ) -> (Vec<super::LedgerData>, Hash256) {
         use crate::verify::compute_header_hash;
         use henyey_common::protocol::LclContext;
-        use stellar_xdr::curr::{Hash, StellarValue, TimePoint, VecM};
+        use stellar_xdr::{Hash, StellarValue, TimePoint, VecM};
 
         let mut entries = Vec::with_capacity(count as usize);
         let mut prev_hash = Hash256::ZERO;
@@ -1466,7 +1466,7 @@ mod tests {
                     tx_set_hash: Hash([0u8; 32]),
                     close_time: TimePoint(0),
                     upgrades: VecM::default(),
-                    ext: stellar_xdr::curr::StellarValueExt::Basic,
+                    ext: stellar_xdr::StellarValueExt::Basic,
                 },
                 tx_set_result_hash: Hash([0u8; 32]),
                 bucket_list_hash: Hash([0u8; 32]),
@@ -1479,7 +1479,7 @@ mod tests {
                 base_reserve: 5000000,
                 max_tx_set_size: 100,
                 skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
-                ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                ext: stellar_xdr::LedgerHeaderExt::V0,
             };
 
             let lcl_context = LclContext::new(25, prev_hash);
@@ -1919,7 +1919,7 @@ mod tests {
     /// helper — valid case, mismatched tx-set hash, and absent-result skip.
     #[test]
     fn test_verify_txsets_valid_mismatch_and_absent_skip() {
-        use stellar_xdr::curr::{Hash, StellarValue, TransactionSet};
+        use stellar_xdr::{Hash, StellarValue, TransactionSet};
 
         let (_tmp_dir, manager) = make_test_catchup_manager();
 
@@ -1980,7 +1980,7 @@ mod tests {
     #[test]
     fn test_header_chain_verified_over_full_range_before_replay() {
         use crate::verify::compute_header_hash;
-        use stellar_xdr::curr::Hash;
+        use stellar_xdr::Hash;
 
         let tmpdir = tempfile::tempdir().unwrap();
         let bucket_manager =

--- a/crates/history/src/cdp.rs
+++ b/crates/history/src/cdp.rs
@@ -55,7 +55,7 @@
 
 use crate::{HistoryError, Result};
 use std::io::Read;
-use stellar_xdr::curr::{Hash, LedgerCloseMeta, Limits, ReadXdr, WriteXdr};
+use stellar_xdr::{Hash, LedgerCloseMeta, Limits, ReadXdr, WriteXdr};
 
 /// CDP data lake client for fetching `LedgerCloseMeta` from cloud object storage.
 ///
@@ -545,9 +545,7 @@ macro_rules! map_tx_processing {
 /// The returned metadata is in transaction **apply order**, which may differ
 /// from the order in the transaction set for protocol versions with parallel
 /// execution phases.
-pub fn extract_transaction_metas(
-    meta: &LedgerCloseMeta,
-) -> Vec<stellar_xdr::curr::TransactionMeta> {
+pub fn extract_transaction_metas(meta: &LedgerCloseMeta) -> Vec<stellar_xdr::TransactionMeta> {
     map_tx_processing!(meta, |tp| tp.tx_apply_processing.clone())
 }
 
@@ -562,27 +560,27 @@ pub fn extract_transaction_metas(
 #[derive(Debug, Clone)]
 pub struct TransactionProcessingInfo {
     /// The transaction envelope containing the transaction body and signatures.
-    pub envelope: stellar_xdr::curr::TransactionEnvelope,
+    pub envelope: stellar_xdr::TransactionEnvelope,
 
     /// The transaction result pair containing the hash and result code.
-    pub result: stellar_xdr::curr::TransactionResultPair,
+    pub result: stellar_xdr::TransactionResultPair,
 
     /// The transaction metadata containing all ledger entry changes.
     ///
     /// This includes changes from both the transaction body and any
     /// Soroban contract invocations.
-    pub meta: stellar_xdr::curr::TransactionMeta,
+    pub meta: stellar_xdr::TransactionMeta,
 
     /// Fee-related ledger entry changes.
     ///
     /// These changes are applied before the transaction body and include
     /// fee deduction from the source account.
-    pub fee_meta: stellar_xdr::curr::LedgerEntryChanges,
+    pub fee_meta: stellar_xdr::LedgerEntryChanges,
 
     /// Post-transaction fee processing changes.
     ///
     /// These changes are applied after the transaction body, such as Soroban refunds.
-    pub post_fee_meta: stellar_xdr::curr::LedgerEntryChanges,
+    pub post_fee_meta: stellar_xdr::LedgerEntryChanges,
 
     /// Per-transaction base fee from the transaction set.
     ///
@@ -596,7 +594,7 @@ pub struct TransactionProcessingInfo {
 /// The base fee may differ from `ledger_header.base_fee` during surge pricing.
 /// `None` means "use the ledger header's base_fee".
 struct TxWithBaseFee<'a> {
-    env: &'a stellar_xdr::curr::TransactionEnvelope,
+    env: &'a stellar_xdr::TransactionEnvelope,
     base_fee: Option<u32>,
 }
 
@@ -607,23 +605,23 @@ struct TxWithBaseFee<'a> {
 /// structure (phases -> V0 components / V1 parallel stages -> clusters -> txs)
 /// so that consumers can operate on a flat iterator.
 fn visit_generalized_tx_set(
-    tx_set: &stellar_xdr::curr::GeneralizedTransactionSet,
+    tx_set: &stellar_xdr::GeneralizedTransactionSet,
 ) -> Vec<TxWithBaseFee<'_>> {
-    let stellar_xdr::curr::GeneralizedTransactionSet::V1(v1) = tx_set;
+    let stellar_xdr::GeneralizedTransactionSet::V1(v1) = tx_set;
     let mut result = Vec::new();
 
     for phase in v1.phases.iter() {
         match phase {
-            stellar_xdr::curr::TransactionPhase::V0(components) => {
+            stellar_xdr::TransactionPhase::V0(components) => {
                 for comp in components.iter() {
-                    let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) = comp;
+                    let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) = comp;
                     let base_fee = c.base_fee.and_then(|fee| u32::try_from(fee).ok());
                     for env in c.txs.iter() {
                         result.push(TxWithBaseFee { env, base_fee });
                     }
                 }
             }
-            stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+            stellar_xdr::TransactionPhase::V1(parallel) => {
                 let base_fee = parallel.base_fee.and_then(|fee| u32::try_from(fee).ok());
                 for stage in parallel.execution_stages.iter() {
                     for cluster in stage.iter() {
@@ -644,7 +642,7 @@ fn visit_generalized_tx_set(
 /// The `GeneralizedTransactionSet` can contain per-phase/per-component base fees
 /// that differ from `header.base_fee` during surge pricing.
 fn build_tx_hash_to_base_fee_map(
-    tx_set: &stellar_xdr::curr::GeneralizedTransactionSet,
+    tx_set: &stellar_xdr::GeneralizedTransactionSet,
     network_id: &Hash,
 ) -> std::collections::HashMap<Hash, Option<u32>> {
     visit_generalized_tx_set(tx_set)
@@ -657,33 +655,30 @@ fn build_tx_hash_to_base_fee_map(
 }
 
 /// Compute the network-aware transaction hash.
-fn compute_tx_hash(
-    env: &stellar_xdr::curr::TransactionEnvelope,
-    network_id: &Hash,
-) -> Option<Hash> {
+fn compute_tx_hash(env: &stellar_xdr::TransactionEnvelope, network_id: &Hash) -> Option<Hash> {
     use sha2::{Digest, Sha256};
-    use stellar_xdr::curr::EnvelopeType;
+    use stellar_xdr::EnvelopeType;
 
     let mut hasher = Sha256::new();
     hasher.update(network_id);
 
     let envelope_type = match env {
-        stellar_xdr::curr::TransactionEnvelope::TxV0(_) => EnvelopeType::TxV0,
-        stellar_xdr::curr::TransactionEnvelope::Tx(_) => EnvelopeType::Tx,
-        stellar_xdr::curr::TransactionEnvelope::TxFeeBump(_) => EnvelopeType::TxFeeBump,
+        stellar_xdr::TransactionEnvelope::TxV0(_) => EnvelopeType::TxV0,
+        stellar_xdr::TransactionEnvelope::Tx(_) => EnvelopeType::Tx,
+        stellar_xdr::TransactionEnvelope::TxFeeBump(_) => EnvelopeType::TxFeeBump,
     };
     hasher.update((envelope_type as i32).to_be_bytes());
 
     match env {
-        stellar_xdr::curr::TransactionEnvelope::TxV0(tx_v0) => {
+        stellar_xdr::TransactionEnvelope::TxV0(tx_v0) => {
             let tx_xdr = henyey_common::xdr_to_bytes(&tx_v0.tx);
             hasher.update(&tx_xdr);
         }
-        stellar_xdr::curr::TransactionEnvelope::Tx(tx_v1) => {
+        stellar_xdr::TransactionEnvelope::Tx(tx_v1) => {
             let tx_xdr = henyey_common::xdr_to_bytes(&tx_v1.tx);
             hasher.update(&tx_xdr);
         }
-        stellar_xdr::curr::TransactionEnvelope::TxFeeBump(tx_bump) => {
+        stellar_xdr::TransactionEnvelope::TxFeeBump(tx_bump) => {
             let tx_xdr = henyey_common::xdr_to_bytes(&tx_bump.tx);
             hasher.update(&tx_xdr);
         }
@@ -696,15 +691,15 @@ fn compute_tx_hash(
 /// Common fields extracted from V1/V2 `TransactionResultMeta` variants.
 struct TxProcessingFields {
     tx_hash: Hash,
-    result: stellar_xdr::curr::TransactionResultPair,
-    meta: stellar_xdr::curr::TransactionMeta,
-    fee_meta: stellar_xdr::curr::LedgerEntryChanges,
-    post_fee_meta: stellar_xdr::curr::LedgerEntryChanges,
+    result: stellar_xdr::TransactionResultPair,
+    meta: stellar_xdr::TransactionMeta,
+    fee_meta: stellar_xdr::LedgerEntryChanges,
+    post_fee_meta: stellar_xdr::LedgerEntryChanges,
 }
 
 /// Shared extraction logic for V1/V2 `LedgerCloseMeta` (generalized tx set).
 fn extract_generalized_tx_processing(
-    tx_set: &stellar_xdr::curr::GeneralizedTransactionSet,
+    tx_set: &stellar_xdr::GeneralizedTransactionSet,
     processing: impl Iterator<Item = TxProcessingFields>,
     network_id: &Hash,
     version_label: &str,
@@ -780,7 +775,7 @@ pub fn extract_transaction_processing(
                         result: tp.result.clone(),
                         meta: tp.tx_apply_processing.clone(),
                         fee_meta: tp.fee_processing.clone(),
-                        post_fee_meta: stellar_xdr::curr::LedgerEntryChanges::default(),
+                        post_fee_meta: stellar_xdr::LedgerEntryChanges::default(),
                         base_fee: None, // V0 doesn't have per-tx base fees
                     })
                 })
@@ -801,7 +796,7 @@ pub fn extract_transaction_processing(
                 result: tp.result.clone(),
                 meta: tp.tx_apply_processing.clone(),
                 fee_meta: tp.fee_processing.clone(),
-                post_fee_meta: stellar_xdr::curr::LedgerEntryChanges::default(),
+                post_fee_meta: stellar_xdr::LedgerEntryChanges::default(),
             }),
             network_id,
             "V1",
@@ -824,9 +819,9 @@ pub fn extract_transaction_processing(
 /// Build a map from transaction hash to envelope for matching.
 /// This version uses the network-aware hash (network_id || ENVELOPE_TYPE || tx).
 fn build_tx_hash_map_with_network(
-    txs: &[stellar_xdr::curr::TransactionEnvelope],
+    txs: &[stellar_xdr::TransactionEnvelope],
     network_id: &Hash,
-) -> std::collections::HashMap<Hash, stellar_xdr::curr::TransactionEnvelope> {
+) -> std::collections::HashMap<Hash, stellar_xdr::TransactionEnvelope> {
     txs.iter()
         .filter_map(|env| {
             let hash = compute_tx_hash(env, network_id)?;
@@ -836,7 +831,7 @@ fn build_tx_hash_map_with_network(
 }
 
 /// Extract ledger header from LedgerCloseMeta.
-pub fn extract_ledger_header(meta: &LedgerCloseMeta) -> stellar_xdr::curr::LedgerHeader {
+pub fn extract_ledger_header(meta: &LedgerCloseMeta) -> stellar_xdr::LedgerHeader {
     match meta {
         LedgerCloseMeta::V0(v0) => v0.ledger_header.header.clone(),
         LedgerCloseMeta::V1(v1) => v1.ledger_header.header.clone(),
@@ -847,7 +842,7 @@ pub fn extract_ledger_header(meta: &LedgerCloseMeta) -> stellar_xdr::curr::Ledge
 /// Extract transaction envelopes from LedgerCloseMeta.
 pub fn extract_transaction_envelopes(
     meta: &LedgerCloseMeta,
-) -> Vec<stellar_xdr::curr::TransactionEnvelope> {
+) -> Vec<stellar_xdr::TransactionEnvelope> {
     match meta {
         LedgerCloseMeta::V0(v0) => v0.tx_set.txs.to_vec(),
         LedgerCloseMeta::V1(v1) => extract_txs_from_generalized_set(&v1.tx_set),
@@ -857,8 +852,8 @@ pub fn extract_transaction_envelopes(
 
 /// Helper to extract transactions from a GeneralizedTransactionSet.
 fn extract_txs_from_generalized_set(
-    tx_set: &stellar_xdr::curr::GeneralizedTransactionSet,
-) -> Vec<stellar_xdr::curr::TransactionEnvelope> {
+    tx_set: &stellar_xdr::GeneralizedTransactionSet,
+) -> Vec<stellar_xdr::TransactionEnvelope> {
     visit_generalized_tx_set(tx_set)
         .into_iter()
         .map(|t| t.env.clone())
@@ -868,7 +863,7 @@ fn extract_txs_from_generalized_set(
 /// Extract transaction result pairs from LedgerCloseMeta.
 pub fn extract_transaction_results(
     meta: &LedgerCloseMeta,
-) -> Vec<stellar_xdr::curr::TransactionResultPair> {
+) -> Vec<stellar_xdr::TransactionResultPair> {
     map_tx_processing!(meta, |tp| tp.result.clone())
 }
 
@@ -909,7 +904,7 @@ pub fn extract_ledger_close_data(
     expected_header_hash: Option<henyey_common::Hash256>,
 ) -> henyey_ledger::LedgerCloseData {
     use henyey_ledger::LedgerCloseData;
-    use stellar_xdr::curr::{LedgerUpgrade, Limits, ReadXdr};
+    use stellar_xdr::{LedgerUpgrade, Limits, ReadXdr};
 
     let header = extract_ledger_header(meta);
     let tx_set = extract_transaction_set(meta);
@@ -942,7 +937,7 @@ pub fn extract_ledger_close_data(
 
 /// Extract evicted ledger keys from LedgerCloseMeta (V2 only).
 /// These are entries that were evicted from the live bucket list.
-pub fn extract_evicted_keys(meta: &LedgerCloseMeta) -> Vec<stellar_xdr::curr::LedgerKey> {
+pub fn extract_evicted_keys(meta: &LedgerCloseMeta) -> Vec<stellar_xdr::LedgerKey> {
     match meta {
         LedgerCloseMeta::V0(_) | LedgerCloseMeta::V1(_) => Vec::new(),
         LedgerCloseMeta::V2(v2) => v2.evicted_keys.to_vec(),
@@ -963,9 +958,9 @@ pub fn extract_evicted_keys(meta: &LedgerCloseMeta) -> Vec<stellar_xdr::curr::Le
 /// }
 /// ```
 pub fn extract_restored_keys(
-    tx_metas: &[stellar_xdr::curr::TransactionMeta],
-) -> Vec<stellar_xdr::curr::LedgerKey> {
-    use stellar_xdr::curr::LedgerEntryChange;
+    tx_metas: &[stellar_xdr::TransactionMeta],
+) -> Vec<stellar_xdr::LedgerKey> {
+    use stellar_xdr::LedgerEntryChange;
 
     let mut restored_keys = Vec::new();
 
@@ -986,7 +981,7 @@ pub fn extract_restored_keys(
 
 /// Extract upgrade changes from LedgerCloseMeta.
 /// These are ledger entry changes from protocol upgrades (not from transactions).
-pub fn extract_upgrade_metas(meta: &LedgerCloseMeta) -> Vec<stellar_xdr::curr::UpgradeEntryMeta> {
+pub fn extract_upgrade_metas(meta: &LedgerCloseMeta) -> Vec<stellar_xdr::UpgradeEntryMeta> {
     match meta {
         LedgerCloseMeta::V0(v0) => v0.upgrades_processing.to_vec(),
         LedgerCloseMeta::V1(v1) => v1.upgrades_processing.to_vec(),
@@ -997,7 +992,7 @@ pub fn extract_upgrade_metas(meta: &LedgerCloseMeta) -> Vec<stellar_xdr::curr::U
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, ContractCodeEntry, ContractCodeEntryExt,
         ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, Hash, LedgerEntry,
         LedgerEntryChange, LedgerEntryChanges, LedgerEntryData, LedgerEntryExt, LedgerKey,

--- a/crates/history/src/checkpoint_builder.rs
+++ b/crates/history/src/checkpoint_builder.rs
@@ -51,7 +51,7 @@ use henyey_common::fs_utils::durable_rename;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeaderHistoryEntry, Limits, ReadXdr, TransactionHistoryEntry,
     TransactionHistoryResultEntry, WriteXdr,
 };
@@ -689,7 +689,7 @@ impl CheckpointBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntryExt, StellarValue,
         StellarValueExt, TimePoint, TransactionHistoryEntry, TransactionHistoryEntryExt,
         TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
@@ -728,7 +728,7 @@ mod tests {
     fn make_tx_entry(seq: u32) -> TransactionHistoryEntry {
         TransactionHistoryEntry {
             ledger_seq: seq,
-            tx_set: stellar_xdr::curr::TransactionSet {
+            tx_set: stellar_xdr::TransactionSet {
                 previous_ledger_hash: Hash([0u8; 32]),
                 txs: VecM::default(),
             },

--- a/crates/history/src/compare.rs
+++ b/crates/history/src/compare.rs
@@ -16,7 +16,7 @@
 
 use std::fmt;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeaderHistoryEntry, TransactionHistoryEntry, TransactionHistoryResultEntry, WriteXdr,
 };
 
@@ -291,8 +291,8 @@ fn compare_ledger_headers(
         }
 
         // Compare the full header by XDR serialization.
-        let l_xdr = l.header.to_xdr(stellar_xdr::curr::Limits::none());
-        let r_xdr = r.header.to_xdr(stellar_xdr::curr::Limits::none());
+        let l_xdr = l.header.to_xdr(stellar_xdr::Limits::none());
+        let r_xdr = r.header.to_xdr(stellar_xdr::Limits::none());
         if let Some((l_bytes, r_bytes)) = report_xdr_errors(
             l_xdr,
             r_xdr,
@@ -421,8 +421,8 @@ fn compare_ledger_headers(
 /// Ordering guarantee for `(Err, Err)`: local mismatch is pushed first,
 /// reference second.
 fn report_xdr_errors(
-    l_xdr: Result<Vec<u8>, stellar_xdr::curr::Error>,
-    r_xdr: Result<Vec<u8>, stellar_xdr::curr::Error>,
+    l_xdr: Result<Vec<u8>, stellar_xdr::Error>,
+    r_xdr: Result<Vec<u8>, stellar_xdr::Error>,
     ledger_seq: u32,
     category: Category,
     payload_name: &str,
@@ -477,7 +477,7 @@ fn report_xdr_errors(
 /// Trait for history entry types that can be compared by XDR serialization.
 trait ComparableEntry {
     fn ledger_seq(&self) -> u32;
-    fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::curr::Error>;
+    fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::Error>;
     fn category() -> Category;
     fn payload_name() -> &'static str;
 }
@@ -486,8 +486,8 @@ impl ComparableEntry for TransactionHistoryEntry {
     fn ledger_seq(&self) -> u32 {
         self.ledger_seq
     }
-    fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::curr::Error> {
-        self.tx_set.to_xdr(stellar_xdr::curr::Limits::none())
+    fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::Error> {
+        self.tx_set.to_xdr(stellar_xdr::Limits::none())
     }
     fn category() -> Category {
         Category::Transactions
@@ -501,8 +501,8 @@ impl ComparableEntry for TransactionHistoryResultEntry {
     fn ledger_seq(&self) -> u32 {
         self.ledger_seq
     }
-    fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::curr::Error> {
-        self.tx_result_set.to_xdr(stellar_xdr::curr::Limits::none())
+    fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::Error> {
+        self.tx_result_set.to_xdr(stellar_xdr::Limits::none())
     }
     fn category() -> Category {
         Category::Results
@@ -634,7 +634,7 @@ mod tests {
     use super::*;
     use crate::archive_state::{HASBucketLevel, HASBucketNext};
     use henyey_bucket::BUCKET_LIST_LEVELS;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, TransactionHistoryEntryExt, TransactionHistoryResultEntryExt, TransactionResultSet,
         TransactionSet,
     };
@@ -648,7 +648,7 @@ mod tests {
             ledger_seq,
             tx_set: TransactionSet {
                 previous_ledger_hash: Hash([0u8; 32]),
-                txs: stellar_xdr::curr::VecM::default(),
+                txs: stellar_xdr::VecM::default(),
             },
             ext: TransactionHistoryEntryExt::V0,
         }
@@ -659,7 +659,7 @@ mod tests {
             ledger_seq,
             tx_set: TransactionSet {
                 previous_ledger_hash: Hash([hash_byte; 32]),
-                txs: stellar_xdr::curr::VecM::default(),
+                txs: stellar_xdr::VecM::default(),
             },
             ext: TransactionHistoryEntryExt::V0,
         }
@@ -669,7 +669,7 @@ mod tests {
         TransactionHistoryResultEntry {
             ledger_seq,
             tx_result_set: TransactionResultSet {
-                results: stellar_xdr::curr::VecM::default(),
+                results: stellar_xdr::VecM::default(),
             },
             ext: TransactionHistoryResultEntryExt::default(),
         }
@@ -681,15 +681,15 @@ mod tests {
     ) -> TransactionHistoryResultEntry {
         // Create entries with different content by varying the number of
         // (empty) result pairs.
-        let results: Vec<stellar_xdr::curr::TransactionResultPair> = (0..num_results)
-            .map(|_| stellar_xdr::curr::TransactionResultPair {
-                transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                result: stellar_xdr::curr::TransactionResult {
+        let results: Vec<stellar_xdr::TransactionResultPair> = (0..num_results)
+            .map(|_| stellar_xdr::TransactionResultPair {
+                transaction_hash: stellar_xdr::Hash([0u8; 32]),
+                result: stellar_xdr::TransactionResult {
                     fee_charged: 100,
-                    result: stellar_xdr::curr::TransactionResultResult::TxSuccess(
-                        stellar_xdr::curr::VecM::default(),
+                    result: stellar_xdr::TransactionResultResult::TxSuccess(
+                        stellar_xdr::VecM::default(),
                     ),
-                    ext: stellar_xdr::curr::TransactionResultExt::V0,
+                    ext: stellar_xdr::TransactionResultExt::V0,
                 },
             })
             .collect();
@@ -1093,7 +1093,7 @@ mod tests {
     fn test_report_xdr_errors_local_err() {
         let mut out = Vec::new();
         let result = report_xdr_errors(
-            Err(stellar_xdr::curr::Error::Invalid),
+            Err(stellar_xdr::Error::Invalid),
             Ok(vec![4, 5, 6]),
             42,
             Category::Transactions,
@@ -1113,7 +1113,7 @@ mod tests {
         let mut out = Vec::new();
         let result = report_xdr_errors(
             Ok(vec![1, 2, 3]),
-            Err(stellar_xdr::curr::Error::Invalid),
+            Err(stellar_xdr::Error::Invalid),
             99,
             Category::Results,
             "tx_result_set",
@@ -1131,8 +1131,8 @@ mod tests {
     fn test_report_xdr_errors_both_err() {
         let mut out = Vec::new();
         let result = report_xdr_errors(
-            Err(stellar_xdr::curr::Error::Invalid),
-            Err(stellar_xdr::curr::Error::Invalid),
+            Err(stellar_xdr::Error::Invalid),
+            Err(stellar_xdr::Error::Invalid),
             7,
             Category::LedgerHeaders,
             "header",
@@ -1152,7 +1152,7 @@ mod tests {
     // ========================================================================
 
     fn make_ledger_header_entry(ledger_seq: u32, base_fee: u32) -> LedgerHeaderHistoryEntry {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntryExt, StellarValue,
             StellarValueExt, TimePoint, VecM,
         };
@@ -1237,8 +1237,8 @@ mod tests {
         fn ledger_seq(&self) -> u32 {
             self.seq
         }
-        fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::curr::Error> {
-            Err(stellar_xdr::curr::Error::Invalid)
+        fn payload_xdr(&self) -> std::result::Result<Vec<u8>, stellar_xdr::Error> {
+            Err(stellar_xdr::Error::Invalid)
         }
         fn category() -> Category {
             Category::Transactions

--- a/crates/history/src/download.rs
+++ b/crates/history/src/download.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use flate2::read::GzDecoder;
 use reqwest::Client;
-use stellar_xdr::curr::ReadXdr;
+use stellar_xdr::ReadXdr;
 use tracing::{debug, warn};
 
 use crate::error::HistoryError;
@@ -214,7 +214,7 @@ pub fn decompress_gzip(compressed: &[u8]) -> Result<Vec<u8>, HistoryError> {
 ///
 /// A vector of parsed entries, or an error if parsing fails.
 pub fn parse_xdr_stream<T: ReadXdr>(data: &[u8]) -> Result<Vec<T>, HistoryError> {
-    use stellar_xdr::curr::{Limited, Limits};
+    use stellar_xdr::{Limited, Limits};
 
     let mut entries = Vec::new();
     let cursor = std::io::Cursor::new(data);
@@ -224,9 +224,7 @@ pub fn parse_xdr_stream<T: ReadXdr>(data: &[u8]) -> Result<Vec<T>, HistoryError>
     loop {
         match T::read_xdr(&mut limited) {
             Ok(entry) => entries.push(entry),
-            Err(stellar_xdr::curr::Error::Io(ref e))
-                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
-            {
+            Err(stellar_xdr::Error::Io(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 // Normal end of stream
                 break;
             }
@@ -288,8 +286,8 @@ pub fn parse_record_marked_xdr_stream<T: ReadXdr>(data: &[u8]) -> Result<Vec<T>,
         }
 
         let record_data = &data[offset..offset + record_len];
-        let entry = T::from_xdr(record_data, stellar_xdr::curr::Limits::none())
-            .map_err(HistoryError::Xdr)?;
+        let entry =
+            T::from_xdr(record_data, stellar_xdr::Limits::none()).map_err(HistoryError::Xdr)?;
         entries.push(entry);
 
         offset += record_len;

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -376,7 +376,7 @@ pub enum HistoryError {
 
     /// XDR error.
     #[error("XDR error: {0}")]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     /// XDR parsing error.
     #[error("XDR parsing error: {0}")]

--- a/crates/history/src/publish.rs
+++ b/crates/history/src/publish.rs
@@ -57,7 +57,7 @@ use henyey_common::fs_utils::{
 };
 use henyey_common::Hash256;
 use std::path::{Path, PathBuf};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeaderHistoryEntry, TransactionHistoryEntry, TransactionHistoryResultEntry, WriteXdr,
 };
 use tracing::{debug, info, warn};
@@ -407,7 +407,7 @@ impl PublishManager {
 
                     let xdr = result_entry
                         .tx_result_set
-                        .to_xdr(stellar_xdr::curr::Limits::none())
+                        .to_xdr(stellar_xdr::Limits::none())
                         .map_err(|e| HistoryError::VerificationFailed(e.to_string()))?;
                     verify::verify_tx_result_set(header, &xdr)?;
                 }
@@ -683,7 +683,7 @@ mod tests {
 
     #[test]
     fn test_publish_checkpoint_rejects_bad_header_entry_hash() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntryExt, StellarValue,
             StellarValueExt, TimePoint, VecM,
         };
@@ -738,7 +738,7 @@ mod tests {
     async fn test_build_has_hash_matches_bucket_list_hash() {
         use henyey_bucket::BucketList;
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let mut bl = BucketList::new();
 
@@ -849,7 +849,7 @@ mod tests {
     async fn test_build_has_hash_matches_with_hot_archive() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let mut bl = BucketList::new();
         let mut habl = HotArchiveBucketList::new();
@@ -1051,7 +1051,7 @@ mod tests {
     async fn test_quickstart_local_mode_has_hash_matches_header() {
         use henyey_bucket::{BucketList, HotArchiveBucketList};
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountEntryExt, AccountId, BucketListType, LedgerEntry, LedgerEntryData,
             LedgerEntryExt, PublicKey, SequenceNumber, String32, StringM, Thresholds, Uint256,
             VecM,
@@ -1292,7 +1292,7 @@ mod tests {
 
     #[test]
     fn test_write_xdr_gz_atomic() {
-        use stellar_xdr::curr::LedgerHeaderHistoryEntry;
+        use stellar_xdr::LedgerHeaderHistoryEntry;
 
         let temp = TempDir::new().unwrap();
         let config = PublishConfig {
@@ -1390,28 +1390,26 @@ mod tests {
 
         // Create an in-memory bucket with entries, serialize to XDR bytes,
         // then create a disk-backed bucket from those bytes.
-        let entries = vec![stellar_xdr::curr::BucketEntry::Liveentry(
-            stellar_xdr::curr::LedgerEntry {
+        let entries = vec![stellar_xdr::BucketEntry::Liveentry(
+            stellar_xdr::LedgerEntry {
                 last_modified_ledger_seq: 1,
-                data: stellar_xdr::curr::LedgerEntryData::Account(
-                    stellar_xdr::curr::AccountEntry {
-                        account_id: stellar_xdr::curr::AccountId(
-                            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                                stellar_xdr::curr::Uint256([1u8; 32]),
-                            ),
-                        ),
-                        balance: 100,
-                        seq_num: stellar_xdr::curr::SequenceNumber(1),
-                        num_sub_entries: 0,
-                        inflation_dest: None,
-                        flags: 0,
-                        home_domain: stellar_xdr::curr::String32::default(),
-                        thresholds: stellar_xdr::curr::Thresholds([1, 0, 0, 0]),
-                        signers: Vec::new().try_into().unwrap(),
-                        ext: stellar_xdr::curr::AccountEntryExt::V0,
-                    },
-                ),
-                ext: stellar_xdr::curr::LedgerEntryExt::V0,
+                data: stellar_xdr::LedgerEntryData::Account(stellar_xdr::AccountEntry {
+                    account_id: stellar_xdr::AccountId(
+                        stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(
+                            [1u8; 32],
+                        )),
+                    ),
+                    balance: 100,
+                    seq_num: stellar_xdr::SequenceNumber(1),
+                    num_sub_entries: 0,
+                    inflation_dest: None,
+                    flags: 0,
+                    home_domain: stellar_xdr::String32::default(),
+                    thresholds: stellar_xdr::Thresholds([1, 0, 0, 0]),
+                    signers: Vec::new().try_into().unwrap(),
+                    ext: stellar_xdr::AccountEntryExt::V0,
+                }),
+                ext: stellar_xdr::LedgerEntryExt::V0,
             },
         )];
         let in_memory_bucket = henyey_bucket::Bucket::from_entries(entries).unwrap();
@@ -1479,11 +1477,11 @@ mod tests {
     /// Helper: create a header with hashes matching the given tx set and result set.
     fn make_header_with_hashes(
         ledger_seq: u32,
-        prev_hash: stellar_xdr::curr::Hash,
+        prev_hash: stellar_xdr::Hash,
         tx_set: &henyey_ledger::TransactionSetVariant,
-        result_set: &stellar_xdr::curr::TransactionResultSet,
-    ) -> stellar_xdr::curr::LedgerHeader {
-        use stellar_xdr::curr::*;
+        result_set: &stellar_xdr::TransactionResultSet,
+    ) -> stellar_xdr::LedgerHeader {
+        use stellar_xdr::*;
 
         let tx_set_hash = crate::verify::compute_tx_set_hash(tx_set).unwrap();
         let result_xdr = result_set.to_xdr(Limits::none()).unwrap();
@@ -1514,11 +1512,11 @@ mod tests {
     }
 
     /// Helper: create a LedgerHeaderHistoryEntry with computed hash.
-    fn make_header_entry(header: stellar_xdr::curr::LedgerHeader) -> LedgerHeaderHistoryEntry {
-        use stellar_xdr::curr::LedgerHeaderHistoryEntryExt;
+    fn make_header_entry(header: stellar_xdr::LedgerHeader) -> LedgerHeaderHistoryEntry {
+        use stellar_xdr::LedgerHeaderHistoryEntryExt;
         let hash = henyey_ledger::compute_header_hash(&header).unwrap();
         LedgerHeaderHistoryEntry {
-            hash: stellar_xdr::curr::Hash(hash.0),
+            hash: stellar_xdr::Hash(hash.0),
             header,
             ext: LedgerHeaderHistoryEntryExt::default(),
         }
@@ -1528,16 +1526,16 @@ mod tests {
     /// Helper to construct an empty TransactionHistoryEntry and TransactionHistoryResultEntry
     /// for a header. Used only in tests for publish-side verification.
     fn make_empty_entries(
-        header: &stellar_xdr::curr::LedgerHeader,
+        header: &stellar_xdr::LedgerHeader,
     ) -> (
-        stellar_xdr::curr::TransactionHistoryEntry,
-        stellar_xdr::curr::TransactionHistoryResultEntry,
+        stellar_xdr::TransactionHistoryEntry,
+        stellar_xdr::TransactionHistoryResultEntry,
     ) {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionHistoryEntryExt, TransactionHistoryResultEntry,
             TransactionHistoryResultEntryExt, TransactionResultSet, TransactionSet,
         };
-        let tx_history = stellar_xdr::curr::TransactionHistoryEntry {
+        let tx_history = stellar_xdr::TransactionHistoryEntry {
             ledger_seq: header.ledger_seq,
             tx_set: TransactionSet {
                 previous_ledger_hash: header.previous_ledger_hash.clone(),
@@ -1557,7 +1555,7 @@ mod tests {
 
     #[test]
     fn test_publish_checkpoint_sparse_entries() {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let temp = TempDir::new().unwrap();
         let manager = PublishManager::new(PublishConfig {
@@ -1662,7 +1660,7 @@ mod tests {
 
     #[test]
     fn test_publish_checkpoint_all_empty() {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let temp = TempDir::new().unwrap();
         let manager = PublishManager::new(PublishConfig {
@@ -1720,7 +1718,7 @@ mod tests {
 
     #[test]
     fn test_publish_checkpoint_rejects_one_sided_presence() {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let temp = TempDir::new().unwrap();
         let manager = PublishManager::new(PublishConfig {
@@ -1780,7 +1778,7 @@ mod tests {
 
     #[test]
     fn test_publish_checkpoint_rejects_duplicate_entries() {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let temp = TempDir::new().unwrap();
         let manager = PublishManager::new(PublishConfig {

--- a/crates/history/src/replay/diff.rs
+++ b/crates/history/src/replay/diff.rs
@@ -4,7 +4,7 @@
 //! logging detailed mismatch information for debugging.
 
 use henyey_common::Hash256;
-use stellar_xdr::curr::{LedgerHeader, TransactionEnvelope, TransactionResultPair};
+use stellar_xdr::{LedgerHeader, TransactionEnvelope, TransactionResultPair};
 
 /// Log detailed information about transaction result mismatches.
 ///
@@ -72,9 +72,7 @@ fn summarize_operations(tx: &TransactionEnvelope) -> Vec<String> {
         TransactionEnvelope::TxV0(env) => env.tx.operations.as_slice(),
         TransactionEnvelope::Tx(env) => env.tx.operations.as_slice(),
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
-                inner.tx.operations.as_slice()
-            }
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.operations.as_slice(),
         },
     };
 

--- a/crates/history/src/replay/execution.rs
+++ b/crates/history/src/replay/execution.rs
@@ -20,7 +20,7 @@ use henyey_ledger::{
 };
 use henyey_tx::{muxed_to_account_id, soroban::SorobanConfig, LedgerContext, TransactionFrame};
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     BucketListType, ConfigSettingEntry, ConfigSettingId, LedgerEntry, LedgerEntryData,
     LedgerEntryExt, LedgerHeader, LedgerKey, LedgerKeyConfigSetting, StateArchivalSettings,
     TransactionResultSet, WriteXdr,
@@ -34,7 +34,7 @@ use super::{LedgerReplayResult, ReplayConfig, ReplayExecutionContext};
 fn debug_xdr_hash<T: WriteXdr>(items: &[T]) -> String {
     let mut hasher = Sha256::new();
     for item in items {
-        if let Ok(xdr) = item.to_xdr(stellar_xdr::curr::Limits::none()) {
+        if let Ok(xdr) = item.to_xdr(stellar_xdr::Limits::none()) {
             hasher.update(&xdr);
         }
     }
@@ -293,25 +293,25 @@ pub(super) fn soroban_entry_size(
     entry: &LedgerEntry,
     protocol_version: u32,
     cost_params: Option<(
-        &stellar_xdr::curr::ContractCostParams,
-        &stellar_xdr::curr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
     )>,
 ) -> i64 {
     use henyey_tx::operations::execute::entry_size_for_rent_by_protocol_with_cost_params;
-    use stellar_xdr::curr::WriteXdr;
+    use stellar_xdr::WriteXdr;
 
     match &entry.data {
         LedgerEntryData::ContractData(_) => {
             // Contract data uses XDR size
             entry
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .map(|xdr_bytes| xdr_bytes.len() as i64)
                 .unwrap_or(0)
         }
         LedgerEntryData::ContractCode(_) => {
             // Contract code uses rent-adjusted size (includes compiled module memory)
             entry
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .map(|xdr_bytes| {
                     let xdr_size = xdr_bytes.len() as u32;
                     entry_size_for_rent_by_protocol_with_cost_params(
@@ -337,8 +337,8 @@ pub(super) fn compute_soroban_state_size_delta(
     changes: &[EntryChange],
     protocol_version: u32,
     cost_params: Option<(
-        &stellar_xdr::curr::ContractCostParams,
-        &stellar_xdr::curr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
     )>,
 ) -> i64 {
     let mut delta: i64 = 0;
@@ -372,9 +372,9 @@ pub(super) fn compute_soroban_state_size_window_entry(
     seq: u32,
     bucket_list: &henyey_bucket::BucketList,
     soroban_state_size: u64,
-    archival_override: Option<&stellar_xdr::curr::StateArchivalSettings>,
+    archival_override: Option<&stellar_xdr::StateArchivalSettings>,
 ) -> Result<Option<LedgerEntry>> {
-    use stellar_xdr::curr::VecM;
+    use stellar_xdr::VecM;
 
     // Load StateArchival settings
     let archival = if let Some(override_settings) = archival_override {
@@ -681,7 +681,7 @@ pub fn replay_ledger_with_execution(
                 })?,
             };
         let xdr = result_set
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .map_err(|e| {
                 HistoryError::CatchupFailed(format!("failed to encode tx result set: {}", e))
             })?;
@@ -898,12 +898,12 @@ mod tests {
     use super::*;
     use henyey_bucket::{BucketList, HotArchiveBucketList};
     use henyey_common::NetworkId;
-    use stellar_xdr::curr::{Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt};
+    use stellar_xdr::{Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt};
 
     use super::super::tests::{make_empty_tx_set, make_test_header};
 
     fn make_contract_data_entry(seq: u32, key_bytes: &[u8], val_bytes: &[u8]) -> LedgerEntry {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, ScAddress, ScVal,
         };
         LedgerEntry {
@@ -913,13 +913,9 @@ mod tests {
                 contract: ScAddress::Contract(ContractId(Hash(std::array::from_fn(|i| {
                     key_bytes.get(i).copied().unwrap_or(0)
                 })))),
-                key: ScVal::Bytes(
-                    stellar_xdr::curr::ScBytes::try_from(key_bytes.to_vec()).unwrap(),
-                ),
+                key: ScVal::Bytes(stellar_xdr::ScBytes::try_from(key_bytes.to_vec()).unwrap()),
                 durability: ContractDataDurability::Persistent,
-                val: ScVal::Bytes(
-                    stellar_xdr::curr::ScBytes::try_from(val_bytes.to_vec()).unwrap(),
-                ),
+                val: ScVal::Bytes(stellar_xdr::ScBytes::try_from(val_bytes.to_vec()).unwrap()),
             }),
             ext: LedgerEntryExt::V0,
         }
@@ -933,7 +929,7 @@ mod tests {
     /// `account_id_byte`. Used to construct multiple distinct `LedgerKey`s in
     /// tests that need more than one Account in the bucket list.
     fn make_account_entry_with_id(seq: u32, account_id_byte: u8) -> LedgerEntry {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountEntryExt, AccountId, PublicKey, SequenceNumber, Thresholds,
             Uint256,
         };
@@ -948,9 +944,9 @@ mod tests {
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
+                home_domain: stellar_xdr::String32::default(),
                 thresholds: Thresholds([1, 0, 0, 0]),
-                signers: stellar_xdr::curr::VecM::default(),
+                signers: stellar_xdr::VecM::default(),
                 ext: AccountEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,
@@ -961,7 +957,7 @@ mod tests {
     /// from `hash_byte` and a fixed 100-byte WASM payload. Mirrors the helper
     /// in `crates/tx/src/operations/execute/restore_footprint.rs`.
     fn make_contract_code_entry(seq: u32, hash_byte: u8) -> LedgerEntry {
-        use stellar_xdr::curr::{ContractCodeEntry, ContractCodeEntryExt};
+        use stellar_xdr::{ContractCodeEntry, ContractCodeEntryExt};
         LedgerEntry {
             last_modified_ledger_seq: seq,
             data: LedgerEntryData::ContractCode(ContractCodeEntry {
@@ -983,7 +979,7 @@ mod tests {
         ledger_seq: u32,
         live: Vec<LedgerEntry>,
     ) {
-        use stellar_xdr::curr::BucketListType;
+        use stellar_xdr::BucketListType;
         bucket_list
             .add_batch(
                 ledger_seq,
@@ -1390,7 +1386,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_soroban_state_size_window_entry_at_sample_boundary() {
-        use stellar_xdr::curr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
+        use stellar_xdr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
 
         // Create archival settings with sample_period=100, sample_size=5
         let archival = StateArchivalSettings {
@@ -1400,7 +1396,7 @@ mod tests {
         };
 
         // Create initial window with 5 samples
-        let initial_window: stellar_xdr::curr::VecM<u64> =
+        let initial_window: stellar_xdr::VecM<u64> =
             vec![1000, 2000, 3000, 4000, 5000].try_into().unwrap();
 
         // Set up bucket list with required config entries
@@ -1469,7 +1465,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_soroban_state_size_window_entry_not_at_boundary() {
-        use stellar_xdr::curr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
+        use stellar_xdr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
 
         // Create archival settings with sample_period=100
         let archival = StateArchivalSettings {
@@ -1478,7 +1474,7 @@ mod tests {
             ..StateArchivalSettings::default()
         };
 
-        let initial_window: stellar_xdr::curr::VecM<u64> =
+        let initial_window: stellar_xdr::VecM<u64> =
             vec![1000, 2000, 3000, 4000, 5000].try_into().unwrap();
 
         let mut bucket_list = BucketList::new();
@@ -1531,7 +1527,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_soroban_state_size_window_entry_resize_smaller() {
-        use stellar_xdr::curr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
+        use stellar_xdr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
 
         // New settings want size 3 instead of 5
         let archival = StateArchivalSettings {
@@ -1541,7 +1537,7 @@ mod tests {
         };
 
         // Current window has 5 entries
-        let initial_window: stellar_xdr::curr::VecM<u64> =
+        let initial_window: stellar_xdr::VecM<u64> =
             vec![1000, 2000, 3000, 4000, 5000].try_into().unwrap();
 
         let mut bucket_list = BucketList::new();
@@ -1744,7 +1740,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_soroban_state_size_window_entry_zero_sample_period_errors() {
-        use stellar_xdr::curr::StateArchivalSettings;
+        use stellar_xdr::StateArchivalSettings;
 
         let archival = StateArchivalSettings {
             live_soroban_state_size_window_sample_period: 0,
@@ -1765,7 +1761,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_soroban_state_size_window_entry_missing_window_errors() {
-        use stellar_xdr::curr::StateArchivalSettings;
+        use stellar_xdr::StateArchivalSettings;
 
         let archival = StateArchivalSettings {
             live_soroban_state_size_window_sample_period: 100,
@@ -1784,7 +1780,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_soroban_state_size_window_entry_empty_window_errors() {
-        use stellar_xdr::curr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
+        use stellar_xdr::{BucketListType, ConfigSettingEntry, StateArchivalSettings};
 
         let archival = StateArchivalSettings {
             live_soroban_state_size_window_sample_period: 100,
@@ -1794,7 +1790,7 @@ mod tests {
 
         // Add an empty window to the bucket list
         let mut bucket_list = BucketList::new();
-        let empty_window: stellar_xdr::curr::VecM<u64> = vec![].try_into().unwrap();
+        let empty_window: stellar_xdr::VecM<u64> = vec![].try_into().unwrap();
         let window_entry = LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ConfigSetting(ConfigSettingEntry::LiveSorobanStateSizeWindow(
@@ -1826,7 +1822,7 @@ mod tests {
     #[test]
     fn test_load_state_archival_wrong_variant_errors() {
         use henyey_ledger::execution::load_config_setting;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ConfigSettingContractComputeV0, ConfigSettingEntry, ConfigSettingId, LedgerEntry,
             LedgerEntryData, LedgerEntryExt, LedgerKey, LedgerKeyConfigSetting,
         };
@@ -1891,7 +1887,7 @@ mod tests {
     fn test_load_state_archival_io_error_propagates() {
         use henyey_ledger::execution::load_config_setting;
         use std::sync::Arc;
-        use stellar_xdr::curr::{ConfigSettingEntry, ConfigSettingId};
+        use stellar_xdr::{ConfigSettingEntry, ConfigSettingId};
 
         let snapshot = henyey_ledger::LedgerSnapshot::empty(1);
         let lookup_fn: henyey_ledger::EntryLookupFn = Arc::new(|_key| {
@@ -1937,7 +1933,7 @@ mod tests {
     async fn test_replay_fee_event_code_path_executes() {
         use henyey_common::NetworkId;
         use henyey_crypto::{sign_hash, SecretKey};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountEntryExt, AccountId, BucketListType, ContractCodeEntry,
             ContractCodeEntryExt, DecoratedSignature, ExtendFootprintTtlOp, ExtensionPoint,
             LedgerFootprint, LedgerKeyContractCode, Memo, MuxedAccount, Operation, OperationBody,
@@ -1949,7 +1945,7 @@ mod tests {
 
         let network_id = NetworkId::testnet();
         let secret = SecretKey::from_seed(&[1u8; 32]);
-        let source_id = AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+        let source_id = AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
             *secret.public_key().as_bytes(),
         )));
 
@@ -1978,7 +1974,7 @@ mod tests {
             data: LedgerEntryData::ContractCode(ContractCodeEntry {
                 ext: ContractCodeEntryExt::V0,
                 hash: code_hash.clone(),
-                code: stellar_xdr::curr::BytesM::try_from(vec![1u8, 2u8, 3u8]).unwrap(),
+                code: stellar_xdr::BytesM::try_from(vec![1u8, 2u8, 3u8]).unwrap(),
             }),
             ext: LedgerEntryExt::V0,
         };
@@ -2133,7 +2129,7 @@ mod tests {
         use henyey_bucket::EvictionIterator;
         use henyey_common::xdr_to_bytes;
         use sha2::{Digest, Sha256};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ConfigSettingEntry, ContractCostParamEntry, ContractCostParams, ContractDataDurability,
             ContractDataEntry, ContractId, ExtensionPoint, LedgerKeyConfigSetting,
             LedgerKeyContractData, LedgerKeyTtl, ScAddress, ScBytes, ScVal, StateArchivalSettings,
@@ -2261,7 +2257,7 @@ mod tests {
             .add_batch(
                 1,
                 25,
-                stellar_xdr::curr::BucketListType::Live,
+                stellar_xdr::BucketListType::Live,
                 all_entries,
                 vec![],
                 vec![],

--- a/crates/history/src/replay/metadata.rs
+++ b/crates/history/src/replay/metadata.rs
@@ -9,7 +9,7 @@
 // items below don't need individual `#[cfg(test)]` attributes.
 use crate::{verify, HistoryError, Result};
 use henyey_ledger::TransactionSetVariant;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerEntry, LedgerHeader, LedgerKey, TransactionMeta, TransactionResultPair,
     TransactionResultSet, WriteXdr,
 };
@@ -54,7 +54,7 @@ pub(crate) fn replay_ledger(
                 .map_err(|_| HistoryError::CatchupFailed("tx result set too large".to_string()))?,
         };
         let xdr = result_set
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .map_err(|e| {
                 HistoryError::CatchupFailed(format!("failed to encode tx result set: {}", e))
             })?;
@@ -119,8 +119,8 @@ impl LedgerChanges {
         }
     }
 
-    fn push(&mut self, change: &stellar_xdr::curr::LedgerEntryChange) {
-        use stellar_xdr::curr::LedgerEntryChange;
+    fn push(&mut self, change: &stellar_xdr::LedgerEntryChange) {
+        use stellar_xdr::LedgerEntryChange;
         match change {
             LedgerEntryChange::Created(entry) => self.init.push(entry.clone()),
             LedgerEntryChange::Updated(entry) => self.live.push(entry.clone()),
@@ -149,14 +149,14 @@ fn count_operations(tx_set: &TransactionSetVariant) -> u32 {
         .transactions()
         .into_iter()
         .map(|tx_env| {
-            use stellar_xdr::curr::TransactionEnvelope;
+            use stellar_xdr::TransactionEnvelope;
             match tx_env {
                 TransactionEnvelope::TxV0(tx) => tx.tx.operations.len() as u32,
                 TransactionEnvelope::Tx(tx) => tx.tx.operations.len() as u32,
                 TransactionEnvelope::TxFeeBump(tx) => {
                     // Fee bump wraps an inner transaction; +1 for the wrapper itself
                     match &tx.tx.inner_tx {
-                        stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+                        stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                             inner.tx.operations.len() as u32 + 1
                         }
                     }
@@ -170,7 +170,7 @@ fn count_operations(tx_set: &TransactionSetVariant) -> u32 {
 mod tests {
     use super::*;
     use henyey_common::Hash256;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, ExtensionPoint, GeneralizedTransactionSet, Hash,
         LedgerEntryChange, LedgerEntryChanges, LedgerEntryData, LedgerEntryExt, OperationMeta,
         OperationMetaV2, PublicKey, SequenceNumber, StateArchivalSettings, String32, Thresholds,
@@ -276,7 +276,7 @@ mod tests {
             results: VecM::default(),
         };
         let result_xdr = result_set
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("tx result set xdr");
         let result_hash = Hash256::hash(&result_xdr);
 

--- a/crates/history/src/replay/mod.rs
+++ b/crates/history/src/replay/mod.rs
@@ -57,7 +57,7 @@ use henyey_bucket::EvictionIterator;
 use henyey_common::{Hash256, NetworkId};
 use henyey_ledger::EntryChange;
 use henyey_tx::soroban::PersistentModuleCache;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerEntry, LedgerHeader, LedgerKey, StateArchivalSettings, TransactionResultPair,
 };
 
@@ -289,7 +289,7 @@ impl ReplayedLedgerState {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use stellar_xdr::curr::{Hash, StellarValue, TimePoint, TransactionSet, VecM};
+    use stellar_xdr::{Hash, StellarValue, TimePoint, TransactionSet, VecM};
 
     pub(crate) fn make_test_header(seq: u32) -> LedgerHeader {
         LedgerHeader {
@@ -299,7 +299,7 @@ pub(crate) mod tests {
                 tx_set_hash: Hash([0u8; 32]),
                 close_time: TimePoint(1234567890),
                 upgrades: VecM::default(),
-                ext: stellar_xdr::curr::StellarValueExt::Basic,
+                ext: stellar_xdr::StellarValueExt::Basic,
             },
             tx_set_result_hash: Hash([0u8; 32]),
             bucket_list_hash: Hash([0u8; 32]),
@@ -312,7 +312,7 @@ pub(crate) mod tests {
             base_reserve: 5000000,
             max_tx_set_size: 100,
             skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
-            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            ext: stellar_xdr::LedgerHeaderExt::V0,
         }
     }
 

--- a/crates/history/src/test_utils.rs
+++ b/crates/history/src/test_utils.rs
@@ -21,7 +21,7 @@ use flate2::{write::GzEncoder, Compression};
 use henyey_bucket::{Bucket, BucketList, HotArchiveBucketList, HOT_ARCHIVE_BUCKET_LIST_LEVELS};
 use henyey_common::Hash256;
 use sha2::{Digest, Sha256};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt,
     StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr,
 };
@@ -219,7 +219,7 @@ pub async fn build_single_checkpoint_archive(
         ext: LedgerHeaderHistoryEntryExt::default(),
     };
     let header_xdr = header_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("header xdr");
 
     let zero_hash = "0".repeat(64);

--- a/crates/history/src/verify.rs
+++ b/crates/history/src/verify.rs
@@ -39,7 +39,7 @@ use henyey_bucket::{BUCKET_LIST_LEVELS, HOT_ARCHIVE_BUCKET_LIST_LEVELS};
 use henyey_common::Hash256;
 use henyey_crypto::Sha256Hasher;
 use henyey_ledger::TransactionSetVariant;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeader, LedgerHeaderHistoryEntry, Limits, ScpHistoryEntry, TransactionHistoryResultEntry,
     WriteXdr,
 };
@@ -480,12 +480,13 @@ pub fn verify_bucket_hash(data: &[u8], expected_hash: &Hash256) -> Result<()> {
 ///
 /// This is the hash that gets stored in the next ledger's `previous_ledger_hash`.
 pub fn compute_header_hash(header: &LedgerHeader) -> Result<Hash256> {
-    let xdr_bytes = header
-        .to_xdr(stellar_xdr::curr::Limits::none())
-        .map_err(|e| HistoryError::CorruptHeader {
-            ledger: header.ledger_seq,
-            detail: format!("failed to encode header: {}", e),
-        })?;
+    let xdr_bytes =
+        header
+            .to_xdr(stellar_xdr::Limits::none())
+            .map_err(|e| HistoryError::CorruptHeader {
+                ledger: header.ledger_seq,
+                detail: format!("failed to encode header: {}", e),
+            })?;
 
     Ok(Hash256::hash(&xdr_bytes))
 }
@@ -778,7 +779,7 @@ pub fn verify_tx_result_ordering(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{Hash, LedgerHeaderHistoryEntryExt, StellarValue, TimePoint, VecM};
+    use stellar_xdr::{Hash, LedgerHeaderHistoryEntryExt, StellarValue, TimePoint, VecM};
 
     fn make_test_header(seq: u32, prev_hash: Hash256) -> LedgerHeader {
         LedgerHeader {
@@ -788,7 +789,7 @@ mod tests {
                 tx_set_hash: Hash([0u8; 32]),
                 close_time: TimePoint(0),
                 upgrades: VecM::default(),
-                ext: stellar_xdr::curr::StellarValueExt::Basic,
+                ext: stellar_xdr::StellarValueExt::Basic,
             },
             tx_set_result_hash: Hash([0u8; 32]),
             bucket_list_hash: Hash([0u8; 32]),
@@ -801,7 +802,7 @@ mod tests {
             base_reserve: 5000000,
             max_tx_set_size: 100,
             skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
-            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            ext: stellar_xdr::LedgerHeaderExt::V0,
         }
     }
 
@@ -939,7 +940,7 @@ mod tests {
     // Item 4: Transaction result ordering tests
     #[test]
     fn test_verify_tx_result_ordering_valid() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
             VecM,
         };
@@ -972,7 +973,7 @@ mod tests {
 
     #[test]
     fn test_verify_tx_result_ordering_out_of_range() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
             VecM,
         };
@@ -989,7 +990,7 @@ mod tests {
 
     #[test]
     fn test_verify_tx_result_ordering_not_increasing() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
             VecM,
         };
@@ -1021,7 +1022,7 @@ mod tests {
 
     #[test]
     fn test_verify_tx_result_ordering_descending() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
             VecM,
         };
@@ -1047,7 +1048,7 @@ mod tests {
 
     #[test]
     fn test_verify_tx_result_ordering_single_entry() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
             VecM,
         };
@@ -1193,7 +1194,7 @@ mod tests {
 
     #[test]
     fn test_verify_tx_result_ordering_first_checkpoint() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
             VecM,
         };
@@ -1533,7 +1534,7 @@ mod tests {
     // --- Precedence regression tests for verify_tx_result_ordering ---
 
     fn make_tx_result_entry(ledger_seq: u32) -> TransactionHistoryResultEntry {
-        use stellar_xdr::curr::{TransactionHistoryResultEntryExt, TransactionResultSet};
+        use stellar_xdr::{TransactionHistoryResultEntryExt, TransactionResultSet};
         TransactionHistoryResultEntry {
             ledger_seq,
             tx_result_set: TransactionResultSet {
@@ -2165,14 +2166,14 @@ mod tests {
         let mut upper = make_chain(128, 191, 25);
         // Tamper: set first header's previous_ledger_hash to garbage so it
         // doesn't match hash(lower[126]).
-        upper[0].previous_ledger_hash = stellar_xdr::curr::Hash([0xDD; 32]);
+        upper[0].previous_ledger_hash = stellar_xdr::Hash([0xDD; 32]);
 
         let mut headers: Vec<_> = lower.into_iter().chain(upper).collect();
         // Re-compute internal chain for upper group: header 129's prev must
         // match hash of (tampered) header 128, etc. Use make_chain's approach.
         for i in 128..headers.len() {
             let prev_hash = compute_header_hash(&headers[i - 1]).unwrap();
-            headers[i].previous_ledger_hash = stellar_xdr::curr::Hash(prev_hash.0);
+            headers[i].previous_ledger_hash = stellar_xdr::Hash(prev_hash.0);
         }
 
         let hash_at_50 = compute_header_hash(&headers[49]).unwrap();

--- a/crates/history/tests/download_utils.rs
+++ b/crates/history/tests/download_utils.rs
@@ -2,7 +2,7 @@ use flate2::{write::GzEncoder, Compression};
 use henyey_history::download::{
     decompress_gzip, parse_record_marked_xdr_stream_or_empty, parse_xdr_stream,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt,
     StellarValue, StellarValueExt, TimePoint, VecM, WriteXdr,
 };
@@ -72,16 +72,8 @@ fn test_parse_xdr_stream_raw() {
     let entry_a = make_header(63);
     let entry_b = make_header(64);
     let mut stream = Vec::new();
-    stream.extend_from_slice(
-        &entry_a
-            .to_xdr(stellar_xdr::curr::Limits::none())
-            .expect("xdr a"),
-    );
-    stream.extend_from_slice(
-        &entry_b
-            .to_xdr(stellar_xdr::curr::Limits::none())
-            .expect("xdr b"),
-    );
+    stream.extend_from_slice(&entry_a.to_xdr(stellar_xdr::Limits::none()).expect("xdr a"));
+    stream.extend_from_slice(&entry_b.to_xdr(stellar_xdr::Limits::none()).expect("xdr b"));
 
     let parsed = parse_xdr_stream::<LedgerHeaderHistoryEntry>(&stream).expect("parse");
     assert_eq!(parsed.len(), 2);
@@ -93,12 +85,8 @@ fn test_parse_xdr_stream_raw() {
 fn test_parse_xdr_stream_record_marked() {
     let entry_a = make_header(127);
     let entry_b = make_header(128);
-    let entry_a_xdr = entry_a
-        .to_xdr(stellar_xdr::curr::Limits::none())
-        .expect("xdr a");
-    let entry_b_xdr = entry_b
-        .to_xdr(stellar_xdr::curr::Limits::none())
-        .expect("xdr b");
+    let entry_a_xdr = entry_a.to_xdr(stellar_xdr::Limits::none()).expect("xdr a");
+    let entry_b_xdr = entry_b.to_xdr(stellar_xdr::Limits::none()).expect("xdr b");
 
     let mut stream = Vec::new();
     stream.extend_from_slice(&record_marked(&entry_a_xdr));

--- a/crates/history/tests/publish_catchup_roundtrip.rs
+++ b/crates/history/tests/publish_catchup_roundtrip.rs
@@ -35,7 +35,7 @@ use henyey_history::{
     RemoteArchive, RemoteArchiveConfig,
 };
 use henyey_ledger::{LedgerManager, LedgerManagerConfig};
-use stellar_xdr::curr::{LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt};
+use stellar_xdr::{LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt};
 
 /// Build the deterministic single empty-bucket checkpoint and publish it into
 /// `staging_dir`. Returns `(checkpoint_seq, expected_header_hash)`.

--- a/crates/history/tests/replay_integration.rs
+++ b/crates/history/tests/replay_integration.rs
@@ -21,7 +21,7 @@ use henyey_history::{
     verify, CatchupConfiguration, HistoryError,
 };
 use henyey_ledger::TransactionSetVariant;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt,
     StellarValue, StellarValueExt, TimePoint, TransactionHistoryEntry, TransactionHistoryEntryExt,
     TransactionHistoryResultEntry, TransactionHistoryResultEntryExt, TransactionResultSet,
@@ -173,7 +173,7 @@ async fn test_catchup_replay_bucket_hash_verification() {
         .add_batch(
             target,
             25,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -201,7 +201,7 @@ async fn test_catchup_replay_bucket_hash_verification() {
         results: VecM::default(),
     };
     let result_xdr = result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result xdr");
     let tx_result_hash = Hash256::hash(&result_xdr);
 
@@ -226,10 +226,10 @@ async fn test_catchup_replay_bucket_hash_verification() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         let entry63_xdr = entry63
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header63 xdr");
         let entry64_xdr = entry64
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header64 xdr");
         record_marked(&[entry63_xdr, entry64_xdr])
     };
@@ -241,7 +241,7 @@ async fn test_catchup_replay_bucket_hash_verification() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         let entry64_xdr = entry64
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header64 xdr");
         record_marked(&[entry64_xdr])
     };
@@ -251,7 +251,7 @@ async fn test_catchup_replay_bucket_hash_verification() {
         ext: TransactionHistoryEntryExt::V0,
     };
     let tx_history_xdr = record_marked(&[tx_history_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx history xdr")]);
     let tx_result_entry = TransactionHistoryResultEntry {
         ledger_seq: target,
@@ -259,7 +259,7 @@ async fn test_catchup_replay_bucket_hash_verification() {
         ext: TransactionHistoryResultEntryExt::default(),
     };
     let tx_result_xdr = record_marked(&[tx_result_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result history xdr")]);
 
     let mut levels = Vec::with_capacity(BUCKET_LIST_LEVELS);
@@ -418,7 +418,7 @@ async fn test_catchup_replay_bucket_hash_verification() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_catchup_recent_large_gap_replays_with_parity() {
     use henyey_history::CatchupMode;
-    use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase, TransactionSetV1};
+    use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase, TransactionSetV1};
 
     let target = 200u32;
     let lcl = 100u32;
@@ -428,7 +428,7 @@ async fn test_catchup_recent_large_gap_replays_with_parity() {
         results: VecM::default(),
     };
     let empty_result_xdr = empty_result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result xdr");
     let empty_tx_result_hash = Hash256::hash(&empty_result_xdr);
 
@@ -496,7 +496,7 @@ async fn test_catchup_recent_large_gap_replays_with_parity() {
                     ext: LedgerHeaderHistoryEntryExt::default(),
                 };
                 entry
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                     .expect("header xdr")
             })
             .collect();
@@ -633,7 +633,7 @@ async fn test_catchup_recent_large_gap_replays_with_parity() {
 /// - The tx set hash in ledger 64 uses Generalized v23+ format
 #[tokio::test]
 async fn test_catchup_self_corrects_lcl_protocol_from_archive() {
-    use stellar_xdr::curr::{GeneralizedTransactionSet, TransactionPhase, TransactionSetV1};
+    use stellar_xdr::{GeneralizedTransactionSet, TransactionPhase, TransactionSetV1};
 
     let checkpoint = 63u32;
     let target = 64u32;
@@ -665,7 +665,7 @@ async fn test_catchup_self_corrects_lcl_protocol_from_archive() {
         results: VecM::default(),
     };
     let empty_result_xdr = empty_result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result xdr");
     let empty_tx_result_hash = Hash256::hash(&empty_result_xdr);
 
@@ -788,7 +788,7 @@ async fn test_catchup_self_corrects_lcl_protocol_from_archive() {
                 ext: LedgerHeaderHistoryEntryExt::default(),
             };
             entry
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .expect("header xdr")
         })
         .collect();
@@ -811,7 +811,7 @@ async fn test_catchup_self_corrects_lcl_protocol_from_archive() {
                 ext: LedgerHeaderHistoryEntryExt::default(),
             };
             entry
-                .to_xdr(stellar_xdr::curr::Limits::none())
+                .to_xdr(stellar_xdr::Limits::none())
                 .expect("header xdr")
         })
         .collect();
@@ -993,7 +993,7 @@ async fn test_replay_hash_mismatch_produces_replay_hash_mismatch_error() {
         results: VecM::default(),
     };
     let result_xdr = result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result xdr");
     let tx_result_hash = Hash256::hash(&result_xdr);
 
@@ -1025,10 +1025,10 @@ async fn test_replay_hash_mismatch_produces_replay_hash_mismatch_error() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         let entry63_xdr = entry63
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header63 xdr");
         let entry64_xdr = entry64
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header64 xdr");
         record_marked(&[entry63_xdr, entry64_xdr])
     };
@@ -1039,7 +1039,7 @@ async fn test_replay_hash_mismatch_produces_replay_hash_mismatch_error() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         let entry64_xdr = entry64
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header64 xdr");
         record_marked(&[entry64_xdr])
     };
@@ -1049,7 +1049,7 @@ async fn test_replay_hash_mismatch_produces_replay_hash_mismatch_error() {
         ext: TransactionHistoryEntryExt::V0,
     };
     let tx_history_xdr = record_marked(&[tx_history_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx history xdr")]);
     let tx_result_entry = TransactionHistoryResultEntry {
         ledger_seq: target,
@@ -1057,7 +1057,7 @@ async fn test_replay_hash_mismatch_produces_replay_hash_mismatch_error() {
         ext: TransactionHistoryResultEntryExt::default(),
     };
     let tx_result_xdr = record_marked(&[tx_result_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result history xdr")]);
 
     let mut levels = Vec::with_capacity(BUCKET_LIST_LEVELS);
@@ -1261,7 +1261,7 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
         .add_batch(
             target,
             25,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -1289,7 +1289,7 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
         results: VecM::default(),
     };
     let result_xdr = result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result xdr");
     let tx_result_hash = Hash256::hash(&result_xdr);
 
@@ -1314,10 +1314,10 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         let entry63_xdr = entry63
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header63 xdr");
         let entry64_xdr = entry64
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header64 xdr");
         record_marked(&[entry63_xdr, entry64_xdr])
     };
@@ -1329,7 +1329,7 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         let entry64_xdr = entry64
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header64 xdr");
         record_marked(&[entry64_xdr])
     };
@@ -1339,7 +1339,7 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
         ext: TransactionHistoryEntryExt::V0,
     };
     let tx_history_xdr = record_marked(&[tx_history_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx history xdr")]);
     let tx_result_entry = TransactionHistoryResultEntry {
         ledger_seq: target,
@@ -1347,7 +1347,7 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
         ext: TransactionHistoryResultEntryExt::default(),
     };
     let tx_result_xdr = record_marked(&[tx_result_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result history xdr")]);
 
     let mut levels = Vec::with_capacity(BUCKET_LIST_LEVELS);
@@ -1495,7 +1495,7 @@ async fn test_replay_with_validate_bucket_hash_enabled() {
 async fn test_inv_c15_rejects_bucket_apply_older_than_lcl() {
     use henyey_bucket::HotArchiveBucketList;
     use henyey_history::catchup::CheckpointData;
-    use stellar_xdr::curr::ScpHistoryEntry;
+    use stellar_xdr::ScpHistoryEntry;
 
     let checkpoint = 127u32;
     let target = 128u32;
@@ -1616,7 +1616,7 @@ async fn test_inv_c15_rejects_bucket_apply_older_than_lcl() {
 async fn test_inv_c15_allows_bucket_apply_at_lcl() {
     use henyey_bucket::HotArchiveBucketList;
     use henyey_history::catchup::CheckpointData;
-    use stellar_xdr::curr::ScpHistoryEntry;
+    use stellar_xdr::ScpHistoryEntry;
 
     let checkpoint = 127u32;
     let target = 128u32;
@@ -1664,19 +1664,18 @@ async fn test_inv_c15_allows_bucket_apply_at_lcl() {
     };
 
     // Build a header for target (128) to replay.
-    let tx_result_set = stellar_xdr::curr::TransactionResultSet {
+    let tx_result_set = stellar_xdr::TransactionResultSet {
         results: VecM::default(),
     };
     let result_xdr = tx_result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("result xdr");
     let tx_result_hash = Hash256::hash(&result_xdr);
 
-    let tx_set =
-        stellar_xdr::curr::GeneralizedTransactionSet::V1(stellar_xdr::curr::TransactionSetV1 {
-            previous_ledger_hash: Hash(*checkpoint_hash.as_bytes()),
-            phases: VecM::default(),
-        });
+    let tx_set = stellar_xdr::GeneralizedTransactionSet::V1(stellar_xdr::TransactionSetV1 {
+        previous_ledger_hash: Hash(*checkpoint_hash.as_bytes()),
+        phases: VecM::default(),
+    });
     let tx_set_hash = henyey_history::verify::compute_tx_set_hash(
         &TransactionSetVariant::Generalized(tx_set.clone()),
     )
@@ -1788,7 +1787,7 @@ async fn test_inv_c15_allows_bucket_apply_at_lcl() {
 async fn test_checkpoint_data_path_preserves_online_run_mode() {
     use henyey_history::catchup::CheckpointData;
     use henyey_history::CatchupRunMode;
-    use stellar_xdr::curr::ScpHistoryEntry;
+    use stellar_xdr::ScpHistoryEntry;
 
     let checkpoint = 127u32;
     let target = 128u32;
@@ -1948,7 +1947,7 @@ async fn test_offline_complete_rejected_at_checkpoint_data_entry_point() {
     use henyey_history::catchup::CheckpointData;
     use henyey_history::CatchupConfiguration;
     use henyey_history::CatchupRunMode;
-    use stellar_xdr::curr::ScpHistoryEntry;
+    use stellar_xdr::ScpHistoryEntry;
 
     let ledger_manager = henyey_ledger::LedgerManager::new(
         "Test SDF Network ; September 2015".to_string(),
@@ -2032,7 +2031,7 @@ async fn test_checkpoint_data_config_rejects_non_minimal_depth() {
     use henyey_history::catchup::CheckpointData;
     use henyey_history::CatchupConfiguration;
     use henyey_history::CatchupRunMode;
-    use stellar_xdr::curr::ScpHistoryEntry;
+    use stellar_xdr::ScpHistoryEntry;
 
     let ledger_manager = henyey_ledger::LedgerManager::new(
         "Test SDF Network ; September 2015".to_string(),
@@ -2182,7 +2181,7 @@ async fn test_catchup_pins_downloads_to_gate_archive() {
         .add_batch(
             target,
             25,
-            stellar_xdr::curr::BucketListType::Live,
+            stellar_xdr::BucketListType::Live,
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -2210,7 +2209,7 @@ async fn test_catchup_pins_downloads_to_gate_archive() {
         results: VecM::default(),
     };
     let result_xdr = result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result xdr");
     let tx_result_hash = Hash256::hash(&result_xdr);
 
@@ -2254,7 +2253,7 @@ async fn test_catchup_pins_downloads_to_gate_archive() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         record_marked(&[entry63
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header63 xdr")])
     };
 
@@ -2265,7 +2264,7 @@ async fn test_catchup_pins_downloads_to_gate_archive() {
             ext: LedgerHeaderHistoryEntryExt::default(),
         };
         record_marked(&[entry64
-            .to_xdr(stellar_xdr::curr::Limits::none())
+            .to_xdr(stellar_xdr::Limits::none())
             .expect("header64 xdr")])
     };
     let headers_xdr_good = make_data_checkpoint_headers(header64_hash, header64.clone());
@@ -2278,7 +2277,7 @@ async fn test_catchup_pins_downloads_to_gate_archive() {
         ext: TransactionHistoryEntryExt::V0,
     };
     let tx_history_xdr = record_marked(&[tx_history_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx history xdr")]);
     let tx_result_entry = TransactionHistoryResultEntry {
         ledger_seq: target,
@@ -2286,7 +2285,7 @@ async fn test_catchup_pins_downloads_to_gate_archive() {
         ext: TransactionHistoryResultEntryExt::default(),
     };
     let tx_result_xdr = record_marked(&[tx_result_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result history xdr")]);
 
     let mut levels = Vec::with_capacity(BUCKET_LIST_LEVELS);

--- a/crates/historywork/src/download.rs
+++ b/crates/historywork/src/download.rs
@@ -17,7 +17,7 @@ use henyey_common::Hash256;
 use henyey_history::{archive::HistoryArchive, archive_state::HistoryArchiveState, verify};
 use henyey_ledger::TransactionSetVariant;
 use henyey_work::{Work, WorkContext, WorkOutcome};
-use stellar_xdr::curr::{LedgerHeaderHistoryEntry, TransactionHistoryEntryExt, WriteXdr};
+use stellar_xdr::{LedgerHeaderHistoryEntry, TransactionHistoryEntryExt, WriteXdr};
 
 use crate::{set_progress, HistoryWorkStage, SharedHistoryState};
 
@@ -552,10 +552,7 @@ impl Work for DownloadTxResultsWork {
                     return WorkOutcome::Failed(err);
                 }
             };
-            let xdr = match entry
-                .tx_result_set
-                .to_xdr(stellar_xdr::curr::Limits::none())
-            {
+            let xdr = match entry.tx_result_set.to_xdr(stellar_xdr::Limits::none()) {
                 Ok(xdr) => xdr,
                 Err(err) => {
                     emit_archive_counter(

--- a/crates/historywork/src/lib.rs
+++ b/crates/historywork/src/lib.rs
@@ -92,7 +92,7 @@ use anyhow::{anyhow, Result};
 use tokio::sync::Mutex;
 
 use henyey_history::CheckpointData;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     LedgerHeaderHistoryEntry, ScpHistoryEntry, TransactionHistoryEntry,
     TransactionHistoryResultEntry,
 };

--- a/crates/historywork/tests/history_work.rs
+++ b/crates/historywork/tests/history_work.rs
@@ -18,7 +18,7 @@ use henyey_history::{
 use henyey_historywork::{HistoryWorkBuilder, HistoryWorkState};
 use henyey_ledger::TransactionSetVariant;
 use henyey_work::{WorkScheduler, WorkSchedulerConfig};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt,
     LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0, StellarValue, StellarValueExt,
     TimePoint, TransactionHistoryEntry, TransactionHistoryEntryExt, TransactionHistoryResultEntry,
@@ -96,7 +96,7 @@ async fn test_history_work_chain() {
         results: VecM::default(),
     };
     let tx_result_xdr = tx_result_set
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result xdr");
     let tx_result_hash = Hash256::hash(&tx_result_xdr);
 
@@ -108,7 +108,7 @@ async fn test_history_work_chain() {
         ext: LedgerHeaderHistoryEntryExt::default(),
     };
     let header_xdr_raw = header_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("xdr");
     let header_xdr = record_marked(&[header_xdr_raw]);
 
@@ -163,7 +163,7 @@ async fn test_history_work_chain() {
         ext: TransactionHistoryEntryExt::default(),
     };
     let tx_entry_xdr_raw = tx_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx entry xdr");
     let tx_entry_xdr = record_marked(&[tx_entry_xdr_raw]);
     fixtures.insert(
@@ -177,7 +177,7 @@ async fn test_history_work_chain() {
         ext: TransactionHistoryResultEntryExt::default(),
     };
     let tx_result_entry_xdr_raw = tx_result_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("tx result entry xdr");
     let tx_result_entry_xdr = record_marked(&[tx_result_entry_xdr_raw]);
     fixtures.insert(
@@ -193,7 +193,7 @@ async fn test_history_work_chain() {
         },
     });
     let scp_entry_xdr_raw = scp_entry
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .expect("scp entry xdr");
     let scp_entry_xdr = record_marked(&[scp_entry_xdr_raw]);
     fixtures.insert(

--- a/crates/invariant/src/conservation.rs
+++ b/crates/invariant/src/conservation.rs
@@ -33,7 +33,7 @@
 //! scan is out of scope — henyey's `Invariant` trait only exposes the per-op
 //! hook). Strictness: non-strict (`Invariant(false)`).
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Asset, ContractEvent, ContractId, ContractIdPreimage, Hash, HashIdPreimage,
     HashIdPreimageContractId, LedgerEntry, LedgerEntryData, LiquidityPoolEntryBody, Operation,
     OperationResult, OperationResultTr, ScAddress, ScVal,
@@ -125,7 +125,7 @@ fn native_balance(entry: &LedgerEntry, native_sac_id: &ContractId) -> NativeBala
 /// Extracts the native-XLM balance from a `ContractData` entry, mirroring the
 /// CONTRACT_DATA branch of stellar-core's `getAssetBalance`.
 fn sac_native_balance(
-    cd: &stellar_xdr::curr::ContractDataEntry,
+    cd: &stellar_xdr::ContractDataEntry,
     native_sac_id: &ContractId,
 ) -> NativeBalance {
     // The entry must be stored under the native SAC contract address.
@@ -296,7 +296,7 @@ impl Invariant for ConservationOfLumens {
             // misleading invariant message. See #2998.
             let inflation_payouts: i64 = match op_result {
                 OperationResult::OpInner(OperationResultTr::Inflation(
-                    stellar_xdr::curr::InflationResult::Success(payouts),
+                    stellar_xdr::InflationResult::Success(payouts),
                 )) => {
                     let mut sum: i64 = 0;
                     for p in payouts.iter() {

--- a/crates/invariant/src/entry_valid.rs
+++ b/crates/invariant/src/entry_valid.rs
@@ -11,7 +11,7 @@
 //! (all Soroban entry forms, asset contract validation, etc.) is tracked
 //! as follow-up work.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, ContractEvent, DataEntry,
     LedgerEntry, LedgerEntryData, LedgerEntryExt, OfferEntry, Operation, OperationResult,
     TrustLineAsset, TrustLineEntry, TrustLineEntryExt, TrustLineEntryV1Ext, TrustLineFlags,

--- a/crates/invariant/src/lib.rs
+++ b/crates/invariant/src/lib.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ContractEvent, LedgerEntry, LedgerHeader, LedgerKey, Operation, OperationResult,
 };
 
@@ -525,7 +525,7 @@ mod tests {
     // Helpers
 
     fn default_header(seq: u32) -> LedgerHeader {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         LedgerHeader {
             ledger_version: 24,
             previous_ledger_hash: Hash([0; 32]),
@@ -551,7 +551,7 @@ mod tests {
     }
 
     fn dummy_operation() -> Operation {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         Operation {
             source_account: None,
             body: OperationBody::Inflation,
@@ -559,7 +559,7 @@ mod tests {
     }
 
     fn dummy_op_result() -> OperationResult {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
         OperationResult::OpInner(OperationResultTr::Inflation(InflationResult::NotTime))
     }
 }

--- a/crates/invariant/src/sponsorship.rs
+++ b/crates/invariant/src/sponsorship.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, AccountId, ContractEvent,
     LedgerEntry, LedgerEntryData, LedgerEntryExt, Operation, OperationResult, TrustLineAsset,
 };
@@ -368,7 +368,7 @@ mod tests {
     //!   - the trailing unmatched-residual `count != 0` error branch.
 
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntryExtensionV1, AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AlphaNum4,
         Asset, AssetCode4, ClaimPredicate, ClaimableBalanceEntry, ClaimableBalanceEntryExt,
         ClaimableBalanceId, Claimant, ClaimantV0, Hash, InflationResult, LedgerEntryExtensionV1,
@@ -496,7 +496,7 @@ mod tests {
         }
     }
 
-    type VecMOrVec = stellar_xdr::curr::VecM<SponsorshipDescriptor, 20>;
+    type VecMOrVec = stellar_xdr::VecM<SponsorshipDescriptor, 20>;
 
     fn run(
         created: &[LedgerEntry],

--- a/crates/invariant/src/sub_entries.rs
+++ b/crates/invariant/src/sub_entries.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountId, ContractEvent, LedgerEntry, LedgerEntryData, Operation,
     OperationResult, TrustLineAsset,
 };

--- a/crates/invariant/tests/conservation.rs
+++ b/crates/invariant/tests/conservation.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use henyey_invariant::{ConservationOfLumens, Invariant, InvariantManager, OperationDelta};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountId, AlphaNum4, Asset, AssetCode4, ClaimPredicate,
     ClaimableBalanceEntry, ClaimableBalanceEntryExt, ClaimableBalanceId, Claimant, ClaimantV0,
     ContractDataDurability, ContractDataEntry, ContractId, ContractIdPreimage, ExtensionPoint,
@@ -195,12 +195,12 @@ fn dummy_op() -> Operation {
 
 /// A non-inflation op result (Payment success) so the no-inflation branch runs.
 fn payment_result() -> OperationResult {
-    use stellar_xdr::curr::PaymentResult;
+    use stellar_xdr::PaymentResult;
     OperationResult::OpInner(OperationResultTr::Payment(PaymentResult::Success))
 }
 
 fn inflation_result(payouts: Vec<(u8, i64)>) -> OperationResult {
-    use stellar_xdr::curr::InflationPayout;
+    use stellar_xdr::InflationPayout;
     let payouts: VecM<InflationPayout> = payouts
         .into_iter()
         .map(|(seed, amount)| InflationPayout {
@@ -253,7 +253,7 @@ impl DeltaBuilder {
         header_previous: Option<&LedgerHeader>,
     ) -> Result<(), String> {
         let network_id = [0u8; 32];
-        let deleted_keys: Vec<stellar_xdr::curr::LedgerKey> = vec![]; // not read by invariant
+        let deleted_keys: Vec<stellar_xdr::LedgerKey> = vec![]; // not read by invariant
         let delta = OperationDelta {
             created: &self.created,
             updated: &self.updated,
@@ -611,7 +611,7 @@ fn test_conservation_mismatched_update_lengths_fail_fast() {
     let inv = ConservationOfLumens::new();
     let h = header(1_000_000, 0);
     let network_id = [0u8; 32];
-    let deleted_keys: Vec<stellar_xdr::curr::LedgerKey> = vec![];
+    let deleted_keys: Vec<stellar_xdr::LedgerKey> = vec![];
 
     // Two post-states but only one pre-state → length divergence.
     let updated = vec![account_entry(2, 500), account_entry(3, 2500)];

--- a/crates/ledger/src/close.rs
+++ b/crates/ledger/src/close.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use henyey_common::{xdr_to_bytes, Hash256};
 use henyey_crypto::Sha256Hasher;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, ConfigUpgradeSetKey, GeneralizedTransactionSet, LedgerCloseMeta, LedgerHeader,
     LedgerHeaderExt, LedgerHeaderExtensionV1, LedgerHeaderExtensionV1Ext, LedgerUpgrade,
     OperationBody, ScpHistoryEntry, StellarValueExt, TransactionEnvelope, TransactionResultPair,
@@ -84,7 +84,7 @@ pub struct ConfigUpgradeResult {
     /// Whether Soroban memory cost parameters changed (requires cost model reload).
     pub memory_cost_params_changed: bool,
     /// Per-upgrade entry changes, keyed by serialized `ConfigUpgradeSetKey`.
-    pub per_upgrade_changes: HashMap<Vec<u8>, stellar_xdr::curr::LedgerEntryChanges>,
+    pub per_upgrade_changes: HashMap<Vec<u8>, stellar_xdr::LedgerEntryChanges>,
 }
 
 /// Complete input data for closing a ledger.
@@ -279,17 +279,17 @@ pub enum TransactionSetVariant {
     Generalized(GeneralizedTransactionSet),
 }
 
-impl From<&stellar_xdr::curr::TransactionHistoryEntry> for TransactionSetVariant {
+impl From<&stellar_xdr::TransactionHistoryEntry> for TransactionSetVariant {
     /// Extract the transaction set from a history entry.
     ///
     /// For V1 entries, extracts the generalized transaction set from the ext field.
     /// For V0 entries, uses the classic transaction set.
-    fn from(entry: &stellar_xdr::curr::TransactionHistoryEntry) -> Self {
+    fn from(entry: &stellar_xdr::TransactionHistoryEntry) -> Self {
         match &entry.ext {
-            stellar_xdr::curr::TransactionHistoryEntryExt::V1(generalized) => {
+            stellar_xdr::TransactionHistoryEntryExt::V1(generalized) => {
                 TransactionSetVariant::Generalized(generalized.clone())
             }
-            stellar_xdr::curr::TransactionHistoryEntryExt::V0 => {
+            stellar_xdr::TransactionHistoryEntryExt::V0 => {
                 TransactionSetVariant::Classic(entry.tx_set.clone())
             }
         }
@@ -302,20 +302,22 @@ impl TransactionSetVariant {
         match self {
             TransactionSetVariant::Classic(set) => set.txs.len(),
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 let mut count = 0;
                 for phase in set_v1.phases.iter() {
                     match phase {
-                        stellar_xdr::curr::TransactionPhase::V0(components) => {
+                        stellar_xdr::TransactionPhase::V0(components) => {
                             for comp in components.iter() {
                                 match comp {
-                                    stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) => {
+                                    stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(
+                                        c,
+                                    ) => {
                                         count += c.txs.len();
                                     }
                                 }
                             }
                         }
-                        stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+                        stellar_xdr::TransactionPhase::V1(parallel) => {
                             for stage in parallel.execution_stages.iter() {
                                 for cluster in stage.iter() {
                                     count += cluster.0.len();
@@ -349,7 +351,7 @@ impl TransactionSetVariant {
         match self {
             TransactionSetVariant::Classic(set) => Hash256::from(set.previous_ledger_hash.0),
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 Hash256::from(set_v1.previous_ledger_hash.0)
             }
         }
@@ -358,9 +360,9 @@ impl TransactionSetVariant {
     /// Create an empty generalized transaction set for a given ledger header.
     pub fn empty_generalized(header: &LedgerHeader) -> Self {
         TransactionSetVariant::Generalized(GeneralizedTransactionSet::V1(
-            stellar_xdr::curr::TransactionSetV1 {
+            stellar_xdr::TransactionSetV1 {
                 previous_ledger_hash: header.previous_ledger_hash.clone(),
-                phases: stellar_xdr::curr::VecM::default(),
+                phases: stellar_xdr::VecM::default(),
             },
         ))
     }
@@ -370,20 +372,22 @@ impl TransactionSetVariant {
         match self {
             TransactionSetVariant::Classic(set) => set.txs.iter().collect(),
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 let mut txs = Vec::new();
                 for phase in set_v1.phases.iter() {
                     match phase {
-                        stellar_xdr::curr::TransactionPhase::V0(components) => {
+                        stellar_xdr::TransactionPhase::V0(components) => {
                             for comp in components.iter() {
                                 match comp {
-                                    stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(c) => {
+                                    stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(
+                                        c,
+                                    ) => {
                                         txs.extend(c.txs.iter());
                                     }
                                 }
                             }
                         }
-                        stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+                        stellar_xdr::TransactionPhase::V1(parallel) => {
                             for stage in parallel.execution_stages.iter() {
                                 for cluster in stage.iter() {
                                     txs.extend(cluster.0.iter());
@@ -416,14 +420,14 @@ impl TransactionSetVariant {
                 sorted_for_apply_sequential(txs, set_hash)
             }
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 let mut txs = Vec::new();
                 for phase in set_v1.phases.iter() {
                     match phase {
-                        stellar_xdr::curr::TransactionPhase::V0(components) => {
+                        stellar_xdr::TransactionPhase::V0(components) => {
                             txs.extend(sorted_component_txs(components.iter(), set_hash));
                         }
-                        stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+                        stellar_xdr::TransactionPhase::V1(parallel) => {
                             let base_fee = base_fee_to_u32(parallel.base_fee);
                             txs.extend(sorted_for_apply_parallel(
                                 parallel.execution_stages.as_slice(),
@@ -455,10 +459,10 @@ impl TransactionSetVariant {
                 sorted_for_apply_sequential(txs, set_hash)
             }
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 let mut txs = Vec::new();
                 for phase in set_v1.phases.iter() {
-                    if let stellar_xdr::curr::TransactionPhase::V0(components) = phase {
+                    if let stellar_xdr::TransactionPhase::V0(components) = phase {
                         txs.extend(sorted_component_txs(components.iter(), set_hash));
                     }
                 }
@@ -478,9 +482,9 @@ impl TransactionSetVariant {
         match self {
             TransactionSetVariant::Classic(_) => None,
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 for phase in set_v1.phases.iter() {
-                    if let stellar_xdr::curr::TransactionPhase::V1(parallel) = phase {
+                    if let stellar_xdr::TransactionPhase::V1(parallel) = phase {
                         let base_fee = base_fee_to_u32(parallel.base_fee);
 
                         let stages = sorted_stages_for_parallel(
@@ -533,14 +537,14 @@ fn cmp_hashes(left: &Hash256, right: &Hash256, set_hash: &Hash256) -> Ordering {
     }
 }
 
-fn tx_source_id(tx: &TransactionEnvelope) -> stellar_xdr::curr::AccountId {
+fn tx_source_id(tx: &TransactionEnvelope) -> stellar_xdr::AccountId {
     match tx {
         TransactionEnvelope::TxV0(env) => henyey_tx::muxed_to_account_id(
-            &stellar_xdr::curr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone()),
+            &stellar_xdr::MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone()),
         ),
         TransactionEnvelope::Tx(env) => henyey_tx::muxed_to_account_id(&env.tx.source_account),
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                 henyey_tx::muxed_to_account_id(&inner.tx.source_account)
             }
         },
@@ -552,18 +556,17 @@ fn tx_sequence_number(tx: &TransactionEnvelope) -> i64 {
         TransactionEnvelope::TxV0(env) => env.tx.seq_num.0,
         TransactionEnvelope::Tx(env) => env.tx.seq_num.0,
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
         },
     }
 }
 
 fn collect_component_txs<'a>(
-    components: impl IntoIterator<Item = &'a stellar_xdr::curr::TxSetComponent>,
+    components: impl IntoIterator<Item = &'a stellar_xdr::TxSetComponent>,
 ) -> Vec<TxWithFee> {
     let mut txs = Vec::new();
     for component in components {
-        let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(component) =
-            component;
+        let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(component) = component;
         let base_fee = base_fee_to_u32(component.base_fee);
         txs.extend(
             component
@@ -577,7 +580,7 @@ fn collect_component_txs<'a>(
 }
 
 fn sorted_component_txs<'a>(
-    components: impl IntoIterator<Item = &'a stellar_xdr::curr::TxSetComponent>,
+    components: impl IntoIterator<Item = &'a stellar_xdr::TxSetComponent>,
     set_hash: Hash256,
 ) -> Vec<TxWithFee> {
     sorted_for_apply_sequential(collect_component_txs(components), set_hash)
@@ -649,7 +652,7 @@ fn sorted_for_apply_sequential(txs: Vec<TxWithFee>, set_hash: Hash256) -> Vec<Tx
 /// Clusters within a stage are NOT sorted -- they are independent, so stellar-core
 /// preserves XDR order to keep deterministic result ordering.
 fn sort_parallel_stages(
-    stages: &[stellar_xdr::curr::ParallelTxExecutionStage],
+    stages: &[stellar_xdr::ParallelTxExecutionStage],
     set_hash: &Hash256,
 ) -> Vec<Vec<Vec<Arc<TransactionEnvelope>>>> {
     // Pre-compute TX hashes alongside each TX to avoid redundant XDR+SHA256 during sort.
@@ -706,7 +709,7 @@ fn sort_parallel_stages(
 /// Returns stages > clusters > sorted (tx, base_fee) triples using the same
 /// canonical ordering as `sorted_for_apply_parallel`.
 fn sorted_stages_for_parallel(
-    stages: &[stellar_xdr::curr::ParallelTxExecutionStage],
+    stages: &[stellar_xdr::ParallelTxExecutionStage],
     set_hash: Hash256,
     base_fee: Option<u32>,
 ) -> ParallelStages {
@@ -722,7 +725,7 @@ fn sorted_stages_for_parallel(
 }
 
 fn sorted_for_apply_parallel(
-    stages: &[stellar_xdr::curr::ParallelTxExecutionStage],
+    stages: &[stellar_xdr::ParallelTxExecutionStage],
     set_hash: Hash256,
     base_fee: Option<u32>,
 ) -> Vec<TxWithFee> {
@@ -774,7 +777,7 @@ fn envelope_is_soroban(env: &TransactionEnvelope) -> bool {
         TransactionEnvelope::TxV0(e) => &e.tx.operations,
         TransactionEnvelope::Tx(e) => &e.tx.operations,
         TransactionEnvelope::TxFeeBump(e) => match &e.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => &inner.tx.operations,
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => &inner.tx.operations,
         },
     };
     ops.iter().any(|op| {
@@ -801,19 +804,19 @@ impl TransactionSetVariant {
                 (sorted.clone(), None, sorted)
             }
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 let mut classic_txs = Vec::new();
                 let mut soroban_phase = None;
                 let mut all_txs = Vec::new();
 
                 for phase in Vec::from(set_v1.phases) {
                     match phase {
-                        stellar_xdr::curr::TransactionPhase::V0(components) => {
+                        stellar_xdr::TransactionPhase::V0(components) => {
                             let sorted = sorted_for_apply_sequential(
                                 Vec::from(components)
                                     .into_iter()
                                     .flat_map(|component| {
-                                        let stellar_xdr::curr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(
+                                        let stellar_xdr::TxSetComponent::TxsetCompTxsMaybeDiscountedFee(
                                             component,
                                         ) = component;
                                         let base_fee = base_fee_to_u32(component.base_fee);
@@ -827,7 +830,7 @@ impl TransactionSetVariant {
                             classic_txs = sorted.clone();
                             all_txs.extend(sorted);
                         }
-                        stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+                        stellar_xdr::TransactionPhase::V1(parallel) => {
                             let base_fee = base_fee_to_u32(parallel.base_fee);
                             let stages: ParallelStages = Vec::from(parallel.execution_stages)
                                 .into_iter()
@@ -881,19 +884,19 @@ impl TransactionSetVariant {
                 (sorted.clone(), None, sorted)
             }
             TransactionSetVariant::Generalized(set) => {
-                let stellar_xdr::curr::GeneralizedTransactionSet::V1(set_v1) = set;
+                let stellar_xdr::GeneralizedTransactionSet::V1(set_v1) = set;
                 let mut classic_txs = Vec::new();
                 let mut soroban_phase = None;
                 let mut all_txs = Vec::new();
 
                 for phase in set_v1.phases.iter() {
                     match phase {
-                        stellar_xdr::curr::TransactionPhase::V0(components) => {
+                        stellar_xdr::TransactionPhase::V0(components) => {
                             let sorted = sorted_component_txs(components.iter(), hash);
                             classic_txs = sorted.clone();
                             all_txs.extend(sorted);
                         }
-                        stellar_xdr::curr::TransactionPhase::V1(parallel) => {
+                        stellar_xdr::TransactionPhase::V1(parallel) => {
                             let base_fee = base_fee_to_u32(parallel.base_fee);
                             let stages = sorted_stages_for_parallel(
                                 parallel.execution_stages.as_slice(),
@@ -1329,7 +1332,7 @@ impl UpgradeContext {
         protocol_version: u32,
         soroban_state: &crate::soroban_state::SharedSorobanState,
     ) -> Result<ConfigUpgradeResult, LedgerError> {
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
 
         let mut state_archival_changed = false;
         let mut memory_cost_params_changed = false;
@@ -1481,8 +1484,8 @@ impl UpgradeContext {
         &self,
         ltx: &mut CloseLedgerState,
         ledger_seq: u32,
-    ) -> Result<stellar_xdr::curr::LedgerEntryChanges, LedgerError> {
-        use stellar_xdr::curr::{
+    ) -> Result<stellar_xdr::LedgerEntryChanges, LedgerError> {
+        use stellar_xdr::{
             ConfigSettingEntry, ConfigSettingId, LedgerEntryChange, LedgerEntryChanges,
             LedgerEntryData, LedgerKey, LedgerKeyConfigSetting, VecM,
         };
@@ -1630,7 +1633,7 @@ mod tests {
     use super::*;
     use henyey_crypto::Sha256Hasher;
     use std::collections::HashMap;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         DependentTxCluster, FeeBumpTransaction, FeeBumpTransactionEnvelope,
         FeeBumpTransactionInnerTx, GeneralizedTransactionSet, Hash, Limits, Memo, MuxedAccount,
         ParallelTxExecutionStage, Preconditions, Transaction, TransactionEnvelope, TransactionExt,
@@ -1643,7 +1646,7 @@ mod tests {
         let tx = Transaction {
             source_account: source,
             fee: 100,
-            seq_num: stellar_xdr::curr::SequenceNumber(seq),
+            seq_num: stellar_xdr::SequenceNumber(seq),
             cond: Preconditions::None,
             memo: Memo::None,
             operations: VecM::default(),
@@ -1665,7 +1668,7 @@ mod tests {
             fee_source,
             fee: 200,
             inner_tx: FeeBumpTransactionInnerTx::Tx(inner),
-            ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+            ext: stellar_xdr::FeeBumpTransactionExt::V0,
         };
         TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
             tx: fee_bump,
@@ -1725,7 +1728,7 @@ mod tests {
         }
     }
 
-    fn fee_source_id(tx: &TransactionEnvelope) -> stellar_xdr::curr::AccountId {
+    fn fee_source_id(tx: &TransactionEnvelope) -> stellar_xdr::AccountId {
         match tx {
             TransactionEnvelope::TxV0(env) => henyey_tx::muxed_to_account_id(
                 &MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone()),
@@ -1737,7 +1740,7 @@ mod tests {
         }
     }
 
-    fn inner_source_id(tx: &TransactionEnvelope) -> stellar_xdr::curr::AccountId {
+    fn inner_source_id(tx: &TransactionEnvelope) -> stellar_xdr::AccountId {
         match tx {
             TransactionEnvelope::TxV0(env) => henyey_tx::muxed_to_account_id(
                 &MuxedAccount::Ed25519(env.tx.source_account_ed25519.clone()),
@@ -1885,7 +1888,7 @@ mod tests {
                     let fee_bump_b = make_fee_bump(9, inner_b, 1);
                     let classic = make_tx(classic_seed, 1);
                     let txs = vec![fee_bump_a.clone(), classic.clone(), fee_bump_b.clone()];
-                    let set = stellar_xdr::curr::TransactionSet {
+                    let set = stellar_xdr::TransactionSet {
                         previous_ledger_hash: Hash::from(Hash256::ZERO),
                         txs: txs.clone().try_into().unwrap(),
                     };

--- a/crates/ledger/src/close_state.rs
+++ b/crates/ledger/src/close_state.rs
@@ -35,7 +35,7 @@
 use crate::delta::{ChangeCheckpoint, DeltaCategorization, LedgerDelta};
 use crate::snapshot::SnapshotHandle;
 use crate::Result;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountId, LedgerEntry, LedgerEntryChanges, LedgerEntryData, LedgerHeader,
     LedgerKey,
 };
@@ -100,7 +100,7 @@ impl CloseLedgerState {
 
     /// Load an account by ID.
     pub fn get_account(&self, account_id: &AccountId) -> Result<Option<AccountEntry>> {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
         match self.get_entry(&key)? {
@@ -345,7 +345,7 @@ fn is_offer_key(key: &LedgerKey) -> bool {
 mod tests {
     use super::*;
     use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountId, LedgerEntry, LedgerEntryChange, LedgerEntryData, LedgerEntryExt,
         LedgerHeader, LedgerKey, LedgerKeyAccount, PublicKey, Thresholds, Uint256,
     };
@@ -363,14 +363,14 @@ mod tests {
             data: LedgerEntryData::Account(AccountEntry {
                 account_id,
                 balance,
-                seq_num: stellar_xdr::curr::SequenceNumber(0),
+                seq_num: stellar_xdr::SequenceNumber(0),
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
+                home_domain: stellar_xdr::String32::default(),
                 thresholds: Thresholds([1, 0, 0, 0]),
-                signers: stellar_xdr::curr::VecM::default(),
-                ext: stellar_xdr::curr::AccountEntryExt::V0,
+                signers: stellar_xdr::VecM::default(),
+                ext: stellar_xdr::AccountEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,
         }

--- a/crates/ledger/src/config_upgrade.rs
+++ b/crates/ledger/src/config_upgrade.rs
@@ -25,7 +25,7 @@ use henyey_common::protocol::{
 use henyey_common::Hash256;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ConfigSettingEntry, ConfigSettingId, ConfigUpgradeSet, ConfigUpgradeSetKey,
     ContractDataDurability, EncodedLedgerKey, FreezeBypassTxs, FrozenLedgerKeys,
     FrozenLedgerKeysDelta, Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerKey,
@@ -183,7 +183,7 @@ impl ConfigUpgradeSetFrame {
 
         // Extract CONTRACT_DATA
         let contract_data = match &entry.data {
-            stellar_xdr::curr::LedgerEntryData::ContractData(cd) => cd,
+            stellar_xdr::LedgerEntryData::ContractData(cd) => cd,
             _ => return Ok(None),
         };
 
@@ -252,7 +252,7 @@ impl ConfigUpgradeSetFrame {
 
     /// Get the TTL key for a CONTRACT_DATA entry.
     fn get_ttl_key(data_key: &LedgerKey) -> LedgerKey {
-        LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl {
+        LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl {
             key_hash: Hash(Hash256::hash_xdr(data_key).0),
         })
     }
@@ -260,9 +260,7 @@ impl ConfigUpgradeSetFrame {
     /// Check if a TTL entry indicates the data is live.
     fn is_live(ttl_entry: &LedgerEntry, current_ledger: u32) -> bool {
         match &ttl_entry.data {
-            stellar_xdr::curr::LedgerEntryData::Ttl(ttl) => {
-                ttl.live_until_ledger_seq >= current_ledger
-            }
+            stellar_xdr::LedgerEntryData::Ttl(ttl) => ttl.live_until_ledger_seq >= current_ledger,
             _ => false,
         }
     }
@@ -329,7 +327,7 @@ impl ConfigUpgradeSetFrame {
         }
         for updated_entry in self.config_upgrade_set.updated_entry.iter() {
             let setting_id = updated_entry.discriminant();
-            let key = LedgerKey::ConfigSetting(stellar_xdr::curr::LedgerKeyConfigSetting {
+            let key = LedgerKey::ConfigSetting(stellar_xdr::LedgerKeyConfigSetting {
                 config_setting_id: setting_id,
             });
             let entry = ltx.get_entry(&key)?.ok_or_else(|| {
@@ -392,7 +390,7 @@ impl ConfigUpgradeSetFrame {
             }
 
             // Construct the ledger key for this config setting
-            let key = LedgerKey::ConfigSetting(stellar_xdr::curr::LedgerKeyConfigSetting {
+            let key = LedgerKey::ConfigSetting(stellar_xdr::LedgerKeyConfigSetting {
                 config_setting_id: setting_id,
             });
 
@@ -479,7 +477,7 @@ impl ConfigUpgradeSetFrame {
         ltx: &mut CloseLedgerState,
     ) -> Result<(), LedgerError> {
         // Load the base CONFIG_SETTING_FROZEN_LEDGER_KEYS entry
-        let key = LedgerKey::ConfigSetting(stellar_xdr::curr::LedgerKeyConfigSetting {
+        let key = LedgerKey::ConfigSetting(stellar_xdr::LedgerKeyConfigSetting {
             config_setting_id: ConfigSettingId::FrozenLedgerKeys,
         });
         let previous = ltx
@@ -560,7 +558,7 @@ impl ConfigUpgradeSetFrame {
         ltx: &mut CloseLedgerState,
     ) -> Result<(), LedgerError> {
         // Load the base CONFIG_SETTING_FREEZE_BYPASS_TXS entry
-        let key = LedgerKey::ConfigSetting(stellar_xdr::curr::LedgerKeyConfigSetting {
+        let key = LedgerKey::ConfigSetting(stellar_xdr::LedgerKeyConfigSetting {
             config_setting_id: ConfigSettingId::FreezeBypassTxs,
         });
         let previous = ltx
@@ -655,7 +653,7 @@ impl ConfigUpgradeSetFrame {
         };
 
         // Load the current window from the CloseLedgerState (sees prior config upgrades)
-        let window_key = LedgerKey::ConfigSetting(stellar_xdr::curr::LedgerKeyConfigSetting {
+        let window_key = LedgerKey::ConfigSetting(stellar_xdr::LedgerKeyConfigSetting {
             config_setting_id: ConfigSettingId::LiveSorobanStateSizeWindow,
         });
         let window_entry = ltx.get_entry(&window_key).map_err(|e| {
@@ -709,7 +707,7 @@ impl ConfigUpgradeSetFrame {
             "Resized LiveSorobanStateSizeWindow due to config upgrade"
         );
 
-        let new_window: stellar_xdr::curr::VecM<u64> = window_vec
+        let new_window: stellar_xdr::VecM<u64> = window_vec
             .try_into()
             .map_err(|_| LedgerError::Internal("Failed to convert window vec".to_string()))?;
 
@@ -789,10 +787,7 @@ impl ConfigUpgradeSetFrame {
     /// - V21 (before V22): VerifyEcdsaSecp256r1Sig(44) + 1 = 45
     /// - V22-V24 (before V25): Bls12381FrInv(69) + 1 = 70
     /// - V25+: Bn254FrInv(84) + 1 = 85
-    fn is_valid_cost_params(
-        params: &stellar_xdr::curr::ContractCostParams,
-        ledger_version: u32,
-    ) -> bool {
+    fn is_valid_cost_params(params: &stellar_xdr::ContractCostParams, ledger_version: u32) -> bool {
         // Determine expected number of cost types by protocol version.
         // These values come from the ContractCostType XDR enum.
         let expected_count: usize =
@@ -1038,17 +1033,17 @@ pub struct SorobanUpgradeConfig {
     /// Override for `CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS`.
     /// When `None`, the CPU cost-params entry is **not** included in the set
     /// (stellar-core sets `updated = false`).
-    pub cpu_cost_params: Option<stellar_xdr::curr::ContractCostParams>,
+    pub cpu_cost_params: Option<stellar_xdr::ContractCostParams>,
     /// Override for `CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES`.
     /// When `None`, the memory cost-params entry is **not** included.
-    pub mem_cost_params: Option<stellar_xdr::curr::ContractCostParams>,
+    pub mem_cost_params: Option<stellar_xdr::ContractCostParams>,
     /// Delta for `CONFIG_SETTING_FROZEN_LEDGER_KEYS_DELTA`. The delta settings
     /// have no stored ledger entry; the entry is appended **only** when this is
     /// `Some`.
     pub frozen_ledger_keys_delta: Option<FrozenLedgerKeysDelta>,
     /// Delta for `CONFIG_SETTING_FREEZE_BYPASS_TXS_DELTA`. Appended **only**
     /// when `Some`.
-    pub freeze_bypass_txs_delta: Option<stellar_xdr::curr::FreezeBypassTxsDelta>,
+    pub freeze_bypass_txs_delta: Option<stellar_xdr::FreezeBypassTxsDelta>,
 }
 
 /// Build the serialized `ConfigUpgradeSet` bytes for the `create_upgrade`
@@ -1167,7 +1162,7 @@ pub fn build_config_upgrade_set(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::ContractId;
+    use stellar_xdr::ContractId;
 
     fn make_test_key() -> ConfigUpgradeSetKey {
         ConfigUpgradeSetKey {
@@ -1252,7 +1247,7 @@ mod tests {
     /// below the (incorrect) old Rust minimums but above the real stellar-core minimums.
     #[test]
     fn test_contract_ledger_cost_v0_accepts_stellar_core_minimum_values() {
-        use stellar_xdr::curr::ConfigSettingContractLedgerCostV0;
+        use stellar_xdr::ConfigSettingContractLedgerCostV0;
 
         // Values at the stellar-core minimum floor - must be accepted
         let cost_at_minimum =
@@ -1307,7 +1302,7 @@ mod tests {
     /// MinimumSorobanNetworkConfig floor values, not the higher initial values.
     #[test]
     fn test_all_config_settings_accept_stellar_core_minimum_values() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ConfigSettingContractBandwidthV0, ConfigSettingContractComputeV0,
             ConfigSettingContractEventsV0, StateArchivalSettings,
         };
@@ -1391,8 +1386,8 @@ mod tests {
     }
 
     /// Helper to create valid cost params with the given count.
-    fn make_cost_params(count: usize) -> stellar_xdr::curr::ContractCostParams {
-        use stellar_xdr::curr::{ContractCostParamEntry, ExtensionPoint};
+    fn make_cost_params(count: usize) -> stellar_xdr::ContractCostParams {
+        use stellar_xdr::{ContractCostParamEntry, ExtensionPoint};
 
         let entries: Vec<ContractCostParamEntry> = (0..count)
             .map(|_| ContractCostParamEntry {
@@ -1401,7 +1396,7 @@ mod tests {
                 linear_term: 10,
             })
             .collect();
-        stellar_xdr::curr::ContractCostParams(entries.try_into().unwrap())
+        stellar_xdr::ContractCostParams(entries.try_into().unwrap())
     }
 
     #[test]
@@ -1447,7 +1442,7 @@ mod tests {
 
     #[test]
     fn test_cost_params_validation_negative_values_rejected() {
-        use stellar_xdr::curr::{ContractCostParamEntry, ExtensionPoint};
+        use stellar_xdr::{ContractCostParamEntry, ExtensionPoint};
 
         // Create 85 valid params for V25, then make one have negative constTerm
         let mut entries: Vec<ContractCostParamEntry> = (0..85)
@@ -1458,7 +1453,7 @@ mod tests {
             })
             .collect();
         entries[42].const_term = -1;
-        let params = stellar_xdr::curr::ContractCostParams(entries.try_into().unwrap());
+        let params = stellar_xdr::ContractCostParams(entries.try_into().unwrap());
         assert!(
             !ConfigUpgradeSetFrame::is_valid_cost_params(&params, 25),
             "Negative constTerm should be rejected"
@@ -1473,7 +1468,7 @@ mod tests {
             })
             .collect();
         entries[10].linear_term = -5;
-        let params = stellar_xdr::curr::ContractCostParams(entries.try_into().unwrap());
+        let params = stellar_xdr::ContractCostParams(entries.try_into().unwrap());
         assert!(
             !ConfigUpgradeSetFrame::is_valid_cost_params(&params, 25),
             "Negative linearTerm should be rejected"
@@ -1531,21 +1526,21 @@ mod tests {
         }
     }
 
-    fn test_account_id() -> stellar_xdr::curr::AccountId {
-        stellar_xdr::curr::AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([42u8; 32]),
+    fn test_account_id() -> stellar_xdr::AccountId {
+        stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([42u8; 32]),
         ))
     }
 
-    fn test_issuer_id() -> stellar_xdr::curr::AccountId {
-        stellar_xdr::curr::AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([99u8; 32]),
+    fn test_issuer_id() -> stellar_xdr::AccountId {
+        stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([99u8; 32]),
         ))
     }
 
     #[test]
     fn test_frozen_keys_delta_valid_account_key() {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: test_account_id(),
         });
         let delta = make_freeze_delta(vec![encode_ledger_key(&key)]);
@@ -1573,7 +1568,7 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_valid_contract_code_key() {
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([20u8; 32]),
         });
         let delta = make_freeze_delta(vec![encode_ledger_key(&key)]);
@@ -1586,7 +1581,7 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_valid_trustline_key() {
-        use stellar_xdr::curr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine};
+        use stellar_xdr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine};
         let key = LedgerKey::Trustline(LedgerKeyTrustLine {
             account_id: test_account_id(),
             asset: TrustLineAsset::CreditAlphanum4(AlphaNum4 {
@@ -1615,7 +1610,7 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_rejects_unsupported_key_type_offer() {
-        let key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: test_account_id(),
             offer_id: 42,
         });
@@ -1629,11 +1624,9 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_rejects_unsupported_key_type_data() {
-        let key = LedgerKey::Data(stellar_xdr::curr::LedgerKeyData {
+        let key = LedgerKey::Data(stellar_xdr::LedgerKeyData {
             account_id: test_account_id(),
-            data_name: stellar_xdr::curr::String64(
-                stellar_xdr::curr::StringM::<64>::try_from("test").unwrap(),
-            ),
+            data_name: stellar_xdr::String64(stellar_xdr::StringM::<64>::try_from("test").unwrap()),
         });
         let delta = make_freeze_delta(vec![encode_ledger_key(&key)]);
         let entry = ConfigSettingEntry::FrozenLedgerKeysDelta(delta);
@@ -1645,11 +1638,10 @@ mod tests {
 
     #[test]
     fn test_freeze_bypass_delta_rejected_before_v26() {
-        let entry =
-            ConfigSettingEntry::FreezeBypassTxsDelta(stellar_xdr::curr::FreezeBypassTxsDelta {
-                add_txs: vec![].try_into().unwrap(),
-                remove_txs: vec![].try_into().unwrap(),
-            });
+        let entry = ConfigSettingEntry::FreezeBypassTxsDelta(stellar_xdr::FreezeBypassTxsDelta {
+            add_txs: vec![].try_into().unwrap(),
+            remove_txs: vec![].try_into().unwrap(),
+        });
         assert!(
             !ConfigUpgradeSetFrame::is_valid_config_setting_entry(&entry, 25),
             "FreezeBypassTxsDelta should be rejected before protocol 26"
@@ -1669,10 +1661,10 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_rejects_pool_share_trustline() {
-        use stellar_xdr::curr::LedgerKeyTrustLine;
+        use stellar_xdr::LedgerKeyTrustLine;
         let key = LedgerKey::Trustline(LedgerKeyTrustLine {
             account_id: test_account_id(),
-            asset: TrustLineAsset::PoolShare(stellar_xdr::curr::PoolId(Hash([50u8; 32]))),
+            asset: TrustLineAsset::PoolShare(stellar_xdr::PoolId(Hash([50u8; 32]))),
         });
         let delta = make_freeze_delta(vec![encode_ledger_key(&key)]);
         let entry = ConfigSettingEntry::FrozenLedgerKeysDelta(delta);
@@ -1684,7 +1676,7 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_rejects_issuer_trustline() {
-        use stellar_xdr::curr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine};
+        use stellar_xdr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine};
         // Create a trustline where the account is the issuer of the asset
         let issuer = test_issuer_id();
         let key = LedgerKey::Trustline(LedgerKeyTrustLine {
@@ -1704,7 +1696,7 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_rejects_issuer_trustline_alphanum12() {
-        use stellar_xdr::curr::{AlphaNum12, AssetCode12, LedgerKeyTrustLine};
+        use stellar_xdr::{AlphaNum12, AssetCode12, LedgerKeyTrustLine};
         let issuer = test_issuer_id();
         let key = LedgerKey::Trustline(LedgerKeyTrustLine {
             account_id: issuer.clone(),
@@ -1735,14 +1727,14 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_mixed_valid_and_invalid() {
-        use stellar_xdr::curr::LedgerKeyTrustLine;
+        use stellar_xdr::LedgerKeyTrustLine;
         // First key is valid (account), second is invalid (pool-share trustline)
-        let valid_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let valid_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: test_account_id(),
         });
         let invalid_key = LedgerKey::Trustline(LedgerKeyTrustLine {
             account_id: test_account_id(),
-            asset: TrustLineAsset::PoolShare(stellar_xdr::curr::PoolId(Hash([50u8; 32]))),
+            asset: TrustLineAsset::PoolShare(stellar_xdr::PoolId(Hash([50u8; 32]))),
         });
         let delta = make_freeze_delta(vec![
             encode_ledger_key(&valid_key),
@@ -1757,7 +1749,7 @@ mod tests {
 
     #[test]
     fn test_frozen_keys_delta_rejected_before_v26() {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: test_account_id(),
         });
         let delta = make_freeze_delta(vec![encode_ledger_key(&key)]);
@@ -1785,7 +1777,7 @@ mod tests {
     fn test_apply_to_errors_on_missing_config_setting() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // Build a ConfigUpgradeSetFrame with one setting (ContractComputeV0).
         let upgrade_set = ConfigUpgradeSet {
@@ -1836,7 +1828,7 @@ mod tests {
     fn test_upgrade_needed_all_match() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let compute_setting =
             ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
@@ -1884,7 +1876,7 @@ mod tests {
     fn test_upgrade_needed_one_differs() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let proposed = ConfigSettingEntry::ContractComputeV0(ConfigSettingContractComputeV0 {
             ledger_max_instructions: 200_000_000, // different
@@ -1937,7 +1929,7 @@ mod tests {
     fn test_upgrade_needed_pre_soroban() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let upgrade_set = ConfigUpgradeSet {
             updated_entry: vec![ConfigSettingEntry::ContractComputeV0(
@@ -1975,7 +1967,7 @@ mod tests {
     fn test_upgrade_needed_missing_entry_returns_error() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let upgrade_set = ConfigUpgradeSet {
             updated_entry: vec![ConfigSettingEntry::ContractComputeV0(
@@ -2022,7 +2014,7 @@ mod tests {
     fn test_make_from_key_propagates_get_entry_error() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let key = make_test_key();
 
@@ -2059,7 +2051,7 @@ mod tests {
     fn test_make_from_key_errors_on_missing_ttl() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let key = make_test_key();
         let lk = ConfigUpgradeSetFrame::get_ledger_key(&key);
@@ -2120,7 +2112,7 @@ mod tests {
     fn test_apply_to_captures_window_resize_in_checkpoint() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // Create a StateArchival entry that changes window sample size from 5 to 3
         let old_archival = StateArchivalSettings {
@@ -2234,7 +2226,7 @@ mod tests {
     fn test_apply_to_no_window_changes_when_size_unchanged() {
         use crate::close_state::CloseLedgerState;
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let archival = StateArchivalSettings {
             max_entry_ttl: 100,
@@ -2317,7 +2309,7 @@ mod tests {
     /// the re-emit and skip paths. Non-upgradeable and delta ids are never
     /// queried by the builder.
     fn fixture_load_entry(id: ConfigSettingId) -> Option<ConfigSettingEntry> {
-        use stellar_xdr::curr::ConfigSettingEntry as E;
+        use stellar_xdr::ConfigSettingEntry as E;
         match id {
             ConfigSettingId::ContractMaxSizeBytes => Some(E::ContractMaxSizeBytes(65_536)),
             ConfigSettingId::ContractComputeV0 => Some(E::ContractComputeV0(Default::default())),

--- a/crates/ledger/src/delta.rs
+++ b/crates/ledger/src/delta.rs
@@ -36,7 +36,7 @@
 
 use crate::{LedgerError, Result};
 use std::collections::HashMap;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, LedgerEntry, LedgerEntryChange, LedgerEntryChanges, LedgerEntryData, LedgerKey,
     LedgerKeyAccount, VecM,
 };
@@ -369,10 +369,7 @@ impl LedgerDelta {
     /// Parity: LedgerTxnTests.cpp:853 "fails for configuration"
     pub fn record_delete(&mut self, entry: LedgerEntry) -> Result<()> {
         // ConfigSetting entries cannot be erased (parity: stellar-core LedgerTxn::erase)
-        if matches!(
-            entry.data,
-            stellar_xdr::curr::LedgerEntryData::ConfigSetting(_)
-        ) {
+        if matches!(entry.data, stellar_xdr::LedgerEntryData::ConfigSetting(_)) {
             return Err(LedgerError::InvalidEntry(
                 "cannot delete ConfigSetting entries".to_string(),
             ));
@@ -932,12 +929,12 @@ fn categorize_changes(
             EntryChange::Updated { current, .. } => current,
         };
         let is_offer_or_pool = match &entry_ref.data {
-            stellar_xdr::curr::LedgerEntryData::Offer(_) => {
+            stellar_xdr::LedgerEntryData::Offer(_) => {
                 has_offers = true;
                 true
             }
-            stellar_xdr::curr::LedgerEntryData::Trustline(tl)
-                if matches!(tl.asset, stellar_xdr::curr::TrustLineAsset::PoolShare(_)) =>
+            stellar_xdr::LedgerEntryData::Trustline(tl)
+                if matches!(tl.asset, stellar_xdr::TrustLineAsset::PoolShare(_)) =>
             {
                 has_pool_share_trustlines = true;
                 true
@@ -1041,7 +1038,7 @@ fn emit_new_entry(changes: &mut Vec<LedgerEntryChange>, change: &EntryChange) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, LedgerEntryChange, LedgerEntryData,
         LedgerEntryExt, PublicKey, SequenceNumber, Thresholds, Uint256,
     };
@@ -1059,9 +1056,9 @@ mod tests {
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
+                home_domain: stellar_xdr::String32::default(),
                 thresholds: Thresholds([1, 0, 0, 0]),
-                signers: stellar_xdr::curr::VecM::default(),
+                signers: stellar_xdr::VecM::default(),
                 ext: AccountEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,
@@ -1666,7 +1663,7 @@ mod tests {
     // =========================================================================
 
     fn create_config_setting_entry() -> LedgerEntry {
-        use stellar_xdr::curr::ConfigSettingEntry;
+        use stellar_xdr::ConfigSettingEntry;
 
         LedgerEntry {
             last_modified_ledger_seq: 1,
@@ -1708,7 +1705,7 @@ mod tests {
         // Update is allowed
         let mut updated = config.clone();
         if let LedgerEntryData::ConfigSetting(ref mut setting) = updated.data {
-            *setting = stellar_xdr::curr::ConfigSettingEntry::ContractMaxSizeBytes(32768);
+            *setting = stellar_xdr::ConfigSettingEntry::ContractMaxSizeBytes(32768);
         }
         delta.record_update(config, updated).unwrap();
         assert_eq!(delta.num_changes(), 1);
@@ -1941,7 +1938,7 @@ mod tests {
     /// Regression test for AUDIT-H18.
     #[test]
     fn test_apply_refund_buying_liabilities() {
-        use stellar_xdr::curr::{AccountEntryExtensionV1, AccountEntryExtensionV1Ext, Liabilities};
+        use stellar_xdr::{AccountEntryExtensionV1, AccountEntryExtensionV1Ext, Liabilities};
 
         let mut delta = LedgerDelta::new(1);
 
@@ -1958,9 +1955,9 @@ mod tests {
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
+                home_domain: stellar_xdr::String32::default(),
                 thresholds: Thresholds([1, 0, 0, 0]),
-                signers: stellar_xdr::curr::VecM::default(),
+                signers: stellar_xdr::VecM::default(),
                 ext: AccountEntryExt::V1(AccountEntryExtensionV1 {
                     liabilities: Liabilities {
                         buying: 500,
@@ -2204,8 +2201,8 @@ mod tests {
         key_hash[0] = seed;
         LedgerEntry {
             last_modified_ledger_seq: 1,
-            data: LedgerEntryData::Ttl(stellar_xdr::curr::TtlEntry {
-                key_hash: stellar_xdr::curr::Hash(key_hash),
+            data: LedgerEntryData::Ttl(stellar_xdr::TtlEntry {
+                key_hash: stellar_xdr::Hash(key_hash),
                 live_until_ledger_seq: live_until,
             }),
             ext: LedgerEntryExt::V0,
@@ -2548,8 +2545,8 @@ mod tests {
     fn test_merge_ttl_key_with_non_ttl_data_errors() {
         // TTL key but Account data is an invariant violation — must error.
         let ttl_key_hash = [42u8; 32];
-        let ttl_key = LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl {
-            key_hash: stellar_xdr::curr::Hash(ttl_key_hash),
+        let ttl_key = LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl {
+            key_hash: stellar_xdr::Hash(ttl_key_hash),
         });
 
         // Build a bogus entry: TTL key but Account data

--- a/crates/ledger/src/error.rs
+++ b/crates/ledger/src/error.rs
@@ -58,7 +58,7 @@ pub enum LedgerError {
 
     /// XDR encoding or decoding error.
     #[error("XDR error: {0}")]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     /// Generic serialization error.
     #[error("serialization error: {0}")]

--- a/crates/ledger/src/execution/account_loading.rs
+++ b/crates/ledger/src/execution/account_loading.rs
@@ -3,7 +3,7 @@
 //! Pre-loads accounts, trustlines, and other entries needed by each operation
 //! type before execution. Extracted from the main executor module for readability.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, LedgerKey, LedgerKeyClaimableBalance, LedgerKeyLiquidityPool, LedgerKeyTrustLine,
     Limits, OperationBody, PoolId, TrustLineAsset, WriteXdr,
 };
@@ -22,7 +22,7 @@ impl TransactionExecutor {
     pub(super) fn load_operation_accounts(
         &mut self,
         snapshot: &SnapshotHandle,
-        op: &stellar_xdr::curr::Operation,
+        op: &stellar_xdr::Operation,
         source_id: &AccountId,
     ) -> Result<()> {
         let op_source = op
@@ -153,7 +153,7 @@ impl TransactionExecutor {
                     }
                 }
                 if op_data.offer_id != 0 {
-                    keys.push(LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+                    keys.push(LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
                         seller_id: op_source.clone(),
                         offer_id: op_data.offer_id,
                     }));
@@ -186,7 +186,7 @@ impl TransactionExecutor {
                     }
                 }
                 if op_data.offer_id != 0 {
-                    keys.push(LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+                    keys.push(LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
                         seller_id: op_source.clone(),
                         offer_id: op_data.offer_id,
                     }));
@@ -259,20 +259,20 @@ impl TransactionExecutor {
             OperationBody::ChangeTrust(op_data) => {
                 // Load existing trustline if any
                 let tl_asset = match &op_data.line {
-                    stellar_xdr::curr::ChangeTrustAsset::Native => None,
-                    stellar_xdr::curr::ChangeTrustAsset::CreditAlphanum4(a) => {
+                    stellar_xdr::ChangeTrustAsset::Native => None,
+                    stellar_xdr::ChangeTrustAsset::CreditAlphanum4(a) => {
                         Some(TrustLineAsset::CreditAlphanum4(a.clone()))
                     }
-                    stellar_xdr::curr::ChangeTrustAsset::CreditAlphanum12(a) => {
+                    stellar_xdr::ChangeTrustAsset::CreditAlphanum12(a) => {
                         Some(TrustLineAsset::CreditAlphanum12(a.clone()))
                     }
-                    stellar_xdr::curr::ChangeTrustAsset::PoolShare(params) => {
+                    stellar_xdr::ChangeTrustAsset::PoolShare(params) => {
                         // Compute pool ID from params
                         use sha2::{Digest, Sha256};
                         let xdr = params
                             .to_xdr(Limits::none())
                             .map_err(|e| LedgerError::Serialization(e.to_string()))?;
-                        let pool_id = PoolId(stellar_xdr::curr::Hash(Sha256::digest(&xdr).into()));
+                        let pool_id = PoolId(stellar_xdr::Hash(Sha256::digest(&xdr).into()));
                         Some(TrustLineAsset::PoolShare(pool_id))
                     }
                 };
@@ -295,7 +295,7 @@ impl TransactionExecutor {
                 // which doesn't record the access in transaction changes.
                 // We still need to load the account into state so the existence check works.
                 match &op_data.line {
-                    stellar_xdr::curr::ChangeTrustAsset::CreditAlphanum4(a) => {
+                    stellar_xdr::ChangeTrustAsset::CreditAlphanum4(a) => {
                         let asset_code = String::from_utf8_lossy(a.asset_code.as_slice());
                         tracing::debug!(
                             asset_code = %asset_code,
@@ -304,7 +304,7 @@ impl TransactionExecutor {
                         );
                         self.load_account_without_record(snapshot, &a.issuer)?;
                     }
-                    stellar_xdr::curr::ChangeTrustAsset::CreditAlphanum12(a) => {
+                    stellar_xdr::ChangeTrustAsset::CreditAlphanum12(a) => {
                         let asset_code = String::from_utf8_lossy(a.asset_code.as_slice());
                         tracing::debug!(
                             asset_code = %asset_code,
@@ -313,13 +313,14 @@ impl TransactionExecutor {
                         );
                         self.load_account_without_record(snapshot, &a.issuer)?;
                     }
-                    stellar_xdr::curr::ChangeTrustAsset::PoolShare(params) => {
+                    stellar_xdr::ChangeTrustAsset::PoolShare(params) => {
                         use sha2::{Digest, Sha256};
                         let xdr = params
                             .to_xdr(Limits::none())
                             .map_err(|e| LedgerError::Serialization(e.to_string()))?;
-                        let pool_id = PoolId(stellar_xdr::curr::Hash(Sha256::digest(&xdr).into()));
-                        let stellar_xdr::curr::LiquidityPoolParameters::LiquidityPoolConstantProduct(cp) = params;
+                        let pool_id = PoolId(stellar_xdr::Hash(Sha256::digest(&xdr).into()));
+                        let stellar_xdr::LiquidityPoolParameters::LiquidityPoolConstantProduct(cp) =
+                            params;
                         let mut keys = vec![LedgerKey::LiquidityPool(LedgerKeyLiquidityPool {
                             liquidity_pool_id: pool_id,
                         })];
@@ -340,7 +341,7 @@ impl TransactionExecutor {
             }
             OperationBody::RevokeSponsorship(op_data) => {
                 // Load the target entry that sponsorship is being revoked from
-                use stellar_xdr::curr::RevokeSponsorshipOp;
+                use stellar_xdr::RevokeSponsorshipOp;
                 match op_data {
                     RevokeSponsorshipOp::LedgerEntry(ledger_key) => {
                         // Load the entry directly by its key

--- a/crates/ledger/src/execution/apply.rs
+++ b/crates/ledger/src/execution/apply.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet};
 
 use henyey_crypto::account_id_to_strkey;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, ContractEvent, DiagnosticEvent, LedgerKey, OperationBody, OperationResult,
     OperationType, SorobanTransactionData, TransactionResultCode, TrustLineFlags,
 };
@@ -43,13 +43,13 @@ pub(super) const AUTHORIZED_FLAG: u32 = TrustLineFlags::AuthorizedFlag as u32;
 #[derive(Debug, Clone)]
 pub(super) enum RestoreSource {
     /// Data/code key restored from hot archive with its original entry.
-    HotArchive(Box<stellar_xdr::curr::LedgerEntry>),
+    HotArchive(Box<stellar_xdr::LedgerEntry>),
     /// TTL key for a hot-archive-restored entry with its synthesized TTL entry.
     /// The stored entry represents the TTL value at restoration time (before any
     /// host-side extensions), enabling RESTORED vs RESTORED+UPDATED comparison.
-    HotArchiveTtl(Box<stellar_xdr::curr::LedgerEntry>),
+    HotArchiveTtl(Box<stellar_xdr::LedgerEntry>),
     /// Key restored from live bucket list with its original entry.
-    LiveBucketList(Box<stellar_xdr::curr::LedgerEntry>),
+    LiveBucketList(Box<stellar_xdr::LedgerEntry>),
 }
 
 /// Tracks entries restored from different sources per CAP-0066 (Soroban only).
@@ -150,7 +150,7 @@ impl RestoredEntries {
     /// Iterate hot-archive entries that have original values (data/code keys only).
     pub(super) fn hot_archive_entries_with_originals(
         &self,
-    ) -> impl Iterator<Item = (&LedgerKey, &stellar_xdr::curr::LedgerEntry)> {
+    ) -> impl Iterator<Item = (&LedgerKey, &stellar_xdr::LedgerEntry)> {
         self.entries.iter().filter_map(|(k, v)| match v {
             RestoreSource::HotArchive(entry) => Some((k, entry.as_ref())),
             _ => None,
@@ -160,7 +160,7 @@ impl RestoredEntries {
     // --- Live BL insertion ---
 
     /// Internal: insert a single live-BL key with hot-archive conflict check.
-    fn insert_live_bl_inner(&mut self, key: LedgerKey, original: stellar_xdr::curr::LedgerEntry) {
+    fn insert_live_bl_inner(&mut self, key: LedgerKey, original: stellar_xdr::LedgerEntry) {
         assert!(
             !matches!(
                 self.entries.get(&key),
@@ -230,18 +230,14 @@ impl RestoredEntries {
     /// `build_entry_changes_with_hot_archive`). Production code must use
     /// [`Self::insert_live_bl_pair`] which enforces the atomic pairing invariant.
     #[cfg(test)]
-    pub(super) fn insert_live_bl(
-        &mut self,
-        key: LedgerKey,
-        original: stellar_xdr::curr::LedgerEntry,
-    ) {
+    pub(super) fn insert_live_bl(&mut self, key: LedgerKey, original: stellar_xdr::LedgerEntry) {
         self.insert_live_bl_inner(key, original);
     }
 
     /// Iterate all live-BL entries (key + original entry).
     pub(super) fn live_bl_entries(
         &self,
-    ) -> impl Iterator<Item = (&LedgerKey, &stellar_xdr::curr::LedgerEntry)> {
+    ) -> impl Iterator<Item = (&LedgerKey, &stellar_xdr::LedgerEntry)> {
         self.entries.iter().filter_map(|(k, v)| match v {
             RestoreSource::LiveBucketList(entry) => Some((k, entry.as_ref())),
             _ => None,
@@ -269,7 +265,7 @@ impl RestoredEntries {
     pub(super) fn insert_hot_archive_entry_for_test(
         &mut self,
         key: LedgerKey,
-        original: stellar_xdr::curr::LedgerEntry,
+        original: stellar_xdr::LedgerEntry,
     ) {
         assert!(
             !matches!(key, LedgerKey::Ttl(_)),
@@ -283,7 +279,7 @@ impl RestoredEntries {
     pub(super) fn insert_hot_archive_ttl_for_test(
         &mut self,
         key: LedgerKey,
-        original: stellar_xdr::curr::LedgerEntry,
+        original: stellar_xdr::LedgerEntry,
     ) {
         assert!(
             matches!(key, LedgerKey::Ttl(_)),
@@ -444,7 +440,7 @@ pub(super) fn collect_soroban_restored_entries(
 }
 
 impl TransactionExecutor {
-    /// Build an op-scoped [`stellar_xdr::curr::LedgerHeader`] used as both the
+    /// Build an op-scoped [`stellar_xdr::LedgerHeader`] used as both the
     /// `current` and `previous` header for `ConservationOfLumens`.
     ///
     /// Only `total_coins`/`fee_pool` are read by the invariant, and it reads
@@ -455,8 +451,8 @@ impl TransactionExecutor {
     /// payouts; fee-pool changes are applied at tx-set level via
     /// `record_fee_pool_delta`, outside the per-op delta). The concrete field
     /// values are therefore irrelevant; we emit a minimal header.
-    fn op_scoped_header(&self) -> stellar_xdr::curr::LedgerHeader {
-        use stellar_xdr::curr::{
+    fn op_scoped_header(&self) -> stellar_xdr::LedgerHeader {
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint,
         };
         LedgerHeader {
@@ -961,7 +957,7 @@ impl TransactionExecutor {
                 tracker.consumed_rent_fee,
             ));
             let refund = tracker.refund_amount();
-            let stage = stellar_xdr::curr::TransactionEventStage::AfterAllTxs;
+            let stage = stellar_xdr::TransactionEventStage::AfterAllTxs;
             tx_event_manager.new_fee_event(&fee_source_id, -refund, stage);
             fee_refund = refund;
         }
@@ -1191,7 +1187,7 @@ impl TransactionExecutor {
 mod tests {
     use super::*;
     use henyey_tx::operations::execute::HotArchiveRestore;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, Hash,
         LedgerEntryData, LedgerEntryExt, LedgerKeyContractData, ScAddress, ScVal, TtlEntry,
     };
@@ -1204,8 +1200,8 @@ mod tests {
         })
     }
 
-    fn make_entry(seq: u32) -> stellar_xdr::curr::LedgerEntry {
-        stellar_xdr::curr::LedgerEntry {
+    fn make_entry(seq: u32) -> stellar_xdr::LedgerEntry {
+        stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: seq,
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
@@ -1252,7 +1248,7 @@ mod tests {
             key: ScVal::Void,
             durability: ContractDataDurability::Persistent,
         });
-        let live_entry = stellar_xdr::curr::LedgerEntry {
+        let live_entry = stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
@@ -1327,7 +1323,7 @@ mod tests {
             key: ScVal::Void,
             durability: ContractDataDurability::Persistent,
         });
-        let live_entry = stellar_xdr::curr::LedgerEntry {
+        let live_entry = stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
@@ -1364,7 +1360,7 @@ mod tests {
             key: ScVal::Void,
             durability: ContractDataDurability::Persistent,
         });
-        let live_entry = stellar_xdr::curr::LedgerEntry {
+        let live_entry = stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
@@ -1406,7 +1402,7 @@ mod tests {
             key: ScVal::Void,
             durability: ContractDataDurability::Persistent,
         });
-        let live_entry1 = stellar_xdr::curr::LedgerEntry {
+        let live_entry1 = stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
@@ -1422,7 +1418,7 @@ mod tests {
             key: ScVal::Void,
             durability: ContractDataDurability::Persistent,
         });
-        let live_entry2 = stellar_xdr::curr::LedgerEntry {
+        let live_entry2 = stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
@@ -1450,7 +1446,7 @@ mod tests {
             _ => unreachable!(),
         };
         let entry = make_entry(1);
-        let ttl_entry = stellar_xdr::curr::LedgerEntry {
+        let ttl_entry = stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::Ttl(TtlEntry {
                 key_hash: ttl_key_hash,
@@ -1540,7 +1536,7 @@ mod tests {
     use henyey_common::NetworkId;
     use henyey_tx::soroban::PersistentModuleCache;
     use sha2::{Digest, Sha256};
-    use stellar_xdr::curr::{ContractCodeEntry, ContractCodeEntryExt};
+    use stellar_xdr::{ContractCodeEntry, ContractCodeEntryExt};
 
     /// Valid Soroban WASM fixture A (small contract).
     const WASM_A: &[u8] =
@@ -1567,9 +1563,9 @@ mod tests {
     }
 
     /// Build a `LedgerEntry` wrapping a `ContractCodeEntry` for the given WASM.
-    fn make_contract_code_ledger_entry(wasm: &[u8]) -> stellar_xdr::curr::LedgerEntry {
+    fn make_contract_code_ledger_entry(wasm: &[u8]) -> stellar_xdr::LedgerEntry {
         let hash_bytes: [u8; 32] = Sha256::digest(wasm).into();
-        stellar_xdr::curr::LedgerEntry {
+        stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 100,
             data: LedgerEntryData::ContractCode(ContractCodeEntry {
                 ext: ContractCodeEntryExt::V0,
@@ -1729,14 +1725,12 @@ mod tests {
 
     /// Helper: build a V1 `LedgerEntry` with known cost inputs for the
     /// given WASM blob.
-    fn make_v1_contract_code_ledger_entry(
-        wasm: &[u8],
-    ) -> (stellar_xdr::curr::LedgerEntry, [u8; 32]) {
-        use stellar_xdr::curr::{
+    fn make_v1_contract_code_ledger_entry(wasm: &[u8]) -> (stellar_xdr::LedgerEntry, [u8; 32]) {
+        use stellar_xdr::{
             ContractCodeCostInputs, ContractCodeEntryV1, ExtensionPoint as XdrExtensionPoint,
         };
         let hash_bytes: [u8; 32] = Sha256::digest(wasm).into();
-        let entry = stellar_xdr::curr::LedgerEntry {
+        let entry = stellar_xdr::LedgerEntry {
             last_modified_ledger_seq: 100,
             data: LedgerEntryData::ContractCode(ContractCodeEntry {
                 ext: ContractCodeEntryExt::V1(ContractCodeEntryV1 {

--- a/crates/ledger/src/execution/config.rs
+++ b/crates/ledger/src/execution/config.rs
@@ -731,7 +731,7 @@ mod tests {
     /// non-ConfigSetting LedgerEntryData variant (data corruption).
     #[test]
     fn test_load_config_setting_wrong_data_variant() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountId, LedgerEntryExt, PublicKey, SequenceNumber, Thresholds, Uint256,
         };
 
@@ -774,7 +774,7 @@ mod tests {
 
     /// Helper: create a LedgerEntry wrapping a ConfigSettingEntry.
     fn make_config_entry(setting: ConfigSettingEntry) -> LedgerEntry {
-        use stellar_xdr::curr::LedgerEntryExt;
+        use stellar_xdr::LedgerEntryExt;
         LedgerEntry {
             last_modified_ledger_seq: 1,
             data: LedgerEntryData::ConfigSetting(setting),
@@ -803,7 +803,7 @@ mod tests {
     /// V26+ with both settings present and populated returns correct config.
     #[test]
     fn test_load_frozen_key_config_v26_happy_path() {
-        use stellar_xdr::curr::{EncodedLedgerKey, FreezeBypassTxs, FrozenLedgerKeys, Hash};
+        use stellar_xdr::{EncodedLedgerKey, FreezeBypassTxs, FrozenLedgerKeys, Hash};
 
         let lookup: crate::EntryLookupFn = std::sync::Arc::new(move |key: &LedgerKey| {
             if let LedgerKey::ConfigSetting(cs) = key {
@@ -837,7 +837,7 @@ mod tests {
     /// V26+ with both settings present but empty (VecM::default) succeeds with empty config.
     #[test]
     fn test_load_frozen_key_config_v26_empty_settings() {
-        use stellar_xdr::curr::{FreezeBypassTxs, FrozenLedgerKeys};
+        use stellar_xdr::{FreezeBypassTxs, FrozenLedgerKeys};
 
         let lookup: crate::EntryLookupFn = std::sync::Arc::new(|key: &LedgerKey| {
             if let LedgerKey::ConfigSetting(cs) = key {
@@ -891,7 +891,7 @@ mod tests {
     /// V26+ with missing FreezeBypassTxs setting must error.
     #[test]
     fn test_load_frozen_key_config_missing_bypass_txs() {
-        use stellar_xdr::curr::FrozenLedgerKeys;
+        use stellar_xdr::FrozenLedgerKeys;
 
         let lookup: crate::EntryLookupFn = std::sync::Arc::new(|key: &LedgerKey| {
             if let LedgerKey::ConfigSetting(cs) = key {
@@ -953,7 +953,7 @@ mod tests {
     /// V26+ with wrong ConfigSettingEntry subtype for FreezeBypassTxs must error.
     #[test]
     fn test_load_frozen_key_config_wrong_subtype_bypass_txs() {
-        use stellar_xdr::curr::FrozenLedgerKeys;
+        use stellar_xdr::FrozenLedgerKeys;
 
         // Return correct FrozenLedgerKeys, but wrong subtype for FreezeBypassTxs
         let lookup: crate::EntryLookupFn = std::sync::Arc::new(|key: &LedgerKey| {
@@ -998,7 +998,7 @@ mod tests {
     fn soroban_info_lookup(
         overrides: std::collections::HashMap<ConfigSettingId, Option<ConfigSettingEntry>>,
     ) -> crate::EntryLookupFn {
-        use stellar_xdr::curr::LedgerEntryExt;
+        use stellar_xdr::LedgerEntryExt;
         std::sync::Arc::new(move |key: &LedgerKey| {
             if let LedgerKey::ConfigSetting(cs) = key {
                 let id = cs.config_setting_id;
@@ -1190,7 +1190,7 @@ mod tests {
     /// V23 settings present and correct are loaded properly.
     #[test]
     fn test_load_soroban_network_info_v23_settings_present() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ConfigSettingContractLedgerCostExtV0, ConfigSettingContractParallelComputeV0,
             ConfigSettingScpTiming,
         };
@@ -1271,7 +1271,7 @@ mod tests {
     /// require_config succeeds when the entry exists and the extract closure matches.
     #[test]
     fn test_require_config_happy_path() {
-        use stellar_xdr::curr::ConfigSettingContractComputeV0;
+        use stellar_xdr::ConfigSettingContractComputeV0;
 
         let lookup: crate::EntryLookupFn = std::sync::Arc::new(|key: &LedgerKey| {
             if let LedgerKey::ConfigSetting(cs) = key {
@@ -1339,7 +1339,7 @@ mod tests {
     /// require_config errors when the ConfigSettingEntry variant doesn't match the extractor.
     #[test]
     fn test_require_config_wrong_variant() {
-        use stellar_xdr::curr::ConfigSettingContractComputeV0;
+        use stellar_xdr::ConfigSettingContractComputeV0;
 
         // Store a ContractComputeV0 but try to extract StateArchivalSettings
         let lookup: crate::EntryLookupFn = std::sync::Arc::new(|key: &LedgerKey| {

--- a/crates/ledger/src/execution/meta.rs
+++ b/crates/ledger/src/execution/meta.rs
@@ -15,7 +15,7 @@ pub(super) use henyey_common::asset::non_native_asset_to_trustline_asset as asse
 /// Sorting by (key_hash, type_order) places each TTL immediately before its
 /// associated contract entry.
 fn soroban_create_sort_key(entry: &LedgerEntry) -> Option<(Vec<u8>, u8)> {
-    if let stellar_xdr::curr::LedgerEntryData::Ttl(ttl) = &entry.data {
+    if let stellar_xdr::LedgerEntryData::Ttl(ttl) = &entry.data {
         Some((ttl.key_hash.0.to_vec(), 0))
     } else if henyey_common::is_soroban_entry(entry) {
         let key = henyey_common::entry_to_key(entry);
@@ -26,19 +26,19 @@ fn soroban_create_sort_key(entry: &LedgerEntry) -> Option<(Vec<u8>, u8)> {
     }
 }
 
-pub(super) fn asset_issuer_id(asset: &stellar_xdr::curr::Asset) -> Option<AccountId> {
+pub(super) fn asset_issuer_id(asset: &stellar_xdr::Asset) -> Option<AccountId> {
     henyey_common::asset::get_issuer(asset).ok().cloned()
 }
 
 pub(super) fn make_account_key(account_id: &AccountId) -> LedgerKey {
-    LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     })
 }
 
 pub(super) fn make_trustline_key(
     account_id: &AccountId,
-    asset: &stellar_xdr::curr::TrustLineAsset,
+    asset: &stellar_xdr::TrustLineAsset,
 ) -> LedgerKey {
     LedgerKey::Trustline(LedgerKeyTrustLine {
         account_id: account_id.clone(),
@@ -1048,7 +1048,7 @@ pub(super) struct TransactionMetaParts {
     pub op_changes: Vec<LedgerEntryChanges>,
     pub op_events: Vec<Vec<ContractEvent>>,
     pub tx_events: Vec<TransactionEvent>,
-    pub soroban_return_value: Option<stellar_xdr::curr::ScVal>,
+    pub soroban_return_value: Option<stellar_xdr::ScVal>,
     pub diagnostic_events: Vec<DiagnosticEvent>,
     pub soroban_fee_info: Option<(i64, i64, i64)>,
     pub emit_soroban_tx_meta_ext_v1: bool,
@@ -1152,7 +1152,7 @@ pub(super) fn empty_transaction_meta() -> TransactionMeta {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_ttl_entry(key_hash: [u8; 32], live_until: u32) -> LedgerEntry {
         LedgerEntry {

--- a/crates/ledger/src/execution/mod.rs
+++ b/crates/ledger/src/execution/mod.rs
@@ -54,7 +54,7 @@ use henyey_tx::{
     validation, ClassicEventConfig, LedgerContext, LedgerStateManager, OpEventManager,
     TransactionFrame, TxError, TxEventManager,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountId, AccountMergeResult, AllowTrustOp, AlphaNum12, AlphaNum4, Asset,
     AssetCode, ClaimableBalanceEntry, ClaimableBalanceId, ConfigSettingEntry, ConfigSettingId,
     ContractEvent, CreateClaimableBalanceResult, DiagnosticEvent, ExtensionPoint, InflationResult,
@@ -175,13 +175,13 @@ impl TransactionExecutionRequest {
 }
 
 pub(super) struct OperationExecutionRequest<'a> {
-    pub(super) op: &'a stellar_xdr::curr::Operation,
+    pub(super) op: &'a stellar_xdr::Operation,
     pub(super) source: &'a AccountId,
     pub(super) tx_source: &'a AccountId,
     pub(super) tx_seq: i64,
     pub(super) op_index: u32,
     pub(super) context: &'a LedgerContext,
-    pub(super) soroban_data: Option<&'a stellar_xdr::curr::SorobanTransactionData>,
+    pub(super) soroban_data: Option<&'a stellar_xdr::SorobanTransactionData>,
 }
 
 impl HotArchiveLookupImpl {
@@ -1041,14 +1041,14 @@ impl TransactionExecutor {
         self.loaded_accounts.insert(account_id.clone(), true);
 
         // Try to load from snapshot
-        let key = stellar_xdr::curr::LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = stellar_xdr::LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
 
         if let Some(entry) = self.get_entry_from_snapshot(snapshot, &key)? {
             if record {
                 // Log signer info for debugging (only in record mode)
-                if let stellar_xdr::curr::LedgerEntryData::Account(ref acct) = entry.data {
+                if let stellar_xdr::LedgerEntryData::Account(ref acct) = entry.data {
                     tracing::trace!(
                         account = ?account_id,
                         num_signers = acct.signers.len(),
@@ -1076,7 +1076,7 @@ impl TransactionExecutor {
         &mut self,
         snapshot: &SnapshotHandle,
         account_id: &AccountId,
-        asset: &stellar_xdr::curr::TrustLineAsset,
+        asset: &stellar_xdr::TrustLineAsset,
     ) -> Result<bool> {
         if self
             .state
@@ -1091,13 +1091,13 @@ impl TransactionExecutor {
             return Ok(false);
         }
 
-        let key = stellar_xdr::curr::LedgerKey::Trustline(stellar_xdr::curr::LedgerKeyTrustLine {
+        let key = stellar_xdr::LedgerKey::Trustline(stellar_xdr::LedgerKeyTrustLine {
             account_id: account_id.clone(),
             asset: asset.clone(),
         });
 
         if let Some(entry) = self.get_entry_from_snapshot(snapshot, &key)? {
-            if let stellar_xdr::curr::LedgerEntryData::Trustline(ref tl) = entry.data {
+            if let stellar_xdr::LedgerEntryData::Trustline(ref tl) = entry.data {
                 tracing::debug!(
                     account = %account_id_to_strkey(account_id),
                     asset = ?asset,
@@ -1135,7 +1135,7 @@ impl TransactionExecutor {
             return Ok(false);
         }
 
-        let key = stellar_xdr::curr::LedgerKey::ClaimableBalance(LedgerKeyClaimableBalance {
+        let key = stellar_xdr::LedgerKey::ClaimableBalance(LedgerKeyClaimableBalance {
             balance_id: balance_id.clone(),
         });
 
@@ -1152,7 +1152,7 @@ impl TransactionExecutor {
         &mut self,
         snapshot: &SnapshotHandle,
         account_id: &AccountId,
-        data_name: &stellar_xdr::curr::String64,
+        data_name: &stellar_xdr::String64,
     ) -> Result<bool> {
         // Convert to string for state lookup (matches how data_entries are keyed)
         let name_str = String::from_utf8_lossy(data_name.as_slice()).to_string();
@@ -1167,7 +1167,7 @@ impl TransactionExecutor {
             return Ok(false);
         }
 
-        let key = stellar_xdr::curr::LedgerKey::Data(stellar_xdr::curr::LedgerKeyData {
+        let key = stellar_xdr::LedgerKey::Data(stellar_xdr::LedgerKeyData {
             account_id: account_id.clone(),
             data_name: data_name.clone(),
         });
@@ -1188,7 +1188,7 @@ impl TransactionExecutor {
         seller_id: &AccountId,
         offer_id: i64,
     ) -> Result<()> {
-        let key = stellar_xdr::curr::LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let key = stellar_xdr::LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: seller_id.clone(),
             offer_id,
         });
@@ -1231,7 +1231,7 @@ impl TransactionExecutor {
             return Ok(None);
         }
 
-        let key = stellar_xdr::curr::LedgerKey::LiquidityPool(LedgerKeyLiquidityPool {
+        let key = stellar_xdr::LedgerKey::LiquidityPool(LedgerKeyLiquidityPool {
             liquidity_pool_id: pool_id.clone(),
         });
 
@@ -1281,14 +1281,14 @@ impl TransactionExecutor {
     fn load_path_payment_pools(
         &mut self,
         snapshot: &SnapshotHandle,
-        send_asset: &stellar_xdr::curr::Asset,
-        dest_asset: &stellar_xdr::curr::Asset,
-        path: &[stellar_xdr::curr::Asset],
+        send_asset: &stellar_xdr::Asset,
+        dest_asset: &stellar_xdr::Asset,
+        path: &[stellar_xdr::Asset],
     ) -> Result<()> {
-        use stellar_xdr::curr::{LiquidityPoolConstantProductParameters, LiquidityPoolParameters};
+        use stellar_xdr::{LiquidityPoolConstantProductParameters, LiquidityPoolParameters};
 
         // Build the full conversion path: send_asset -> path[0] -> ... -> dest_asset
-        let mut assets: Vec<&stellar_xdr::curr::Asset> = vec![send_asset];
+        let mut assets: Vec<&stellar_xdr::Asset> = vec![send_asset];
         assets.extend(path.iter());
         assets.push(dest_asset);
 
@@ -1355,7 +1355,7 @@ impl TransactionExecutor {
         for (buying, selling) in pairs {
             for offer_key in self.state.top_n_offer_keys(buying, selling, n) {
                 if let Some(offer) = self.state.get_offer_by_key(&offer_key) {
-                    keys.insert(LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+                    keys.insert(LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                         account_id: offer.seller_id.clone(),
                     }));
                     if let Some(tl_asset) = asset_to_trustline_asset(&offer.selling) {
@@ -1416,7 +1416,7 @@ impl TransactionExecutor {
             .state
             .get_offers_by_account_and_asset(account_id, asset);
         for offer in &offers {
-            let offer_key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+            let offer_key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
                 seller_id: offer.seller_id.clone(),
                 offer_id: offer.offer_id,
             });
@@ -1534,7 +1534,7 @@ impl TransactionExecutor {
     pub fn load_soroban_footprint(
         &mut self,
         snapshot: &SnapshotHandle,
-        footprint: &stellar_xdr::curr::LedgerFootprint,
+        footprint: &stellar_xdr::LedgerFootprint,
     ) -> Result<()> {
         use sha2::{Digest, Sha256};
 
@@ -1577,9 +1577,9 @@ impl TransactionExecutor {
                 let key_bytes = key
                     .to_xdr(Limits::none())
                     .map_err(|e| LedgerError::Serialization(e.to_string()))?;
-                let key_hash = stellar_xdr::curr::Hash(Sha256::digest(&key_bytes).into());
+                let key_hash = stellar_xdr::Hash(Sha256::digest(&key_bytes).into());
                 ttl_key_cache.insert(key.clone(), key_hash.clone());
-                let ttl_key = LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl { key_hash });
+                let ttl_key = LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl { key_hash });
 
                 let entry_in_state = self.state.get_entry(key).is_some();
                 let ttl_in_state = self.state.get_entry(&ttl_key).is_some()
@@ -1765,14 +1765,14 @@ impl TransactionExecutor {
         // This is needed because flush_modified_entries updates snapshots to current values
         let mut state_overrides: HashMap<LedgerKey, LedgerEntry> = HashMap::new();
         if let Some(acc) = self.state.get_account(&fee_source_id) {
-            let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: fee_source_id.clone(),
             });
             state_overrides.insert(key, self.state.ledger_entry_for_account(acc));
         }
         if fee_source_id != inner_source_id {
             if let Some(acc) = self.state.get_account(&inner_source_id) {
-                let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+                let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                     account_id: inner_source_id.clone(),
                 });
                 state_overrides.insert(key, self.state.ledger_entry_for_account(acc));
@@ -1791,7 +1791,7 @@ impl TransactionExecutor {
         if protocol_version_is_before(self.protocol_version, ProtocolVersion::V10) {
             if let Some(acc) = self.state.get_account_mut(&inner_source_id) {
                 // Set the account's seq_num to the transaction's seq_num
-                acc.seq_num = stellar_xdr::curr::SequenceNumber(frame.sequence_number());
+                acc.seq_num = stellar_xdr::SequenceNumber(frame.sequence_number());
                 henyey_tx::state::update_account_seq_info(acc, self.ledger_seq, self.close_time);
             }
         }
@@ -2051,15 +2051,14 @@ impl TransactionExecutor {
         // for metadata. In single-phase mode, the signer removal still happens but the
         // metadata changes are captured by the normal flush mechanism.
         let fee_bump_wrapper_changes = if frame.is_fee_bump() {
-            let fee_source_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            let fee_source_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: fee_source_id.clone(),
             });
             if let Some(fee_source_before) = self.state.get_entry(&fee_source_key) {
                 // Remove the PreAuthTx signer matching the fee bump outer hash from
                 // the fee source, matching stellar-core's removeOneTimeSignerKeyFromFeeSource().
-                let signer_key = stellar_xdr::curr::SignerKey::PreAuthTx(
-                    stellar_xdr::curr::Uint256(outer_hash.0),
-                );
+                let signer_key =
+                    stellar_xdr::SignerKey::PreAuthTx(stellar_xdr::Uint256(outer_hash.0));
                 self.state
                     .remove_account_signer(&fee_source_id, &signer_key)
                     .map_err(|e| LedgerError::Internal(format!("signer removal error: {}", e)))?;
@@ -2416,7 +2415,7 @@ impl TransactionExecutor {
         // Capture pre-mutation state for all source accounts BEFORE any modifications.
         let mut state_overrides = HashMap::new();
         for account_id in &source_accounts {
-            let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: account_id.clone(),
             });
             if let Some(entry) = self.state.get_entry(&key) {
@@ -2427,7 +2426,7 @@ impl TransactionExecutor {
         // Step 1: Sequence bump (processSeqNum equivalent).
         let seq_bump_start = std::time::Instant::now();
         if let Some(acc) = self.state.get_account_mut(inner_source_id) {
-            acc.seq_num = stellar_xdr::curr::SequenceNumber(frame.sequence_number());
+            acc.seq_num = stellar_xdr::SequenceNumber(frame.sequence_number());
             henyey_tx::state::update_account_seq_info(acc, self.ledger_seq, self.close_time);
         }
         let seq_bump_us = seq_bump_start.elapsed().as_micros() as u64;
@@ -2507,13 +2506,12 @@ impl TransactionExecutor {
         // Mirrors FeeBumpTransactionFrame::apply() lines 162-165.
         if frame.is_fee_bump() {
             let fee_source_id = henyey_tx::muxed_to_account_id(&frame.fee_source_account());
-            let fee_source_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            let fee_source_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: fee_source_id.clone(),
             });
             if let Some(fee_source_before) = self.state.get_entry(&fee_source_key) {
-                let signer_key = stellar_xdr::curr::SignerKey::PreAuthTx(
-                    stellar_xdr::curr::Uint256(outer_hash.0),
-                );
+                let signer_key =
+                    stellar_xdr::SignerKey::PreAuthTx(stellar_xdr::Uint256(outer_hash.0));
                 self.state
                     .remove_account_signer(&fee_source_id, &signer_key)
                     .map_err(|e| LedgerError::Internal(format!("signer removal error: {}", e)))?;
@@ -2634,12 +2632,12 @@ pub use henyey_common::ThresholdLevel;
 /// that every signature in the envelope was consumed by at least one check.
 pub(crate) struct SignatureTracker<'a> {
     tx_hash: &'a Hash256,
-    signatures: &'a [stellar_xdr::curr::DecoratedSignature],
+    signatures: &'a [stellar_xdr::DecoratedSignature],
     used: Vec<bool>,
 }
 
 impl<'a> SignatureTracker<'a> {
-    fn new(tx_hash: &'a Hash256, signatures: &'a [stellar_xdr::curr::DecoratedSignature]) -> Self {
+    fn new(tx_hash: &'a Hash256, signatures: &'a [stellar_xdr::DecoratedSignature]) -> Self {
         let used = vec![false; signatures.len()];
         Self {
             tx_hash,
@@ -2657,7 +2655,7 @@ impl<'a> SignatureTracker<'a> {
         let mut signers: Vec<(SignerKey, u32)> = Vec::new();
         let master_weight = account.thresholds.0[0] as u32;
         if master_weight > 0 {
-            let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref key) = account.account_id.0;
+            let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref key) = account.account_id.0;
             let signer_key = SignerKey::Ed25519(key.clone());
             signers.push((signer_key, master_weight));
         }
@@ -2673,7 +2671,7 @@ impl<'a> SignatureTracker<'a> {
     /// source. Creates a synthetic signer with just the account's public key at
     /// weight 1, needed threshold 0.
     fn check_signature_no_account(&mut self, account_id: &AccountId) -> bool {
-        let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref key) = account_id.0;
+        let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref key) = account_id.0;
         let signer_key = SignerKey::Ed25519(key.clone());
         let signers = vec![(signer_key, 1u32)];
         self.check_signature_from_signers(&signers, 0)
@@ -2914,12 +2912,10 @@ pub(crate) fn fee_source_account_id(env: &TransactionEnvelope) -> AccountId {
         TransactionEnvelope::TxFeeBump(e) => e.tx.fee_source.clone(),
     };
     match muxed {
-        MuxedAccount::Ed25519(key) => {
-            AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key))
+        MuxedAccount::Ed25519(key) => AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(key)),
+        MuxedAccount::MuxedEd25519(m) => {
+            AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(m.ed25519))
         }
-        MuxedAccount::MuxedEd25519(m) => AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(m.ed25519),
-        ),
     }
 }
 
@@ -3142,7 +3138,7 @@ mod tests {
     /// for indices in `actual_restored_indices`, not all `archived_soroban_entries`.
     #[test]
     fn test_extract_hot_archive_restored_keys_uses_actual_indices() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, ContractId, LedgerFootprint, LedgerKey, LedgerKeyContractData,
             ScAddress, ScVal, SorobanResources, SorobanResourcesExtV0, SorobanTransactionData,
             SorobanTransactionDataExt,
@@ -3150,17 +3146,17 @@ mod tests {
 
         // Create a footprint with 3 keys in read_write
         let key0 = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(ContractId(stellar_xdr::curr::Hash([0u8; 32]))),
+            contract: ScAddress::Contract(ContractId(stellar_xdr::Hash([0u8; 32]))),
             key: ScVal::U32(0),
             durability: ContractDataDurability::Persistent,
         });
         let key1 = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(ContractId(stellar_xdr::curr::Hash([1u8; 32]))),
+            contract: ScAddress::Contract(ContractId(stellar_xdr::Hash([1u8; 32]))),
             key: ScVal::U32(1),
             durability: ContractDataDurability::Persistent,
         });
         let key2 = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(ContractId(stellar_xdr::curr::Hash([2u8; 32]))),
+            contract: ScAddress::Contract(ContractId(stellar_xdr::Hash([2u8; 32]))),
             key: ScVal::U32(2),
             durability: ContractDataDurability::Persistent,
         });
@@ -3271,14 +3267,14 @@ mod tests {
     /// the result is empty regardless of what the envelope declares.
     #[test]
     fn test_extract_hot_archive_restored_keys_empty_indices() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, ContractId, LedgerFootprint, LedgerKey, LedgerKeyContractData,
             ScAddress, ScVal, SorobanResources, SorobanResourcesExtV0, SorobanTransactionData,
             SorobanTransactionDataExt,
         };
 
         let key0 = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(ContractId(stellar_xdr::curr::Hash([0u8; 32]))),
+            contract: ScAddress::Contract(ContractId(stellar_xdr::Hash([0u8; 32]))),
             key: ScVal::U32(0),
             durability: ContractDataDurability::Persistent,
         });
@@ -3330,13 +3326,13 @@ mod tests {
     #[test]
     fn test_ve06_failed_op_hot_archive_keys_not_collected() {
         use std::collections::HashSet;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, ContractId, LedgerKey, LedgerKeyContractData, OperationResult,
             ScAddress, ScVal,
         };
 
         let archived_key = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(ContractId(stellar_xdr::curr::Hash([0xCCu8; 32]))),
+            contract: ScAddress::Contract(ContractId(stellar_xdr::Hash([0xCCu8; 32]))),
             key: ScVal::U32(42),
             durability: ContractDataDurability::Persistent,
         });
@@ -3348,8 +3344,8 @@ mod tests {
 
         // Case 1: operation succeeded → keys ARE collected.
         let success_result =
-            OperationResult::OpInner(stellar_xdr::curr::OperationResultTr::RestoreFootprint(
-                stellar_xdr::curr::RestoreFootprintResult::Success,
+            OperationResult::OpInner(stellar_xdr::OperationResultTr::RestoreFootprint(
+                stellar_xdr::RestoreFootprintResult::Success,
             ));
         assert!(is_operation_success(&success_result));
 
@@ -3365,8 +3361,8 @@ mod tests {
 
         // Case 2: operation failed → keys are NOT collected (VE-06 fix).
         let failed_result =
-            OperationResult::OpInner(stellar_xdr::curr::OperationResultTr::InvokeHostFunction(
-                stellar_xdr::curr::InvokeHostFunctionResult::EntryArchived,
+            OperationResult::OpInner(stellar_xdr::OperationResultTr::InvokeHostFunction(
+                stellar_xdr::InvokeHostFunctionResult::EntryArchived,
             ));
         assert!(!is_operation_success(&failed_result));
 
@@ -3388,7 +3384,7 @@ mod tests {
     /// structured as a Vec that can accumulate keys across transactions.
     #[test]
     fn test_restored_keys_accumulation_pattern() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, ContractId, LedgerKey, LedgerKeyContractData, ScAddress, ScVal,
         };
 
@@ -3397,7 +3393,7 @@ mod tests {
 
         // TX1 restores key0
         let key0 = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(ContractId(stellar_xdr::curr::Hash([0u8; 32]))),
+            contract: ScAddress::Contract(ContractId(stellar_xdr::Hash([0u8; 32]))),
             key: ScVal::U32(0),
             durability: ContractDataDurability::Persistent,
         });
@@ -3405,7 +3401,7 @@ mod tests {
 
         // TX2 restores key1
         let key1 = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(ContractId(stellar_xdr::curr::Hash([1u8; 32]))),
+            contract: ScAddress::Contract(ContractId(stellar_xdr::Hash([1u8; 32]))),
             key: ScVal::U32(1),
             durability: ContractDataDurability::Persistent,
         });
@@ -3436,7 +3432,7 @@ mod tests {
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
         use crate::LedgerDelta;
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // --- Build a ContractCode entry and its TTL in the snapshot ---
         let code_hash = Hash([0xCC; 32]);
@@ -3567,7 +3563,7 @@ mod tests {
     fn test_deleted_account_not_reloaded_from_snapshot() {
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0xAA; 32])));
         let account_entry = LedgerEntry {
@@ -3645,7 +3641,7 @@ mod tests {
     fn test_load_entry_respects_delta_deleted_keys() {
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // Create an account that exists in the "bucket list" snapshot.
         let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0xBB; 32])));
@@ -3711,7 +3707,7 @@ mod tests {
     fn test_record_entry_access_stamps_loaded_data_entry() {
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let owner = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0x11; 32])));
         let sponsor = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0x22; 32])));
@@ -3782,7 +3778,7 @@ mod tests {
         use crate::soroban_state::SharedSorobanState;
         use sha2::{Digest, Sha256};
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // --- Build a ContractData entry ---
         let contract_address = ScAddress::Contract(ContractId(Hash([0xAB; 32])));
@@ -3882,7 +3878,7 @@ mod tests {
             atomic::{AtomicBool, Ordering},
             Arc,
         };
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let contract_address = ScAddress::Contract(ContractId(Hash([0xCD; 32])));
         let data_key = LedgerKey::ContractData(LedgerKeyContractData {
@@ -3955,7 +3951,7 @@ mod tests {
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
         use sha2::{Digest, Sha256};
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let contract_address = ScAddress::Contract(ContractId(Hash([0xEF; 32])));
         let data_key = LedgerKey::ContractData(LedgerKeyContractData {
@@ -4048,7 +4044,7 @@ mod tests {
         use crate::soroban_state::SharedSorobanState;
         use sha2::{Digest, Sha256};
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // --- Build a ContractData entry ---
         let contract_address = ScAddress::Contract(ContractId(Hash([0x77; 32])));
@@ -4144,7 +4140,7 @@ mod tests {
         use crate::snapshot::{EntriesLookupFn, LedgerSnapshot, SnapshotHandle};
         use std::collections::HashSet;
         use std::sync::Arc;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let make_account_id = |seed: u8| -> AccountId {
             let mut bytes = [0u8; 32];
@@ -4302,7 +4298,7 @@ mod tests {
     #[test]
     fn test_prior_stage_state_filters_non_soroban_deletions() {
         use crate::LedgerDelta;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let mut delta = LedgerDelta::new(101);
 
@@ -4385,11 +4381,11 @@ mod tests {
         assert!(executor.hot_archive_restored_keys().is_empty());
 
         // Record some keys.
-        let key1 = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
-            hash: stellar_xdr::curr::Hash([1u8; 32]),
+        let key1 = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
+            hash: stellar_xdr::Hash([1u8; 32]),
         });
-        let key2 = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
-            hash: stellar_xdr::curr::Hash([2u8; 32]),
+        let key2 = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
+            hash: stellar_xdr::Hash([2u8; 32]),
         });
         executor.record_hot_archive_restores(&[key1.clone(), key2.clone()]);
         assert_eq!(executor.hot_archive_restored_keys().len(), 2);
@@ -4429,11 +4425,11 @@ mod tests {
             ClassicEventConfig::default(),
         );
 
-        let key1 = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
-            hash: stellar_xdr::curr::Hash([10u8; 32]),
+        let key1 = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
+            hash: stellar_xdr::Hash([10u8; 32]),
         });
-        let key2 = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
-            hash: stellar_xdr::curr::Hash([20u8; 32]),
+        let key2 = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
+            hash: stellar_xdr::Hash([20u8; 32]),
         });
 
         // Record one key from "this cluster's" work.
@@ -4456,8 +4452,8 @@ mod tests {
     fn test_prior_stage_state_carries_restored_keys() {
         let delta = crate::LedgerDelta::new(100);
         let mut restored = std::collections::HashSet::new();
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
-            hash: stellar_xdr::curr::Hash([77u8; 32]),
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
+            hash: stellar_xdr::Hash([77u8; 32]),
         });
         restored.insert(key.clone());
 
@@ -4472,7 +4468,7 @@ mod tests {
     /// fields.
     #[test]
     fn test_hot_archive_restored_keys_sort_uses_native_ord() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, ContractId, Hash, LedgerKey, LedgerKeyContractData, ScAddress,
             ScVal,
         };
@@ -4557,7 +4553,7 @@ mod tests {
     #[test]
     fn test_execute_with_pre_apply_result_partial_fee_failing_body() {
         use henyey_crypto::{sign_hash, SecretKey};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountEntryExt, AccountId, DecoratedSignature, LedgerEntry,
             LedgerEntryData, LedgerEntryExt, LedgerKey, MuxedAccount, Operation, OperationBody,
             PaymentOp, Preconditions, PublicKey, SequenceNumber, SignatureHint, Thresholds,
@@ -4579,7 +4575,7 @@ mod tests {
             *secret.public_key().as_bytes(),
         )));
 
-        let account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: source_id.clone(),
         });
         let account_entry = LedgerEntry {
@@ -4610,7 +4606,7 @@ mod tests {
             source_account: None,
             body: OperationBody::Payment(PaymentOp {
                 destination: dest,
-                asset: stellar_xdr::curr::Asset::Native,
+                asset: stellar_xdr::Asset::Native,
                 amount: 1,
             }),
         };
@@ -4619,7 +4615,7 @@ mod tests {
             fee: 200,
             seq_num: SequenceNumber(2),
             cond: Preconditions::None,
-            memo: stellar_xdr::curr::Memo::None,
+            memo: stellar_xdr::Memo::None,
             operations: vec![op].try_into().unwrap(),
             ext: TransactionExt::V0,
         };
@@ -4638,7 +4634,7 @@ mod tests {
         let hint = SignatureHint([pk_bytes[28], pk_bytes[29], pk_bytes[30], pk_bytes[31]]);
         let decorated = DecoratedSignature {
             hint,
-            signature: stellar_xdr::curr::Signature(signature.0.to_vec().try_into().unwrap()),
+            signature: stellar_xdr::Signature(signature.0.to_vec().try_into().unwrap()),
         };
         if let TransactionEnvelope::Tx(ref mut env) = envelope {
             env.signatures = vec![decorated].try_into().unwrap();

--- a/crates/ledger/src/execution/preconditions.rs
+++ b/crates/ledger/src/execution/preconditions.rs
@@ -11,7 +11,7 @@ use henyey_tx::{
     validation::{self, LedgerContext as ValidationContext},
     TransactionFrame,
 };
-use stellar_xdr::curr::{Preconditions, TransactionEnvelope, TransactionResultCode};
+use stellar_xdr::{Preconditions, TransactionEnvelope, TransactionResultCode};
 
 use crate::snapshot::SnapshotHandle;
 use crate::{LedgerError, Result};
@@ -180,7 +180,7 @@ impl TransactionExecutor {
                 .envelope()
             {
                 TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-                    stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+                    stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                         let inner_env = TransactionEnvelope::Tx(inner.clone());
                         let inner_frame =
                             TransactionFrame::from_owned_with_network(inner_env, self.network_id);

--- a/crates/ledger/src/execution/result_mapping.rs
+++ b/crates/ledger/src/execution/result_mapping.rs
@@ -40,17 +40,17 @@ pub(super) fn insufficient_refundable_fee_result(op: &Operation) -> OperationRes
     match &op.body {
         OperationBody::InvokeHostFunction(_) => {
             OperationResult::OpInner(OperationResultTr::InvokeHostFunction(
-                stellar_xdr::curr::InvokeHostFunctionResult::InsufficientRefundableFee,
+                stellar_xdr::InvokeHostFunctionResult::InsufficientRefundableFee,
             ))
         }
         OperationBody::ExtendFootprintTtl(_) => {
             OperationResult::OpInner(OperationResultTr::ExtendFootprintTtl(
-                stellar_xdr::curr::ExtendFootprintTtlResult::InsufficientRefundableFee,
+                stellar_xdr::ExtendFootprintTtlResult::InsufficientRefundableFee,
             ))
         }
         OperationBody::RestoreFootprint(_) => {
             OperationResult::OpInner(OperationResultTr::RestoreFootprint(
-                stellar_xdr::curr::RestoreFootprintResult::InsufficientRefundableFee,
+                stellar_xdr::RestoreFootprintResult::InsufficientRefundableFee,
             ))
         }
         _ => OperationResult::OpNotSupported,
@@ -170,7 +170,7 @@ pub fn build_tx_result_pair(
         };
 
         let inner_pair = InnerTransactionResultPair {
-            transaction_hash: stellar_xdr::curr::Hash(inner_hash.0),
+            transaction_hash: stellar_xdr::Hash(inner_hash.0),
             result: InnerTransactionResult {
                 fee_charged: inner_fee_charged,
                 result: inner_result,
@@ -216,7 +216,7 @@ pub fn build_tx_result_pair(
     };
 
     Ok(TransactionResultPair {
-        transaction_hash: stellar_xdr::curr::Hash(tx_hash.0),
+        transaction_hash: stellar_xdr::Hash(tx_hash.0),
         result,
     })
 }
@@ -225,7 +225,7 @@ pub fn build_tx_result_pair(
 mod tests {
     use super::*;
     use henyey_common::NetworkId;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         CreateAccountOp, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionInnerTx,
         HostFunction, InvokeHostFunctionOp, LedgerFootprint, Memo, SequenceNumber,
         SorobanResources, SorobanTransactionDataExt, Transaction, TransactionExt,
@@ -235,7 +235,7 @@ mod tests {
     /// Build a classic fee-bump TransactionFrame with configurable inner fee and op count.
     fn make_classic_fee_bump_frame(inner_fee: u32, num_ops: usize) -> TransactionFrame {
         let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));
-        let destination = AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
+        let destination = AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
             [1u8; 32],
         )));
 
@@ -267,7 +267,7 @@ mod tests {
             fee_source: source,
             fee: (inner_fee as i64) * 2,
             inner_tx: FeeBumpTransactionInnerTx::Tx(inner_env),
-            ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+            ext: stellar_xdr::FeeBumpTransactionExt::V0,
         };
 
         let envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -286,15 +286,13 @@ mod tests {
         let operation = Operation {
             source_account: None,
             body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-                host_function: HostFunction::InvokeContract(
-                    stellar_xdr::curr::InvokeContractArgs {
-                        contract_address: stellar_xdr::curr::ScAddress::Contract(
-                            stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash([0u8; 32])),
-                        ),
-                        function_name: stellar_xdr::curr::ScSymbol("test".try_into().unwrap()),
-                        args: VecM::default(),
-                    },
-                ),
+                host_function: HostFunction::InvokeContract(stellar_xdr::InvokeContractArgs {
+                    contract_address: stellar_xdr::ScAddress::Contract(stellar_xdr::ContractId(
+                        stellar_xdr::Hash([0u8; 32]),
+                    )),
+                    function_name: stellar_xdr::ScSymbol("test".try_into().unwrap()),
+                    args: VecM::default(),
+                }),
                 auth: VecM::default(),
             }),
         };
@@ -332,7 +330,7 @@ mod tests {
             fee_source: source,
             fee: (inner_fee as i64) * 2,
             inner_tx: FeeBumpTransactionInnerTx::Tx(inner_env),
-            ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+            ext: stellar_xdr::FeeBumpTransactionExt::V0,
         };
 
         let envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {

--- a/crates/ledger/src/execution/signatures.rs
+++ b/crates/ledger/src/execution/signatures.rs
@@ -11,8 +11,8 @@ use henyey_tx::OperationTypeExt;
 pub(super) fn is_operation_success(result: &OperationResult) -> bool {
     match result {
         OperationResult::OpInner(inner) => {
-            use stellar_xdr::curr::OperationResultTr;
-            use stellar_xdr::curr::*;
+            use stellar_xdr::OperationResultTr;
+            use stellar_xdr::*;
             match inner {
                 OperationResultTr::CreateAccount(r) => {
                     matches!(r, CreateAccountResult::Success)
@@ -104,7 +104,7 @@ pub(super) fn is_operation_success(result: &OperationResult) -> bool {
 
 pub(super) fn has_sufficient_signer_weight(
     tx_hash: &Hash256,
-    signatures: &[stellar_xdr::curr::DecoratedSignature],
+    signatures: &[stellar_xdr::DecoratedSignature],
     account: &AccountEntry,
     required_weight: u32,
 ) -> bool {
@@ -112,7 +112,7 @@ pub(super) fn has_sufficient_signer_weight(
     let mut counted: HashSet<Hash256> = HashSet::new();
 
     // Master key signer.
-    let stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref master_key) = account.account_id.0;
+    let stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref master_key) = account.account_id.0;
     let master_key_bytes = &master_key.0;
     let master_weight = account.thresholds.0[0] as u32;
     tracing::trace!(
@@ -179,7 +179,7 @@ pub(super) fn has_sufficient_signer_weight(
 
 pub(super) fn has_required_extra_signers(
     tx_hash: &Hash256,
-    signatures: &[stellar_xdr::curr::DecoratedSignature],
+    signatures: &[stellar_xdr::DecoratedSignature],
     extra_signers: &[SignerKey],
 ) -> bool {
     extra_signers.iter().all(|signer| match signer {
@@ -203,7 +203,7 @@ pub(super) fn has_required_extra_signers(
 /// and tx-set validation (`validate_fee_bump_for_tx_set`).
 pub(super) fn fee_bump_outer_auth_check(
     tx_hash: &Hash256,
-    signatures: &[stellar_xdr::curr::DecoratedSignature],
+    signatures: &[stellar_xdr::DecoratedSignature],
     fee_source_account: &AccountEntry,
 ) -> bool {
     let required_weight = threshold_low(fee_source_account);
@@ -216,7 +216,7 @@ pub(super) fn fee_bump_inner_hash(
 ) -> Result<Hash256> {
     match frame.envelope() {
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                 let inner_env = TransactionEnvelope::Tx(inner.clone());
                 let inner_frame = TransactionFrame::from_owned_with_network(inner_env, *network_id);
                 inner_frame
@@ -289,8 +289,8 @@ pub(super) fn get_needed_threshold(account: &AccountEntry, level: ThresholdLevel
 
 /// Check if a decorated signature matches an Ed25519SignedPayload signer key.
 pub(super) fn has_signed_payload_match(
-    sig: &stellar_xdr::curr::DecoratedSignature,
-    signed_payload: &stellar_xdr::curr::SignerKeyEd25519SignedPayload,
+    sig: &stellar_xdr::DecoratedSignature,
+    signed_payload: &stellar_xdr::SignerKeyEd25519SignedPayload,
 ) -> bool {
     henyey_crypto::verify_ed25519_signed_payload(sig, signed_payload)
 }
@@ -333,7 +333,7 @@ pub(super) fn check_operation_signatures(
     frame: &TransactionFrame,
     state: &LedgerStateManager,
     tx_hash: &Hash256,
-    signatures: &[stellar_xdr::curr::DecoratedSignature],
+    signatures: &[stellar_xdr::DecoratedSignature],
     inner_source_id: &AccountId,
 ) -> Option<(Vec<OperationResult>, ExecutionFailure)> {
     // Create a signature tracker for used-signature tracking
@@ -450,7 +450,7 @@ pub(super) fn check_operation_signatures(
 /// OperationResult defaults to opINNER with a default inner result for the
 /// operation type (typically the "Success" variant).
 pub(super) fn default_success_op_result(op: &Operation) -> OperationResult {
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     let inner = match &op.body {
         OperationBody::CreateAccount(_) => {
@@ -543,20 +543,20 @@ pub(super) fn default_success_op_result(op: &Operation) -> OperationResult {
 /// Default empty offer success result used for manage offer operations.
 /// stellar-core default-constructs ManageOfferSuccessResult with MANAGE_OFFER_CREATED (0)
 /// discriminant and a zero-initialized OfferEntry payload.
-fn empty_offer_success_result() -> stellar_xdr::curr::ManageOfferSuccessResult {
-    stellar_xdr::curr::ManageOfferSuccessResult {
+fn empty_offer_success_result() -> stellar_xdr::ManageOfferSuccessResult {
+    stellar_xdr::ManageOfferSuccessResult {
         offers_claimed: VecM::default(),
-        offer: stellar_xdr::curr::ManageOfferSuccessResultOffer::Created(
-            stellar_xdr::curr::OfferEntry::default(),
+        offer: stellar_xdr::ManageOfferSuccessResultOffer::Created(
+            stellar_xdr::OfferEntry::default(),
         ),
     }
 }
 
 /// Default zero-value simple payment result used for path payment operations.
-fn zero_simple_payment_result() -> stellar_xdr::curr::SimplePaymentResult {
-    stellar_xdr::curr::SimplePaymentResult {
-        destination: AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([0; 32]),
+fn zero_simple_payment_result() -> stellar_xdr::SimplePaymentResult {
+    stellar_xdr::SimplePaymentResult {
+        destination: AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([0; 32]),
         )),
         asset: Asset::Native,
         amount: 0,
@@ -564,15 +564,13 @@ fn zero_simple_payment_result() -> stellar_xdr::curr::SimplePaymentResult {
 }
 
 pub(super) fn signer_key_id(key: &SignerKey) -> Hash256 {
-    let bytes = key
-        .to_xdr(stellar_xdr::curr::Limits::none())
-        .unwrap_or_default();
+    let bytes = key.to_xdr(stellar_xdr::Limits::none()).unwrap_or_default();
     Hash256::hash(&bytes)
 }
 
 pub(super) fn has_ed25519_signature_raw(
     tx_hash: &Hash256,
-    signatures: &[stellar_xdr::curr::DecoratedSignature],
+    signatures: &[stellar_xdr::DecoratedSignature],
     key_bytes: &[u8; 32],
 ) -> bool {
     signatures
@@ -581,8 +579,8 @@ pub(super) fn has_ed25519_signature_raw(
 }
 
 pub(super) fn has_hashx_signature(
-    signatures: &[stellar_xdr::curr::DecoratedSignature],
-    key: &stellar_xdr::curr::Uint256,
+    signatures: &[stellar_xdr::DecoratedSignature],
+    key: &stellar_xdr::Uint256,
 ) -> bool {
     signatures.iter().any(|sig| {
         // HashX signatures can be any length - the signature is the preimage
@@ -600,8 +598,8 @@ pub(super) fn has_hashx_signature(
 
 pub(super) fn has_signed_payload_signature(
     _tx_hash: &Hash256,
-    signatures: &[stellar_xdr::curr::DecoratedSignature],
-    signed_payload: &stellar_xdr::curr::SignerKeyEd25519SignedPayload,
+    signatures: &[stellar_xdr::DecoratedSignature],
+    signed_payload: &stellar_xdr::SignerKeyEd25519SignedPayload,
 ) -> bool {
     signatures
         .iter()
@@ -676,7 +674,7 @@ pub(super) fn check_operations_valid(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     #[test]
     fn test_default_success_op_result_create_passive_sell_offer() {

--- a/crates/ledger/src/execution/tx_set.rs
+++ b/crates/ledger/src/execution/tx_set.rs
@@ -425,8 +425,8 @@ fn apply_soroban_fee_refunds(
     tx_result_metas: &mut [TransactionResultMetaV1],
     ledger_seq: u32,
     protocol_version: u32,
-) -> Vec<(usize, stellar_xdr::curr::LedgerEntryChanges)> {
-    use stellar_xdr::curr::{LedgerEntryChange, LedgerEntryChanges, LedgerKeyAccount};
+) -> Vec<(usize, stellar_xdr::LedgerEntryChanges)> {
+    use stellar_xdr::{LedgerEntryChange, LedgerEntryChanges, LedgerKeyAccount};
 
     let mut total_refunds = 0i64;
     let mut per_tx_changes = Vec::new();
@@ -885,13 +885,13 @@ pub fn execute_soroban_parallel_phase(
     // Only adjust fee pool if the refund was actually credited.
     // On failure, correct fee_charged back to full pre-charged fee (AUDIT-233).
     // Also capture STATE/UPDATED changes for post_tx_apply_fee_processing meta.
-    use stellar_xdr::curr::{LedgerEntryChange, LedgerEntryChanges};
+    use stellar_xdr::{LedgerEntryChange, LedgerEntryChanges};
     let mut total_refunds = 0i64;
     for idx in 0..all_results.len() {
         let refund = all_results[idx].fee_refund;
         if refund > 0 && idx < flat_txs.len() {
             let source = fee_source_account_id(flat_txs[idx]);
-            let account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            let account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: source.clone(),
             });
             let pre_entry = delta.get_current_entry(&account_key);
@@ -987,14 +987,14 @@ pub(crate) fn pre_deduct_all_fees_on_delta(
                     .sum::<usize>(),
         );
         for (tx, _) in classic_txs {
-            fee_keys.push(LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            fee_keys.push(LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: fee_source_account_id(tx),
             }));
         }
         for stage in &soroban_phase.stages {
             for cluster in stage {
                 for (tx, _) in cluster {
-                    fee_keys.push(LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+                    fee_keys.push(LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                         account_id: fee_source_account_id(tx),
                     }));
                 }
@@ -1060,12 +1060,12 @@ pub(crate) fn pre_deduct_all_fees_on_delta(
 fn soroban_write_footprint(tx: &TransactionEnvelope) -> Option<Vec<LedgerKey>> {
     let data = match tx {
         TransactionEnvelope::Tx(env) => match &env.tx.ext {
-            stellar_xdr::curr::TransactionExt::V1(data) => Some(data),
+            stellar_xdr::TransactionExt::V1(data) => Some(data),
             _ => None,
         },
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => match &inner.tx.ext {
-                stellar_xdr::curr::TransactionExt::V1(data) => Some(data),
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => match &inner.tx.ext {
+                stellar_xdr::TransactionExt::V1(data) => Some(data),
                 _ => None,
             },
         },
@@ -1617,7 +1617,7 @@ pub fn compute_state_size_window_entry(
     sample_size: u32,
 ) -> Result<Option<LedgerEntry>> {
     use henyey_common::protocol::MIN_SOROBAN_PROTOCOL_VERSION;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ConfigSettingEntry, ConfigSettingId, LedgerEntryData, LedgerEntryExt, LedgerKey,
         LedgerKeyConfigSetting, VecM,
     };
@@ -1746,7 +1746,7 @@ fn collect_dex_asset_pairs(transactions: &[TxWithFee]) -> HashSet<(Asset, Asset)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, AlphaNum4, Asset, AssetCode4, ManageSellOfferOp, Memo, MuxedAccount,
         PathPaymentStrictReceiveOp, Preconditions, PublicKey, SequenceNumber, Transaction,
         TransactionExt, TransactionV1Envelope, Uint256, VecM,
@@ -1803,7 +1803,7 @@ mod tests {
                 selling: Asset::Native,
                 buying: usd.clone(),
                 amount: 100,
-                price: stellar_xdr::curr::Price { n: 1, d: 1 },
+                price: stellar_xdr::Price { n: 1, d: 1 },
                 offer_id: 0,
             },
         ))]);
@@ -1814,11 +1814,11 @@ mod tests {
 
         // ManageBuyOffer also captured
         let tx2 = make_tx_with_ops(vec![op(OperationBody::ManageBuyOffer(
-            stellar_xdr::curr::ManageBuyOfferOp {
+            stellar_xdr::ManageBuyOfferOp {
                 selling: eur.clone(),
                 buying: usd.clone(),
                 buy_amount: 100,
-                price: stellar_xdr::curr::Price { n: 2, d: 1 },
+                price: stellar_xdr::Price { n: 2, d: 1 },
                 offer_id: 0,
             },
         ))]);
@@ -1857,13 +1857,11 @@ mod tests {
     mod compute_state_size_window {
         use super::*;
         use henyey_bucket::BucketList;
-        use stellar_xdr::curr::{
-            BucketListType, ConfigSettingEntry, LedgerEntryData, LedgerEntryExt,
-        };
+        use stellar_xdr::{BucketListType, ConfigSettingEntry, LedgerEntryData, LedgerEntryExt};
 
         fn make_bucket_list_with_window(window: Vec<u64>) -> BucketList {
             let mut bl = BucketList::new();
-            let window_vecm: stellar_xdr::curr::VecM<u64> = window.try_into().unwrap();
+            let window_vecm: stellar_xdr::VecM<u64> = window.try_into().unwrap();
             let entry = LedgerEntry {
                 last_modified_ledger_seq: 1,
                 data: LedgerEntryData::ConfigSetting(
@@ -1961,7 +1959,7 @@ mod tests {
 
     fn make_simple_tx_result_pair(fee_charged: i64) -> TransactionResultPair {
         TransactionResultPair {
-            transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            transaction_hash: stellar_xdr::Hash([0u8; 32]),
             result: TransactionResult {
                 fee_charged,
                 result: TransactionResultResult::TxSuccess(Vec::new().try_into().unwrap()),
@@ -1975,7 +1973,7 @@ mod tests {
         inner_fee_charged: i64,
     ) -> TransactionResultPair {
         let inner_pair = InnerTransactionResultPair {
-            transaction_hash: stellar_xdr::curr::Hash([1u8; 32]),
+            transaction_hash: stellar_xdr::Hash([1u8; 32]),
             result: InnerTransactionResult {
                 fee_charged: inner_fee_charged,
                 result: InnerTransactionResultResult::TxSuccess(Vec::new().try_into().unwrap()),
@@ -1983,7 +1981,7 @@ mod tests {
             },
         };
         TransactionResultPair {
-            transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            transaction_hash: stellar_xdr::Hash([0u8; 32]),
             result: TransactionResult {
                 fee_charged: outer_fee_charged,
                 result: TransactionResultResult::TxFeeBumpInnerSuccess(inner_pair),
@@ -2030,7 +2028,7 @@ mod tests {
     fn test_correct_fee_charged_fee_bump_inner_failed_protocol_24() {
         // Fee-bump inner failed on p24: both outer and inner should be corrected
         let inner_pair = InnerTransactionResultPair {
-            transaction_hash: stellar_xdr::curr::Hash([1u8; 32]),
+            transaction_hash: stellar_xdr::Hash([1u8; 32]),
             result: InnerTransactionResult {
                 fee_charged: 4000,
                 result: InnerTransactionResultResult::TxFailed(Vec::new().try_into().unwrap()),
@@ -2038,7 +2036,7 @@ mod tests {
             },
         };
         let mut pair = TransactionResultPair {
-            transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            transaction_hash: stellar_xdr::Hash([0u8; 32]),
             result: TransactionResult {
                 fee_charged: 7000,
                 result: TransactionResultResult::TxFeeBumpInnerFailed(inner_pair),

--- a/crates/ledger/src/header.rs
+++ b/crates/ledger/src/header.rs
@@ -27,7 +27,7 @@
 
 use crate::{LedgerError, Result};
 use henyey_common::Hash256;
-use stellar_xdr::curr::{LedgerHeader, Limits, WriteXdr};
+use stellar_xdr::{LedgerHeader, Limits, WriteXdr};
 
 /// Skip list update intervals (from stellar-core).
 /// The skip list stores bucket_list_hash values at these intervals.
@@ -45,7 +45,7 @@ pub struct NextHeaderFields {
     pub total_coins: i64,
     pub fee_pool: i64,
     pub inflation_seq: u32,
-    pub stellar_value_ext: stellar_xdr::curr::StellarValueExt,
+    pub stellar_value_ext: stellar_xdr::StellarValueExt,
 }
 
 /// Compute the canonical hash of a ledger header.
@@ -96,7 +96,7 @@ pub fn compute_header_hash(header: &LedgerHeader) -> Result<Hash256> {
 ///
 /// This must be called after setting the bucket_list_hash but before computing
 /// the header hash.
-pub fn calculate_skip_values(header: &LedgerHeader) -> [stellar_xdr::curr::Hash; 4] {
+pub fn calculate_skip_values(header: &LedgerHeader) -> [stellar_xdr::Hash; 4] {
     let seq = header.ledger_seq;
     let mut skip_list = header.skip_list.clone();
 
@@ -205,10 +205,10 @@ pub fn create_next_header(
     let mut header = LedgerHeader {
         ledger_version: prev_header.ledger_version,
         previous_ledger_hash: prev_header_hash.into(),
-        scp_value: stellar_xdr::curr::StellarValue {
+        scp_value: stellar_xdr::StellarValue {
             tx_set_hash: fields.tx_set_hash.into(),
-            close_time: stellar_xdr::curr::TimePoint(fields.close_time),
-            upgrades: stellar_xdr::curr::VecM::default(),
+            close_time: stellar_xdr::TimePoint(fields.close_time),
+            upgrades: stellar_xdr::VecM::default(),
             ext: fields.stellar_value_ext,
         },
         tx_set_result_hash: fields.tx_set_result_hash.into(),
@@ -252,17 +252,17 @@ pub fn protocol_version(header: &LedgerHeader) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::Hash;
+    use stellar_xdr::Hash;
 
     fn create_test_header(seq: u32) -> LedgerHeader {
         LedgerHeader {
             ledger_version: 20,
             previous_ledger_hash: Hash([0u8; 32]),
-            scp_value: stellar_xdr::curr::StellarValue {
+            scp_value: stellar_xdr::StellarValue {
                 tx_set_hash: Hash([0u8; 32]),
-                close_time: stellar_xdr::curr::TimePoint(1000 + seq as u64),
-                upgrades: stellar_xdr::curr::VecM::default(),
-                ext: stellar_xdr::curr::StellarValueExt::Basic,
+                close_time: stellar_xdr::TimePoint(1000 + seq as u64),
+                upgrades: stellar_xdr::VecM::default(),
+                ext: stellar_xdr::StellarValueExt::Basic,
             },
             tx_set_result_hash: Hash([0u8; 32]),
             bucket_list_hash: Hash([0u8; 32]),
@@ -275,7 +275,7 @@ mod tests {
             base_reserve: 5_000_000,
             max_tx_set_size: 1000,
             skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
-            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            ext: stellar_xdr::LedgerHeaderExt::V0,
         }
     }
 
@@ -328,7 +328,7 @@ mod tests {
                 total_coins: 100_000_000_000_000_000,
                 fee_pool: 0,
                 inflation_seq: 0,
-                stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
             },
         );
         assert!(result.is_err(), "Should fail on ledger_seq overflow");
@@ -349,7 +349,7 @@ mod tests {
                 total_coins: 100_000_000_000_000_000,
                 fee_pool: 0,
                 inflation_seq: 0,
-                stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
             },
         );
         assert!(result.is_ok());
@@ -371,7 +371,7 @@ mod tests {
                 total_coins: 100_000_000_000_000_000,
                 fee_pool: -1,
                 inflation_seq: 0,
-                stellar_value_ext: stellar_xdr::curr::StellarValueExt::Basic,
+                stellar_value_ext: stellar_xdr::StellarValueExt::Basic,
             },
         );
         assert!(result.is_err(), "Should fail on negative fee_pool");

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -129,10 +129,7 @@ pub type Result<T> = std::result::Result<T, LedgerError>;
 /// view with delta overlay) implement this trait, allowing config-loading and
 /// other read-path code to be generic over the entry source.
 pub trait EntryReader {
-    fn get_entry(
-        &self,
-        key: &stellar_xdr::curr::LedgerKey,
-    ) -> Result<Option<stellar_xdr::curr::LedgerEntry>>;
+    fn get_entry(&self, key: &stellar_xdr::LedgerKey) -> Result<Option<stellar_xdr::LedgerEntry>>;
 }
 
 /// Simplified view of the current ledger header.
@@ -166,8 +163,8 @@ pub struct LedgerInfo {
     pub protocol_version: u32,
 }
 
-impl From<&stellar_xdr::curr::LedgerHeader> for LedgerInfo {
-    fn from(header: &stellar_xdr::curr::LedgerHeader) -> Self {
+impl From<&stellar_xdr::LedgerHeader> for LedgerInfo {
+    fn from(header: &stellar_xdr::LedgerHeader) -> Self {
         Self {
             sequence: header.ledger_seq,
             previous_ledger_hash: henyey_common::Hash256::from(header.previous_ledger_hash.0),
@@ -205,7 +202,7 @@ impl From<&stellar_xdr::curr::LedgerHeader> for LedgerInfo {
 ///
 /// These affect the available balance for sending and receiving.
 pub mod reserves {
-    use stellar_xdr::curr::AccountEntry;
+    use stellar_xdr::AccountEntry;
 
     /// Number of stroops per XLM (1 XLM = 10,000,000 stroops).
     pub const STROOPS_PER_XLM: i64 = 10_000_000;
@@ -233,10 +230,10 @@ pub mod reserves {
 
         // Get sponsorship info if available
         let (num_sponsoring, num_sponsored) = match &account.ext {
-            stellar_xdr::curr::AccountEntryExt::V0 => (0, 0),
-            stellar_xdr::curr::AccountEntryExt::V1(v1) => match &v1.ext {
-                stellar_xdr::curr::AccountEntryExtensionV1Ext::V0 => (0, 0),
-                stellar_xdr::curr::AccountEntryExtensionV1Ext::V2(v2) => {
+            stellar_xdr::AccountEntryExt::V0 => (0, 0),
+            stellar_xdr::AccountEntryExt::V1(v1) => match &v1.ext {
+                stellar_xdr::AccountEntryExtensionV1Ext::V0 => (0, 0),
+                stellar_xdr::AccountEntryExtensionV1Ext::V2(v2) => {
                     (v2.num_sponsoring as i64, v2.num_sponsored as i64)
                 }
             },
@@ -258,8 +255,8 @@ pub mod reserves {
     /// The selling liabilities in stroops, or 0 for V0 accounts.
     pub fn selling_liabilities(account: &AccountEntry) -> i64 {
         match &account.ext {
-            stellar_xdr::curr::AccountEntryExt::V0 => 0,
-            stellar_xdr::curr::AccountEntryExt::V1(v1) => v1.liabilities.selling,
+            stellar_xdr::AccountEntryExt::V0 => 0,
+            stellar_xdr::AccountEntryExt::V1(v1) => v1.liabilities.selling,
         }
     }
 
@@ -274,8 +271,8 @@ pub mod reserves {
     /// The buying liabilities in stroops, or 0 for V0 accounts.
     pub fn buying_liabilities(account: &AccountEntry) -> i64 {
         match &account.ext {
-            stellar_xdr::curr::AccountEntryExt::V0 => 0,
-            stellar_xdr::curr::AccountEntryExt::V1(v1) => v1.liabilities.buying,
+            stellar_xdr::AccountEntryExt::V0 => 0,
+            stellar_xdr::AccountEntryExt::V1(v1) => v1.liabilities.buying,
         }
     }
 
@@ -323,15 +320,15 @@ pub mod reserves {
 /// - Selling liabilities cannot exceed balance
 /// - Buying liabilities cannot exceed `limit - balance`
 pub mod trustlines {
-    use stellar_xdr::curr::TrustLineEntry;
+    use stellar_xdr::TrustLineEntry;
 
     /// Get the selling liabilities for a trustline.
     ///
     /// Returns 0 for V0 trustlines (no liability tracking).
     pub fn selling_liabilities(trustline: &TrustLineEntry) -> i64 {
         match &trustline.ext {
-            stellar_xdr::curr::TrustLineEntryExt::V0 => 0,
-            stellar_xdr::curr::TrustLineEntryExt::V1(v1) => v1.liabilities.selling,
+            stellar_xdr::TrustLineEntryExt::V0 => 0,
+            stellar_xdr::TrustLineEntryExt::V1(v1) => v1.liabilities.selling,
         }
     }
 
@@ -340,8 +337,8 @@ pub mod trustlines {
     /// Returns 0 for V0 trustlines (no liability tracking).
     pub fn buying_liabilities(trustline: &TrustLineEntry) -> i64 {
         match &trustline.ext {
-            stellar_xdr::curr::TrustLineEntryExt::V0 => 0,
-            stellar_xdr::curr::TrustLineEntryExt::V1(v1) => v1.liabilities.buying,
+            stellar_xdr::TrustLineEntryExt::V0 => 0,
+            stellar_xdr::TrustLineEntryExt::V1(v1) => v1.liabilities.buying,
         }
     }
 
@@ -391,7 +388,7 @@ pub mod trustlines {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext,
         AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountId, Liabilities, PublicKey,
         SequenceNumber, Thresholds, Uint256,
@@ -408,9 +405,9 @@ mod tests {
             num_sub_entries,
             inflation_dest: None,
             flags: 0,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([1, 0, 0, 0]),
-            signers: stellar_xdr::curr::VecM::default(),
+            signers: stellar_xdr::VecM::default(),
             ext: AccountEntryExt::V0,
         }
     }
@@ -429,9 +426,9 @@ mod tests {
             num_sub_entries,
             inflation_dest: None,
             flags: 0,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([1, 0, 0, 0]),
-            signers: stellar_xdr::curr::VecM::default(),
+            signers: stellar_xdr::VecM::default(),
             ext: AccountEntryExt::V1(AccountEntryExtensionV1 {
                 liabilities: Liabilities { buying, selling },
                 ext: AccountEntryExtensionV1Ext::V0,
@@ -455,15 +452,15 @@ mod tests {
             num_sub_entries,
             inflation_dest: None,
             flags: 0,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([1, 0, 0, 0]),
-            signers: stellar_xdr::curr::VecM::default(),
+            signers: stellar_xdr::VecM::default(),
             ext: AccountEntryExt::V1(AccountEntryExtensionV1 {
                 liabilities: Liabilities { buying, selling },
                 ext: AccountEntryExtensionV1Ext::V2(AccountEntryExtensionV2 {
                     num_sponsoring,
                     num_sponsored,
-                    signer_sponsoring_i_ds: stellar_xdr::curr::VecM::default(),
+                    signer_sponsoring_i_ds: stellar_xdr::VecM::default(),
                     ext: AccountEntryExtensionV2Ext::V0,
                 }),
             }),
@@ -862,7 +859,7 @@ mod tests {
     // Parity: LiabilitiesTests.cpp:542 "add trustline selling liabilities"
     // =========================================================================
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AlphaNum4, AssetCode4, TrustLineAsset, TrustLineEntry, TrustLineEntryExt, TrustLineEntryV1,
         TrustLineEntryV1Ext,
     };

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -57,7 +57,7 @@ use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, BucketListType, ConfigSettingEntry, ConfigSettingId, ExtensionPoint,
     GeneralizedTransactionSet, Hash, LedgerCloseMeta, LedgerCloseMetaExt, LedgerCloseMetaExtV1,
     LedgerCloseMetaV2, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerHeader,
@@ -134,7 +134,7 @@ pub fn prepend_fee_event(
     }
 
     if let TransactionMeta::V4(ref mut v4) = meta {
-        let existing_events: Vec<stellar_xdr::curr::TransactionEvent> =
+        let existing_events: Vec<stellar_xdr::TransactionEvent> =
             v4.events.iter().cloned().collect();
         let mut combined = Vec::with_capacity(fee_events.len() + existing_events.len());
         combined.extend(fee_events);
@@ -205,12 +205,12 @@ pub struct CacheInitResult {
 /// which uses per-type `deletedKeys` rather than one all-types set.
 #[derive(Default)]
 struct PerTypeSeen {
-    offers: HashSet<stellar_xdr::curr::LedgerKeyOffer>,
-    trustlines: HashSet<stellar_xdr::curr::LedgerKeyTrustLine>,
-    contract_data: HashSet<stellar_xdr::curr::LedgerKeyContractData>,
-    contract_code: HashSet<stellar_xdr::curr::LedgerKeyContractCode>,
+    offers: HashSet<stellar_xdr::LedgerKeyOffer>,
+    trustlines: HashSet<stellar_xdr::LedgerKeyTrustLine>,
+    contract_data: HashSet<stellar_xdr::LedgerKeyContractData>,
+    contract_code: HashSet<stellar_xdr::LedgerKeyContractCode>,
     config_settings: HashSet<LedgerKeyConfigSetting>,
-    ttl: HashSet<stellar_xdr::curr::LedgerKeyTtl>,
+    ttl: HashSet<stellar_xdr::LedgerKeyTtl>,
     /// Catch-all for any other `LedgerKey` variant, keeping the abstraction total
     /// and provably equivalent to the prior all-types `HashSet<LedgerKey>`.
     other: HashSet<LedgerKey>,
@@ -273,13 +273,7 @@ struct LevelScanResult {
     /// Live entries of interest, deduped within this level (curr shadows snap).
     entries: HashMap<LedgerKey, LedgerEntry>,
     /// TTL entries keyed by TTL key hash (separate because TTLs need special handling).
-    ttl_entries: HashMap<
-        Hash,
-        (
-            stellar_xdr::curr::LedgerKeyTtl,
-            crate::soroban_state::TtlData,
-        ),
-    >,
+    ttl_entries: HashMap<Hash, (stellar_xdr::LedgerKeyTtl, crate::soroban_state::TtlData)>,
     /// Keys that were DEAD at this level — used for cross-level shadowing.
     /// A dead entry at a lower level must prevent live entries at higher levels
     /// from being included in the final result.
@@ -295,13 +289,7 @@ struct LevelScanResult {
 /// (pre-collected entries) and the fallback path (full bucket iteration).
 struct LevelScanner {
     entries: HashMap<LedgerKey, LedgerEntry>,
-    ttl_entries: HashMap<
-        Hash,
-        (
-            stellar_xdr::curr::LedgerKeyTtl,
-            crate::soroban_state::TtlData,
-        ),
-    >,
+    ttl_entries: HashMap<Hash, (stellar_xdr::LedgerKeyTtl, crate::soroban_state::TtlData)>,
     seen_keys: HashSet<LedgerKey>,
     dead_keys: HashSet<LedgerKey>,
     dead_ttl_keys: HashSet<Hash>,
@@ -358,7 +346,7 @@ impl LevelScanner {
 
             // TTL entries go into a separate map keyed by hash
             if let LedgerEntryData::Ttl(ref ttl) = le.data {
-                let ttl_key = stellar_xdr::curr::LedgerKeyTtl {
+                let ttl_key = stellar_xdr::LedgerKeyTtl {
                     key_hash: ttl.key_hash.clone(),
                 };
                 let ttl_data = crate::soroban_state::TtlData::new(
@@ -408,7 +396,7 @@ fn scan_single_level(
                     | LedgerKey::Ttl(_)
                     | LedgerKey::ConfigSetting(_)
             ) || matches!(&key, LedgerKey::Trustline(tl_key)
-                if matches!(tl_key.asset, stellar_xdr::curr::TrustLineAsset::PoolShare(_)));
+                if matches!(tl_key.asset, stellar_xdr::TrustLineAsset::PoolShare(_)));
             if !is_scan_relevant {
                 continue;
             }
@@ -466,7 +454,7 @@ fn merge_level_results(
                     offer_count += 1;
                 }
                 LedgerEntryData::Trustline(ref tl) => {
-                    if let stellar_xdr::curr::TrustLineAsset::PoolShare(ref pool_id) = tl.asset {
+                    if let stellar_xdr::TrustLineAsset::PoolShare(ref pool_id) = tl.asset {
                         pool_share_tl_account_index
                             .entry(tl.account_id.clone())
                             .or_default()
@@ -598,7 +586,7 @@ fn scan_and_merge_streaming(
                         | LedgerKey::Ttl(_)
                         | LedgerKey::ConfigSetting(_)
                 ) || matches!(&key, LedgerKey::Trustline(tl_key)
-                    if matches!(tl_key.asset, stellar_xdr::curr::TrustLineAsset::PoolShare(_)));
+                    if matches!(tl_key.asset, stellar_xdr::TrustLineAsset::PoolShare(_)));
                 if !is_scan_relevant {
                     continue;
                 }
@@ -628,7 +616,7 @@ fn scan_and_merge_streaming(
                     if let LedgerEntryData::Ttl(ref ttl) = le.data {
                         let key_hash = ttl.key_hash.clone();
                         if global_ttl_seen.insert(key_hash.clone()) {
-                            let ttl_key = stellar_xdr::curr::LedgerKeyTtl {
+                            let ttl_key = stellar_xdr::LedgerKeyTtl {
                                 key_hash: key_hash.clone(),
                             };
                             let ttl_data = crate::soroban_state::TtlData::new(
@@ -655,7 +643,7 @@ fn scan_and_merge_streaming(
                                 level_entry_count += 1;
                             }
                             LedgerEntryData::Trustline(ref tl) => {
-                                if let stellar_xdr::curr::TrustLineAsset::PoolShare(ref pool_id) =
+                                if let stellar_xdr::TrustLineAsset::PoolShare(ref pool_id) =
                                     tl.asset
                                 {
                                     pool_share_tl_account_index
@@ -897,9 +885,7 @@ fn scan_and_merge(
                             offer_count += 1;
                         }
                         LedgerEntryData::Trustline(ref tl) => {
-                            if let stellar_xdr::curr::TrustLineAsset::PoolShare(ref pool_id) =
-                                tl.asset
-                            {
+                            if let stellar_xdr::TrustLineAsset::PoolShare(ref pool_id) = tl.asset {
                                 pool_share_tl_account_index
                                     .entry(tl.account_id.clone())
                                     .or_default()
@@ -1135,7 +1121,7 @@ pub(crate) fn handle_upgrade_affecting_soroban_state_size(
     ledger_seq: u32,
     soroban_state: &crate::soroban_state::SharedSorobanState,
 ) -> Result<()> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ConfigSettingEntry, ConfigSettingId, LedgerEntry, LedgerEntryData, LedgerEntryExt,
         LedgerKey, LedgerKeyConfigSetting,
     };
@@ -1190,7 +1176,7 @@ pub(crate) fn handle_upgrade_affecting_soroban_state_size(
             for size in &mut window_vec {
                 *size = new_size;
             }
-            let new_window: stellar_xdr::curr::VecM<u64> = window_vec
+            let new_window: stellar_xdr::VecM<u64> = window_vec
                 .try_into()
                 .map_err(|_| LedgerError::Internal("Failed to convert window vec".to_string()))?;
             let new_window_entry = LedgerEntry {
@@ -2266,10 +2252,10 @@ impl LedgerManager {
         if close_data.prev_ledger_hash != state.header_hash {
             // Describe the StellarValueExt for logging with details
             let stellar_value_ext_desc = match &state.header.scp_value.ext {
-                stellar_xdr::curr::StellarValueExt::Basic => "Basic".to_string(),
-                stellar_xdr::curr::StellarValueExt::Signed(sig) => {
+                stellar_xdr::StellarValueExt::Basic => "Basic".to_string(),
+                stellar_xdr::StellarValueExt::Signed(sig) => {
                     let node_id_bytes = match &sig.node_id.0 {
-                        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => key.0,
+                        stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => key.0,
                     };
                     format!(
                         "Signed(node_id={}, sig_len={})",
@@ -2280,7 +2266,7 @@ impl LedgerManager {
             };
 
             // Compute recomputed hash to verify
-            use stellar_xdr::curr::{Limits, WriteXdr};
+            use stellar_xdr::{Limits, WriteXdr};
             match state.header.to_xdr(Limits::none()) {
                 Ok(header_xdr) => {
                     let header_xdr_hex = Hash256::from_bytes({
@@ -2646,14 +2632,13 @@ impl LedgerManager {
                         }
                     }
                     LedgerEntryData::Trustline(tl)
-                        if matches!(tl.asset, stellar_xdr::curr::TrustLineAsset::PoolShare(_)) =>
+                        if matches!(tl.asset, stellar_xdr::TrustLineAsset::PoolShare(_)) =>
                     {
                         match change {
                             EntryChange::Created(entry) => {
                                 if let LedgerEntryData::Trustline(ref tl) = entry.data {
-                                    if let stellar_xdr::curr::TrustLineAsset::PoolShare(
-                                        ref pool_id,
-                                    ) = tl.asset
+                                    if let stellar_xdr::TrustLineAsset::PoolShare(ref pool_id) =
+                                        tl.asset
                                     {
                                         self.pool_share_tl_account_index
                                             .write()
@@ -2665,9 +2650,8 @@ impl LedgerManager {
                             }
                             EntryChange::Deleted { previous } => {
                                 if let LedgerEntryData::Trustline(ref tl) = previous.data {
-                                    if let stellar_xdr::curr::TrustLineAsset::PoolShare(
-                                        ref pool_id,
-                                    ) = tl.asset
+                                    if let stellar_xdr::TrustLineAsset::PoolShare(ref pool_id) =
+                                        tl.asset
                                     {
                                         let mut idx = self.pool_share_tl_account_index.write();
                                         if let Some(pools) = idx.get_mut(&tl.account_id) {
@@ -2828,7 +2812,7 @@ impl LedgerManager {
         entry: LedgerEntry,
         live_until_ledger: u32,
     ) -> Result<()> {
-        use stellar_xdr::curr::LedgerEntryData;
+        use stellar_xdr::LedgerEntryData;
 
         // Verify it's a CONTRACT_DATA entry
         let _cd = match &entry.data {
@@ -2844,14 +2828,14 @@ impl LedgerManager {
         let ttl_data = crate::soroban_state::TtlData::new(live_until_ledger, last_modified);
 
         // Build the LedgerKey for TTL
-        let data_key = LedgerKey::ContractData(stellar_xdr::curr::LedgerKeyContractData {
+        let data_key = LedgerKey::ContractData(stellar_xdr::LedgerKeyContractData {
             contract: _cd.contract.clone(),
             key: _cd.key.clone(),
             durability: _cd.durability,
         });
         let key_hash = Hash256::hash_xdr(&data_key);
-        let ttl_key = stellar_xdr::curr::LedgerKeyTtl {
-            key_hash: stellar_xdr::curr::Hash(key_hash.0),
+        let ttl_key = stellar_xdr::LedgerKeyTtl {
+            key_hash: stellar_xdr::Hash(key_hash.0),
         };
 
         let mut state = self.soroban_state.write();
@@ -2931,7 +2915,7 @@ impl LedgerManager {
         };
 
         let mut compiled = 0u32;
-        let mut seen_hashes = std::collections::HashSet::<stellar_xdr::curr::Hash>::new();
+        let mut seen_hashes = std::collections::HashSet::<stellar_xdr::Hash>::new();
 
         // Scan levels from 0 (newest) to 10 (oldest). Within each level,
         // curr shadows snap. Dead entries shadow live entries at higher levels.
@@ -2958,7 +2942,7 @@ impl LedgerManager {
                             henyey_bucket::BucketEntry::Liveentry(le)
                             | henyey_bucket::BucketEntry::Initentry(le) => {
                                 if let LedgerEntryData::ContractCode(ref cc) = le.data {
-                                    let hash = stellar_xdr::curr::Hash(
+                                    let hash = stellar_xdr::Hash(
                                         <sha2::Sha256 as sha2::Digest>::digest(cc.code.as_slice())
                                             .into(),
                                     );
@@ -2999,7 +2983,7 @@ impl LedgerManager {
     /// invariant violations (e.g. missing TTL entry).
     pub fn get_config_upgrade_set(
         &self,
-        key: &stellar_xdr::curr::ConfigUpgradeSetKey,
+        key: &stellar_xdr::ConfigUpgradeSetKey,
     ) -> crate::Result<Option<std::sync::Arc<crate::config_upgrade::ConfigUpgradeSetFrame>>> {
         if !self.is_initialized() {
             return Ok(None);
@@ -3041,8 +3025,8 @@ struct LedgerCloseContext<'a> {
     stats: LedgerCloseStats,
     upgrade_ctx: UpgradeContext,
     id_pool: u64,
-    tx_results: Vec<stellar_xdr::curr::TransactionResultPair>,
-    tx_result_metas: Vec<stellar_xdr::curr::TransactionResultMetaV1>,
+    tx_results: Vec<stellar_xdr::TransactionResultPair>,
+    tx_result_metas: Vec<stellar_xdr::TransactionResultMetaV1>,
     /// Keys of entries restored from hot archive during transaction execution.
     /// Passed to HotArchiveBucketList::add_batch to remove restored entries from archive.
     hot_archive_restored_keys: Vec<LedgerKey>,
@@ -3166,7 +3150,7 @@ fn create_ledger_entries_for_v20(
     ledger_seq: u32,
     initial_bucket_list_size: u64,
 ) -> Result<()> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ConfigSettingContractBandwidthV0, ConfigSettingContractComputeV0,
         ConfigSettingContractEventsV0, ConfigSettingContractExecutionLanesV0,
         ConfigSettingContractHistoricalDataV0, ConfigSettingContractLedgerCostV0,
@@ -3340,8 +3324,8 @@ fn create_ledger_entries_for_v20(
 /// Build the initial V20 CPU cost parameter table (23 entries: indices 0..=22).
 ///
 /// Parity: NetworkConfig.cpp:246-338 `initialCpuCostParamsEntryForV20`
-fn initial_cpu_cost_params_for_v20() -> Vec<stellar_xdr::curr::ContractCostParamEntry> {
-    use stellar_xdr::curr::{ContractCostParamEntry, ExtensionPoint};
+fn initial_cpu_cost_params_for_v20() -> Vec<stellar_xdr::ContractCostParamEntry> {
+    use stellar_xdr::{ContractCostParamEntry, ExtensionPoint};
     let e = |const_term: i64, linear_term: i64| ContractCostParamEntry {
         ext: ExtensionPoint::V0,
         const_term,
@@ -3378,8 +3362,8 @@ fn initial_cpu_cost_params_for_v20() -> Vec<stellar_xdr::curr::ContractCostParam
 /// Build the initial V20 memory cost parameter table (23 entries: indices 0..=22).
 ///
 /// Parity: NetworkConfig.cpp:688-776 `initialMemCostParamsEntryForV20`
-fn initial_mem_cost_params_for_v20() -> Vec<stellar_xdr::curr::ContractCostParamEntry> {
-    use stellar_xdr::curr::{ContractCostParamEntry, ExtensionPoint};
+fn initial_mem_cost_params_for_v20() -> Vec<stellar_xdr::ContractCostParamEntry> {
+    use stellar_xdr::{ContractCostParamEntry, ExtensionPoint};
     let e = |const_term: i64, linear_term: i64| ContractCostParamEntry {
         ext: ExtensionPoint::V0,
         const_term,
@@ -3425,7 +3409,7 @@ fn resize_and_update_cost_params(
     cpu_updates: &[(usize, i64, i64)],
     mem_updates: &[(usize, i64, i64)],
 ) -> Result<()> {
-    use stellar_xdr::curr::{ContractCostParamEntry, ContractCostParams};
+    use stellar_xdr::{ContractCostParamEntry, ContractCostParams};
 
     let make_entry = |const_term: i64, linear_term: i64| ContractCostParamEntry {
         ext: ExtensionPoint::V0,
@@ -3655,7 +3639,7 @@ fn create_and_update_ledger_entries_for_v23(
     ltx: &mut CloseLedgerState,
     ledger_seq: u32,
 ) -> Result<()> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ConfigSettingContractLedgerCostExtV0, ConfigSettingContractParallelComputeV0,
         ConfigSettingScpTiming,
     };
@@ -3929,7 +3913,7 @@ fn update_cost_types_for_v26(ltx: &mut CloseLedgerState, ledger_seq: u32) -> Res
 /// Parity: NetworkConfig.cpp createLedgerEntriesForV26
 /// Creates 2 CONFIG_SETTING entries with empty frozen key and bypass tx sets.
 fn create_ledger_entries_for_v26(ltx: &mut CloseLedgerState, ledger_seq: u32) -> Result<()> {
-    use stellar_xdr::curr::{FreezeBypassTxs, FrozenLedgerKeys, VecM};
+    use stellar_xdr::{FreezeBypassTxs, FrozenLedgerKeys, VecM};
 
     let make_entry = |config: ConfigSettingEntry| -> LedgerEntry {
         LedgerEntry {
@@ -4212,7 +4196,7 @@ impl LedgerCloseContext<'_> {
             // (which is skipped in simulation mode).
             let tx_set = std::mem::replace(
                 &mut self.close_data.tx_set,
-                TransactionSetVariant::Classic(stellar_xdr::curr::TransactionSet {
+                TransactionSetVariant::Classic(stellar_xdr::TransactionSet {
                     previous_ledger_hash: Hash([0; 32]),
                     txs: Default::default(),
                 }),
@@ -4317,8 +4301,8 @@ impl LedgerCloseContext<'_> {
                 soroban_config: soroban_config.clone(),
                 frozen_key_config: frozen_key_config.clone(),
                 ledger_flags: match &self.prev_header.ext {
-                    stellar_xdr::curr::LedgerHeaderExt::V0 => 0,
-                    stellar_xdr::curr::LedgerHeaderExt::V1(ext) => ext.flags,
+                    stellar_xdr::LedgerHeaderExt::V0 => 0,
+                    stellar_xdr::LedgerHeaderExt::V1(ext) => ext.flags,
                 },
                 soroban_resource_limits: self
                     .manager
@@ -4375,7 +4359,7 @@ impl LedgerCloseContext<'_> {
             // classic executor so classic TXs see ALL fee deductions (including
             // Soroban fees on shared accounts).
             for entry in self.ltx.current_delta().current_entries() {
-                if matches!(entry.data, stellar_xdr::curr::LedgerEntryData::Account(_)) {
+                if matches!(entry.data, stellar_xdr::LedgerEntryData::Account(_)) {
                     executor_ref.state_mut().load_entry(entry);
                 }
             }
@@ -4680,7 +4664,7 @@ impl LedgerCloseContext<'_> {
         prev_version: u32,
         protocol_version: u32,
     ) -> Result<(bool, bool, Vec<UpgradeEntryMeta>)> {
-        use stellar_xdr::curr::{LedgerEntryChanges, LedgerUpgrade, Limits, WriteXdr};
+        use stellar_xdr::{LedgerEntryChanges, LedgerUpgrade, Limits, WriteXdr};
 
         // LEDGER_SPEC §7.3.4 step 2 (LEDGER §7.3.4-2): re-validate each upgrade
         // via isValidForApply at apply time and SKIP invalid ones with a
@@ -5044,16 +5028,16 @@ impl LedgerCloseContext<'_> {
         // Note: we use upgrade_ctx.upgrades (not close_data.upgrades) because
         // close_data.upgrades is drained by std::mem::take in apply_upgrades_to_delta
         // to build UpgradeEntryMeta.
-        let raw_upgrades: Vec<stellar_xdr::curr::UpgradeType> = self
+        let raw_upgrades: Vec<stellar_xdr::UpgradeType> = self
             .upgrade_ctx
             .upgrades
             .iter()
             .filter_map(|upgrade| {
-                use stellar_xdr::curr::WriteXdr;
+                use stellar_xdr::WriteXdr;
                 upgrade
-                    .to_xdr(stellar_xdr::curr::Limits::none())
+                    .to_xdr(stellar_xdr::Limits::none())
                     .ok()
-                    .and_then(|bytes| stellar_xdr::curr::UpgradeType::try_from(bytes).ok())
+                    .and_then(|bytes| stellar_xdr::UpgradeType::try_from(bytes).ok())
             })
             .collect();
         if let Ok(upgrades_vec) = raw_upgrades.try_into() {
@@ -5063,7 +5047,7 @@ impl LedgerCloseContext<'_> {
         new_header.id_pool = self.id_pool;
 
         // Compute header hash - add detailed XDR logging for debugging
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
         let header_xdr_bytes = new_header.to_xdr(Limits::none())?;
         let header_xdr_hex = header_xdr_bytes.iter().fold(
             String::with_capacity(header_xdr_bytes.len() * 2),
@@ -5140,7 +5124,7 @@ impl LedgerCloseContext<'_> {
         // TransactionResultSet wrapper.
         let tx_result_hash = {
             use sha2::{Digest, Sha256};
-            use stellar_xdr::curr::{Limited, Limits, WriteXdr};
+            use stellar_xdr::{Limited, Limits, WriteXdr};
 
             struct Sha256Writer(Sha256);
             impl std::io::Write for Sha256Writer {
@@ -5601,7 +5585,9 @@ impl LedgerCloseContext<'_> {
                                 !matches!(
                                     &e.data,
                                     LedgerEntryData::ConfigSetting(
-                                        stellar_xdr::curr::ConfigSettingEntry::LiveSorobanStateSizeWindow(_)
+                                        stellar_xdr::ConfigSettingEntry::LiveSorobanStateSizeWindow(
+                                            _
+                                        )
                                     )
                                 )
                             });
@@ -6009,12 +5995,12 @@ impl LedgerCloseContext<'_> {
                 // purpose; mirror its field set here so analysts comparing
                 // live vs replay diagnostics see directly comparable output.
                 let stellar_value_ext_desc = match &new_header.scp_value.ext {
-                    stellar_xdr::curr::StellarValueExt::Basic => "Basic",
-                    stellar_xdr::curr::StellarValueExt::Signed(_) => "Signed",
+                    stellar_xdr::StellarValueExt::Basic => "Basic",
+                    stellar_xdr::StellarValueExt::Signed(_) => "Signed",
                 };
                 let header_ext_desc = match &new_header.ext {
-                    stellar_xdr::curr::LedgerHeaderExt::V0 => "V0".to_string(),
-                    stellar_xdr::curr::LedgerHeaderExt::V1(v1) => {
+                    stellar_xdr::LedgerHeaderExt::V0 => "V0".to_string(),
+                    stellar_xdr::LedgerHeaderExt::V1(v1) => {
                         format!("V1(flags={})", v1.flags)
                     }
                 };
@@ -6055,12 +6041,10 @@ impl LedgerCloseContext<'_> {
                 // side can diff against CDP's tx_apply_processing changes and
                 // localize the first divergent prior tx.
                 use sha2::{Digest, Sha256};
-                use stellar_xdr::curr::{
-                    LedgerEntryChange, LedgerEntryData, TransactionMeta, WriteXdr,
-                };
+                use stellar_xdr::{LedgerEntryChange, LedgerEntryData, TransactionMeta, WriteXdr};
                 for (i, meta_v1) in self.tx_result_metas.iter().enumerate() {
                     let mut changes_summary: Vec<String> = Vec::new();
-                    let walk = |changes: &stellar_xdr::curr::LedgerEntryChanges,
+                    let walk = |changes: &stellar_xdr::LedgerEntryChanges,
                                 summary: &mut Vec<String>,
                                 phase: &str| {
                         for change in changes.iter() {
@@ -6076,7 +6060,7 @@ impl LedgerCloseContext<'_> {
                             }
                             let data_bytes = entry
                                 .data
-                                .to_xdr(stellar_xdr::curr::Limits::none())
+                                .to_xdr(stellar_xdr::Limits::none())
                                 .unwrap_or_default();
                             let data_hash = format!("{:x}", Sha256::digest(&data_bytes));
                             summary.push(format!(
@@ -6167,8 +6151,8 @@ impl LedgerCloseContext<'_> {
 
         // Describe the StellarValueExt for logging
         let stellar_value_ext_desc = match &new_header.scp_value.ext {
-            stellar_xdr::curr::StellarValueExt::Basic => "Basic".to_string(),
-            stellar_xdr::curr::StellarValueExt::Signed(_) => "Signed".to_string(),
+            stellar_xdr::StellarValueExt::Basic => "Basic".to_string(),
+            stellar_xdr::StellarValueExt::Signed(_) => "Signed".to_string(),
         };
 
         info!(
@@ -6473,11 +6457,11 @@ fn create_genesis_header() -> LedgerHeader {
     LedgerHeader {
         ledger_version: 0,
         previous_ledger_hash: Hash([0u8; 32]),
-        scp_value: stellar_xdr::curr::StellarValue {
+        scp_value: stellar_xdr::StellarValue {
             tx_set_hash: Hash([0u8; 32]),
-            close_time: stellar_xdr::curr::TimePoint(0),
-            upgrades: stellar_xdr::curr::VecM::default(),
-            ext: stellar_xdr::curr::StellarValueExt::Basic,
+            close_time: stellar_xdr::TimePoint(0),
+            upgrades: stellar_xdr::VecM::default(),
+            ext: stellar_xdr::StellarValueExt::Basic,
         },
         tx_set_result_hash: Hash([0u8; 32]),
         bucket_list_hash: Hash([0u8; 32]),
@@ -6491,7 +6475,7 @@ fn create_genesis_header() -> LedgerHeader {
         base_reserve: 100_000_000, // 10 XLM in stroops
         max_tx_set_size: 100,
         skip_list: std::array::from_fn(|_| Hash([0u8; 32])),
-        ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+        ext: stellar_xdr::LedgerHeaderExt::V0,
     }
 }
 
@@ -6503,7 +6487,7 @@ fn create_genesis_header() -> LedgerHeader {
 /// `MinimumSorobanNetworkConfig`).
 #[doc(hidden)]
 pub fn new_bucket_list_with_soroban_config() -> BucketList {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         BucketListType, ConfigSettingContractBandwidthV0, ConfigSettingContractComputeV0,
         ConfigSettingContractEventsV0, ConfigSettingContractExecutionLanesV0,
         ConfigSettingContractHistoricalDataV0, ConfigSettingContractLedgerCostV0,
@@ -6619,7 +6603,7 @@ mod tests {
     use super::*;
     use crate::delta::LedgerDelta;
     use henyey_bucket::EvictionIteratorExt;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Asset, ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint,
         LedgerScpMessages, OfferEntry, OfferEntryExt, Price, ScAddress, ScVal, ScpHistoryEntry,
         ScpHistoryEntryV0, TransactionSet, TtlEntry, WriteXdr,
@@ -6631,8 +6615,8 @@ mod tests {
     const TEST_PROTOCOL: u32 = 25;
 
     fn make_account_id(bytes: [u8; 32]) -> AccountId {
-        AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(bytes),
+        AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(bytes),
         ))
     }
 
@@ -6659,9 +6643,7 @@ mod tests {
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
                 contract: ScAddress::Contract(ContractId(Hash([1u8; 32]))),
-                key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                    key_bytes.to_vec().try_into().unwrap(),
-                )),
+                key: ScVal::Bytes(stellar_xdr::ScBytes(key_bytes.to_vec().try_into().unwrap())),
                 durability: ContractDataDurability::Persistent,
                 val: ScVal::I32(42),
             }),
@@ -6796,7 +6778,7 @@ mod tests {
         )
         .unwrap();
 
-        let dead_key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let dead_key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([5u8; 32]),
             offer_id: 99,
         });
@@ -6951,7 +6933,7 @@ mod tests {
         use henyey_bucket::Bucket;
 
         let entry = make_offer_entry(1, [1u8; 32]);
-        let dead_key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let dead_key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([1u8; 32]),
             offer_id: 1,
         });
@@ -6978,7 +6960,7 @@ mod tests {
         if let LedgerEntryData::Offer(ref mut o) = entry_v2.data {
             o.amount = 7777;
         }
-        let key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([1u8; 32]),
             offer_id: 1,
         });
@@ -7012,11 +6994,11 @@ mod tests {
         // Entries with different keys across levels should all be included.
         let offer1 = make_offer_entry(1, [1u8; 32]);
         let offer2 = make_offer_entry(2, [2u8; 32]);
-        let key1 = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let key1 = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([1u8; 32]),
             offer_id: 1,
         });
-        let key2 = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let key2 = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([2u8; 32]),
             offer_id: 2,
         });
@@ -7044,7 +7026,7 @@ mod tests {
         // a live entry at a higher (older) level from appearing in the result.
         // This was the root cause of the soroban_state_size inflation bug.
         let offer = make_offer_entry(1, [1u8; 32]);
-        let key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([1u8; 32]),
             offer_id: 1,
         });
@@ -7086,31 +7068,29 @@ mod tests {
         // NOT (proving type-tagging makes the narrowing exact).
         let shared = [3u8; 32];
         let keys: Vec<LedgerKey> = vec![
-            LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+            LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
                 seller_id: make_account_id(shared),
                 offer_id: 1,
             }),
-            LedgerKey::Trustline(stellar_xdr::curr::LedgerKeyTrustLine {
+            LedgerKey::Trustline(stellar_xdr::LedgerKeyTrustLine {
                 account_id: make_account_id(shared),
-                asset: stellar_xdr::curr::TrustLineAsset::PoolShare(PoolId(Hash(shared))),
+                asset: stellar_xdr::TrustLineAsset::PoolShare(PoolId(Hash(shared))),
             }),
-            LedgerKey::ContractData(stellar_xdr::curr::LedgerKeyContractData {
+            LedgerKey::ContractData(stellar_xdr::LedgerKeyContractData {
                 contract: ScAddress::Contract(ContractId(Hash(shared))),
                 key: ScVal::I32(7),
                 durability: ContractDataDurability::Persistent,
             }),
-            LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
-                hash: Hash(shared),
-            }),
+            LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode { hash: Hash(shared) }),
             LedgerKey::ConfigSetting(LedgerKeyConfigSetting {
-                config_setting_id: stellar_xdr::curr::ConfigSettingId::ContractMaxSizeBytes,
+                config_setting_id: stellar_xdr::ConfigSettingId::ContractMaxSizeBytes,
             }),
-            LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl {
+            LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl {
                 key_hash: Hash(shared),
             }),
             // A non-scan-relevant variant lands in the catch-all set, proving the
             // abstraction is total (handles EVERY LedgerKey variant).
-            LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: make_account_id(shared),
             }),
         ];
@@ -7140,8 +7120,8 @@ mod tests {
     fn make_contract_code_entry(hash_bytes: [u8; 32]) -> LedgerEntry {
         LedgerEntry {
             last_modified_ledger_seq: 100,
-            data: LedgerEntryData::ContractCode(stellar_xdr::curr::ContractCodeEntry {
-                ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+            data: LedgerEntryData::ContractCode(stellar_xdr::ContractCodeEntry {
+                ext: stellar_xdr::ContractCodeEntryExt::V0,
                 hash: Hash(hash_bytes),
                 code: vec![0u8; 4].try_into().unwrap(),
             }),
@@ -7152,13 +7132,13 @@ mod tests {
     fn make_pool_share_trustline_entry(acct: [u8; 32], pool: [u8; 32]) -> LedgerEntry {
         LedgerEntry {
             last_modified_ledger_seq: 100,
-            data: LedgerEntryData::Trustline(stellar_xdr::curr::TrustLineEntry {
+            data: LedgerEntryData::Trustline(stellar_xdr::TrustLineEntry {
                 account_id: make_account_id(acct),
-                asset: stellar_xdr::curr::TrustLineAsset::PoolShare(PoolId(Hash(pool))),
+                asset: stellar_xdr::TrustLineAsset::PoolShare(PoolId(Hash(pool))),
                 balance: 0,
                 limit: i64::MAX,
                 flags: 0,
-                ext: stellar_xdr::curr::TrustLineEntryExt::V0,
+                ext: stellar_xdr::TrustLineEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,
         }
@@ -7174,7 +7154,7 @@ mod tests {
         // (live entry, its LedgerKey, a closure asserting the final state is empty)
         // Offer
         {
-            let key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+            let key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
                 seller_id: make_account_id([5u8; 32]),
                 offer_id: 99,
             });
@@ -7274,7 +7254,7 @@ mod tests {
                 dead_keys: HashSet::new(),
                 dead_ttl_keys: [Hash([9u8; 32])].into_iter().collect(),
             };
-            let ttl_key = stellar_xdr::curr::LedgerKeyTtl {
+            let ttl_key = stellar_xdr::LedgerKeyTtl {
                 key_hash: Hash([9u8; 32]),
             };
             let ttl_data = crate::soroban_state::TtlData::new(1000, 1);
@@ -7419,7 +7399,7 @@ mod tests {
         )
         .unwrap();
 
-        let dead_key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let dead_key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([7u8; 32]),
             offer_id: 77,
         });
@@ -7609,7 +7589,7 @@ mod tests {
         )
         .unwrap();
         // Kill it at ledger 2
-        let dead_key = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let dead_key = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([1u8; 32]),
             offer_id: 1,
         });
@@ -7805,17 +7785,17 @@ mod tests {
     #[test]
     fn test_streaming_pool_share_trustline_indexing() {
         let mut bl = new_bl_with_config();
-        let pool_hash = stellar_xdr::curr::PoolId(Hash([99u8; 32]));
+        let pool_hash = stellar_xdr::PoolId(Hash([99u8; 32]));
         let account = make_account_id([1u8; 32]);
         let tl_entry = LedgerEntry {
             last_modified_ledger_seq: 1,
-            data: LedgerEntryData::Trustline(stellar_xdr::curr::TrustLineEntry {
+            data: LedgerEntryData::Trustline(stellar_xdr::TrustLineEntry {
                 account_id: account.clone(),
-                asset: stellar_xdr::curr::TrustLineAsset::PoolShare(pool_hash.clone()),
+                asset: stellar_xdr::TrustLineAsset::PoolShare(pool_hash.clone()),
                 balance: 100,
                 limit: 1000,
                 flags: 0,
-                ext: stellar_xdr::curr::TrustLineEntryExt::V0,
+                ext: stellar_xdr::TrustLineEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,
         };
@@ -7961,11 +7941,11 @@ mod tests {
             .unwrap();
         }
         // Kill offers 2 and 4
-        let dead2 = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let dead2 = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([2u8; 32]),
             offer_id: 2,
         });
-        let dead4 = LedgerKey::Offer(stellar_xdr::curr::LedgerKeyOffer {
+        let dead4 = LedgerKey::Offer(stellar_xdr::LedgerKeyOffer {
             seller_id: make_account_id([4u8; 32]),
             offer_id: 4,
         });
@@ -8451,20 +8431,20 @@ mod tests {
             hash_bytes[0] = i;
             let code_entry = LedgerEntry {
                 last_modified_ledger_seq: 1,
-                data: LedgerEntryData::ContractCode(stellar_xdr::curr::ContractCodeEntry {
-                    ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+                data: LedgerEntryData::ContractCode(stellar_xdr::ContractCodeEntry {
+                    ext: stellar_xdr::ContractCodeEntryExt::V0,
                     hash: Hash(hash_bytes),
                     code: vec![0u8; 50].try_into().unwrap(),
                 }),
                 ext: LedgerEntryExt::V0,
             };
-            let code_key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+            let code_key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
                 hash: Hash(hash_bytes),
             });
 
             // Create TTL entry with SHA256 hash of the key
             use sha2::{Digest, Sha256};
-            let key_bytes = code_key.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+            let key_bytes = code_key.to_xdr(stellar_xdr::Limits::none()).unwrap();
             let mut hasher = Sha256::new();
             hasher.update(&key_bytes);
             let hash_result = hasher.finalize();
@@ -9160,7 +9140,7 @@ mod tests {
     /// apply_upgrades_to_delta before build_and_hash_header runs).
     #[test]
     fn test_header_scp_value_upgrades_populated_after_drain() {
-        use stellar_xdr::curr::{LedgerUpgrade, Limits, ReadXdr};
+        use stellar_xdr::{LedgerUpgrade, Limits, ReadXdr};
 
         let manager = LedgerManager::new(
             "Test SDF Network ; September 2015".to_string(),
@@ -9227,7 +9207,7 @@ mod tests {
     /// Mirrors stellar-core `LedgerManagerImpl.cpp:1660-1711`.
     #[test]
     fn test_apply_time_revalidation_skips_version_regression() {
-        use stellar_xdr::curr::{LedgerUpgrade, Limits, ReadXdr};
+        use stellar_xdr::{LedgerUpgrade, Limits, ReadXdr};
 
         let manager = LedgerManager::new(
             "Test SDF Network ; September 2015".to_string(),
@@ -9287,7 +9267,7 @@ mod tests {
     /// set in `scp_value.upgrades`.
     #[test]
     fn test_apply_time_revalidation_skips_invalid_base_fee() {
-        use stellar_xdr::curr::{LedgerUpgrade, Limits, ReadXdr};
+        use stellar_xdr::{LedgerUpgrade, Limits, ReadXdr};
 
         let manager = LedgerManager::new(
             "Test SDF Network ; September 2015".to_string(),
@@ -9353,7 +9333,7 @@ mod tests {
     /// upgrade in the same set.
     #[test]
     fn test_apply_time_revalidation_effective_version_ordering() {
-        use stellar_xdr::curr::LedgerUpgrade;
+        use stellar_xdr::LedgerUpgrade;
 
         let manager = LedgerManager::new(
             "Test SDF Network ; September 2015".to_string(),
@@ -9810,14 +9790,12 @@ mod tests {
     // --- Tests for build_soroban_rent_config ---
 
     /// A simple EntryReader backed by a HashMap for testing.
-    struct MapReader(
-        std::collections::HashMap<stellar_xdr::curr::LedgerKey, stellar_xdr::curr::LedgerEntry>,
-    );
+    struct MapReader(std::collections::HashMap<stellar_xdr::LedgerKey, stellar_xdr::LedgerEntry>);
     impl crate::EntryReader for MapReader {
         fn get_entry(
             &self,
-            key: &stellar_xdr::curr::LedgerKey,
-        ) -> Result<Option<stellar_xdr::curr::LedgerEntry>> {
+            key: &stellar_xdr::LedgerKey,
+        ) -> Result<Option<stellar_xdr::LedgerEntry>> {
             Ok(self.0.get(key).cloned())
         }
     }
@@ -9825,13 +9803,13 @@ mod tests {
     fn make_config_ledger_entry(setting: ConfigSettingEntry) -> LedgerEntry {
         LedgerEntry {
             last_modified_ledger_seq: 1,
-            data: stellar_xdr::curr::LedgerEntryData::ConfigSetting(setting),
-            ext: stellar_xdr::curr::LedgerEntryExt::V0,
+            data: stellar_xdr::LedgerEntryData::ConfigSetting(setting),
+            ext: stellar_xdr::LedgerEntryExt::V0,
         }
     }
 
-    fn config_key(id: ConfigSettingId) -> stellar_xdr::curr::LedgerKey {
-        stellar_xdr::curr::LedgerKey::ConfigSetting(stellar_xdr::curr::LedgerKeyConfigSetting {
+    fn config_key(id: ConfigSettingId) -> stellar_xdr::LedgerKey {
+        stellar_xdr::LedgerKey::ConfigSetting(stellar_xdr::LedgerKeyConfigSetting {
             config_setting_id: id,
         })
     }
@@ -9846,19 +9824,19 @@ mod tests {
 
     #[test]
     fn test_build_soroban_rent_config_complete_reader_returns_some() {
-        use stellar_xdr::curr::{ConfigSettingContractComputeV0, ContractCostParams};
+        use stellar_xdr::{ConfigSettingContractComputeV0, ContractCostParams};
 
         let mut map = std::collections::HashMap::new();
         map.insert(
             config_key(ConfigSettingId::ContractCostParamsCpuInstructions),
             make_config_ledger_entry(ConfigSettingEntry::ContractCostParamsCpuInstructions(
-                ContractCostParams(stellar_xdr::curr::VecM::default()),
+                ContractCostParams(stellar_xdr::VecM::default()),
             )),
         );
         map.insert(
             config_key(ConfigSettingId::ContractCostParamsMemoryBytes),
             make_config_ledger_entry(ConfigSettingEntry::ContractCostParamsMemoryBytes(
-                ContractCostParams(stellar_xdr::curr::VecM::default()),
+                ContractCostParams(stellar_xdr::VecM::default()),
             )),
         );
         map.insert(
@@ -9883,14 +9861,14 @@ mod tests {
 
     #[test]
     fn test_build_soroban_rent_config_partial_state_cpu_only_errors() {
-        use stellar_xdr::curr::ContractCostParams;
+        use stellar_xdr::ContractCostParams;
 
         // Only CPU key present, others missing — inconsistent state.
         let mut map = std::collections::HashMap::new();
         map.insert(
             config_key(ConfigSettingId::ContractCostParamsCpuInstructions),
             make_config_ledger_entry(ConfigSettingEntry::ContractCostParamsCpuInstructions(
-                ContractCostParams(stellar_xdr::curr::VecM::default()),
+                ContractCostParams(stellar_xdr::VecM::default()),
             )),
         );
 
@@ -9907,14 +9885,14 @@ mod tests {
 
     #[test]
     fn test_build_soroban_rent_config_partial_state_cpu_absent_errors() {
-        use stellar_xdr::curr::{ConfigSettingContractComputeV0, ContractCostParams};
+        use stellar_xdr::{ConfigSettingContractComputeV0, ContractCostParams};
 
         // CPU absent but Memory + Compute present — inconsistent state (reverse case).
         let mut map = std::collections::HashMap::new();
         map.insert(
             config_key(ConfigSettingId::ContractCostParamsMemoryBytes),
             make_config_ledger_entry(ConfigSettingEntry::ContractCostParamsMemoryBytes(
-                ContractCostParams(stellar_xdr::curr::VecM::default()),
+                ContractCostParams(stellar_xdr::VecM::default()),
             )),
         );
         map.insert(
@@ -9942,21 +9920,21 @@ mod tests {
 
     #[test]
     fn test_build_soroban_rent_config_wrong_variant_errors() {
-        use stellar_xdr::curr::{ConfigSettingContractComputeV0, ContractCostParams};
+        use stellar_xdr::{ConfigSettingContractComputeV0, ContractCostParams};
 
         // All three keys present, but MemoryBytes has the wrong variant.
         let mut map = std::collections::HashMap::new();
         map.insert(
             config_key(ConfigSettingId::ContractCostParamsCpuInstructions),
             make_config_ledger_entry(ConfigSettingEntry::ContractCostParamsCpuInstructions(
-                ContractCostParams(stellar_xdr::curr::VecM::default()),
+                ContractCostParams(stellar_xdr::VecM::default()),
             )),
         );
         // Wrong variant for MemoryBytes — put CPU params where Memory should be.
         map.insert(
             config_key(ConfigSettingId::ContractCostParamsMemoryBytes),
             make_config_ledger_entry(ConfigSettingEntry::ContractCostParamsCpuInstructions(
-                ContractCostParams(stellar_xdr::curr::VecM::default()),
+                ContractCostParams(stellar_xdr::VecM::default()),
             )),
         );
         map.insert(
@@ -9996,13 +9974,11 @@ mod tests {
         };
 
         // Create an empty V4 transaction meta
-        let mut meta = TransactionMeta::V4(stellar_xdr::curr::TransactionMetaV4 {
+        let mut meta = TransactionMeta::V4(stellar_xdr::TransactionMetaV4 {
             ext: ExtensionPoint::V0,
-            tx_changes_before: stellar_xdr::curr::LedgerEntryChanges(
-                Vec::new().try_into().unwrap(),
-            ),
+            tx_changes_before: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             operations: Vec::new().try_into().unwrap(),
-            tx_changes_after: stellar_xdr::curr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
+            tx_changes_after: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             soroban_meta: None,
             events: Vec::new().try_into().unwrap(),
             diagnostic_events: Vec::new().try_into().unwrap(),
@@ -10055,13 +10031,11 @@ mod tests {
         };
 
         // Create meta and prepend with pre-refund fee (the correct behavior)
-        let mut meta_pre = TransactionMeta::V4(stellar_xdr::curr::TransactionMetaV4 {
+        let mut meta_pre = TransactionMeta::V4(stellar_xdr::TransactionMetaV4 {
             ext: ExtensionPoint::V0,
-            tx_changes_before: stellar_xdr::curr::LedgerEntryChanges(
-                Vec::new().try_into().unwrap(),
-            ),
+            tx_changes_before: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             operations: Vec::new().try_into().unwrap(),
-            tx_changes_after: stellar_xdr::curr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
+            tx_changes_after: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             soroban_meta: None,
             events: Vec::new().try_into().unwrap(),
             diagnostic_events: Vec::new().try_into().unwrap(),
@@ -10076,13 +10050,11 @@ mod tests {
         );
 
         // Create meta and prepend with post-refund fee (the old buggy behavior)
-        let mut meta_post = TransactionMeta::V4(stellar_xdr::curr::TransactionMetaV4 {
+        let mut meta_post = TransactionMeta::V4(stellar_xdr::TransactionMetaV4 {
             ext: ExtensionPoint::V0,
-            tx_changes_before: stellar_xdr::curr::LedgerEntryChanges(
-                Vec::new().try_into().unwrap(),
-            ),
+            tx_changes_before: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             operations: Vec::new().try_into().unwrap(),
-            tx_changes_after: stellar_xdr::curr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
+            tx_changes_after: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             soroban_meta: None,
             events: Vec::new().try_into().unwrap(),
             diagnostic_events: Vec::new().try_into().unwrap(),
@@ -10136,13 +10108,11 @@ mod tests {
             backfill_stellar_asset_events: false,
         };
 
-        let mut meta1 = TransactionMeta::V4(stellar_xdr::curr::TransactionMetaV4 {
+        let mut meta1 = TransactionMeta::V4(stellar_xdr::TransactionMetaV4 {
             ext: ExtensionPoint::V0,
-            tx_changes_before: stellar_xdr::curr::LedgerEntryChanges(
-                Vec::new().try_into().unwrap(),
-            ),
+            tx_changes_before: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             operations: Vec::new().try_into().unwrap(),
-            tx_changes_after: stellar_xdr::curr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
+            tx_changes_after: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             soroban_meta: None,
             events: Vec::new().try_into().unwrap(),
             diagnostic_events: Vec::new().try_into().unwrap(),
@@ -10156,13 +10126,11 @@ mod tests {
             classic_events,
         );
 
-        let mut meta2 = TransactionMeta::V4(stellar_xdr::curr::TransactionMetaV4 {
+        let mut meta2 = TransactionMeta::V4(stellar_xdr::TransactionMetaV4 {
             ext: ExtensionPoint::V0,
-            tx_changes_before: stellar_xdr::curr::LedgerEntryChanges(
-                Vec::new().try_into().unwrap(),
-            ),
+            tx_changes_before: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             operations: Vec::new().try_into().unwrap(),
-            tx_changes_after: stellar_xdr::curr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
+            tx_changes_after: stellar_xdr::LedgerEntryChanges(Vec::new().try_into().unwrap()),
             soroban_meta: None,
             events: Vec::new().try_into().unwrap(),
             diagnostic_events: Vec::new().try_into().unwrap(),
@@ -10198,7 +10166,7 @@ mod tests {
     /// accounts that were added to the bucket list during genesis bootstrap.
     #[test]
     fn test_create_snapshot_finds_genesis_account() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountEntryExt, LedgerHeader, SequenceNumber, String32, Thresholds,
         };
 
@@ -10270,7 +10238,7 @@ mod tests {
     /// catchup). This validates the defensive check added in create_snapshot.
     #[test]
     fn test_create_snapshot_returns_error_after_reset() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             AccountEntry, AccountEntryExt, LedgerHeader, SequenceNumber, String32, Thresholds,
         };
 
@@ -10540,14 +10508,14 @@ mod tests {
             .unwrap_or_else(|| panic!("config setting {id:?} not present at protocol {protocol}"))
     }
 
-    fn genesis_cpu_params(protocol: u32) -> Vec<stellar_xdr::curr::ContractCostParamEntry> {
+    fn genesis_cpu_params(protocol: u32) -> Vec<stellar_xdr::ContractCostParamEntry> {
         match genesis_config_entry(protocol, ConfigSettingId::ContractCostParamsCpuInstructions) {
             ConfigSettingEntry::ContractCostParamsCpuInstructions(p) => p.0.to_vec(),
             other => panic!("unexpected variant: {other:?}"),
         }
     }
 
-    fn genesis_mem_params(protocol: u32) -> Vec<stellar_xdr::curr::ContractCostParamEntry> {
+    fn genesis_mem_params(protocol: u32) -> Vec<stellar_xdr::ContractCostParamEntry> {
         match genesis_config_entry(protocol, ConfigSettingId::ContractCostParamsMemoryBytes) {
             ConfigSettingEntry::ContractCostParamsMemoryBytes(p) => p.0.to_vec(),
             other => panic!("unexpected variant: {other:?}"),
@@ -10618,8 +10586,8 @@ mod tests {
     /// Run V20 + recalibration in isolation and return the (cpu, mem) cost
     /// param tables, BEFORE the V21+ cascade overwrites any indices.
     fn recalibrated_v20_params_isolated() -> (
-        Vec<stellar_xdr::curr::ContractCostParamEntry>,
-        Vec<stellar_xdr::curr::ContractCostParamEntry>,
+        Vec<stellar_xdr::ContractCostParamEntry>,
+        Vec<stellar_xdr::ContractCostParamEntry>,
     ) {
         use crate::snapshot::{LedgerSnapshot, SnapshotHandle};
         let snapshot = SnapshotHandle::new(LedgerSnapshot::empty(1));

--- a/crates/ledger/src/offer.rs
+++ b/crates/ledger/src/offer.rs
@@ -18,7 +18,7 @@
 //!
 //! ```
 //! use henyey_ledger::offer::OfferDescriptor;
-//! use stellar_xdr::curr::Price;
+//! use stellar_xdr::Price;
 //!
 //! let offer1 = OfferDescriptor {
 //!     price: Price { n: 1, d: 2 },  // 0.5
@@ -36,7 +36,7 @@
 
 use std::hash::{Hash, Hasher};
 
-use stellar_xdr::curr::{Asset, LedgerEntry, OfferEntry, Price, WriteXdr};
+use stellar_xdr::{Asset, LedgerEntry, OfferEntry, Price, WriteXdr};
 
 /// A lightweight descriptor for an offer used in sorting and comparison.
 ///
@@ -71,7 +71,7 @@ impl OfferDescriptor {
     /// Panics if the ledger entry does not contain an offer.
     pub fn from_ledger_entry(entry: &LedgerEntry) -> Self {
         match &entry.data {
-            stellar_xdr::curr::LedgerEntryData::Offer(offer) => Self::from_offer_entry(offer),
+            stellar_xdr::LedgerEntryData::Offer(offer) => Self::from_offer_entry(offer),
             _ => panic!("Expected offer entry"),
         }
     }
@@ -156,10 +156,10 @@ impl AssetPair {
 impl Hash for AssetPair {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Hash the XDR bytes of both assets
-        if let Ok(bytes) = self.buying.to_xdr(stellar_xdr::curr::Limits::none()) {
+        if let Ok(bytes) = self.buying.to_xdr(stellar_xdr::Limits::none()) {
             bytes.hash(state);
         }
-        if let Ok(bytes) = self.selling.to_xdr(stellar_xdr::curr::Limits::none()) {
+        if let Ok(bytes) = self.selling.to_xdr(stellar_xdr::Limits::none()) {
             bytes.hash(state);
         }
     }
@@ -211,13 +211,11 @@ mod tests {
     #[test]
     fn test_asset_pair() {
         let native = Asset::Native;
-        let credit = Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-            asset_code: stellar_xdr::curr::AssetCode4([b'U', b'S', b'D', 0]),
-            issuer: stellar_xdr::curr::AccountId(
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                    [0; 32],
-                )),
-            ),
+        let credit = Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+            asset_code: stellar_xdr::AssetCode4([b'U', b'S', b'D', 0]),
+            issuer: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([0; 32]),
+            )),
         });
 
         let pair1 = AssetPair::new(native.clone(), credit.clone());
@@ -233,13 +231,11 @@ mod tests {
         use std::collections::HashMap;
 
         let native = Asset::Native;
-        let credit = Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-            asset_code: stellar_xdr::curr::AssetCode4([b'U', b'S', b'D', 0]),
-            issuer: stellar_xdr::curr::AccountId(
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                    [0; 32],
-                )),
-            ),
+        let credit = Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+            asset_code: stellar_xdr::AssetCode4([b'U', b'S', b'D', 0]),
+            issuer: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([0; 32]),
+            )),
         });
 
         let pair = AssetPair::new(native.clone(), credit.clone());

--- a/crates/ledger/src/p23_hot_archive_bug.rs
+++ b/crates/ledger/src/p23_hot_archive_bug.rs
@@ -42,7 +42,7 @@
 //!    (events are op-meta-only, hashed after the success preimage) and is
 //!    off by default.
 
-use stellar_xdr::curr::{LedgerEntry, LedgerKey, Limits, ReadXdr};
+use stellar_xdr::{LedgerEntry, LedgerKey, Limits, ReadXdr};
 
 use henyey_common::entry_to_key;
 
@@ -223,7 +223,7 @@ mod tests {
     /// `P23_CORRUPTED_AFFECTED_ASSETS_COUNT = 12`).
     #[test]
     fn affected_assets_array_is_12_and_decodes() {
-        use stellar_xdr::curr::{Asset, ReadXdr};
+        use stellar_xdr::{Asset, ReadXdr};
         assert_eq!(P23_CORRUPTED_AFFECTED_ASSETS_COUNT, 12);
         assert_eq!(P23_CORRUPTED_AFFECTED_ASSETS.len(), 12);
         for (i, s) in P23_CORRUPTED_AFFECTED_ASSETS.iter().enumerate() {

--- a/crates/ledger/src/prepare_liabilities.rs
+++ b/crates/ledger/src/prepare_liabilities.rs
@@ -26,7 +26,7 @@ use henyey_tx::operations::execute::{
     adjust_offer_amount, exchange_v10_without_price_error_thresholds, ExchangeResult, RoundingType,
 };
 use std::collections::{BTreeMap, HashMap, HashSet};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext,
     AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountId, Asset, LedgerEntry,
     LedgerEntryData, LedgerEntryExt, LedgerKey, LedgerKeyAccount, LedgerKeyTrustLine, Liabilities,
@@ -466,9 +466,9 @@ fn ensure_trustline_liabilities(trustline: &mut TrustLineEntry) -> &mut Liabilit
 }
 
 /// Build a default signer_sponsoring_ids vector of None values.
-fn build_signer_sponsoring_ids(count: usize) -> VecM<stellar_xdr::curr::SponsorshipDescriptor, 20> {
-    let ids: Vec<stellar_xdr::curr::SponsorshipDescriptor> = (0..count)
-        .map(|_| stellar_xdr::curr::SponsorshipDescriptor(None))
+fn build_signer_sponsoring_ids(count: usize) -> VecM<stellar_xdr::SponsorshipDescriptor, 20> {
+    let ids: Vec<stellar_xdr::SponsorshipDescriptor> = (0..count)
+        .map(|_| stellar_xdr::SponsorshipDescriptor(None))
         .collect();
     ids.try_into().unwrap_or_default()
 }
@@ -485,9 +485,9 @@ fn make_trustline_key(account_id: &AccountId, asset: &Asset) -> LedgerKey {
 ///
 /// Matches stellar-core's `isAuthorizedToMaintainLiabilities` check.
 fn is_authorized_to_maintain_liabilities_tl(tl: &TrustLineEntry) -> bool {
-    const AUTHORIZED_FLAG: u32 = stellar_xdr::curr::TrustLineFlags::AuthorizedFlag as u32;
+    const AUTHORIZED_FLAG: u32 = stellar_xdr::TrustLineFlags::AuthorizedFlag as u32;
     const AUTH_LIAB_FLAG: u32 =
-        stellar_xdr::curr::TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag as u32;
+        stellar_xdr::TrustLineFlags::AuthorizedToMaintainLiabilitiesFlag as u32;
     tl.flags & (AUTHORIZED_FLAG | AUTH_LIAB_FLAG) != 0
 }
 

--- a/crates/ledger/src/snapshot.rs
+++ b/crates/ledger/src/snapshot.rs
@@ -26,7 +26,7 @@ use henyey_common::Hash256;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountId, LedgerEntry, LedgerEntryData, LedgerHeader, LedgerKey, PoolId,
 };
 
@@ -140,15 +140,15 @@ impl LedgerSnapshot {
             ledger_seq,
             header: LedgerHeader {
                 ledger_version: 0,
-                previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                scp_value: stellar_xdr::curr::StellarValue {
-                    tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                    close_time: stellar_xdr::curr::TimePoint(0),
-                    upgrades: stellar_xdr::curr::VecM::default(),
-                    ext: stellar_xdr::curr::StellarValueExt::Basic,
+                previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+                scp_value: stellar_xdr::StellarValue {
+                    tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                    close_time: stellar_xdr::TimePoint(0),
+                    upgrades: stellar_xdr::VecM::default(),
+                    ext: stellar_xdr::StellarValueExt::Basic,
                 },
-                tx_set_result_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                bucket_list_hash: stellar_xdr::curr::Hash([0u8; 32]),
+                tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+                bucket_list_hash: stellar_xdr::Hash([0u8; 32]),
                 ledger_seq,
                 total_coins: 0,
                 fee_pool: 0,
@@ -157,8 +157,8 @@ impl LedgerSnapshot {
                 base_fee: 100,
                 base_reserve: 5_000_000,
                 max_tx_set_size: 1000,
-                skip_list: std::array::from_fn(|_| stellar_xdr::curr::Hash([0u8; 32])),
-                ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+                skip_list: std::array::from_fn(|_| stellar_xdr::Hash([0u8; 32])),
+                ext: stellar_xdr::LedgerHeaderExt::V0,
             },
             header_hash: Hash256::ZERO,
             entries: HashMap::new(),
@@ -216,7 +216,7 @@ impl LedgerSnapshot {
 
     /// Look up an account by ID.
     pub fn get_account(&self, account_id: &AccountId) -> Option<&AccountEntry> {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
 
@@ -548,7 +548,7 @@ impl SnapshotHandle {
 
     /// Look up an account.
     pub fn get_account(&self, account_id: &AccountId) -> Result<Option<AccountEntry>> {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
 
@@ -716,15 +716,15 @@ impl SnapshotBuilder {
     pub fn build_with_default_header(self) -> LedgerSnapshot {
         let header = self.header.unwrap_or_else(|| LedgerHeader {
             ledger_version: 20,
-            previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-            scp_value: stellar_xdr::curr::StellarValue {
-                tx_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                close_time: stellar_xdr::curr::TimePoint(0),
-                upgrades: stellar_xdr::curr::VecM::default(),
-                ext: stellar_xdr::curr::StellarValueExt::Basic,
+            previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+            scp_value: stellar_xdr::StellarValue {
+                tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                close_time: stellar_xdr::TimePoint(0),
+                upgrades: stellar_xdr::VecM::default(),
+                ext: stellar_xdr::StellarValueExt::Basic,
             },
-            tx_set_result_hash: stellar_xdr::curr::Hash([0u8; 32]),
-            bucket_list_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+            bucket_list_hash: stellar_xdr::Hash([0u8; 32]),
             ledger_seq: self.ledger_seq,
             total_coins: 100_000_000_000_000_000,
             fee_pool: 0,
@@ -733,8 +733,8 @@ impl SnapshotBuilder {
             base_fee: 100,
             base_reserve: 5_000_000,
             max_tx_set_size: 1000,
-            skip_list: std::array::from_fn(|_| stellar_xdr::curr::Hash([0u8; 32])),
-            ext: stellar_xdr::curr::LedgerHeaderExt::V0,
+            skip_list: std::array::from_fn(|_| stellar_xdr::Hash([0u8; 32])),
+            ext: stellar_xdr::LedgerHeaderExt::V0,
         });
 
         LedgerSnapshot {
@@ -756,7 +756,7 @@ impl crate::EntryReader for SnapshotHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, LedgerEntryExt, PublicKey, SequenceNumber, Thresholds,
         Uint256,
     };
@@ -767,7 +767,7 @@ mod tests {
 
         let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(key_bytes)));
 
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
 
@@ -780,9 +780,9 @@ mod tests {
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
-                home_domain: stellar_xdr::curr::String32::default(),
+                home_domain: stellar_xdr::String32::default(),
                 thresholds: Thresholds([1, 0, 0, 0]),
-                signers: stellar_xdr::curr::VecM::default(),
+                signers: stellar_xdr::VecM::default(),
                 ext: AccountEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,

--- a/crates/ledger/src/soroban_state.rs
+++ b/crates/ledger/src/soroban_state.rs
@@ -176,13 +176,14 @@ impl<V: Clone> ShardedCowMap<V> {
 }
 use henyey_tx::operations::execute::entry_size_for_rent_by_protocol_with_cost_params;
 use henyey_tx::soroban::convert::{
-    try_convert_cost_params_ws_to_p25, try_convert_ledger_entry_ws_to_p25,
+    try_convert_cost_params_ws_to_p25, try_convert_cost_params_ws_to_p26,
+    try_convert_ledger_entry_ws_to_p25, try_convert_ledger_entry_ws_to_p26,
 };
 use soroban_env_host25::budget::Budget as BudgetP25;
 use soroban_env_host25::e2e_invoke::entry_size_for_rent as entry_size_for_rent_p25;
 use soroban_env_host_p25 as soroban_env_host25;
 use soroban_env_host_p26 as soroban_env_host26;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ConfigSettingId, ContractCostParams, Hash, LedgerEntry, LedgerEntryData, LedgerKey,
     LedgerKeyConfigSetting, LedgerKeyContractCode, LedgerKeyContractData, LedgerKeyTtl, TtlEntry,
 };
@@ -286,7 +287,8 @@ fn build_rent_budget_p25(rent_config: Option<&SorobanRentConfig>) -> BudgetP25 {
 
 /// Build a p26 Budget from on-chain cost parameters (for protocol 26+).
 ///
-/// P26 host uses stellar-xdr 26.0.0 (same as workspace) — no conversion needed.
+/// P26 host pins stellar-xdr 26.0.0, distinct from the workspace XDR, so the
+/// cost params are byte-converted to the P26 type.
 fn build_rent_budget_p26(
     rent_config: Option<&SorobanRentConfig>,
 ) -> soroban_env_host26::budget::Budget {
@@ -299,11 +301,25 @@ fn build_rent_budget_p26(
 
     let instruction_limit = config.tx_max_instructions.saturating_mul(2);
     let memory_limit = config.tx_max_memory_bytes.saturating_mul(2);
+    let cpu_params = match try_convert_cost_params_ws_to_p26(&config.cpu_cost_params) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("build_rent_budget_p26: {e}, using default budget");
+            return soroban_env_host26::budget::Budget::default();
+        }
+    };
+    let mem_params = match try_convert_cost_params_ws_to_p26(&config.mem_cost_params) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("build_rent_budget_p26: {e}, using default budget");
+            return soroban_env_host26::budget::Budget::default();
+        }
+    };
     soroban_env_host26::budget::Budget::try_from_configs(
         instruction_limit,
         memory_limit,
-        config.cpu_cost_params.clone(),
-        config.mem_cost_params.clone(),
+        cpu_params,
+        mem_params,
     )
     .unwrap_or_else(|_| soroban_env_host26::budget::Budget::default())
 }
@@ -672,7 +688,7 @@ impl InMemorySorobanState {
                 key_hash: key.key_hash.clone(),
                 live_until_ledger_seq: ttl_data.live_until_ledger_seq,
             }),
-            ext: stellar_xdr::curr::LedgerEntryExt::V0,
+            ext: stellar_xdr::LedgerEntryExt::V0,
         };
 
         Some(Arc::new(entry))
@@ -1045,10 +1061,19 @@ impl InMemorySorobanState {
             };
         }
         // Protocol >= 26: use p26 host (86 cost types).
-        // P26 host uses stellar-xdr 26.0.0 (same as workspace) — no conversion needed.
+        // P26 host pins stellar-xdr 26.0.0, distinct from the workspace XDR, so
+        // the entry is byte-converted to the P26 type.
         let budget = build_rent_budget_p26(rent_config);
-        soroban_env_host26::e2e_invoke::entry_size_for_rent(&budget, entry, xdr_size)
-            .unwrap_or(xdr_size)
+        match try_convert_ledger_entry_ws_to_p26(entry) {
+            Ok(p26_entry) => {
+                soroban_env_host26::e2e_invoke::entry_size_for_rent(&budget, &p26_entry, xdr_size)
+                    .unwrap_or(xdr_size)
+            }
+            Err(e) => {
+                tracing::warn!("calculate_code_size: {e}, falling back to XDR size");
+                xdr_size
+            }
+        }
     }
 
     /// Update state with new entries from a ledger close.
@@ -1355,7 +1380,7 @@ impl SharedSorobanState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractCodeEntry, ContractCodeEntryExt, ContractDataDurability, ContractDataEntry,
         ContractId, ExtensionPoint, Hash, LedgerEntryExt, LedgerKeyContractCode,
         LedgerKeyContractData, ScAddress, ScVal,
@@ -1370,9 +1395,7 @@ mod tests {
     fn contract_data_shard_index(key_bytes: [u8; 32]) -> usize {
         let ledger_key = LedgerKey::ContractData(LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                key_bytes.to_vec().try_into().unwrap(),
-            )),
+            key: ScVal::Bytes(stellar_xdr::ScBytes(key_bytes.to_vec().try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         });
         let key_hash = Hash256::hash_xdr(&ledger_key);
@@ -1423,13 +1446,11 @@ mod tests {
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
                 contract: make_contract_address(),
-                key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                    key_bytes.to_vec().try_into().unwrap(),
-                )),
+                key: ScVal::Bytes(stellar_xdr::ScBytes(key_bytes.to_vec().try_into().unwrap())),
                 durability: ContractDataDurability::Persistent,
                 val: ScVal::I32(42),
             }),
-            ext: stellar_xdr::curr::LedgerEntryExt::V0,
+            ext: stellar_xdr::LedgerEntryExt::V0,
         }
     }
 
@@ -1441,7 +1462,7 @@ mod tests {
                 hash: Hash(hash),
                 code: vec![0u8; 100].try_into().unwrap(),
             }),
-            ext: stellar_xdr::curr::LedgerEntryExt::V0,
+            ext: stellar_xdr::LedgerEntryExt::V0,
         }
     }
 
@@ -1495,9 +1516,7 @@ mod tests {
 
         let key = LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                [1u8; 32].to_vec().try_into().unwrap(),
-            )),
+            key: ScVal::Bytes(stellar_xdr::ScBytes([1u8; 32].to_vec().try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         };
 
@@ -1553,9 +1572,7 @@ mod tests {
         // Get the key hash
         let key = LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                [1u8; 32].to_vec().try_into().unwrap(),
-            )),
+            key: ScVal::Bytes(stellar_xdr::ScBytes([1u8; 32].to_vec().try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         };
         let key_hash = InMemorySorobanState::contract_data_key_hash(&key);
@@ -1577,9 +1594,7 @@ mod tests {
         // Create TTL before the entry exists
         let key = LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                [1u8; 32].to_vec().try_into().unwrap(),
-            )),
+            key: ScVal::Bytes(stellar_xdr::ScBytes([1u8; 32].to_vec().try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         };
         let key_hash = InMemorySorobanState::contract_data_key_hash(&key);
@@ -1610,9 +1625,7 @@ mod tests {
         // Set TTL
         let key = LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                [1u8; 32].to_vec().try_into().unwrap(),
-            )),
+            key: ScVal::Bytes(stellar_xdr::ScBytes([1u8; 32].to_vec().try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         };
         let key_hash = InMemorySorobanState::contract_data_key_hash(&key);
@@ -1683,7 +1696,7 @@ mod tests {
         // Create a TTL entry for the data that will be "restored" from hot archive
         let restored_key = LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
+            key: ScVal::Bytes(stellar_xdr::ScBytes(
                 [42u8; 32].to_vec().try_into().unwrap(),
             )),
             durability: ContractDataDurability::Persistent,
@@ -1706,7 +1719,7 @@ mod tests {
             data: LedgerEntryData::ContractData(ContractDataEntry {
                 ext: ExtensionPoint::V0,
                 contract: make_contract_address(),
-                key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
+                key: ScVal::Bytes(stellar_xdr::ScBytes(
                     [42u8; 32].to_vec().try_into().unwrap(),
                 )),
                 durability: ContractDataDurability::Persistent,
@@ -1762,7 +1775,7 @@ mod tests {
     /// the in-memory Soroban state cache — they should always go to the database.
     #[test]
     fn test_config_setting_not_in_memory_type() {
-        use stellar_xdr::curr::{ConfigSettingId, LedgerKeyConfigSetting};
+        use stellar_xdr::{ConfigSettingId, LedgerKeyConfigSetting};
 
         // ConfigSetting should NOT be an in-memory type
         let config_key = LedgerKey::ConfigSetting(LedgerKeyConfigSetting {
@@ -1792,12 +1805,10 @@ mod tests {
         assert!(InMemorySorobanState::is_in_memory_type(&ttl_key));
 
         // Account should also not be an in-memory type
-        let account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
-            account_id: stellar_xdr::curr::AccountId(
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                    [0u8; 32],
-                )),
-            ),
+        let account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
+            account_id: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([0u8; 32]),
+            )),
         });
         assert!(!InMemorySorobanState::is_in_memory_type(&account_key));
     }
@@ -2010,7 +2021,7 @@ mod tests {
 
     #[test]
     fn test_xdr_size_matches_serialization() {
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
 
         // Contract data entry
         let entry = make_contract_data_entry([1u8; 32]);
@@ -2030,7 +2041,7 @@ mod tests {
 
     #[test]
     fn test_contract_data_size_tracking_exact_deltas() {
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
 
         let mut state = InMemorySorobanState::new();
 
@@ -2044,9 +2055,7 @@ mod tests {
         let mut updated_entry = make_contract_data_entry([1u8; 32]);
         if let LedgerEntryData::ContractData(cd) = &mut updated_entry.data {
             // Use a much larger value to ensure different XDR size
-            cd.val = ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                vec![0u8; 200].try_into().unwrap(),
-            ));
+            cd.val = ScVal::Bytes(stellar_xdr::ScBytes(vec![0u8; 200].try_into().unwrap()));
         }
         let updated_xdr_size = updated_entry.to_xdr(Limits::none()).unwrap().len() as i64;
         state.update_contract_data(updated_entry).unwrap();
@@ -2059,9 +2068,7 @@ mod tests {
         // Delete and verify size returns to 0
         let key = LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                [1u8; 32].to_vec().try_into().unwrap(),
-            )),
+            key: ScVal::Bytes(stellar_xdr::ScBytes([1u8; 32].to_vec().try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         };
         state.delete_contract_data(&key).unwrap();
@@ -2124,7 +2131,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_preserves_sizes() {
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
 
         let mut state = InMemorySorobanState::new();
 
@@ -2154,9 +2161,7 @@ mod tests {
         // Delete from live
         let key = LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
-                [1u8; 32].to_vec().try_into().unwrap(),
-            )),
+            key: ScVal::Bytes(stellar_xdr::ScBytes([1u8; 32].to_vec().try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         };
         state.delete_contract_data(&key).unwrap();
@@ -2262,7 +2267,7 @@ mod tests {
         // Verify snapshot isolation: snapshot still sees original values.
         let snap_key_a = LedgerKey::ContractData(LedgerKeyContractData {
             contract: make_contract_address(),
-            key: ScVal::Bytes(stellar_xdr::curr::ScBytes(
+            key: ScVal::Bytes(stellar_xdr::ScBytes(
                 key_a_bytes.to_vec().try_into().unwrap(),
             )),
             durability: ContractDataDurability::Persistent,

--- a/crates/ledger/tests/hot_archive_p23_fix.rs
+++ b/crates/ledger/tests/hot_archive_p23_fix.rs
@@ -19,7 +19,7 @@ use henyey_ledger::p23_hot_archive_bug::{
 };
 
 use henyey_common::entry_to_key;
-use stellar_xdr::curr::{LedgerEntry, LedgerKey};
+use stellar_xdr::{LedgerEntry, LedgerKey};
 
 /// A live-state loader that always reports "absent" — matching the real
 /// scenario where the 478 corrupted keys were evicted long before the upgrade
@@ -237,7 +237,7 @@ fn test_is_mainnet_gate() {
 /// the 478 hardcoded keys (an Account entry — the hardcoded entries are all
 /// ContractData).
 fn make_unrelated_entry() -> LedgerEntry {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, LedgerEntryData, LedgerEntryExt, PublicKey,
         SequenceNumber, String32, Thresholds, Uint256, VecM,
     };

--- a/crates/ledger/tests/ledger_close_integration.rs
+++ b/crates/ledger/tests/ledger_close_integration.rs
@@ -5,7 +5,7 @@ use henyey_common::Hash256;
 use henyey_ledger::{
     compute_header_hash, LedgerCloseData, LedgerManager, LedgerManagerConfig, TransactionSetVariant,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountId, Asset, BucketListType, BytesM, ContractCodeEntry,
     ContractCodeEntryExt, ContractEventBody, CreateAccountOp, DecoratedSignature,
     ExtendFootprintTtlOp, ExtensionPoint, FeeBumpTransaction, FeeBumpTransactionEnvelope,
@@ -158,7 +158,7 @@ fn test_ledger_close_meta_structural_validation() {
 /// Parity: LedgerCloseMetaStreamTests.cpp - meta with SCP history entries
 #[test]
 fn test_ledger_close_meta_with_scp_history() {
-    use stellar_xdr::curr::{LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0};
+    use stellar_xdr::{LedgerScpMessages, ScpHistoryEntry, ScpHistoryEntryV0};
 
     let config = LedgerManagerConfig {
         validate_bucket_hash: false,
@@ -848,7 +848,7 @@ fn test_close_ledger_fee_event_fee_bump_soroban() {
         fee_source: MuxedAccount::Ed25519(Uint256(*outer_secret.public_key().as_bytes())),
         fee: 200_000,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut fee_bump_envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -931,7 +931,7 @@ fn test_close_ledger_fee_event_fee_bump_soroban() {
             from_str.contains(&outer_strkey) || {
                 // Compare the raw bytes: the Address should correspond to the outer source
                 match addr {
-                    stellar_xdr::curr::ScAddress::Account(aid) => aid == &outer_source_id,
+                    stellar_xdr::ScAddress::Account(aid) => aid == &outer_source_id,
                     _ => false,
                 }
             },
@@ -990,7 +990,7 @@ fn test_ledger_close_eviction_meta_key_ordering_impl() {
     use henyey_bucket::{BucketList, EvictionIterator};
     use henyey_common::xdr_to_bytes;
     use sha2::{Digest, Sha256};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ConfigSettingContractBandwidthV0, ConfigSettingContractComputeV0,
         ConfigSettingContractEventsV0, ConfigSettingContractExecutionLanesV0,
         ConfigSettingContractHistoricalDataV0, ConfigSettingContractLedgerCostV0,
@@ -1001,7 +1001,7 @@ fn test_ledger_close_eviction_meta_key_ordering_impl() {
 
     // --- Helper: compute the TTL key for a given data key ---
     let ttl_key_for = |data_key: &LedgerKey| -> LedgerKey {
-        let key_bytes = data_key.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+        let key_bytes = data_key.to_xdr(stellar_xdr::Limits::none()).unwrap();
         let hash_bytes: [u8; 32] = Sha256::digest(&key_bytes).into();
         LedgerKey::Ttl(LedgerKeyTtl {
             key_hash: Hash(hash_bytes),
@@ -1287,7 +1287,7 @@ fn test_ledger_close_eviction_meta_key_ordering_impl() {
 /// Bug behavior: op_count == 1 (only the successful tx's operation_results counted).
 #[test]
 fn test_ledger_close_counts_ops_for_pre_execution_rejected_transactions() {
-    use stellar_xdr::curr::BumpSequenceOp;
+    use stellar_xdr::BumpSequenceOp;
 
     let network_id = NetworkId::testnet();
 
@@ -1406,7 +1406,7 @@ fn test_ledger_close_counts_ops_for_pre_execution_rejected_transactions() {
 
     // Find the TxBadSeq result (order-independent)
     let has_bad_seq = result.tx_results.iter().any(|pair| {
-        use stellar_xdr::curr::TransactionResultResult;
+        use stellar_xdr::TransactionResultResult;
         matches!(&pair.result.result, TransactionResultResult::TxBadSeq)
     });
     assert!(has_bad_seq, "expected one TxBadSeq result");
@@ -1441,7 +1441,7 @@ fn test_ledger_close_counts_ops_for_pre_execution_rejected_transactions() {
 async fn test_close_ledger_with_held_snapshot_preserves_results() {
     use henyey_common::NetworkId;
     use henyey_crypto::{sign_hash, SecretKey};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, BucketListType, BytesM, ContractCodeEntry,
         ContractCodeEntryExt, ExtendFootprintTtlOp, LedgerFootprint, LedgerKey,
         LedgerKeyContractCode, MuxedAccount, Operation, OperationBody, Preconditions, PublicKey,
@@ -1468,7 +1468,7 @@ async fn test_close_ledger_with_held_snapshot_preserves_results() {
             inflation_dest: None,
             flags: 0,
             home_domain: Default::default(),
-            thresholds: stellar_xdr::curr::Thresholds([1, 0, 0, 0]),
+            thresholds: stellar_xdr::Thresholds([1, 0, 0, 0]),
             signers: VecM::default(),
             ext: AccountEntryExt::V0,
         }),
@@ -1768,7 +1768,7 @@ async fn test_close_stamps_last_modified_on_all_entries() {
     assert!(
         matches!(
             result.tx_results[0].result.result,
-            stellar_xdr::curr::TransactionResultResult::TxSuccess(_)
+            stellar_xdr::TransactionResultResult::TxSuccess(_)
         ),
         "tx should succeed, got {:?}",
         result.tx_results[0].result.result

--- a/crates/ledger/tests/ledger_close_meta_vectors.rs
+++ b/crates/ledger/tests/ledger_close_meta_vectors.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use henyey_common::Hash256;
 use henyey_crypto::PublicKey;
 use serde_json::Value as JsonValue;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ExtendFootprintTtlResult, Hash, InnerTransactionResult, InnerTransactionResultExt,
     InnerTransactionResultPair, InnerTransactionResultResult, InvokeHostFunctionResult,
     LedgerCloseValueSignature, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntry,

--- a/crates/ledger/tests/transaction_execution/classic_events.rs
+++ b/crates/ledger/tests/transaction_execution/classic_events.rs
@@ -16,9 +16,9 @@ fn test_classic_events_emitted_for_payment() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([4u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 100,
         }),
     };
@@ -65,13 +65,13 @@ fn test_classic_events_emitted_for_payment() {
         panic!("unexpected tx meta");
     };
 
-    let tx_events: &[stellar_xdr::curr::TransactionEvent] = meta.events.as_ref();
+    let tx_events: &[stellar_xdr::TransactionEvent] = meta.events.as_ref();
     assert_eq!(tx_events.len(), 0);
 
     let contract_id = native_asset_contract_id(&network_id);
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     assert_eq!(op_event.contract_id, Some(contract_id));
@@ -117,9 +117,9 @@ fn test_classic_events_payment_with_muxed_destination() {
     });
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: muxed_dest,
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 200,
         }),
     };
@@ -166,16 +166,16 @@ fn test_classic_events_payment_with_muxed_destination() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
     let ScVal::Map(Some(map)) = &op_body.data else {
         panic!("expected map data for muxed destination");
     };
-    let entries: &[stellar_xdr::curr::ScMapEntry] = map.0.as_ref();
+    let entries: &[stellar_xdr::ScMapEntry] = map.0.as_ref();
     assert_eq!(entries.len(), 2);
     let amount_entry = entries
         .iter()
@@ -205,9 +205,9 @@ fn test_classic_events_payment_with_memo_data() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([8u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 150,
         }),
     };
@@ -255,16 +255,16 @@ fn test_classic_events_payment_with_memo_data() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
     let ScVal::Map(Some(map)) = &op_body.data else {
         panic!("expected map data for memo");
     };
-    let entries: &[stellar_xdr::curr::ScMapEntry] = map.0.as_ref();
+    let entries: &[stellar_xdr::ScMapEntry] = map.0.as_ref();
     assert_eq!(entries.len(), 2);
     let amount_entry = entries
         .iter()
@@ -299,9 +299,9 @@ fn test_classic_events_payment_memo_precedence() {
     });
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: muxed_dest,
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 250,
         }),
     };
@@ -349,16 +349,16 @@ fn test_classic_events_payment_memo_precedence() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
     let ScVal::Map(Some(map)) = &op_body.data else {
         panic!("expected map data for muxed destination");
     };
-    let entries: &[stellar_xdr::curr::ScMapEntry] = map.0.as_ref();
+    let entries: &[stellar_xdr::ScMapEntry] = map.0.as_ref();
     assert_eq!(entries.len(), 2);
     let muxed_entry = entries
         .iter()
@@ -429,9 +429,9 @@ fn test_classic_events_emitted_for_account_merge() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -518,9 +518,9 @@ fn test_classic_events_emitted_for_create_account() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -616,9 +616,9 @@ fn test_classic_events_emitted_for_create_claimable_balance() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -723,9 +723,9 @@ fn test_classic_events_emitted_for_claim_claimable_balance() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -827,9 +827,9 @@ fn test_classic_events_emitted_for_allow_trust() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -924,9 +924,9 @@ fn test_classic_events_emitted_for_set_trustline_flags() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -1023,9 +1023,9 @@ fn test_classic_events_emitted_for_clawback() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -1131,9 +1131,9 @@ fn test_classic_events_emitted_for_clawback_claimable_balance() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 1);
     let op_event = &op_event_list[0];
     let ContractEventBody::V0(op_body) = &op_event.body;
@@ -1249,9 +1249,9 @@ fn test_classic_events_emitted_for_liquidity_pool_deposit() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 2);
 
     let pool_address = ScAddress::LiquidityPool(pool_id.clone());
@@ -1383,9 +1383,9 @@ fn test_classic_events_emitted_for_liquidity_pool_withdraw() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), 2);
 
     let pool_address = ScAddress::LiquidityPool(pool_id.clone());
@@ -1585,9 +1585,9 @@ fn test_classic_events_emitted_for_manage_sell_offer() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), claim_atoms.len() * 2);
 
     let mut index = 0;
@@ -1711,7 +1711,7 @@ fn test_classic_events_emitted_for_path_payment_strict_send() {
         "unexpected result: {:?}",
         result.operation_results
     );
-    let (claim_atoms, last): (&[ClaimAtom], &stellar_xdr::curr::SimplePaymentResult) =
+    let (claim_atoms, last): (&[ClaimAtom], &stellar_xdr::SimplePaymentResult) =
         match result.operation_results.get(0).expect("op result") {
             OperationResult::OpInner(OperationResultTr::PathPaymentStrictSend(
                 PathPaymentStrictSendResult::Success(PathPaymentStrictSendResultSuccess {
@@ -1729,9 +1729,9 @@ fn test_classic_events_emitted_for_path_payment_strict_send() {
         panic!("unexpected tx meta");
     };
 
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let op_event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(op_event_list.len(), claim_atoms.len() * 2 + 1);
 
     let mut index = 0;
@@ -1776,7 +1776,7 @@ fn build_pool_share_revoke_snapshot(
     use henyey_ledger::{EntryLookupFn, PoolShareTrustlinesByAccountFn};
     use std::collections::HashMap;
     use std::sync::Arc;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Liabilities, Limits, TrustLineEntryExt, TrustLineEntryExtensionV2,
         TrustLineEntryExtensionV2Ext, TrustLineEntryV1, TrustLineEntryV1Ext, WriteXdr,
     };
@@ -1838,7 +1838,7 @@ fn build_pool_share_revoke_snapshot(
     let (issuer_key, issuer_entry) =
         create_account_entry_with_flags(issuer_id.clone(), 1, 100_000_000, 0x1 | 0x2);
 
-    let trustor_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let trustor_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: trustor_id.clone(),
     });
     let trustor_entry = LedgerEntry {
@@ -1923,7 +1923,7 @@ fn execute_single_op_tx_v4(
     issuer_secret: &SecretKey,
     op: Operation,
     network_id: &NetworkId,
-) -> stellar_xdr::curr::TransactionMetaV4 {
+) -> stellar_xdr::TransactionMetaV4 {
     let tx = Transaction {
         source_account: MuxedAccount::Ed25519(Uint256(*issuer_secret.public_key().as_bytes())),
         fee: 1000,
@@ -2010,9 +2010,9 @@ fn test_classic_events_pool_share_revoke_transfer() {
     };
 
     let meta = execute_single_op_tx_v4(&handle, &issuer_secret, op, &network_id);
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let events: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let events: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
 
     // Expect exactly 3 events: transfer(asset_a) [0], transfer(asset_b) [1],
     // set_authorized [2]. amount_a = floor(100*1000/500)=200, amount_b=400.
@@ -2093,9 +2093,9 @@ fn test_classic_events_pool_share_revoke_burn_when_issuer() {
     };
 
     let meta = execute_single_op_tx_v4(&handle, &issuer_secret, op, &network_id);
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
     assert_eq!(op_events.len(), 1);
-    let events: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let events: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
 
     // transfer(asset_a) [0], burn(asset_b) [1], set_authorized [2].
     assert_eq!(events.len(), 3, "expected transfer + burn + set_authorized");
@@ -2130,7 +2130,7 @@ fn revoke_cb_address(
     pool_id: &PoolId,
     asset: &Asset,
 ) -> ScAddress {
-    use stellar_xdr::curr::{ClaimableBalanceId, HashIdPreimage, HashIdPreimageRevokeId};
+    use stellar_xdr::{ClaimableBalanceId, HashIdPreimage, HashIdPreimageRevokeId};
     let preimage = HashIdPreimage::PoolRevokeOpId(HashIdPreimageRevokeId {
         source_account: source_id.clone(),
         seq_num: SequenceNumber(seq),
@@ -2208,8 +2208,8 @@ fn test_classic_events_create_claimable_balance_with_memo_no_muxed_id() {
     let TransactionMeta::V4(meta) = result.tx_meta.expect("tx meta") else {
         panic!("unexpected tx meta");
     };
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
-    let event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
+    let event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(event_list.len(), 1);
     let ContractEventBody::V0(body) = &event_list[0].body;
     assert_eq!(
@@ -2349,8 +2349,8 @@ fn test_classic_events_emitted_for_path_payment_strict_receive() {
     let TransactionMeta::V4(meta) = result.tx_meta.expect("tx meta") else {
         panic!("unexpected tx meta");
     };
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
-    let event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
+    let event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(event_list.len(), claim_atoms.len() * 2 + 1);
 
     let mut index = 0;
@@ -2437,7 +2437,7 @@ fn test_classic_events_payment_to_issuer_emits_burn() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: issuer_id.clone().into(),
             asset: asset.clone(),
             amount: 10_000_000,
@@ -2479,8 +2479,8 @@ fn test_classic_events_payment_to_issuer_emits_burn() {
     let TransactionMeta::V4(meta) = result.tx_meta.expect("tx meta") else {
         panic!("unexpected tx meta");
     };
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
-    let event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
+    let event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(event_list.len(), 1);
     let ContractEventBody::V0(body) = &event_list[0].body;
     let topics: &[ScVal] = body.topics.as_ref();
@@ -2526,7 +2526,7 @@ fn test_classic_events_payment_from_issuer_emits_mint() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: holder_id.clone().into(),
             asset: asset.clone(),
             amount: 10_000_000,
@@ -2568,8 +2568,8 @@ fn test_classic_events_payment_from_issuer_emits_mint() {
     let TransactionMeta::V4(meta) = result.tx_meta.expect("tx meta") else {
         panic!("unexpected tx meta");
     };
-    let op_events: &[stellar_xdr::curr::OperationMetaV2] = meta.operations.as_ref();
-    let event_list: &[stellar_xdr::curr::ContractEvent] = op_events[0].events.as_ref();
+    let op_events: &[stellar_xdr::OperationMetaV2] = meta.operations.as_ref();
+    let event_list: &[stellar_xdr::ContractEvent] = op_events[0].events.as_ref();
     assert_eq!(event_list.len(), 1);
     let ContractEventBody::V0(body) = &event_list[0].body;
     let topics: &[ScVal] = body.topics.as_ref();
@@ -2599,14 +2599,14 @@ fn test_classic_events_fee_charge_and_refund() {
     tx_mgr.charge_fee(
         &source_id,
         100,
-        stellar_xdr::curr::TransactionEventStage::BeforeAllTxs,
+        stellar_xdr::TransactionEventStage::BeforeAllTxs,
     );
     // Soroban refund: data = -refund, AfterAllTxs — mirrors apply.rs which calls
     // `new_fee_event(&fee_source, -refund, AfterAllTxs)`.
     tx_mgr.new_fee_event(
         &source_id,
         -30,
-        stellar_xdr::curr::TransactionEventStage::AfterAllTxs,
+        stellar_xdr::TransactionEventStage::AfterAllTxs,
     );
 
     let events = tx_mgr.finalize();
@@ -2618,9 +2618,9 @@ fn test_classic_events_fee_charge_and_refund() {
     let charge = &events[0];
     assert_eq!(
         charge.stage,
-        stellar_xdr::curr::TransactionEventStage::BeforeAllTxs
+        stellar_xdr::TransactionEventStage::BeforeAllTxs
     );
-    let stellar_xdr::curr::ContractEventBody::V0(charge_body) = &charge.event.body;
+    let stellar_xdr::ContractEventBody::V0(charge_body) = &charge.event.body;
     let charge_topics: &[ScVal] = charge_body.topics.as_ref();
     assert_eq!(charge_topics[0], scval_symbol("fee"));
     assert_eq!(charge_topics[1], ScVal::Address(from.clone()));
@@ -2630,9 +2630,9 @@ fn test_classic_events_fee_charge_and_refund() {
     let refund = &events[1];
     assert_eq!(
         refund.stage,
-        stellar_xdr::curr::TransactionEventStage::AfterAllTxs
+        stellar_xdr::TransactionEventStage::AfterAllTxs
     );
-    let stellar_xdr::curr::ContractEventBody::V0(refund_body) = &refund.event.body;
+    let stellar_xdr::ContractEventBody::V0(refund_body) = &refund.event.body;
     let refund_topics: &[ScVal] = refund_body.topics.as_ref();
     assert_eq!(refund_topics[0], scval_symbol("fee"));
     assert_eq!(refund_topics[1], ScVal::Address(from));
@@ -2651,7 +2651,7 @@ fn test_classic_events_emitted_for_claim_atoms_v0() {
         issuer: issuer_id.clone(),
     });
 
-    let claim = ClaimAtom::V0(stellar_xdr::curr::ClaimOfferAtomV0 {
+    let claim = ClaimAtom::V0(stellar_xdr::ClaimOfferAtomV0 {
         seller_ed25519: Uint256([182u8; 32]),
         offer_id: 9,
         asset_sold: Asset::Native,

--- a/crates/ledger/tests/transaction_execution/fee_refund_correction.rs
+++ b/crates/ledger/tests/transaction_execution/fee_refund_correction.rs
@@ -115,7 +115,7 @@ fn build_fee_bump_extend_ttl_tx(
         fee_source: MuxedAccount::Ed25519(Uint256(*outer_secret.public_key().as_bytes())),
         fee: outer_fee as i64,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {

--- a/crates/ledger/tests/transaction_execution/main.rs
+++ b/crates/ledger/tests/transaction_execution/main.rs
@@ -8,7 +8,7 @@ use henyey_tx::{
     soroban::{PersistentModuleCache, SorobanConfig},
     ClassicEventConfig, OpEventManager, TxEventManager,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext,
     AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountEntryExtensionV3, AccountId,
     AllowTrustOp, AlphaNum4, Asset, AssetCode, AssetCode4, BytesM, ChangeTrustAsset, ChangeTrustOp,
@@ -47,7 +47,7 @@ fn create_account_entry_with_last_modified(
     balance: i64,
     last_modified_ledger_seq: u32,
 ) -> (LedgerKey, LedgerEntry) {
-    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     });
 
@@ -79,7 +79,7 @@ fn create_account_entry_with_seq_info(
     seq_ledger: u32,
     seq_time: u64,
 ) -> (LedgerKey, LedgerEntry) {
-    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     });
 
@@ -132,7 +132,7 @@ fn create_account_entry_with_flags(
     balance: i64,
     flags: u32,
 ) -> (LedgerKey, LedgerEntry) {
-    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     });
 
@@ -188,9 +188,9 @@ fn set_account_liabilities(entry: &mut LedgerEntry, selling: i64, buying: i64) {
     let LedgerEntryData::Account(account) = &mut entry.data else {
         return;
     };
-    account.ext = AccountEntryExt::V1(stellar_xdr::curr::AccountEntryExtensionV1 {
-        liabilities: stellar_xdr::curr::Liabilities { selling, buying },
-        ext: stellar_xdr::curr::AccountEntryExtensionV1Ext::V0,
+    account.ext = AccountEntryExt::V1(stellar_xdr::AccountEntryExtensionV1 {
+        liabilities: stellar_xdr::Liabilities { selling, buying },
+        ext: stellar_xdr::AccountEntryExtensionV1Ext::V0,
     });
 }
 
@@ -198,9 +198,9 @@ fn set_trustline_liabilities(entry: &mut LedgerEntry, selling: i64, buying: i64)
     let LedgerEntryData::Trustline(trustline) = &mut entry.data else {
         return;
     };
-    trustline.ext = TrustLineEntryExt::V1(stellar_xdr::curr::TrustLineEntryV1 {
-        liabilities: stellar_xdr::curr::Liabilities { selling, buying },
-        ext: stellar_xdr::curr::TrustLineEntryV1Ext::V0,
+    trustline.ext = TrustLineEntryExt::V1(stellar_xdr::TrustLineEntryV1 {
+        liabilities: stellar_xdr::Liabilities { selling, buying },
+        ext: stellar_xdr::TrustLineEntryV1Ext::V0,
     });
 }
 
@@ -327,7 +327,7 @@ fn asset_string_scval(asset: &Asset) -> ScVal {
 }
 
 fn assert_transfer_event(
-    event: &stellar_xdr::curr::ContractEvent,
+    event: &stellar_xdr::ContractEvent,
     from: &ScAddress,
     to: &ScAddress,
     asset: &Asset,
@@ -344,7 +344,7 @@ fn assert_transfer_event(
 }
 
 fn assert_claim_atom_events(
-    events: &[stellar_xdr::curr::ContractEvent],
+    events: &[stellar_xdr::ContractEvent],
     claim: &ClaimAtom,
     source_id: &AccountId,
     start: usize,
@@ -427,7 +427,7 @@ fn assert_claim_atom_events(
 fn native_asset_contract_id(network_id: &NetworkId) -> ContractId {
     let preimage = HashIdPreimage::ContractId(HashIdPreimageContractId {
         network_id: Hash::from(network_id.0),
-        contract_id_preimage: ContractIdPreimage::Asset(stellar_xdr::curr::Asset::Native),
+        contract_id_preimage: ContractIdPreimage::Asset(stellar_xdr::Asset::Native),
     });
     let hash = henyey_common::Hash256::hash_xdr(&preimage);
     ContractId(Hash::from(hash))

--- a/crates/ledger/tests/transaction_execution/preconditions.rs
+++ b/crates/ledger/tests/transaction_execution/preconditions.rs
@@ -548,7 +548,7 @@ fn test_fee_bump_result_encoding() {
         fee_source: source,
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_env),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -624,7 +624,7 @@ fn test_audit_574_fee_bump_outer_failure_is_top_level() {
         fee_source: source,
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_env),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -693,9 +693,9 @@ fn test_operation_failure_rolls_back_changes() {
 
     let op_payment = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 10,
         }),
     };
@@ -759,7 +759,7 @@ fn test_fee_bump_inner_signature_uses_low_threshold() {
 
     // Inner source: master_weight=1, low=1, medium=2, high=3
     // Master key has weight 1 which passes low (1) but fails medium (2)
-    let inner_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let inner_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: inner_account_id.clone(),
     });
     let inner_entry = LedgerEntry {
@@ -823,7 +823,7 @@ fn test_fee_bump_inner_signature_uses_low_threshold() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -910,7 +910,7 @@ fn test_fee_bump_outer_source_frozen_key_rejected() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_env),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -948,7 +948,7 @@ fn test_fee_bump_outer_source_frozen_key_rejected() {
         account_id: fee_account_id.clone(),
     });
     let frozen_key_bytes = fee_account_ledger_key
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .unwrap();
 
     let mut context = henyey_tx::LedgerContext::new(1, 1_000, 100, 5_000_000, 26, network_id);
@@ -1003,9 +1003,9 @@ fn test_fee_bump_outer_source_frozen_bypass_allowed() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([98u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 1_000_000,
         }),
     };
@@ -1029,7 +1029,7 @@ fn test_fee_bump_outer_source_frozen_bypass_allowed() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_env),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -1071,7 +1071,7 @@ fn test_fee_bump_outer_source_frozen_bypass_allowed() {
         account_id: fee_account_id.clone(),
     });
     let frozen_key_bytes = fee_account_ledger_key
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .unwrap();
 
     let mut context = henyey_tx::LedgerContext::new(1, 1_000, 100, 5_000_000, 26, network_id);
@@ -1145,7 +1145,7 @@ fn test_inner_source_frozen_key_rejected() {
         account_id: account_id.clone(),
     });
     let frozen_key_bytes = account_ledger_key
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .unwrap();
 
     let mut context = henyey_tx::LedgerContext::new(1, 1_000, 100, 5_000_000, 26, network_id);
@@ -1189,9 +1189,9 @@ fn test_inner_source_frozen_bypass_allowed() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([96u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 1_000_000,
         }),
     };
@@ -1226,7 +1226,7 @@ fn test_inner_source_frozen_bypass_allowed() {
         account_id: account_id.clone(),
     });
     let frozen_key_bytes = account_ledger_key
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .unwrap();
 
     let mut context = henyey_tx::LedgerContext::new(1, 1_000, 100, 5_000_000, 26, network_id);
@@ -1905,7 +1905,7 @@ fn test_fee_bump_outer_fee_checked_before_fee_source_load() {
 
     // Fee-bump with fee=1 (way too low, base_fee=100 * 1 op = 100 minimum)
     let fee_bump_tx = FeeBumpTransaction {
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_source_secret.public_key().as_bytes())),
         fee: 1, // Insufficient
         inner_tx: FeeBumpTransactionInnerTx::Tx(signed_inner),
@@ -1997,7 +1997,7 @@ fn test_fee_bump_time_bounds_checked_before_inner_source_load() {
 
     // Fee-bump with sufficient fee
     let fee_bump_tx = FeeBumpTransaction {
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_source_secret.public_key().as_bytes())),
         fee: 200, // Sufficient (inner fee=100, so outer must be >= inner)
         inner_tx: FeeBumpTransactionInnerTx::Tx(signed_inner),
@@ -2231,7 +2231,7 @@ fn test_audit_238_fee_bump_bad_outer_sig_before_seq_check() {
     // Inner tx has BAD seq_num (99 instead of 2) — would produce TxBadSeq if reached
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
             asset: Asset::Native,
             amount: 1,
@@ -2263,7 +2263,7 @@ fn test_audit_238_fee_bump_bad_outer_sig_before_seq_check() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -2325,7 +2325,7 @@ fn test_audit_238_fee_bump_good_outer_sig_bad_inner_seq() {
 
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
             asset: Asset::Native,
             amount: 1,
@@ -2357,7 +2357,7 @@ fn test_audit_238_fee_bump_good_outer_sig_bad_inner_seq() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -2409,7 +2409,7 @@ fn test_audit_238_fee_bump_outer_auth_uses_snapshot_not_mutated_state() {
         key: SignerKey::Ed25519(Uint256(*extra_signer_pubkey.as_bytes())),
         weight: 1,
     };
-    let fee_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let fee_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: fee_account_id.clone(),
     });
     let fee_entry = LedgerEntry {
@@ -2490,7 +2490,7 @@ fn test_audit_238_fee_bump_outer_auth_uses_snapshot_not_mutated_state() {
     // TX2: fee-bump signed by extra_signer_secret (removed from fee source by TX1)
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
             asset: Asset::Native,
             amount: 1,
@@ -2522,7 +2522,7 @@ fn test_audit_238_fee_bump_outer_auth_uses_snapshot_not_mutated_state() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -2583,7 +2583,7 @@ fn test_audit_238_fee_bump_outer_auth_same_source() {
 
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
             asset: Asset::Native,
             amount: 1,
@@ -2617,7 +2617,7 @@ fn test_audit_238_fee_bump_outer_auth_same_source() {
         fee_source: MuxedAccount::Ed25519(Uint256(*source_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -2658,9 +2658,7 @@ fn test_execute_transaction_rejects_over_depth_envelope() {
     // Build a deeply nested ScVal to exceed XDR depth limit of 500
     let mut val = ScVal::U32(42);
     for _ in 0..501 {
-        val = ScVal::Vec(Some(stellar_xdr::curr::ScVec(
-            vec![val].try_into().unwrap(),
-        )));
+        val = ScVal::Vec(Some(stellar_xdr::ScVec(vec![val].try_into().unwrap())));
     }
 
     let secret = SecretKey::from_seed(&[7u8; 32]);
@@ -2754,7 +2752,7 @@ fn test_execute_transaction_insufficient_available_balance_rejects() {
 
     // balance=100, num_sub_entries=1 (V0 ext). minBalance with base_reserve=25
     // is (2 + 1) * 25 = 75. Available after fee=50 is 100 - 50 - 75 = -25.
-    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     });
     let entry = LedgerEntry {
@@ -2780,9 +2778,9 @@ fn test_execute_transaction_insufficient_available_balance_rejects() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 1,
         }),
     };
@@ -2844,7 +2842,7 @@ fn test_execute_transaction_insufficient_balance_via_selling_liabilities() {
     let secret = SecretKey::from_seed(&[72u8; 32]);
     let account_id: AccountId = (&secret.public_key()).into();
 
-    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     });
     let entry = LedgerEntry {
@@ -2876,9 +2874,9 @@ fn test_execute_transaction_insufficient_balance_via_selling_liabilities() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 1,
         }),
     };

--- a/crates/ledger/tests/transaction_execution/regression.rs
+++ b/crates/ledger/tests/transaction_execution/regression.rs
@@ -43,7 +43,7 @@ fn test_soroban_refund_event_after_all_txs() {
     let operation = Operation {
         source_account: None,
         body: OperationBody::ExtendFootprintTtl(ExtendFootprintTtlOp {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             extend_to: 100,
         }),
     };
@@ -102,7 +102,7 @@ fn test_soroban_refund_event_after_all_txs() {
         panic!("unexpected tx meta");
     };
 
-    let tx_events: &[stellar_xdr::curr::TransactionEvent] = meta.events.as_ref();
+    let tx_events: &[stellar_xdr::TransactionEvent] = meta.events.as_ref();
     assert_eq!(tx_events.len(), 1);
 
     let contract_id = native_asset_contract_id(&network_id);
@@ -123,7 +123,7 @@ fn create_account_entry_with_sponsored_signers(
     signer_sponsors: Vec<SponsorshipDescriptor>,
     num_sponsored: u32,
 ) -> (LedgerKey, LedgerEntry) {
-    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     });
 
@@ -165,7 +165,7 @@ fn create_sponsor_account_entry(
     balance: i64,
     num_sponsoring: u32,
 ) -> (LedgerKey, LedgerEntry) {
-    let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     });
 
@@ -1320,7 +1320,7 @@ fn test_cross_tx_deleted_trustline_not_reloaded() {
     });
 
     // Source account has a trustline (num_sub_entries=1)
-    let source_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let source_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: source_id.clone(),
     });
     let source_entry = LedgerEntry {
@@ -2198,7 +2198,7 @@ fn test_create_account_sponsor_low_reserve_before_underfunded() {
                 PublicKey::PublicKeyTypeEd25519(k) => k.clone(),
             })),
             body: OperationBody::BeginSponsoringFutureReserves(
-                stellar_xdr::curr::BeginSponsoringFutureReservesOp {
+                stellar_xdr::BeginSponsoringFutureReservesOp {
                     sponsored_id: dest_id.clone(),
                 },
             ),
@@ -2287,7 +2287,7 @@ fn test_create_account_sponsor_low_reserve_before_underfunded() {
 /// claimable balance entry's own CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG.
 #[test]
 fn test_clawback_claimable_balance_not_issuer_error_code() {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ClaimableBalanceEntryExtensionV1, ClaimableBalanceEntryExtensionV1Ext,
         ClaimableBalanceFlags, ClawbackClaimableBalanceResult,
     };
@@ -2448,9 +2448,9 @@ fn test_classic_fees_deducted_upfront_before_tx_execution() {
     for i in 0..3u32 {
         let operation = Operation {
             source_account: None,
-            body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+            body: OperationBody::Payment(stellar_xdr::PaymentOp {
                 destination: MuxedAccount::Ed25519(Uint256([88u8; 32])),
-                asset: stellar_xdr::curr::Asset::Native,
+                asset: stellar_xdr::Asset::Native,
                 amount: 200,
             }),
         };
@@ -2539,7 +2539,7 @@ fn test_set_trust_line_flags_redeems_pool_shares_loaded_from_snapshot() {
     use henyey_ledger::{EntryLookupFn, PoolShareTrustlinesByAccountFn};
     use std::collections::HashMap;
     use std::sync::Arc;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Liabilities, Limits, TrustLineEntryExt, TrustLineEntryExtensionV2,
         TrustLineEntryExtensionV2Ext, TrustLineEntryV1, TrustLineEntryV1Ext, TrustLineFlags,
         WriteXdr,
@@ -2658,7 +2658,7 @@ fn test_set_trust_line_flags_redeems_pool_shares_loaded_from_snapshot() {
         create_account_entry_with_flags(issuer_id.clone(), 1, 100_000_000, 0x1 | 0x2);
 
     // Trustor account — num_sub_entries=4 (2 asset TLs × 1 each + pool share TL counts as 2)
-    let trustor_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let trustor_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: trustor_id.clone(),
     });
     let trustor_entry = LedgerEntry {
@@ -2867,7 +2867,7 @@ fn test_fee_bump_charges_outer_fee_when_inner_auth_fails_at_apply() {
         key: SignerKey::Ed25519(Uint256(*signer_pubkey.as_bytes())),
         weight: 1,
     };
-    let inner_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let inner_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: inner_account_id.clone(),
     });
     let inner_entry = LedgerEntry {
@@ -2954,7 +2954,7 @@ fn test_fee_bump_charges_outer_fee_when_inner_auth_fails_at_apply() {
     // TX2: fee-bump wrapping an inner tx signed by signer_secret (now removed by TX1).
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
             asset: Asset::Native,
             amount: 1,
@@ -2987,7 +2987,7 @@ fn test_fee_bump_charges_outer_fee_when_inner_auth_fails_at_apply() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut env2 = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -3123,7 +3123,7 @@ fn test_op_source_merged_in_prior_tx_returns_bad_auth() {
     // Before fix: Henyey returned true (0 >= 0 bug) → op executed → opNO_ACCOUNT.
     let payment_op = Operation {
         source_account: Some(op_source_muxed),
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(match &dest_id.0 {
                 PublicKey::PublicKeyTypeEd25519(k) => k.clone(),
             }),
@@ -3217,9 +3217,9 @@ fn test_pre_auth_tx_signer_checked_before_removal() {
     // PreAuthTx signer in TX 1.
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([99u8; 32])),
-            asset: stellar_xdr::curr::Asset::Native,
+            asset: stellar_xdr::Asset::Native,
             amount: 1000,
         }),
     };
@@ -3520,7 +3520,7 @@ fn test_fee_bump_soroban_checks_inner_signatures() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut env2 = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -3590,7 +3590,7 @@ fn test_pre_charged_fee_override_on_validation_failure() {
     // Build TX from the missing account — this will trigger TxNoAccount.
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
             asset: Asset::Native,
             amount: 1,
@@ -3774,7 +3774,7 @@ fn test_partial_fee_precharge_still_applies_body() {
 fn test_audit_577_max_seq_num_to_apply_with_pre_charged() {
     use henyey_ledger::execution::{run_transactions_on_executor, FeeStrategy, PreChargedFee};
     use henyey_ledger::LedgerDelta;
-    use stellar_xdr::curr::AccountMergeResult;
+    use stellar_xdr::AccountMergeResult;
 
     let ledger_seq: u32 = 2;
     let starting_seq: i64 = (ledger_seq as i64) << 32; // 8589934592
@@ -3889,7 +3889,7 @@ fn test_audit_577_max_seq_num_to_apply_with_pre_charged() {
 fn test_max_seq_num_to_apply_built_for_merge_protocol24() {
     use henyey_ledger::execution::{run_transactions_on_executor, FeeStrategy};
     use henyey_ledger::LedgerDelta;
-    use stellar_xdr::curr::AccountMergeResult;
+    use stellar_xdr::AccountMergeResult;
 
     let ledger_seq: u32 = 2;
     let starting_seq: i64 = (ledger_seq as i64) << 32;
@@ -4014,7 +4014,7 @@ fn test_single_op_tx_failure_rolls_back_without_per_op_savepoint() {
     let nonexistent_dest = MuxedAccount::Ed25519(Uint256([99u8; 32]));
     let op_payment = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: nonexistent_dest,
             asset: Asset::Native,
             amount: 1_000_000,
@@ -4103,7 +4103,7 @@ fn test_audit_005_fee_bump_pre_auth_signer_removed_from_fee_source() {
     // Build the fee bump transaction first to compute the outer hash.
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256(*inner_secret.public_key().as_bytes())),
             asset: Asset::Native,
             amount: 1,
@@ -4139,7 +4139,7 @@ fn test_audit_005_fee_bump_pre_auth_signer_removed_from_fee_source() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(signed_inner_v1.clone()),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let fee_bump_env = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -4200,7 +4200,7 @@ fn test_audit_005_fee_bump_pre_auth_signer_removed_from_fee_source() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(signed_inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -4256,7 +4256,7 @@ fn test_audit_005_fee_bump_inner_hash_for_signer_removal() {
     // Build the inner TX to compute the inner TX contents hash.
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
             asset: Asset::Native,
             amount: 1,
@@ -4332,7 +4332,7 @@ fn test_audit_005_fee_bump_inner_hash_for_signer_removal() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -4432,7 +4432,7 @@ fn test_audit_007_sequential_soroban_fee_charged_subtracts_refund() {
     let operation = Operation {
         source_account: None,
         body: OperationBody::ExtendFootprintTtl(ExtendFootprintTtlOp {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             extend_to: 100,
         }),
     };
@@ -4625,10 +4625,10 @@ async fn test_audit_095_pre_parallel_apply_globalizes_seq_bumps() {
     // sequences on the shared executor and transfers to the main delta
     // BEFORE clusters start, so peer clusters see bumped sequences.
     let current = delta.current_entries();
-    let _acct1_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let _acct1_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: acct1_id.clone(),
     });
-    let _acct2_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+    let _acct2_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: acct2_id.clone(),
     });
 
@@ -4741,7 +4741,7 @@ fn test_post_seq_failure_removes_preauth_signer() {
     // Create account with seq_num=1, with both ed25519 key weight and PreAuthTx signer.
     // The account has seq_time/seq_ledger set for min_seq_ledger_gap checking.
     let (key, entry) = {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
         let entry = LedgerEntry {
@@ -4928,7 +4928,7 @@ fn test_post_seq_failure_removes_fee_bump_outer_signer() {
             TransactionEnvelope::Tx(ref env) => env.clone(),
             _ => panic!("expected Tx"),
         }),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     let mut fee_bump_envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
@@ -4957,7 +4957,7 @@ fn test_post_seq_failure_removes_fee_bump_outer_signer() {
         weight: 1,
     };
     let (fee_key, fee_entry) = {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: fee_account_id.clone(),
         });
         let entry = LedgerEntry {
@@ -4985,7 +4985,7 @@ fn test_post_seq_failure_removes_fee_bump_outer_signer() {
         weight: 1,
     };
     let (inner_key, inner_entry) = {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: inner_account_id.clone(),
         });
         let entry = LedgerEntry {
@@ -5094,7 +5094,7 @@ fn test_fee_strategy_externally_precharged_too_short() {
 
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
             asset: Asset::Native,
             amount: 1,
@@ -5175,7 +5175,7 @@ fn test_fee_strategy_externally_precharged_too_long() {
 
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
             asset: Asset::Native,
             amount: 1,
@@ -5213,11 +5213,11 @@ fn test_fee_strategy_externally_precharged_too_long() {
     let pre_charged = vec![
         PreChargedFee {
             charged_fee: 100,
-            fee_changes: stellar_xdr::curr::LedgerEntryChanges(vec![].try_into().unwrap()),
+            fee_changes: stellar_xdr::LedgerEntryChanges(vec![].try_into().unwrap()),
         },
         PreChargedFee {
             charged_fee: 100,
-            fee_changes: stellar_xdr::curr::LedgerEntryChanges(vec![].try_into().unwrap()),
+            fee_changes: stellar_xdr::LedgerEntryChanges(vec![].try_into().unwrap()),
         },
     ];
 
@@ -5283,7 +5283,7 @@ async fn test_soroban_fee_source_externally_precharged_too_short() {
     // Only 1 fee for 2 transactions — should trigger length mismatch.
     let fee_source = SorobanFeeSource::ExternallyPrecharged(vec![PreChargedFee {
         charged_fee: 100,
-        fee_changes: stellar_xdr::curr::LedgerEntryChanges(vec![].try_into().unwrap()),
+        fee_changes: stellar_xdr::LedgerEntryChanges(vec![].try_into().unwrap()),
     }]);
 
     let result = execute_soroban_parallel_phase(
@@ -5352,11 +5352,11 @@ async fn test_soroban_fee_source_externally_precharged_too_long() {
     let fee_source = SorobanFeeSource::ExternallyPrecharged(vec![
         PreChargedFee {
             charged_fee: 100,
-            fee_changes: stellar_xdr::curr::LedgerEntryChanges(vec![].try_into().unwrap()),
+            fee_changes: stellar_xdr::LedgerEntryChanges(vec![].try_into().unwrap()),
         },
         PreChargedFee {
             charged_fee: 100,
-            fee_changes: stellar_xdr::curr::LedgerEntryChanges(vec![].try_into().unwrap()),
+            fee_changes: stellar_xdr::LedgerEntryChanges(vec![].try_into().unwrap()),
         },
     ]);
 
@@ -5414,7 +5414,7 @@ fn test_fee_strategy_no_fees_skips_fee_processing() {
     // Simple self-payment so TX passes validation.
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256(*secret.public_key().as_bytes())),
             asset: Asset::Native,
             amount: 1,
@@ -5598,7 +5598,7 @@ fn test_audit_245_fee_bump_outer_signer_removed_in_same_ledger_succeeds() {
     // inner tx from Y (payment to dest).
     let payment_op = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([83u8; 32])),
             asset: Asset::Native,
             amount: 1_000_000,
@@ -5631,7 +5631,7 @@ fn test_audit_245_fee_bump_outer_signer_removed_in_same_ledger_succeeds() {
         fee_source: MuxedAccount::Ed25519(Uint256(*fee_secret.public_key().as_bytes())),
         fee: 200,
         inner_tx: FeeBumpTransactionInnerTx::Tx(inner_v1),
-        ext: stellar_xdr::curr::FeeBumpTransactionExt::V0,
+        ext: stellar_xdr::FeeBumpTransactionExt::V0,
     };
 
     // Sign the fee-bump outer with signer B (removed by TX1, but valid at tx-set time)
@@ -5763,7 +5763,7 @@ fn test_failed_soroban_tx_no_soroban_meta() {
     );
 
     // Fee refund events should still be present (fee accounting is independent).
-    let tx_events: &[stellar_xdr::curr::TransactionEvent] = v4.events.as_ref();
+    let tx_events: &[stellar_xdr::TransactionEvent] = v4.events.as_ref();
     assert!(
         !tx_events.is_empty(),
         "fee refund events must still be emitted for failed Soroban txs"
@@ -5787,7 +5787,7 @@ fn test_preauth_signer_and_seq_bump_produce_single_meta_entry() {
 
     let operation = Operation {
         source_account: None,
-        body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        body: OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([4u8; 32])),
             asset: Asset::Native,
             amount: 1_000_000,
@@ -5824,7 +5824,7 @@ fn test_preauth_signer_and_seq_bump_produce_single_meta_entry() {
 
     // Source account: seq_num=1, ed25519 weight + PreAuthTx signer.
     let (source_key, source_entry) = {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
         let entry = LedgerEntry {
@@ -5865,7 +5865,7 @@ fn test_preauth_signer_and_seq_bump_produce_single_meta_entry() {
 
     // Destination account for the payment operation to succeed.
     let (dest_key, dest_entry) = {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: destination_id.clone(),
         });
         let entry = LedgerEntry {

--- a/crates/ledger/tests/tx_meta_hash_vectors.rs
+++ b/crates/ledger/tests/tx_meta_hash_vectors.rs
@@ -1,7 +1,7 @@
 use henyey_common::entry_to_key;
 use henyey_common::normalize_transaction_meta;
 use henyey_crypto::{seed, xdr_compute_hash};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, ExtensionPoint, LedgerEntry, LedgerEntryChange,
     LedgerEntryChanges, LedgerEntryData, LedgerEntryExt, OperationMetaV2, PublicKey, String32,
     Thresholds, TransactionMeta, TransactionMetaV4, Uint256, VecM,
@@ -10,9 +10,9 @@ use stellar_xdr::curr::{
 fn account_entry(id_byte: u8, balance: i64) -> LedgerEntry {
     let account_id = PublicKey::PublicKeyTypeEd25519(Uint256([id_byte; 32]));
     let account = AccountEntry {
-        account_id: stellar_xdr::curr::AccountId(account_id),
+        account_id: stellar_xdr::AccountId(account_id),
         balance,
-        seq_num: stellar_xdr::curr::SequenceNumber(1),
+        seq_num: stellar_xdr::SequenceNumber(1),
         num_sub_entries: 0,
         inflation_dest: None,
         flags: 0,

--- a/crates/ledger/tests/upgrade_sequence_integration.rs
+++ b/crates/ledger/tests/upgrade_sequence_integration.rs
@@ -33,7 +33,7 @@ use henyey_ledger::{
     compute_header_hash, CloseLedgerState, ConfigUpgradeSetFrame, LedgerCloseData, LedgerManager,
     LedgerManagerConfig, SnapshotBuilder, SnapshotHandle, TransactionSetVariant, UpgradeContext,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ConfigSettingEntry, ConfigSettingId, ConfigUpgradeSet, ConfigUpgradeSetKey,
     ContractDataDurability, ContractId, Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt,
     LedgerHeader, LedgerHeaderExt, LedgerKey, LedgerKeyConfigSetting, LedgerKeyContractData,
@@ -145,8 +145,8 @@ fn make_config_upgrade_entry(
     let xdr_bytes = upgrade_set.to_xdr(Limits::none()).expect("encode");
     LedgerEntry {
         last_modified_ledger_seq: ledger_seq,
-        data: LedgerEntryData::ContractData(stellar_xdr::curr::ContractDataEntry {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+        data: LedgerEntryData::ContractData(stellar_xdr::ContractDataEntry {
+            ext: stellar_xdr::ExtensionPoint::V0,
             contract: ScAddress::Contract(upgrade_key.contract_id.clone()),
             key: ScVal::Bytes(
                 upgrade_key
@@ -859,7 +859,7 @@ async fn test_failed_config_upgrade_does_not_abort_ledger_close() {
     }
 }
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ContractCostParamEntry, ContractCostParams, ExtensionPoint, LedgerCloseMeta, LedgerEntryChange,
 };
 
@@ -1085,7 +1085,7 @@ async fn test_config_upgrade_memory_cost_state_size_recompute_in_meta() {
 
 use henyey_common::NetworkId;
 use henyey_crypto::{sign_hash, SecretKey};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext, AccountId,
     Asset, BucketListType, BumpSequenceOp, DecoratedSignature, LedgerKeyOffer, LedgerKeyTrustLine,
     Liabilities, Memo, MuxedAccount, OfferEntry, Operation, OperationBody, Preconditions, Price,
@@ -1143,7 +1143,7 @@ fn make_native_sell_offer(
             amount,
             price: Price { n: 1, d: 1 },
             flags: 0,
-            ext: stellar_xdr::curr::OfferEntryExt::V0,
+            ext: stellar_xdr::OfferEntryExt::V0,
         }),
         ext: LedgerEntryExt::V0,
     }
@@ -1230,12 +1230,12 @@ fn test_base_reserve_upgrade_prepare_liabilities_meta() {
     )));
 
     // The non-native asset for the offer's buying side.
-    let buying_asset = Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-        asset_code: stellar_xdr::curr::AssetCode4(*b"TEST"),
+    let buying_asset = Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+        asset_code: stellar_xdr::AssetCode4(*b"TEST"),
         issuer: account_id_b.clone(),
     });
-    let tl_asset = TrustLineAsset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-        asset_code: stellar_xdr::curr::AssetCode4(*b"TEST"),
+    let tl_asset = TrustLineAsset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+        asset_code: stellar_xdr::AssetCode4(*b"TEST"),
         issuer: account_id_b.clone(),
     });
 
@@ -1642,7 +1642,7 @@ async fn test_apply_config_upgrade_variant_mutates_state() {
 
     // Build a valid ConfigUpgradeSet that changes ContractComputeV0.
     let proposed =
-        ConfigSettingEntry::ContractComputeV0(stellar_xdr::curr::ConfigSettingContractComputeV0 {
+        ConfigSettingEntry::ContractComputeV0(stellar_xdr::ConfigSettingContractComputeV0 {
             ledger_max_instructions: 222_000_000,
             tx_max_instructions: 10_000_000,
             fee_rate_per_instructions_increment: 100,

--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -41,7 +41,7 @@ use henyey_common::Hash256;
 use henyey_crypto::PublicKey;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     self as xdr, AuthenticatedMessage, AuthenticatedMessageV0, Curve25519Public, EnvelopeType,
     Hello, HmacSha256Key, HmacSha256Mac, StellarMessage, Uint256, WriteXdr,
 };
@@ -1362,7 +1362,7 @@ mod tests {
 
     #[test]
     fn test_auth_cert_xdr_roundtrip() {
-        use stellar_xdr::curr::ReadXdr;
+        use stellar_xdr::ReadXdr;
 
         let secret = SecretKey::generate();
         let local_node = LocalNode::new_testnet(secret);
@@ -2034,7 +2034,7 @@ mod tests {
 #[test]
 fn test_auth_cert_signing_parity() {
     use henyey_common::{Hash256, NetworkId};
-    use stellar_xdr::curr::{EnvelopeType, Limits, WriteXdr};
+    use stellar_xdr::{EnvelopeType, Limits, WriteXdr};
     // 1. EnvelopeType::Auth must have XDR value 3, matching stellar-core.
     assert_eq!(EnvelopeType::Auth as i32, 3);
     let xdr = EnvelopeType::Auth.to_xdr(Limits::none()).unwrap();
@@ -2065,10 +2065,10 @@ fn test_auth_cert_signing_parity() {
         .verify(hash.as_bytes(), &sig)
         .expect("signature must verify");
     // 4. Verify using the same path that AuthCertExt::verify uses.
-    let cert = stellar_xdr::curr::AuthCert {
-        pubkey: stellar_xdr::curr::Curve25519Public { key: x25519_pub },
+    let cert = stellar_xdr::AuthCert {
+        pubkey: stellar_xdr::Curve25519Public { key: x25519_pub },
         expiration,
-        sig: stellar_xdr::curr::Signature(sig.as_bytes().to_vec().try_into().unwrap()),
+        sig: stellar_xdr::Signature(sig.as_bytes().to_vec().try_into().unwrap()),
     };
     cert.verify(&network_id, &pubkey)
         .expect("cert verify must succeed");

--- a/crates/overlay/src/codec.rs
+++ b/crates/overlay/src/codec.rs
@@ -23,7 +23,7 @@
 
 use crate::{OverlayError, Result};
 use bytes::{Buf, BufMut, BytesMut};
-use stellar_xdr::curr::{AuthenticatedMessage, Limits, ReadXdr, WriteXdr};
+use stellar_xdr::{AuthenticatedMessage, Limits, ReadXdr, WriteXdr};
 use tokio_util::codec::{Decoder, Encoder};
 
 /// Maximum message size (16 MB) - prevents memory exhaustion.
@@ -281,7 +281,7 @@ impl Encoder<AuthenticatedMessage> for MessageCodec {
 /// SHA-256. The authoritative implementation is
 /// [`crate::flood::compute_message_hash`]; all flood-gate call sites use it.
 pub mod helpers {
-    use stellar_xdr::curr::StellarMessage;
+    use stellar_xdr::StellarMessage;
 
     /// Returns true if this message type is flow-controlled (uses flood/flow
     /// capacity). This includes both globally-deduplicated flood payloads
@@ -359,7 +359,7 @@ pub mod helpers {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{AuthenticatedMessageV0, HmacSha256Mac, StellarMessage, VecM};
+    use stellar_xdr::{AuthenticatedMessageV0, HmacSha256Mac, StellarMessage, VecM};
 
     fn make_test_message() -> AuthenticatedMessage {
         AuthenticatedMessage::V0(AuthenticatedMessageV0 {
@@ -634,7 +634,7 @@ mod tests {
     fn test_is_flood_message_classification() {
         // Flood messages
         assert!(helpers::is_flood_message(&StellarMessage::Transaction(
-            stellar_xdr::curr::TransactionEnvelope::TxV0(Default::default())
+            stellar_xdr::TransactionEnvelope::TxV0(Default::default())
         )));
         assert!(helpers::is_flood_message(&StellarMessage::FloodAdvert(
             Default::default()
@@ -668,9 +668,9 @@ mod tests {
     #[test]
     fn test_watcher_droppable_keeps_tx_flooding_messages() {
         assert!(!helpers::is_watcher_droppable(
-            &StellarMessage::Transaction(stellar_xdr::curr::TransactionEnvelope::TxV0(
-                Default::default()
-            ))
+            &StellarMessage::Transaction(
+                stellar_xdr::TransactionEnvelope::TxV0(Default::default())
+            )
         ));
         assert!(!helpers::is_watcher_droppable(
             &StellarMessage::FloodAdvert(Default::default())
@@ -708,9 +708,9 @@ mod tests {
 
         // Transaction and SCP messages ARE FloodGate-tracked
         assert!(helpers::is_flood_gate_tracked(
-            &StellarMessage::Transaction(stellar_xdr::curr::TransactionEnvelope::TxV0(
-                Default::default()
-            ))
+            &StellarMessage::Transaction(
+                stellar_xdr::TransactionEnvelope::TxV0(Default::default())
+            )
         ));
         assert!(helpers::is_flood_gate_tracked(&StellarMessage::ScpMessage(
             Default::default()

--- a/crates/overlay/src/connection.rs
+++ b/crates/overlay/src/connection.rs
@@ -25,7 +25,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
-use stellar_xdr::curr::AuthenticatedMessage;
+use stellar_xdr::AuthenticatedMessage;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::timeout;
@@ -71,7 +71,7 @@ impl ConnectionDirection {
 /// 3. Call [`close`](Connection::close) when done (or drop the connection)
 ///
 /// [`MessageCodec`]: crate::MessageCodec
-/// [`AuthenticatedMessage`]: stellar_xdr::curr::AuthenticatedMessage
+/// [`AuthenticatedMessage`]: stellar_xdr::AuthenticatedMessage
 pub struct Connection {
     /// Framed stream for message encoding/decoding.
     framed: Framed<BoxedIo, MessageCodec>,

--- a/crates/overlay/src/error.rs
+++ b/crates/overlay/src/error.rs
@@ -122,7 +122,7 @@ pub enum OverlayError {
     // ===== Wrapped Errors =====
     /// XDR serialization/deserialization error.
     #[error("XDR error: {0}")]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     /// Cryptographic operation failed.
     #[error("crypto error: {0}")]

--- a/crates/overlay/src/flood.rs
+++ b/crates/overlay/src/flood.rs
@@ -33,7 +33,7 @@ use parking_lot::{Mutex, RwLock};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use stellar_xdr::curr::StellarMessage;
+use stellar_xdr::StellarMessage;
 use tracing::{debug, trace, warn};
 
 use crate::PeerId;
@@ -467,7 +467,7 @@ pub struct FloodGateStats {
 ///
 /// This matches stellar-core's `xdrBlake2()` used in `Floodgate::broadcast()`.
 pub fn compute_message_hash(message: &StellarMessage) -> Hash256 {
-    use stellar_xdr::curr::{Limits, WriteXdr};
+    use stellar_xdr::{Limits, WriteXdr};
     let bytes = message
         .to_xdr(Limits::none())
         .expect("XDR serialization of StellarMessage must not fail");
@@ -520,7 +520,7 @@ mod tests {
     /// would silently waste CPU without a wire-visible failure.
     #[test]
     fn test_flood_dedup_hash_is_blake2b_not_sha256() {
-        use stellar_xdr::curr::{Limits, WriteXdr};
+        use stellar_xdr::{Limits, WriteXdr};
 
         let message = StellarMessage::Peers(Default::default());
         let bytes = message.to_xdr(Limits::none()).unwrap();
@@ -619,7 +619,7 @@ mod tests {
 
     #[test]
     fn test_flood_record() {
-        let message = StellarMessage::Peers(stellar_xdr::curr::VecM::default());
+        let message = StellarMessage::Peers(stellar_xdr::VecM::default());
         let record = FloodRecord::new(message, None);
 
         assert!(!record.hash.is_zero());
@@ -733,9 +733,8 @@ mod tests {
         // Pull-control messages are flood messages but NOT gate-tracked
         let advert = StellarMessage::FloodAdvert(Default::default());
         let demand = StellarMessage::FloodDemand(Default::default());
-        let tx = StellarMessage::Transaction(stellar_xdr::curr::TransactionEnvelope::TxV0(
-            Default::default(),
-        ));
+        let tx =
+            StellarMessage::Transaction(stellar_xdr::TransactionEnvelope::TxV0(Default::default()));
 
         // Pull-control messages are flood messages but NOT gate-tracked
         assert!(helpers::is_flood_message(&advert));

--- a/crates/overlay/src/flow_control.rs
+++ b/crates/overlay/src/flow_control.rs
@@ -28,7 +28,7 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use stellar_xdr::curr::{StellarMessage, WriteXdr};
+use stellar_xdr::{StellarMessage, WriteXdr};
 use tracing::{debug, trace, warn};
 
 /// Callback trait for SCP queue trimming decisions.
@@ -1260,8 +1260,8 @@ fn messages_equal(a: &StellarMessage, b: &StellarMessage) -> bool {
         return false;
     }
     // For full equality, compare XDR
-    let a_xdr = a.to_xdr(stellar_xdr::curr::Limits::none());
-    let b_xdr = b.to_xdr(stellar_xdr::curr::Limits::none());
+    let a_xdr = a.to_xdr(stellar_xdr::Limits::none());
+    let b_xdr = b.to_xdr(stellar_xdr::Limits::none());
     match (a_xdr, b_xdr) {
         (Ok(a), Ok(b)) => a == b,
         _ => false,
@@ -1271,20 +1271,20 @@ fn messages_equal(a: &StellarMessage, b: &StellarMessage) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{Hash, ScpEnvelope, SendMoreExtended, TransactionEnvelope};
+    use stellar_xdr::{Hash, ScpEnvelope, SendMoreExtended, TransactionEnvelope};
 
     fn make_tx_message() -> StellarMessage {
         // Create a minimal transaction message for testing
         StellarMessage::Transaction(TransactionEnvelope::TxV0(
-            stellar_xdr::curr::TransactionV0Envelope {
-                tx: stellar_xdr::curr::TransactionV0 {
-                    source_account_ed25519: stellar_xdr::curr::Uint256([0u8; 32]),
+            stellar_xdr::TransactionV0Envelope {
+                tx: stellar_xdr::TransactionV0 {
+                    source_account_ed25519: stellar_xdr::Uint256([0u8; 32]),
                     fee: 100,
-                    seq_num: stellar_xdr::curr::SequenceNumber(1),
+                    seq_num: stellar_xdr::SequenceNumber(1),
                     time_bounds: None,
-                    memo: stellar_xdr::curr::Memo::None,
+                    memo: stellar_xdr::Memo::None,
                     operations: vec![].try_into().unwrap(),
-                    ext: stellar_xdr::curr::TransactionV0Ext::V0,
+                    ext: stellar_xdr::TransactionV0Ext::V0,
                 },
                 signatures: vec![].try_into().unwrap(),
             },
@@ -1293,22 +1293,18 @@ mod tests {
 
     fn make_scp_message() -> StellarMessage {
         StellarMessage::ScpMessage(ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
-                node_id: stellar_xdr::curr::NodeId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                        [0u8; 32],
-                    )),
-                ),
+            statement: stellar_xdr::ScpStatement {
+                node_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0u8; 32]),
+                )),
                 slot_index: 1,
-                pledges: stellar_xdr::curr::ScpStatementPledges::Nominate(
-                    stellar_xdr::curr::ScpNomination {
-                        quorum_set_hash: Hash([0u8; 32]),
-                        votes: vec![].try_into().unwrap(),
-                        accepted: vec![].try_into().unwrap(),
-                    },
-                ),
+                pledges: stellar_xdr::ScpStatementPledges::Nominate(stellar_xdr::ScpNomination {
+                    quorum_set_hash: Hash([0u8; 32]),
+                    votes: vec![].try_into().unwrap(),
+                    accepted: vec![].try_into().unwrap(),
+                }),
             },
-            signature: stellar_xdr::curr::Signature::default(),
+            signature: stellar_xdr::Signature::default(),
         })
     }
 
@@ -1528,22 +1524,22 @@ mod tests {
     fn test_is_flow_controlled_message() {
         let tx = make_tx_message();
         let scp = make_scp_message();
-        let hello = StellarMessage::Hello(stellar_xdr::curr::Hello {
+        let hello = StellarMessage::Hello(stellar_xdr::Hello {
             ledger_version: 1,
             overlay_version: 1,
             overlay_min_version: 1,
             network_id: Hash([0u8; 32]),
             version_str: "test".try_into().unwrap(),
             listening_port: 0,
-            peer_id: stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256([0u8; 32]),
+            peer_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([0u8; 32]),
             )),
-            cert: stellar_xdr::curr::AuthCert {
-                pubkey: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            cert: stellar_xdr::AuthCert {
+                pubkey: stellar_xdr::Curve25519Public { key: [0u8; 32] },
                 expiration: 0,
-                sig: stellar_xdr::curr::Signature::default(),
+                sig: stellar_xdr::Signature::default(),
             },
-            nonce: stellar_xdr::curr::Uint256([0u8; 32]),
+            nonce: stellar_xdr::Uint256([0u8; 32]),
         });
 
         assert!(is_flow_controlled_message(&tx));
@@ -1710,22 +1706,18 @@ mod tests {
 
     fn make_scp_message_at_slot(slot: u64) -> StellarMessage {
         StellarMessage::ScpMessage(ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
-                node_id: stellar_xdr::curr::NodeId(
-                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                        [0u8; 32],
-                    )),
-                ),
+            statement: stellar_xdr::ScpStatement {
+                node_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0u8; 32]),
+                )),
                 slot_index: slot,
-                pledges: stellar_xdr::curr::ScpStatementPledges::Nominate(
-                    stellar_xdr::curr::ScpNomination {
-                        quorum_set_hash: Hash([0u8; 32]),
-                        votes: vec![].try_into().unwrap(),
-                        accepted: vec![].try_into().unwrap(),
-                    },
-                ),
+                pledges: stellar_xdr::ScpStatementPledges::Nominate(stellar_xdr::ScpNomination {
+                    quorum_set_hash: Hash([0u8; 32]),
+                    votes: vec![].try_into().unwrap(),
+                    accepted: vec![].try_into().unwrap(),
+                }),
             },
-            signature: stellar_xdr::curr::Signature::default(),
+            signature: stellar_xdr::Signature::default(),
         })
     }
 
@@ -1831,8 +1823,8 @@ mod tests {
         let scp_size = msg_body_size(&scp);
 
         // Vec-based size (the old approach)
-        let tx_xdr = tx.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
-        let scp_xdr = scp.to_xdr(stellar_xdr::curr::Limits::none()).unwrap();
+        let tx_xdr = tx.to_xdr(stellar_xdr::Limits::none()).unwrap();
+        let scp_xdr = scp.to_xdr(stellar_xdr::Limits::none()).unwrap();
 
         assert_eq!(tx_size, tx_xdr.len() as u64);
         assert_eq!(scp_size, scp_xdr.len() as u64);

--- a/crates/overlay/src/item_fetcher.rs
+++ b/crates/overlay/src/item_fetcher.rs
@@ -54,7 +54,7 @@ use crate::PeerId;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use stellar_xdr::curr::{Hash, ScpEnvelope};
+use stellar_xdr::{Hash, ScpEnvelope};
 use tracing::{debug, trace};
 
 /// Type of item being fetched.
@@ -735,7 +735,7 @@ pub struct ItemFetcherStats {
 /// Uses the same approach as stellar-core: BLAKE2b-256 of the StellarMessage wrapping the envelope.
 fn compute_envelope_hash(env: &ScpEnvelope) -> Hash {
     // Create a StellarMessage::ScpMessage wrapping the envelope
-    let msg = stellar_xdr::curr::StellarMessage::ScpMessage(env.clone());
+    let msg = stellar_xdr::StellarMessage::ScpMessage(env.clone());
 
     // Serialize to XDR
     let xdr_bytes = henyey_common::xdr_to_bytes(&msg);
@@ -748,7 +748,7 @@ fn compute_envelope_hash(env: &ScpEnvelope) -> Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         NodeId, PublicKey, ScpNomination, ScpStatement, ScpStatementPledges, Signature, Uint256,
     };
 

--- a/crates/overlay/src/lib.rs
+++ b/crates/overlay/src/lib.rs
@@ -667,27 +667,25 @@ impl<'de> serde::Deserialize<'de> for PeerAddress {
 ///
 /// When displayed, the full strkey format (G...) is shown for easy identification.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PeerId(pub stellar_xdr::curr::PublicKey);
+pub struct PeerId(pub stellar_xdr::PublicKey);
 
 impl PeerId {
     /// Creates a `PeerId` from an XDR public key.
-    pub fn from_xdr(key: stellar_xdr::curr::PublicKey) -> Self {
+    pub fn from_xdr(key: stellar_xdr::PublicKey) -> Self {
         Self(key)
     }
 
     /// Creates a `PeerId` from raw Ed25519 public key bytes.
     pub fn from_bytes(bytes: [u8; 32]) -> Self {
-        Self(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(bytes),
+        Self(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(bytes),
         ))
     }
 
     /// Returns a reference to the raw 32-byte public key.
     pub fn as_bytes(&self) -> &[u8; 32] {
         match &self.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                bytes,
-            )) => bytes,
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => bytes,
         }
     }
 
@@ -744,7 +742,7 @@ pub trait MessageHandler: Send + Sync {
     async fn handle_message(
         &self,
         peer_id: &PeerId,
-        message: stellar_xdr::curr::StellarMessage,
+        message: stellar_xdr::StellarMessage,
     ) -> Result<()>;
 }
 
@@ -931,7 +929,7 @@ impl LocalNode {
     }
 
     /// Returns this node's public key in XDR format.
-    pub fn xdr_public_key(&self) -> stellar_xdr::curr::PublicKey {
+    pub fn xdr_public_key(&self) -> stellar_xdr::PublicKey {
         (&self.public_key()).into()
     }
 

--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -18,7 +18,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
-use stellar_xdr::curr::ErrorCode;
+use stellar_xdr::ErrorCode;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -59,9 +59,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use stellar_xdr::curr::{
-    PeerAddress as XdrPeerAddress, PeerAddressIp, StellarMessage, Uint256, VecM,
-};
+use stellar_xdr::{PeerAddress as XdrPeerAddress, PeerAddressIp, StellarMessage, Uint256, VecM};
 use tokio::sync::{broadcast, mpsc, Mutex as TokioMutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace, warn};
@@ -1260,7 +1258,7 @@ impl OverlayManager {
     pub fn send_error_and_drop(
         &self,
         peer_id: &PeerId,
-        code: stellar_xdr::curr::ErrorCode,
+        code: stellar_xdr::ErrorCode,
         message: &str,
     ) -> bool {
         let Some(entry) = self.peers.get(peer_id) else {
@@ -1683,7 +1681,7 @@ impl OverlayManager {
 
         // Send SEND_MORE_EXTENDED with 0 additional messages but
         // `increase` additional bytes, matching upstream behavior.
-        let send_more = StellarMessage::SendMoreExtended(stellar_xdr::curr::SendMoreExtended {
+        let send_more = StellarMessage::SendMoreExtended(stellar_xdr::SendMoreExtended {
             num_messages: 0,
             num_bytes: increase,
         });
@@ -3029,7 +3027,7 @@ mod tests {
     async fn test_audit_086_targeted_flood_uses_flow_control() {
         use crate::flow_control::{FlowControl, FlowControlConfig};
         use crate::peer::PeerStats;
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let config = OverlayConfig::default();
         let secret = SecretKey::generate();
@@ -3142,8 +3140,8 @@ mod tests {
 
         let request_msgs = vec![
             StellarMessage::GetScpState(100),
-            StellarMessage::GetScpQuorumset(stellar_xdr::curr::Uint256([1u8; 32])),
-            StellarMessage::GetTxSet(stellar_xdr::curr::Uint256([2u8; 32])),
+            StellarMessage::GetScpQuorumset(stellar_xdr::Uint256([1u8; 32])),
+            StellarMessage::GetTxSet(stellar_xdr::Uint256([2u8; 32])),
         ];
 
         for msg in &request_msgs {
@@ -3241,26 +3239,26 @@ mod tests {
     fn all_fetch_variant_messages(peer: &PeerId) -> Vec<OverlayMessage> {
         let variants = vec![
             StellarMessage::GetScpState(0),
-            StellarMessage::GetScpQuorumset(stellar_xdr::curr::Uint256([1u8; 32])),
-            StellarMessage::GetTxSet(stellar_xdr::curr::Uint256([2u8; 32])),
-            StellarMessage::GeneralizedTxSet(stellar_xdr::curr::GeneralizedTransactionSet::V1(
-                stellar_xdr::curr::TransactionSetV1 {
-                    previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            StellarMessage::GetScpQuorumset(stellar_xdr::Uint256([1u8; 32])),
+            StellarMessage::GetTxSet(stellar_xdr::Uint256([2u8; 32])),
+            StellarMessage::GeneralizedTxSet(stellar_xdr::GeneralizedTransactionSet::V1(
+                stellar_xdr::TransactionSetV1 {
+                    previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
                     phases: vec![].try_into().unwrap(),
                 },
             )),
-            StellarMessage::TxSet(stellar_xdr::curr::TransactionSet {
-                previous_ledger_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                txs: stellar_xdr::curr::VecM::default(),
+            StellarMessage::TxSet(stellar_xdr::TransactionSet {
+                previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+                txs: stellar_xdr::VecM::default(),
             }),
-            StellarMessage::DontHave(stellar_xdr::curr::DontHave {
-                type_: stellar_xdr::curr::MessageType::TxSet,
-                req_hash: stellar_xdr::curr::Uint256([3u8; 32]),
+            StellarMessage::DontHave(stellar_xdr::DontHave {
+                type_: stellar_xdr::MessageType::TxSet,
+                req_hash: stellar_xdr::Uint256([3u8; 32]),
             }),
-            StellarMessage::ScpQuorumset(stellar_xdr::curr::ScpQuorumSet {
+            StellarMessage::ScpQuorumset(stellar_xdr::ScpQuorumSet {
                 threshold: 1,
-                validators: stellar_xdr::curr::VecM::default(),
-                inner_sets: stellar_xdr::curr::VecM::default(),
+                validators: stellar_xdr::VecM::default(),
+                inner_sets: stellar_xdr::VecM::default(),
             }),
         ];
         variants
@@ -4066,22 +4064,22 @@ mod tests {
     }
 
     fn make_hello_msg() -> StellarMessage {
-        StellarMessage::Hello(stellar_xdr::curr::Hello {
+        StellarMessage::Hello(stellar_xdr::Hello {
             ledger_version: 0,
             overlay_version: 0,
             overlay_min_version: 0,
-            network_id: stellar_xdr::curr::Hash([0u8; 32]),
+            network_id: stellar_xdr::Hash([0u8; 32]),
             version_str: "test".try_into().unwrap(),
             listening_port: 0,
-            peer_id: stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256([0u8; 32]),
+            peer_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([0u8; 32]),
             )),
-            cert: stellar_xdr::curr::AuthCert {
-                pubkey: stellar_xdr::curr::Curve25519Public { key: [0u8; 32] },
+            cert: stellar_xdr::AuthCert {
+                pubkey: stellar_xdr::Curve25519Public { key: [0u8; 32] },
                 expiration: 0,
-                sig: stellar_xdr::curr::Signature::default(),
+                sig: stellar_xdr::Signature::default(),
             },
-            nonce: stellar_xdr::curr::Uint256([0u8; 32]),
+            nonce: stellar_xdr::Uint256([0u8; 32]),
         })
     }
 
@@ -4179,21 +4177,21 @@ mod tests {
     }
 
     fn make_flood_tx_msg() -> StellarMessage {
-        use stellar_xdr::curr::TransactionEnvelope;
+        use stellar_xdr::TransactionEnvelope;
         StellarMessage::Transaction(TransactionEnvelope::Tx(
-            stellar_xdr::curr::TransactionV1Envelope {
-                tx: stellar_xdr::curr::Transaction {
-                    source_account: stellar_xdr::curr::MuxedAccount::Ed25519(
-                        stellar_xdr::curr::Uint256([0; 32]),
-                    ),
+            stellar_xdr::TransactionV1Envelope {
+                tx: stellar_xdr::Transaction {
+                    source_account: stellar_xdr::MuxedAccount::Ed25519(stellar_xdr::Uint256(
+                        [0; 32],
+                    )),
                     fee: 100,
-                    seq_num: stellar_xdr::curr::SequenceNumber(1),
-                    cond: stellar_xdr::curr::Preconditions::None,
-                    memo: stellar_xdr::curr::Memo::None,
-                    operations: stellar_xdr::curr::VecM::default(),
-                    ext: stellar_xdr::curr::TransactionExt::V0,
+                    seq_num: stellar_xdr::SequenceNumber(1),
+                    cond: stellar_xdr::Preconditions::None,
+                    memo: stellar_xdr::Memo::None,
+                    operations: stellar_xdr::VecM::default(),
+                    ext: stellar_xdr::TransactionExt::V0,
                 },
-                signatures: stellar_xdr::curr::VecM::default(),
+                signatures: stellar_xdr::VecM::default(),
             },
         ))
     }
@@ -4608,9 +4606,7 @@ mod tests {
         // Verify each received message is the correct GetScpState(ledger_seq).
         for msg in &received {
             match msg {
-                super::OutboundMessage::Send(stellar_xdr::curr::StellarMessage::GetScpState(
-                    seq,
-                )) => {
+                super::OutboundMessage::Send(stellar_xdr::StellarMessage::GetScpState(seq)) => {
                     assert_eq!(
                         *seq, ledger_seq,
                         "GetScpState should contain ledger_seq {}, got {}",
@@ -4832,7 +4828,7 @@ mod tests {
         assert!(
             manager.send_error_and_drop(
                 &peer_id,
-                stellar_xdr::curr::ErrorCode::Misc,
+                stellar_xdr::ErrorCode::Misc,
                 "Survey has invalid signature",
             ),
             "send_error_and_drop should queue the shutdown for a connected peer"
@@ -4841,7 +4837,7 @@ mod tests {
         // First the ERROR_MSG with the exact survey code/string.
         match rx.recv().await.unwrap() {
             OutboundMessage::Send(StellarMessage::ErrorMsg(err)) => {
-                assert_eq!(err.code, stellar_xdr::curr::ErrorCode::Misc);
+                assert_eq!(err.code, stellar_xdr::ErrorCode::Misc);
                 assert_eq!(err.msg.to_string(), "Survey has invalid signature");
             }
             other => panic!(
@@ -4871,7 +4867,7 @@ mod tests {
         assert!(
             !manager.send_error_and_drop(
                 &peer_id,
-                stellar_xdr::curr::ErrorCode::Misc,
+                stellar_xdr::ErrorCode::Misc,
                 "Survey has invalid signature",
             ),
             "send_error_and_drop should report false for an unknown peer"

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -17,7 +17,7 @@ use sha2::Digest;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use stellar_xdr::curr::{ErrorCode, SError, StellarMessage, StringM, Uint256};
+use stellar_xdr::{ErrorCode, SError, StellarMessage, StringM, Uint256};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tracing::{debug, info, trace, warn};
@@ -374,11 +374,11 @@ pub(super) fn send_error_and_drop(
 /// a matching hash is used to measure round-trip time.
 ///
 /// Extracted from `run_peer_loop` for testability (G4).
-fn compute_ping_hash(nanos: u128) -> stellar_xdr::curr::Uint256 {
+fn compute_ping_hash(nanos: u128) -> stellar_xdr::Uint256 {
     let mut hasher = sha2::Sha256::new();
     hasher.update(nanos.to_le_bytes());
     let result = hasher.finalize();
-    stellar_xdr::curr::Uint256(result.into())
+    stellar_xdr::Uint256(result.into())
 }
 
 /// Check if a received hash matches an outstanding ping hash.
@@ -387,10 +387,7 @@ fn compute_ping_hash(nanos: u128) -> stellar_xdr::curr::Uint256 {
 /// received `hash_bytes` matches the stored ping hash.
 ///
 /// Extracted from `run_peer_loop` ping response matching for testability (G4).
-fn is_ping_response(
-    ping_hash: Option<&stellar_xdr::curr::Uint256>,
-    hash: &stellar_xdr::curr::Uint256,
-) -> bool {
+fn is_ping_response(ping_hash: Option<&stellar_xdr::Uint256>, hash: &stellar_xdr::Uint256) -> bool {
     match ping_hash {
         Some(ph) => ph.0 == hash.0,
         None => false,
@@ -404,7 +401,7 @@ fn is_ping_response(
 /// single `check_response` call.
 struct PingTracker {
     sent_time: Option<Instant>,
-    hash: Option<stellar_xdr::curr::Uint256>,
+    hash: Option<stellar_xdr::Uint256>,
     last_rtt: Option<Duration>,
 }
 
@@ -418,7 +415,7 @@ impl PingTracker {
     }
 
     /// Record that a ping was sent with the given hash.
-    fn record_sent(&mut self, hash: stellar_xdr::curr::Uint256) {
+    fn record_sent(&mut self, hash: stellar_xdr::Uint256) {
         self.sent_time = Some(Instant::now());
         self.hash = Some(hash);
     }
@@ -428,7 +425,7 @@ impl PingTracker {
     /// the RTT if this was a match.
     fn check_response(
         &mut self,
-        response_hash: &stellar_xdr::curr::Uint256,
+        response_hash: &stellar_xdr::Uint256,
         peer_id: &PeerId,
     ) -> Option<Duration> {
         let sent = self.sent_time?;
@@ -1314,7 +1311,7 @@ impl OverlayManager {
 mod tests {
     use super::*;
     use crate::flow_control::FlowControlConfig;
-    use stellar_xdr::curr::ErrorCode;
+    use stellar_xdr::ErrorCode;
 
     #[test]
     fn test_idle_timeout_constants_match_upstream() {
@@ -1621,7 +1618,7 @@ mod tests {
 
     #[test]
     fn test_validate_incoming_peers_rules() {
-        let peers_msg = StellarMessage::Peers(stellar_xdr::curr::VecM::default());
+        let peers_msg = StellarMessage::Peers(stellar_xdr::VecM::default());
         let tx_msg = StellarMessage::GetScpState(0);
 
         assert_eq!(
@@ -1648,19 +1645,19 @@ mod tests {
             Default::default()
         )));
         assert!(should_skip_generic_routing(&StellarMessage::Auth(
-            stellar_xdr::curr::Auth { flags: 200 }
+            stellar_xdr::Auth { flags: 200 }
         )));
         assert!(should_skip_generic_routing(&StellarMessage::SendMore(
-            stellar_xdr::curr::SendMore { num_messages: 1 }
+            stellar_xdr::SendMore { num_messages: 1 }
         )));
         assert!(should_skip_generic_routing(
-            &StellarMessage::SendMoreExtended(stellar_xdr::curr::SendMoreExtended {
+            &StellarMessage::SendMoreExtended(stellar_xdr::SendMoreExtended {
                 num_messages: 1,
                 num_bytes: 1,
             })
         ));
         assert!(!should_skip_generic_routing(&StellarMessage::Peers(
-            stellar_xdr::curr::VecM::default()
+            stellar_xdr::VecM::default()
         )));
     }
 
@@ -1685,7 +1682,7 @@ mod tests {
     fn test_capacity_guard_none_drops_peer_flow() {
         // When all flood capacity is exhausted, CapacityGuard::new returns None.
         // In run_peer_loop this would trigger send_error_and_drop + break.
-        use stellar_xdr::curr::TransactionEnvelope;
+        use stellar_xdr::TransactionEnvelope;
         let config = FlowControlConfig::default();
         let fc = Arc::new(FlowControl::new(config.clone()));
 
@@ -1693,19 +1690,19 @@ mod tests {
         let mut guards = Vec::new();
         for _ in 0..config.peer_flood_reading_capacity {
             let msg = StellarMessage::Transaction(TransactionEnvelope::Tx(
-                stellar_xdr::curr::TransactionV1Envelope {
-                    tx: stellar_xdr::curr::Transaction {
-                        source_account: stellar_xdr::curr::MuxedAccount::Ed25519(
-                            stellar_xdr::curr::Uint256([0; 32]),
-                        ),
+                stellar_xdr::TransactionV1Envelope {
+                    tx: stellar_xdr::Transaction {
+                        source_account: stellar_xdr::MuxedAccount::Ed25519(stellar_xdr::Uint256(
+                            [0; 32],
+                        )),
                         fee: 100,
-                        seq_num: stellar_xdr::curr::SequenceNumber(1),
-                        cond: stellar_xdr::curr::Preconditions::None,
-                        memo: stellar_xdr::curr::Memo::None,
-                        operations: stellar_xdr::curr::VecM::default(),
-                        ext: stellar_xdr::curr::TransactionExt::V0,
+                        seq_num: stellar_xdr::SequenceNumber(1),
+                        cond: stellar_xdr::Preconditions::None,
+                        memo: stellar_xdr::Memo::None,
+                        operations: stellar_xdr::VecM::default(),
+                        ext: stellar_xdr::TransactionExt::V0,
                     },
-                    signatures: stellar_xdr::curr::VecM::default(),
+                    signatures: stellar_xdr::VecM::default(),
                 },
             ));
             match crate::flow_control::CapacityGuard::new(Arc::clone(&fc), msg) {
@@ -1716,19 +1713,19 @@ mod tests {
 
         // Next message should fail — capacity exhausted.
         let overflow_msg = StellarMessage::Transaction(TransactionEnvelope::Tx(
-            stellar_xdr::curr::TransactionV1Envelope {
-                tx: stellar_xdr::curr::Transaction {
-                    source_account: stellar_xdr::curr::MuxedAccount::Ed25519(
-                        stellar_xdr::curr::Uint256([1; 32]),
-                    ),
+            stellar_xdr::TransactionV1Envelope {
+                tx: stellar_xdr::Transaction {
+                    source_account: stellar_xdr::MuxedAccount::Ed25519(stellar_xdr::Uint256(
+                        [1; 32],
+                    )),
                     fee: 100,
-                    seq_num: stellar_xdr::curr::SequenceNumber(2),
-                    cond: stellar_xdr::curr::Preconditions::None,
-                    memo: stellar_xdr::curr::Memo::None,
-                    operations: stellar_xdr::curr::VecM::default(),
-                    ext: stellar_xdr::curr::TransactionExt::V0,
+                    seq_num: stellar_xdr::SequenceNumber(2),
+                    cond: stellar_xdr::Preconditions::None,
+                    memo: stellar_xdr::Memo::None,
+                    operations: stellar_xdr::VecM::default(),
+                    ext: stellar_xdr::TransactionExt::V0,
                 },
-                signatures: stellar_xdr::curr::VecM::default(),
+                signatures: stellar_xdr::VecM::default(),
             },
         ));
         let guard = crate::flow_control::CapacityGuard::new(Arc::clone(&fc), overflow_msg);
@@ -1758,7 +1755,7 @@ mod tests {
     fn test_capacity_guard_non_flood_always_accepted() {
         // Non-flow-controlled messages (like GetPeers) should always succeed,
         // even when flood capacity is exhausted.
-        use stellar_xdr::curr::TransactionEnvelope;
+        use stellar_xdr::TransactionEnvelope;
         let config = FlowControlConfig::default();
         let fc = Arc::new(FlowControl::new(config.clone()));
 
@@ -1766,19 +1763,19 @@ mod tests {
         let mut guards = Vec::new();
         for _ in 0..config.peer_flood_reading_capacity {
             let msg = StellarMessage::Transaction(TransactionEnvelope::Tx(
-                stellar_xdr::curr::TransactionV1Envelope {
-                    tx: stellar_xdr::curr::Transaction {
-                        source_account: stellar_xdr::curr::MuxedAccount::Ed25519(
-                            stellar_xdr::curr::Uint256([0; 32]),
-                        ),
+                stellar_xdr::TransactionV1Envelope {
+                    tx: stellar_xdr::Transaction {
+                        source_account: stellar_xdr::MuxedAccount::Ed25519(stellar_xdr::Uint256(
+                            [0; 32],
+                        )),
                         fee: 100,
-                        seq_num: stellar_xdr::curr::SequenceNumber(1),
-                        cond: stellar_xdr::curr::Preconditions::None,
-                        memo: stellar_xdr::curr::Memo::None,
-                        operations: stellar_xdr::curr::VecM::default(),
-                        ext: stellar_xdr::curr::TransactionExt::V0,
+                        seq_num: stellar_xdr::SequenceNumber(1),
+                        cond: stellar_xdr::Preconditions::None,
+                        memo: stellar_xdr::Memo::None,
+                        operations: stellar_xdr::VecM::default(),
+                        ext: stellar_xdr::TransactionExt::V0,
                     },
-                    signatures: stellar_xdr::curr::VecM::default(),
+                    signatures: stellar_xdr::VecM::default(),
                 },
             ));
             match crate::flow_control::CapacityGuard::new(Arc::clone(&fc), msg) {
@@ -1788,7 +1785,7 @@ mod tests {
         }
 
         // Non-flow-controlled message (Peers) should still be accepted.
-        let peers_msg = StellarMessage::Peers(stellar_xdr::curr::VecM::default());
+        let peers_msg = StellarMessage::Peers(stellar_xdr::VecM::default());
         let guard = crate::flow_control::CapacityGuard::new(Arc::clone(&fc), peers_msg);
         assert!(
             guard.is_some(),
@@ -1896,7 +1893,7 @@ mod tests {
 
     #[test]
     fn test_traffic_class_classification() {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // SCP is exempt (None)
         let scp_msg = StellarMessage::ScpMessage(ScpEnvelope {
@@ -2093,18 +2090,18 @@ mod tests {
     #[test]
     fn test_audit_016_fetch_messages_bypass_global_rate_limiter() {
         let fetch_messages = vec![
-            StellarMessage::TxSet(stellar_xdr::curr::TransactionSet {
-                previous_ledger_hash: stellar_xdr::curr::Hash([0; 32]),
-                txs: stellar_xdr::curr::VecM::default(),
+            StellarMessage::TxSet(stellar_xdr::TransactionSet {
+                previous_ledger_hash: stellar_xdr::Hash([0; 32]),
+                txs: stellar_xdr::VecM::default(),
             }),
-            StellarMessage::DontHave(stellar_xdr::curr::DontHave {
-                type_: stellar_xdr::curr::MessageType::TxSet,
-                req_hash: stellar_xdr::curr::Uint256([0; 32]),
+            StellarMessage::DontHave(stellar_xdr::DontHave {
+                type_: stellar_xdr::MessageType::TxSet,
+                req_hash: stellar_xdr::Uint256([0; 32]),
             }),
-            StellarMessage::ScpQuorumset(stellar_xdr::curr::ScpQuorumSet {
+            StellarMessage::ScpQuorumset(stellar_xdr::ScpQuorumSet {
                 threshold: 1,
-                validators: stellar_xdr::curr::VecM::default(),
-                inner_sets: stellar_xdr::curr::VecM::default(),
+                validators: stellar_xdr::VecM::default(),
+                inner_sets: stellar_xdr::VecM::default(),
             }),
         ];
 
@@ -2127,10 +2124,10 @@ mod tests {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
 
-        let matching_hash = stellar_xdr::curr::Uint256([1u8; 32]);
-        let non_matching_hash = stellar_xdr::curr::Uint256([2u8; 32]);
-        let peer_id = PeerId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([0u8; 32]),
+        let matching_hash = stellar_xdr::Uint256([1u8; 32]);
+        let non_matching_hash = stellar_xdr::Uint256([2u8; 32]);
+        let peer_id = PeerId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([0u8; 32]),
         ));
 
         metrics::with_local_recorder(&recorder, || {

--- a/crates/overlay/src/manager/tick.rs
+++ b/crates/overlay/src/manager/tick.rs
@@ -14,7 +14,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use stellar_xdr::curr::ErrorCode;
+use stellar_xdr::ErrorCode;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 

--- a/crates/overlay/src/metrics.rs
+++ b/crates/overlay/src/metrics.rs
@@ -24,7 +24,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use stellar_xdr::curr::StellarMessage;
+use stellar_xdr::StellarMessage;
 
 /// Atomic counter for simple metrics.
 #[derive(Debug, Default)]
@@ -794,7 +794,7 @@ mod tests {
 
     #[test]
     fn test_overlay_message_kind_from_stellar_message() {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         // Test representative variants
         let hello = StellarMessage::Hello(Hello::default());

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -37,7 +37,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use stellar_xdr::curr::{Auth, Hello, StellarMessage};
+use stellar_xdr::{Auth, Hello, StellarMessage};
 use tracing::{debug, info, trace, warn};
 
 /// Auth flag value indicating flow control with byte-level capacity is enabled.
@@ -499,7 +499,7 @@ impl Peer {
         // Matches stellar-core Peer::recvAuth() → sendSendMore().
         // Both grants are derived from configuration at overlay startup —
         // OVERLAY_SPEC §7.2 (initial SEND_MORE_EXTENDED capacity grant) / §5.4.4.
-        let send_more = StellarMessage::SendMoreExtended(stellar_xdr::curr::SendMoreExtended {
+        let send_more = StellarMessage::SendMoreExtended(stellar_xdr::SendMoreExtended {
             num_messages: initial_message_grant,
             num_bytes: initial_byte_grant,
         });
@@ -602,9 +602,9 @@ impl Peer {
         } else {
             &reason
         };
-        let msg = StellarMessage::ErrorMsg(stellar_xdr::curr::SError {
-            code: stellar_xdr::curr::ErrorCode::Conf,
-            msg: stellar_xdr::curr::StringM::try_from(truncated.to_string()).unwrap_or_default(),
+        let msg = StellarMessage::ErrorMsg(stellar_xdr::SError {
+            code: stellar_xdr::ErrorCode::Conf,
+            msg: stellar_xdr::StringM::try_from(truncated.to_string()).unwrap_or_default(),
         });
         if let Err(e) = self.send_raw(msg).await {
             debug!("Failed to send ERR_CONF: {}", e);
@@ -999,7 +999,7 @@ impl Peer {
     /// Note: GetPeers was removed in Protocol 24. This is a no-op.
     /// Send extended flow control message with byte limit.
     pub async fn send_more_extended(&mut self, num_messages: u32, num_bytes: u32) -> Result<()> {
-        let message = StellarMessage::SendMoreExtended(stellar_xdr::curr::SendMoreExtended {
+        let message = StellarMessage::SendMoreExtended(stellar_xdr::SendMoreExtended {
             num_messages,
             num_bytes,
         });
@@ -1162,7 +1162,7 @@ mod tests {
         use crate::auth::{AuthCert, AuthCertExt, AuthContext};
         use crate::connection::Connection;
         use henyey_crypto::SecretKey;
-        use stellar_xdr::curr as xdr;
+        use stellar_xdr as xdr;
         use x25519_dalek::EphemeralSecret;
 
         let (_client, server) = tokio::io::duplex(1024 * 1024);
@@ -1420,7 +1420,7 @@ mod tests {
     use crate::auth::AuthContext;
     use crate::connection::Connection;
     use henyey_crypto::SecretKey;
-    use stellar_xdr::curr::Hello;
+    use stellar_xdr::Hello;
 
     /// Build a responder `Peer` (inbound, `Handshaking`) wired over an in-memory
     /// duplex to a raw client-side `(Connection, AuthContext)` initiator pair.
@@ -1551,7 +1551,7 @@ mod tests {
             StellarMessage::ErrorMsg(e) => {
                 assert_eq!(
                     e.code,
-                    stellar_xdr::curr::ErrorCode::Conf,
+                    stellar_xdr::ErrorCode::Conf,
                     "second frame must be ERR_CONF"
                 );
             }
@@ -1569,7 +1569,7 @@ mod tests {
         let client_local = LocalNode::new_testnet(SecretKey::generate());
         let frames = responder_reply_frames(client_local, |hello| {
             // Wrong network id (compatible overlay version preserved).
-            hello.network_id = stellar_xdr::curr::Hash([0xAB; 32]);
+            hello.network_id = stellar_xdr::Hash([0xAB; 32]);
         })
         .await;
 

--- a/crates/overlay/src/query_policy.rs
+++ b/crates/overlay/src/query_policy.rs
@@ -9,7 +9,7 @@
 //! `GET_SCP_STATE_MAX_RATE` (61), `QUERY_RESPONSE_MULTIPLIER` (136).
 
 use std::time::Duration;
-use stellar_xdr::curr::StellarMessage;
+use stellar_xdr::StellarMessage;
 
 /// Maximum number of ledger slots used for per-peer rate-limit windows.
 /// Matches stellar-core's `Config::MAX_SLOTS_TO_REMEMBER` (default 12).
@@ -76,7 +76,7 @@ pub fn query_rate_limit_window(close_duration: Duration) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{Hello, Uint256};
+    use stellar_xdr::{Hello, Uint256};
 
     #[test]
     fn classify_returns_correct_variants() {
@@ -100,16 +100,16 @@ mod tests {
             ledger_version: 0,
             overlay_version: 0,
             overlay_min_version: 0,
-            network_id: stellar_xdr::curr::Hash([0; 32]),
-            version_str: stellar_xdr::curr::StringM::default(),
+            network_id: stellar_xdr::Hash([0; 32]),
+            version_str: stellar_xdr::StringM::default(),
             listening_port: 0,
-            peer_id: stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                Uint256([0; 32]),
-            )),
-            cert: stellar_xdr::curr::AuthCert {
-                pubkey: stellar_xdr::curr::Curve25519Public { key: [0; 32] },
+            peer_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+                [0; 32],
+            ))),
+            cert: stellar_xdr::AuthCert {
+                pubkey: stellar_xdr::Curve25519Public { key: [0; 32] },
                 expiration: 0,
-                sig: stellar_xdr::curr::Signature::default(),
+                sig: stellar_xdr::Signature::default(),
             },
             nonce: Uint256([0; 32]),
         });

--- a/crates/overlay/tests/item_fetcher_tests.rs
+++ b/crates/overlay/tests/item_fetcher_tests.rs
@@ -3,7 +3,7 @@
 use henyey_overlay::{ItemFetcher, ItemFetcherConfig, ItemType, PeerId};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, NodeId as XdrNodeId, PublicKey, ScpEnvelope, ScpNomination, ScpStatement,
     ScpStatementPledges, Signature, Uint256,
 };

--- a/crates/overlay/tests/overlay_scp_integration.rs
+++ b/crates/overlay/tests/overlay_scp_integration.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use henyey_crypto::SecretKey;
 use henyey_overlay::{LocalNode, OverlayConfig, OverlayError, OverlayManager, PeerAddress};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, ScpEnvelope, ScpNomination, ScpStatement, ScpStatementPledges, StellarMessage, Uint256,
 };
 use tokio::time::timeout;
@@ -25,9 +25,9 @@ async fn try_start(manager: &mut OverlayManager) -> bool {
 fn make_test_envelope(slot: u64) -> ScpEnvelope {
     ScpEnvelope {
         statement: ScpStatement {
-            node_id: stellar_xdr::curr::NodeId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                Uint256([0u8; 32]),
-            )),
+            node_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+                [0u8; 32],
+            ))),
             slot_index: slot,
             pledges: ScpStatementPledges::Nominate(ScpNomination {
                 quorum_set_hash: Hash([0u8; 32]),
@@ -35,7 +35,7 @@ fn make_test_envelope(slot: u64) -> ScpEnvelope {
                 accepted: vec![].try_into().unwrap(),
             }),
         },
-        signature: stellar_xdr::curr::Signature(vec![0u8; 64].try_into().unwrap()),
+        signature: stellar_xdr::Signature(vec![0u8; 64].try_into().unwrap()),
     }
 }
 

--- a/crates/overlay/tests/overlay_tx_integration.rs
+++ b/crates/overlay/tests/overlay_tx_integration.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use henyey_crypto::SecretKey;
 use henyey_overlay::{LocalNode, OverlayConfig, OverlayError, OverlayManager, PeerAddress};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Memo, MuxedAccount, Preconditions, SequenceNumber, StellarMessage, Transaction,
     TransactionEnvelope, TransactionV1Envelope, Uint256,
 };
@@ -32,7 +32,7 @@ fn make_test_transaction() -> TransactionEnvelope {
             cond: Preconditions::None,
             memo: Memo::None,
             operations: vec![].try_into().unwrap(),
-            ext: stellar_xdr::curr::TransactionExt::V0,
+            ext: stellar_xdr::TransactionExt::V0,
         },
         signatures: vec![].try_into().unwrap(),
     })

--- a/crates/rpc/src/context.rs
+++ b/crates/rpc/src/context.rs
@@ -7,7 +7,7 @@ use henyey_app::{App, AppState, LedgerSummary};
 use henyey_bucket::BucketSnapshotManager;
 use henyey_herder::TxQueueResult;
 use henyey_ledger::HeaderSnapshot;
-use stellar_xdr::curr::TransactionEnvelope;
+use stellar_xdr::TransactionEnvelope;
 use tokio::sync::Semaphore;
 
 use crate::fee_window::FeeWindows;

--- a/crates/rpc/src/fee_window.rs
+++ b/crates/rpc/src/fee_window.rs
@@ -25,7 +25,7 @@
 
 use std::sync::RwLock;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     InnerTransactionResultResult, LedgerCloseMeta, SorobanTransactionMetaExt, TransactionMeta,
     TransactionResultPair, TransactionResultResult,
 };
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn test_count_ops_from_result_success() {
-        use stellar_xdr::curr::{OperationResult, TransactionResultResult, VecM};
+        use stellar_xdr::{OperationResult, TransactionResultResult, VecM};
         let ops: VecM<OperationResult> = vec![
             OperationResult::OpNotSupported,
             OperationResult::OpNotSupported,
@@ -618,7 +618,7 @@ mod tests {
 
     #[test]
     fn test_count_ops_from_result_error_codes() {
-        use stellar_xdr::curr::TransactionResultResult;
+        use stellar_xdr::TransactionResultResult;
         // Error codes that carry no operation results should return 0
         assert_eq!(
             count_ops_from_result(&TransactionResultResult::TxTooEarly),

--- a/crates/rpc/src/methods/get_events.rs
+++ b/crates/rpc/src/methods/get_events.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde_json::json;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ContractEvent, ContractEventBody, ContractEventType, Limits, ReadXdr, ScVal, WriteXdr,
 };
 
@@ -563,9 +563,9 @@ mod tests {
 
     #[test]
     fn test_extract_event_value_valid() {
-        use stellar_xdr::curr::{ContractEvent, ContractEventBody, ContractEventV0, WriteXdr};
+        use stellar_xdr::{ContractEvent, ContractEventBody, ContractEventV0, WriteXdr};
         let event = ContractEvent {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             contract_id: None,
             type_: ContractEventType::Contract,
             body: ContractEventBody::V0(ContractEventV0 {
@@ -581,9 +581,9 @@ mod tests {
 
     #[test]
     fn test_insert_event_fields_base64_valid() {
-        use stellar_xdr::curr::{ContractEvent, ContractEventBody, ContractEventV0, WriteXdr};
+        use stellar_xdr::{ContractEvent, ContractEventBody, ContractEventV0, WriteXdr};
         let event = ContractEvent {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             contract_id: None,
             type_: ContractEventType::Contract,
             body: ContractEventBody::V0(ContractEventV0 {
@@ -610,9 +610,9 @@ mod tests {
 
     #[test]
     fn test_insert_event_fields_json_corrupt_topic_errors() {
-        use stellar_xdr::curr::{ContractEvent, ContractEventBody, ContractEventV0, WriteXdr};
+        use stellar_xdr::{ContractEvent, ContractEventBody, ContractEventV0, WriteXdr};
         let event = ContractEvent {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             contract_id: None,
             type_: ContractEventType::Contract,
             body: ContractEventBody::V0(ContractEventV0 {

--- a/crates/rpc/src/methods/get_ledger_entries.rs
+++ b/crates/rpc/src/methods/get_ledger_entries.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde_json::json;
-use stellar_xdr::curr::{LedgerEntry, LedgerKey, Limits, ReadXdr, WriteXdr};
+use stellar_xdr::{LedgerEntry, LedgerKey, Limits, ReadXdr, WriteXdr};
 
 use crate::context::RpcContext;
 use crate::error::JsonRpcError;
@@ -162,15 +162,15 @@ pub(crate) async fn handle(
 /// For contract data and contract code entries, build the corresponding TTL key.
 fn ttl_key_for_entry(entry: &LedgerEntry) -> Option<LedgerKey> {
     let entry_key = match &entry.data {
-        stellar_xdr::curr::LedgerEntryData::ContractData(data) => {
-            LedgerKey::ContractData(stellar_xdr::curr::LedgerKeyContractData {
+        stellar_xdr::LedgerEntryData::ContractData(data) => {
+            LedgerKey::ContractData(stellar_xdr::LedgerKeyContractData {
                 contract: data.contract.clone(),
                 key: data.key.clone(),
                 durability: data.durability,
             })
         }
-        stellar_xdr::curr::LedgerEntryData::ContractCode(code) => {
-            LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        stellar_xdr::LedgerEntryData::ContractCode(code) => {
+            LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
                 hash: code.hash.clone(),
             })
         }
@@ -190,7 +190,7 @@ fn lookup_ttl(
     let Some(ttl_entry) = snapshot.load_result(&ttl_key)? else {
         return Ok(None);
     };
-    if let stellar_xdr::curr::LedgerEntryData::Ttl(ttl_data) = &ttl_entry.data {
+    if let stellar_xdr::LedgerEntryData::Ttl(ttl_data) = &ttl_entry.data {
         Ok(Some(ttl_data.live_until_ledger_seq))
     } else {
         Ok(None)
@@ -200,7 +200,7 @@ fn lookup_ttl(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, LedgerKeyAccount, LedgerKeyContractCode, PublicKey, Uint256, WriteXdr,
     };
 
@@ -217,7 +217,7 @@ mod tests {
 
     fn contract_code_key(byte: u8) -> LedgerKey {
         LedgerKey::ContractCode(LedgerKeyContractCode {
-            hash: stellar_xdr::curr::Hash([byte; 32]),
+            hash: stellar_xdr::Hash([byte; 32]),
         })
     }
 

--- a/crates/rpc/src/methods/latest_ledger.rs
+++ b/crates/rpc/src/methods/latest_ledger.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde_json::json;
-use stellar_xdr::curr::{Limits, WriteXdr};
+use stellar_xdr::{Limits, WriteXdr};
 
 use crate::context::RpcContext;
 use crate::error::JsonRpcError;

--- a/crates/rpc/src/methods/send_transaction.rs
+++ b/crates/rpc/src/methods/send_transaction.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde_json::json;
-use stellar_xdr::curr::{Limits, ReadXdr, TransactionEnvelope, TransactionResultCode};
+use stellar_xdr::{Limits, ReadXdr, TransactionEnvelope, TransactionResultCode};
 
 use crate::context::RpcContext;
 use crate::error::JsonRpcError;
@@ -103,9 +103,9 @@ fn insert_empty_diagnostic_events(
 }
 
 /// Build an error TransactionResult for the response using the actual error code.
-fn build_error_result(code: Option<TransactionResultCode>) -> stellar_xdr::curr::TransactionResult {
+fn build_error_result(code: Option<TransactionResultCode>) -> stellar_xdr::TransactionResult {
     use henyey_tx::TransactionResultCodeExt;
-    use stellar_xdr::curr::{TransactionResult, TransactionResultExt, TransactionResultResult};
+    use stellar_xdr::{TransactionResult, TransactionResultExt, TransactionResultResult};
 
     let result = code
         .map(|c| c.to_xdr_result())
@@ -121,7 +121,7 @@ fn build_error_result(code: Option<TransactionResultCode>) -> stellar_xdr::curr:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{TransactionResultResult, WriteXdr};
+    use stellar_xdr::{TransactionResultResult, WriteXdr};
 
     #[test]
     fn test_build_error_result_structure() {

--- a/crates/rpc/src/methods/transaction_response.rs
+++ b/crates/rpc/src/methods/transaction_response.rs
@@ -1,7 +1,7 @@
 //! Shared response building for getTransaction and getTransactions.
 
 use serde_json::json;
-use stellar_xdr::curr::{TransactionEnvelope, TransactionMeta, TransactionResult};
+use stellar_xdr::{TransactionEnvelope, TransactionMeta, TransactionResult};
 
 use crate::error::JsonRpcError;
 use crate::util::{self, XdrFormat};

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -638,7 +638,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_send_transaction_exempt_from_timeout() {
         use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Limits, Memo, MuxedAccount, Operation, OperationBody, Preconditions, SequenceNumber,
             Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope, Uint256,
             WriteXdr,
@@ -859,7 +859,7 @@ mod tests {
     // Category H: Fee window ingestion recovery (AUDIT-175 regression tests)
     // -----------------------------------------------------------------------
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerCloseMetaV0, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntry,
         LedgerHeaderHistoryEntryExt, Limits, StellarValue, StellarValueExt, TimePoint,
         TransactionSet, WriteXdr,
@@ -867,7 +867,7 @@ mod tests {
 
     /// Build minimal valid LedgerCloseMeta XDR bytes for a given ledger sequence.
     fn make_lcm_bytes(seq: u32) -> Vec<u8> {
-        let lcm = stellar_xdr::curr::LedgerCloseMeta::V0(LedgerCloseMetaV0 {
+        let lcm = stellar_xdr::LedgerCloseMeta::V0(LedgerCloseMetaV0 {
             ledger_header: LedgerHeaderHistoryEntry {
                 hash: Hash([0; 32]),
                 header: LedgerHeader {

--- a/crates/rpc/src/simulate/convert.rs
+++ b/crates/rpc/src/simulate/convert.rs
@@ -52,7 +52,7 @@ impl std::error::Error for ConversionError {}
 /// Convert a workspace (v26) type to a P25 (v25) type via XDR bytes.
 pub(super) fn ws_to_p25<WS, P25>(ws_val: &WS) -> Result<P25, ConversionError>
 where
-    WS: stellar_xdr::curr::WriteXdr,
+    WS: stellar_xdr::WriteXdr,
     P25: soroban_host::xdr::ReadXdr,
 {
     let err = |phase, cause: String| ConversionError {
@@ -63,7 +63,7 @@ where
         cause,
     };
     let bytes = ws_val
-        .to_xdr(stellar_xdr::curr::Limits::none())
+        .to_xdr(stellar_xdr::Limits::none())
         .map_err(|e| err(ConversionPhase::Serialize, e.to_string()))?;
     P25::from_xdr(&bytes, soroban_host::xdr::Limits::none())
         .map_err(|e| err(ConversionPhase::Deserialize, e.to_string()))
@@ -73,7 +73,7 @@ where
 pub(super) fn p25_to_ws<P25, WS>(p25_val: &P25) -> Result<WS, ConversionError>
 where
     P25: soroban_host::xdr::WriteXdr,
-    WS: stellar_xdr::curr::ReadXdr,
+    WS: stellar_xdr::ReadXdr,
 {
     let err = |phase, cause: String| ConversionError {
         direction: ConversionDirection::P25ToWs,
@@ -85,7 +85,7 @@ where
     let bytes = p25_val
         .to_xdr(soroban_host::xdr::Limits::none())
         .map_err(|e| err(ConversionPhase::Serialize, e.to_string()))?;
-    WS::from_xdr(&bytes, stellar_xdr::curr::Limits::none())
+    WS::from_xdr(&bytes, stellar_xdr::Limits::none())
         .map_err(|e| err(ConversionPhase::Deserialize, e.to_string()))
 }
 
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn test_ws_to_p25_success() {
         // Round-trip a simple XDR type that exists in both versions.
-        let ws_val = stellar_xdr::curr::Uint256([42u8; 32]);
+        let ws_val = stellar_xdr::Uint256([42u8; 32]);
         let result: Result<soroban_host::xdr::Uint256, _> = ws_to_p25(&ws_val);
         assert_eq!(result.unwrap().0, [42u8; 32]);
     }
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn test_p25_to_ws_success() {
         let p25_val = soroban_host::xdr::Uint256([99u8; 32]);
-        let result: Result<stellar_xdr::curr::Uint256, _> = p25_to_ws(&p25_val);
+        let result: Result<stellar_xdr::Uint256, _> = p25_to_ws(&p25_val);
         assert_eq!(result.unwrap().0, [99u8; 32]);
     }
 
@@ -147,7 +147,7 @@ mod tests {
         // deserialize as Uint256 (32 bytes).
         let p25_val = soroban_host::xdr::Uint256([0u8; 32]);
         // Serialize Uint256 (32 bytes) and try to read as a LedgerHeader — will fail.
-        let result: Result<stellar_xdr::curr::LedgerHeader, _> = p25_to_ws(&p25_val);
+        let result: Result<stellar_xdr::LedgerHeader, _> = p25_to_ws(&p25_val);
         let err = result.unwrap_err();
         assert!(matches!(err.phase, ConversionPhase::Deserialize));
         assert!(matches!(err.direction, ConversionDirection::P25ToWs));

--- a/crates/rpc/src/simulate/mod.rs
+++ b/crates/rpc/src/simulate/mod.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use soroban_env_host_p25 as soroban_host;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     HostFunction, LedgerKey, Limits, OperationBody, ReadXdr, SorobanTransactionData,
     TransactionEnvelope,
 };
@@ -40,7 +40,7 @@ use response::{
 enum SorobanOp {
     InvokeHostFunction {
         host_fn: HostFunction,
-        auth: Vec<stellar_xdr::curr::SorobanAuthorizationEntry>,
+        auth: Vec<stellar_xdr::SorobanAuthorizationEntry>,
     },
     ExtendFootprintTtl {
         keys: Vec<LedgerKey>,
@@ -53,7 +53,7 @@ enum SorobanOp {
 
 struct InvokeRequest {
     host_fn: HostFunction,
-    source_account: stellar_xdr::curr::AccountId,
+    source_account: stellar_xdr::AccountId,
     ledger_info: soroban_host::LedgerInfo,
     snapshot_source: BucketListSnapshotSource,
     soroban_info: henyey_ledger::SorobanNetworkInfo,
@@ -66,21 +66,14 @@ struct InvokeRequest {
 /// Represents a single ledger entry state change from simulation.
 struct LedgerEntryDiff {
     key: LedgerKey,
-    state_before: Option<stellar_xdr::curr::LedgerEntry>,
-    state_after: Option<stellar_xdr::curr::LedgerEntry>,
+    state_before: Option<stellar_xdr::LedgerEntry>,
+    state_after: Option<stellar_xdr::LedgerEntry>,
 }
 
 /// Extract the Soroban operation, source account, and optional footprint from the envelope.
 fn extract_soroban_op(
     tx_env: &TransactionEnvelope,
-) -> Result<
-    (
-        stellar_xdr::curr::AccountId,
-        SorobanOp,
-        stellar_xdr::curr::Memo,
-    ),
-    JsonRpcError,
-> {
+) -> Result<(stellar_xdr::AccountId, SorobanOp, stellar_xdr::Memo), JsonRpcError> {
     let (source, ops, ext, memo) = match tx_env {
         TransactionEnvelope::Tx(tx) => (
             &tx.tx.source_account,
@@ -94,7 +87,7 @@ fn extract_soroban_op(
             ));
         }
         TransactionEnvelope::TxFeeBump(fb) => match &fb.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => (
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => (
                 &inner.tx.source_account,
                 &inner.tx.operations,
                 &inner.tx.ext,
@@ -113,7 +106,7 @@ fn extract_soroban_op(
 
     match &ops[0].body {
         OperationBody::InvokeHostFunction(op) => {
-            let auth: Vec<stellar_xdr::curr::SorobanAuthorizationEntry> =
+            let auth: Vec<stellar_xdr::SorobanAuthorizationEntry> =
                 op.auth.iter().cloned().collect();
             Ok((
                 source_account,
@@ -153,8 +146,8 @@ fn extract_soroban_op(
 const MAX_MEMO_TEXT_BYTES: usize = 28;
 
 /// Validate memo (MemoText must be <= MAX_MEMO_TEXT_BYTES bytes).
-fn validate_memo(memo: &stellar_xdr::curr::Memo) -> Result<(), JsonRpcError> {
-    if let stellar_xdr::curr::Memo::Text(text) = memo {
+fn validate_memo(memo: &stellar_xdr::Memo) -> Result<(), JsonRpcError> {
+    if let stellar_xdr::Memo::Text(text) = memo {
         if text.len() > MAX_MEMO_TEXT_BYTES {
             return Err(JsonRpcError::invalid_params(format!(
                 "memo text too long: {} bytes (max {})",
@@ -166,13 +159,13 @@ fn validate_memo(memo: &stellar_xdr::curr::Memo) -> Result<(), JsonRpcError> {
     Ok(())
 }
 
-fn muxed_to_account_id(source: &stellar_xdr::curr::MuxedAccount) -> stellar_xdr::curr::AccountId {
+fn muxed_to_account_id(source: &stellar_xdr::MuxedAccount) -> stellar_xdr::AccountId {
     match source {
-        stellar_xdr::curr::MuxedAccount::Ed25519(key) => stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key.clone()),
-        ),
-        stellar_xdr::curr::MuxedAccount::MuxedEd25519(muxed) => stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(muxed.ed25519.clone()),
+        stellar_xdr::MuxedAccount::Ed25519(key) => {
+            stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(key.clone()))
+        }
+        stellar_xdr::MuxedAccount::MuxedEd25519(muxed) => stellar_xdr::AccountId(
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(muxed.ed25519.clone()),
         ),
     }
 }
@@ -180,10 +173,10 @@ fn muxed_to_account_id(source: &stellar_xdr::curr::MuxedAccount) -> stellar_xdr:
 /// Extract the read_only + read_write keys from the SorobanTransactionData footprint
 /// embedded in the transaction envelope's ext field.
 fn extract_footprint_keys(
-    ext: &stellar_xdr::curr::TransactionExt,
+    ext: &stellar_xdr::TransactionExt,
 ) -> Result<Vec<LedgerKey>, JsonRpcError> {
     let soroban_data = match ext {
-        stellar_xdr::curr::TransactionExt::V1(data) => data,
+        stellar_xdr::TransactionExt::V1(data) => data,
         _ => {
             return Err(JsonRpcError::invalid_params(
                 "ExtendFootprintTtl/RestoreFootprint requires SorobanTransactionData in tx ext",
@@ -213,8 +206,8 @@ struct BucketEntryReader<'a>(&'a henyey_bucket::SearchableBucketListSnapshot);
 impl henyey_ledger::EntryReader for BucketEntryReader<'_> {
     fn get_entry(
         &self,
-        key: &stellar_xdr::curr::LedgerKey,
-    ) -> henyey_ledger::Result<Option<stellar_xdr::curr::LedgerEntry>> {
+        key: &stellar_xdr::LedgerKey,
+    ) -> henyey_ledger::Result<Option<stellar_xdr::LedgerEntry>> {
         Ok(self.0.load_result(key)?)
     }
 }
@@ -467,7 +460,7 @@ pub(crate) async fn handle(
 /// Resolve the effective `RecordingInvocationAuthMode` from the request parameter.
 fn resolve_auth_mode(
     auth_mode_str: &str,
-    tx_auth: &[stellar_xdr::curr::SorobanAuthorizationEntry],
+    tx_auth: &[stellar_xdr::SorobanAuthorizationEntry],
 ) -> Result<soroban_host::e2e_invoke::RecordingInvocationAuthMode, JsonRpcError> {
     use soroban_host::e2e_invoke::RecordingInvocationAuthMode;
 
@@ -580,7 +573,7 @@ async fn handle_invoke(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_tx_envelope(ops: Vec<Operation>) -> TransactionEnvelope {
         let source = MuxedAccount::Ed25519(Uint256([1u8; 32]));
@@ -1144,7 +1137,7 @@ mod tests {
         fn get_entry(
             &self,
             _key: &LedgerKey,
-        ) -> henyey_ledger::Result<Option<stellar_xdr::curr::LedgerEntry>> {
+        ) -> henyey_ledger::Result<Option<stellar_xdr::LedgerEntry>> {
             Err(henyey_ledger::LedgerError::Internal(
                 "simulated I/O failure".to_string(),
             ))
@@ -1174,7 +1167,7 @@ mod tests {
         fn get_entry(
             &self,
             _key: &LedgerKey,
-        ) -> henyey_ledger::Result<Option<stellar_xdr::curr::LedgerEntry>> {
+        ) -> henyey_ledger::Result<Option<stellar_xdr::LedgerEntry>> {
             Ok(None)
         }
     }

--- a/crates/rpc/src/simulate/preflight.rs
+++ b/crates/rpc/src/simulate/preflight.rs
@@ -4,7 +4,7 @@
 use std::rc::Rc;
 
 use soroban_env_host_p25 as soroban_host;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ExtendFootprintTtlOp, ExtensionPoint, LedgerEntryType, LedgerFootprint, LedgerKey, Limits,
     OperationBody, ReadXdr, RestoreFootprintOp, SorobanResources, SorobanTransactionData,
     SorobanTransactionDataExt, WriteXdr,
@@ -21,8 +21,8 @@ pub(super) struct InvokeSimulationOutput {
 }
 
 pub(super) fn run_invoke_simulation(
-    host_fn: stellar_xdr::curr::HostFunction,
-    source_account: stellar_xdr::curr::AccountId,
+    host_fn: stellar_xdr::HostFunction,
+    source_account: stellar_xdr::AccountId,
     ledger_info: soroban_host::LedgerInfo,
     snapshot_source: BucketListSnapshotSource,
     auth_mode: soroban_host::e2e_invoke::RecordingInvocationAuthMode,
@@ -126,7 +126,7 @@ fn extract_modified_entries(
         // Get state after: decode from encoded_new_value
         let state_after = match change.encoded_new_value.as_ref() {
             Some(v) => Some(
-                stellar_xdr::curr::LedgerEntry::from_xdr(v, Limits::none())
+                stellar_xdr::LedgerEntry::from_xdr(v, Limits::none())
                     .map_err(|e| format!("failed to decode new LedgerEntry from change: {e}"))?,
             ),
             None => None,

--- a/crates/rpc/src/simulate/resources.rs
+++ b/crates/rpc/src/simulate/resources.rs
@@ -2,7 +2,7 @@
 //! computation, fee estimation, resource bumping.
 
 use soroban_env_host_p25 as soroban_host;
-use stellar_xdr::curr::{OperationBody, SorobanResources};
+use stellar_xdr::{OperationBody, SorobanResources};
 
 /// Multiplicative adjustment factor for refundable fees (soroban-simulation default).
 const REFUNDABLE_FEE_ADJUSTMENT_FACTOR: f64 = 1.15;
@@ -69,7 +69,7 @@ pub(super) fn estimate_tx_size_for_op(
     operation: &OperationBody,
     resources: &SorobanResources,
 ) -> u32 {
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     let soroban_data = SorobanTransactionData {
         ext: SorobanTransactionDataExt::V0,
@@ -301,7 +301,7 @@ fn compute_resource_fee_core(params: &ResourceFeeParams<'_>) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn test_soroban_network_info() -> henyey_ledger::SorobanNetworkInfo {
         henyey_ledger::SorobanNetworkInfo {

--- a/crates/rpc/src/simulate/response.rs
+++ b/crates/rpc/src/simulate/response.rs
@@ -3,7 +3,7 @@
 
 use serde_json::json;
 use soroban_env_host_p25 as soroban_host;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     HostFunction, InvokeHostFunctionOp, OperationBody, SorobanTransactionData,
     SorobanTransactionDataExt, WriteXdr,
 };
@@ -31,7 +31,7 @@ pub(super) fn build_invoke_response(
     use super::convert::p25_to_ws;
 
     // Convert P25 resources to workspace types
-    let resources: stellar_xdr::curr::SorobanResources = p25_to_ws(&sim_result.resources)
+    let resources: stellar_xdr::SorobanResources = p25_to_ws(&sim_result.resources)
         .map_err(|e| JsonRpcError::internal_logged("xdr_conversion", &e))?;
 
     // Apply resource adjustments (mirrors soroban-simulation default_adjustment)
@@ -42,7 +42,7 @@ pub(super) fn build_invoke_response(
     let rent_changes = soroban_host::e2e_invoke::extract_rent_changes(&sim_result.ledger_changes);
 
     // Convert P25 auth to workspace for the InvokeHostFunctionOp
-    let ws_auth: Vec<stellar_xdr::curr::SorobanAuthorizationEntry> = sim_result
+    let ws_auth: Vec<stellar_xdr::SorobanAuthorizationEntry> = sim_result
         .auth
         .iter()
         .map(|a| p25_to_ws(a).map_err(|e| JsonRpcError::internal_logged("xdr_conversion", &e)))
@@ -63,7 +63,7 @@ pub(super) fn build_invoke_response(
     let ext = if sim_result.restored_rw_entry_indices.is_empty() {
         SorobanTransactionDataExt::V0
     } else {
-        SorobanTransactionDataExt::V1(stellar_xdr::curr::SorobanResourcesExtV0 {
+        SorobanTransactionDataExt::V1(stellar_xdr::SorobanResourcesExtV0 {
             archived_soroban_entries: sim_result
                 .restored_rw_entry_indices
                 .clone()
@@ -109,7 +109,7 @@ pub(super) fn build_invoke_response(
     // Conversion failures are logged but don't fail the response: diagnostic
     // events are informational and stellar-core treats them as non-fatal.
     if !diagnostic_events.is_empty() {
-        let mut ws_events: Vec<stellar_xdr::curr::DiagnosticEvent> =
+        let mut ws_events: Vec<stellar_xdr::DiagnosticEvent> =
             Vec::with_capacity(diagnostic_events.len());
         for e in &diagnostic_events {
             match p25_to_ws(e) {
@@ -125,7 +125,7 @@ pub(super) fn build_invoke_response(
     }
 
     // Encode auth entries and return value
-    let return_value: Option<stellar_xdr::curr::ScVal> = match &sim_result.invoke_result {
+    let return_value: Option<stellar_xdr::ScVal> = match &sim_result.invoke_result {
         Ok(val) => {
             Some(p25_to_ws(val).map_err(|e| JsonRpcError::internal_logged("xdr_conversion", &e))?)
         }
@@ -302,7 +302,7 @@ fn insert_sim_xdr_array_field<T: WriteXdr + serde::Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn test_account_key(key_byte: u8) -> LedgerKey {
         LedgerKey::Account(LedgerKeyAccount {

--- a/crates/rpc/src/simulate/snapshot.rs
+++ b/crates/rpc/src/simulate/snapshot.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use henyey_bucket::SearchableBucketListSnapshot;
 use soroban_env_host_p25 as soroban_host;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext, AccountEntryExtensionV2,
     AccountEntryExtensionV2Ext, AccountEntryExtensionV3, ExtensionPoint, LedgerEntry,
     LedgerEntryData, LedgerKey, Liabilities, SponsorshipDescriptor, TimePoint,
@@ -125,9 +125,7 @@ fn get_entry_ttl(
 
     match snapshot.load_result(&ttl_key)? {
         Some(entry) => match entry.data {
-            stellar_xdr::curr::LedgerEntryData::Ttl(ttl_data) => {
-                Ok(Some(ttl_data.live_until_ledger_seq))
-            }
+            stellar_xdr::LedgerEntryData::Ttl(ttl_data) => Ok(Some(ttl_data.live_until_ledger_seq)),
             _ => Ok(None),
         },
         None => Ok(None),
@@ -156,7 +154,7 @@ fn normalize_entry(entry: &mut LedgerEntry) {
 /// Upgrade an `AccountEntry`'s extension chain to V3.
 ///
 /// Mirrors `update_account_entry` from `soroban-simulation/src/snapshot_source.rs`.
-fn update_account_entry(account_entry: &mut stellar_xdr::curr::AccountEntry) {
+fn update_account_entry(account_entry: &mut stellar_xdr::AccountEntry) {
     match &mut account_entry.ext {
         AccountEntryExt::V0 => {
             let mut ext = AccountEntryExtensionV1 {
@@ -209,7 +207,7 @@ fn fill_account_ext_v3(account_ext_v2: &mut AccountEntryExtensionV2) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext,
         AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountEntryExtensionV3, AccountId,
         ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, Hash, Int128Parts,

--- a/crates/rpc/src/util.rs
+++ b/crates/rpc/src/util.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::Serialize;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     DiagnosticEvent, LedgerCloseMeta, LedgerHeaderHistoryEntry, LedgerKey, Limits, ReadXdr,
     TransactionMeta, TransactionResultPair, WriteXdr,
 };
@@ -724,7 +724,7 @@ impl LedgerContext {
 /// Check if XDR-encoded transaction envelope bytes represent a fee bump transaction.
 // SECURITY: XDR input pre-bounded by HTTP body size limit; Limits::none() is safe
 pub(crate) fn is_fee_bump_envelope(envelope_bytes: &[u8]) -> Result<bool, RpcXdrError> {
-    use stellar_xdr::curr::TransactionEnvelope;
+    use stellar_xdr::TransactionEnvelope;
     let env = TransactionEnvelope::from_xdr(envelope_bytes, Limits::none()).map_err(|e| {
         RpcXdrError::XdrParse {
             type_name: "TransactionEnvelope",
@@ -788,7 +788,7 @@ pub(crate) fn insert_diagnostic_events(
 /// Returns `None` if the key is not a TTL-bearing type.
 pub(crate) fn ttl_key_for_ledger_key(key: &LedgerKey) -> Option<LedgerKey> {
     if henyey_common::is_soroban_key(key) {
-        Some(LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl {
+        Some(LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl {
             key_hash: hash_ledger_key(key),
         }))
     } else {
@@ -797,10 +797,10 @@ pub(crate) fn ttl_key_for_ledger_key(key: &LedgerKey) -> Option<LedgerKey> {
 }
 
 /// SHA-256 hash of the XDR-encoded ledger key, returned as an XDR `Hash`.
-pub(crate) fn hash_ledger_key(key: &LedgerKey) -> stellar_xdr::curr::Hash {
+pub(crate) fn hash_ledger_key(key: &LedgerKey) -> stellar_xdr::Hash {
     let xdr_bytes = key.to_xdr(Limits::none()).expect("XDR encode");
     let hash = henyey_crypto::sha256(&xdr_bytes);
-    stellar_xdr::curr::Hash(*hash.as_bytes())
+    stellar_xdr::Hash(*hash.as_bytes())
 }
 
 /// Format a Unix timestamp as an ISO 8601 UTC string (e.g. `2024-01-15T12:30:00Z`).
@@ -1059,7 +1059,7 @@ mod tests {
 
     #[test]
     fn test_extract_result_xdr_success() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             TransactionResult, TransactionResultExt, TransactionResultResult, WriteXdr,
         };
         let result = TransactionResult {
@@ -1068,14 +1068,13 @@ mod tests {
             ext: TransactionResultExt::V0,
         };
         let pair = TransactionResultPair {
-            transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            transaction_hash: stellar_xdr::Hash([0u8; 32]),
             result: result.clone(),
         };
         let bytes = pair.to_xdr(Limits::none()).unwrap();
         let extracted = extract_result_xdr(&bytes).unwrap();
         // Round-trip: the extracted bytes should parse as TransactionResult
-        let parsed =
-            stellar_xdr::curr::TransactionResult::from_xdr(&extracted, Limits::none()).unwrap();
+        let parsed = stellar_xdr::TransactionResult::from_xdr(&extracted, Limits::none()).unwrap();
         assert_eq!(parsed.fee_charged, 100);
     }
 
@@ -1089,19 +1088,15 @@ mod tests {
 
     #[test]
     fn test_is_fee_bump_envelope_non_fee_bump() {
-        use stellar_xdr::curr::{
-            Transaction, TransactionEnvelope, TransactionV1Envelope, WriteXdr,
-        };
+        use stellar_xdr::{Transaction, TransactionEnvelope, TransactionV1Envelope, WriteXdr};
         let tx = Transaction {
-            source_account: stellar_xdr::curr::MuxedAccount::Ed25519(stellar_xdr::curr::Uint256(
-                [0u8; 32],
-            )),
+            source_account: stellar_xdr::MuxedAccount::Ed25519(stellar_xdr::Uint256([0u8; 32])),
             fee: 100,
-            seq_num: stellar_xdr::curr::SequenceNumber(1),
-            cond: stellar_xdr::curr::Preconditions::None,
-            memo: stellar_xdr::curr::Memo::None,
+            seq_num: stellar_xdr::SequenceNumber(1),
+            cond: stellar_xdr::Preconditions::None,
+            memo: stellar_xdr::Memo::None,
             operations: vec![].try_into().unwrap(),
-            ext: stellar_xdr::curr::TransactionExt::V0,
+            ext: stellar_xdr::TransactionExt::V0,
         };
         let env = TransactionEnvelope::Tx(TransactionV1Envelope {
             tx,
@@ -1125,7 +1120,7 @@ mod tests {
 
     #[test]
     fn test_extract_diagnostic_events_v0_meta() {
-        use stellar_xdr::curr::{TransactionMeta, WriteXdr};
+        use stellar_xdr::{TransactionMeta, WriteXdr};
         let meta = TransactionMeta::V0(Default::default());
         let bytes = meta.to_xdr(Limits::none()).unwrap();
         assert!(extract_diagnostic_events(&bytes).unwrap().is_none());
@@ -1133,9 +1128,9 @@ mod tests {
 
     #[test]
     fn test_extract_diagnostic_events_v3_no_soroban() {
-        use stellar_xdr::curr::{TransactionMeta, TransactionMetaV3, WriteXdr};
+        use stellar_xdr::{TransactionMeta, TransactionMetaV3, WriteXdr};
         let meta = TransactionMeta::V3(TransactionMetaV3 {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             tx_changes_before: Default::default(),
             operations: Default::default(),
             tx_changes_after: Default::default(),
@@ -1172,12 +1167,12 @@ mod tests {
 
     #[test]
     fn test_ttl_key_for_contract_data() {
-        let key = LedgerKey::ContractData(stellar_xdr::curr::LedgerKeyContractData {
-            contract: stellar_xdr::curr::ScAddress::Contract(stellar_xdr::curr::ContractId(
-                stellar_xdr::curr::Hash([0xAA; 32]),
-            )),
-            key: stellar_xdr::curr::ScVal::LedgerKeyContractInstance,
-            durability: stellar_xdr::curr::ContractDataDurability::Persistent,
+        let key = LedgerKey::ContractData(stellar_xdr::LedgerKeyContractData {
+            contract: stellar_xdr::ScAddress::Contract(stellar_xdr::ContractId(stellar_xdr::Hash(
+                [0xAA; 32],
+            ))),
+            key: stellar_xdr::ScVal::LedgerKeyContractInstance,
+            durability: stellar_xdr::ContractDataDurability::Persistent,
         });
         let ttl_key = ttl_key_for_ledger_key(&key);
         assert!(ttl_key.is_some());
@@ -1192,12 +1187,10 @@ mod tests {
 
     #[test]
     fn test_ttl_key_for_account() {
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
-            account_id: stellar_xdr::curr::AccountId(
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                    [1u8; 32],
-                )),
-            ),
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
+            account_id: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([1u8; 32]),
+            )),
         });
         assert!(ttl_key_for_ledger_key(&key).is_none());
     }
@@ -1614,7 +1607,7 @@ mod tests {
     /// Build a minimal `LedgerCloseMeta` with the given ledger sequence and
     /// serialize it to XDR bytes.
     fn make_lcm_bytes(seq: u32) -> Vec<u8> {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerCloseMetaV0, LedgerHeader, LedgerHeaderExt, LedgerHeaderHistoryEntryExt,
             StellarValue, StellarValueExt, TimePoint, TransactionSet, WriteXdr,
         };

--- a/crates/rpc/tests/common/fake_app.rs
+++ b/crates/rpc/tests/common/fake_app.rs
@@ -15,7 +15,7 @@ use henyey_bucket::BucketSnapshotManager;
 use henyey_herder::TxQueueResult;
 use henyey_ledger::{compute_header_hash, HeaderSnapshot, LedgerManager, LedgerManagerConfig};
 use henyey_rpc::{RpcAppHandle, RpcServer};
-use stellar_xdr::curr::{LedgerHeader, TransactionEnvelope};
+use stellar_xdr::{LedgerHeader, TransactionEnvelope};
 use tokio::sync::broadcast;
 
 // ---------------------------------------------------------------------------

--- a/crates/rpc/tests/corrupt_data.rs
+++ b/crates/rpc/tests/corrupt_data.rs
@@ -17,7 +17,7 @@ use henyey_db::{
     StoreTxParams, TxStatus,
 };
 use serde_json::json;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ContractEvent, ContractEventBody, ContractEventType, ContractEventV0, ExtensionPoint, Hash,
     LedgerHeader, LedgerHeaderExt, Limits, Memo, MuxedAccount, Preconditions, ScVal,
     SequenceNumber, StellarValue, StellarValueExt, TimePoint, Transaction, TransactionEnvelope,
@@ -637,7 +637,7 @@ async fn get_ledgers_corrupt_metadata() {
 
 /// Build a minimal, valid `LedgerCloseMeta` with the given ledger sequence.
 fn valid_lcm_bytes(seq: u32) -> Vec<u8> {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Hash, LedgerCloseMeta, LedgerCloseMetaV0, LedgerHeader, LedgerHeaderExt,
         LedgerHeaderHistoryEntry, LedgerHeaderHistoryEntryExt, StellarValue, StellarValueExt,
         TimePoint, TransactionSet, WriteXdr,
@@ -744,7 +744,7 @@ async fn get_latest_ledger_sequence_mismatch() {
 #[tokio::test]
 async fn get_latest_ledger_fields_consistent_with_header_xdr() {
     use sha2::{Digest, Sha256};
-    use stellar_xdr::curr::{LedgerHeader as XdrLedgerHeader, ReadXdr};
+    use stellar_xdr::{LedgerHeader as XdrLedgerHeader, ReadXdr};
 
     let h = setup_fake_rpc_with_header(2, 1_700_000_000).await;
 

--- a/crates/rpc/tests/fake_app_dispatch.rs
+++ b/crates/rpc/tests/fake_app_dispatch.rs
@@ -10,7 +10,7 @@ mod common;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use henyey_herder::TxQueueResult;
 use serde_json::json;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Limits, Memo, MuxedAccount, Preconditions, SequenceNumber, Transaction, TransactionEnvelope,
     TransactionExt, TransactionV1Envelope, Uint256, WriteXdr,
 };
@@ -272,7 +272,7 @@ async fn fake_send_transaction_try_again_later() {
 
 #[tokio::test]
 async fn fake_send_transaction_invalid_with_code() {
-    use stellar_xdr::curr::TransactionResultCode;
+    use stellar_xdr::TransactionResultCode;
     let result = send_tx_with_result(TxQueueResult::Invalid(Some(
         TransactionResultCode::TxFailed,
     )))
@@ -313,7 +313,7 @@ async fn fake_send_transaction_filtered() {
 // ---------------------------------------------------------------------------
 
 use henyey_rpc::RpcAppHandle;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, LedgerHeader, LedgerHeaderExt, ReadXdr, StellarValue, StellarValueExt, TimePoint,
 };
 
@@ -638,18 +638,16 @@ async fn fake_non_snapshot_methods_work_while_not_ready() {
 /// None. The handler must return internal error (-32603), not server-not-ready.
 #[tokio::test]
 async fn fake_get_ledger_entries_defensive_fallback() {
-    use stellar_xdr::curr::{LedgerKey, LedgerKeyAccount, WriteXdr};
+    use stellar_xdr::{LedgerKey, LedgerKeyAccount, WriteXdr};
 
     let h = FakeRpcTestHarness::start_default().await;
     let id = json!("gle-defensive");
 
     // Build a valid LedgerKey (Account key with zero pubkey)
     let key = LedgerKey::Account(LedgerKeyAccount {
-        account_id: stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                [0u8; 32],
-            )),
-        ),
+        account_id: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([0u8; 32]),
+        )),
     });
     let key_b64 = BASE64.encode(key.to_xdr(Limits::none()).unwrap());
 
@@ -715,7 +713,7 @@ async fn assert_invalid_params(
 /// Build a minimal valid Soroban InvokeHostFunction envelope (Wasm upload)
 /// that passes `extract_soroban_op()`, memo validation, and structural checks.
 fn valid_soroban_tx_b64() -> String {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         HostFunction, InvokeHostFunctionOp, LedgerFootprint, Operation, OperationBody,
         SorobanResources, SorobanTransactionData, SorobanTransactionDataExt,
     };
@@ -1154,11 +1152,11 @@ async fn fake_type_validation_get_ledger_entries() {
     .await;
 
     // keys[1] as non-string (object) — use valid base64 XDR key for keys[0]
-    use stellar_xdr::curr::{LedgerKey, LedgerKeyAccount, WriteXdr};
+    use stellar_xdr::{LedgerKey, LedgerKeyAccount, WriteXdr};
     let key = LedgerKey::Account(LedgerKeyAccount {
-        account_id: stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32])),
-        ),
+        account_id: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(
+            [0u8; 32],
+        ))),
     });
     let key_b64 = BASE64.encode(key.to_xdr(Limits::none()).unwrap());
     assert_invalid_params(

--- a/crates/scp/src/ballot/envelope.rs
+++ b/crates/scp/src/ballot/envelope.rs
@@ -47,7 +47,7 @@ impl BallotProtocol {
 
         let mut envelope = ScpEnvelope {
             statement: statement.clone(),
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         ctx.driver.sign_envelope(&mut envelope);

--- a/crates/scp/src/ballot/mod.rs
+++ b/crates/scp/src/ballot/mod.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 /// Exceeding this limit indicates a bug in the protocol state machine.
 const MAX_PROTOCOL_TRANSITIONS: u32 = 50;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     NodeId, ScpBallot, ScpEnvelope, ScpQuorumSet, ScpStatement, ScpStatementConfirm,
     ScpStatementExternalize, ScpStatementPledges, ScpStatementPrepare, Value,
 };
@@ -1069,7 +1069,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
-    use stellar_xdr::curr::{ScpNomination, VecM};
+    use stellar_xdr::{ScpNomination, VecM};
 
     /// Helper to construct a `SlotContext` from the old four-parameter pattern.
     macro_rules! ctx {
@@ -1158,7 +1158,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1191,7 +1191,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1215,7 +1215,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1242,7 +1242,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1263,7 +1263,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1286,7 +1286,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1303,7 +1303,7 @@ mod tests {
             n_prepared,
             n_commit,
             n_h,
-            quorum_set_hash: stellar_xdr::curr::Hash([0u8; 32]),
+            quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
         };
         let statement = ScpStatement {
             node_id,
@@ -1312,7 +1312,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -2763,7 +2763,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
@@ -2800,7 +2800,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
@@ -2835,7 +2835,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
@@ -2865,7 +2865,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         let _ = ssfe!(ballot, &envelope, &node, &quorum_set);
@@ -2923,7 +2923,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         ssfe!(ballot, &envelope, &node, &quorum_set).unwrap();
 
@@ -3274,7 +3274,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert!(
@@ -3299,7 +3299,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         ssfe!(bp, &envelope, &node, &quorum_set).unwrap();
         assert!(
@@ -4623,7 +4623,7 @@ mod tests {
     // tests do not depend on a tracing subscriber.
 
     use crate::compare::ballot_summary_of;
-    use stellar_xdr::curr::{Hash, ScpStatementConfirm, ScpStatementExternalize, Signature};
+    use stellar_xdr::{Hash, ScpStatementConfirm, ScpStatementExternalize, Signature};
 
     fn zero_hash() -> Hash {
         Hash::from([0u8; 32])
@@ -5225,7 +5225,7 @@ mod tests {
         let mut bp = BallotProtocol::new();
 
         let value = make_value(&[42]);
-        let qs_hash: stellar_xdr::curr::Hash = hash_quorum_set(&quorum_set).into();
+        let qs_hash: stellar_xdr::Hash = hash_quorum_set(&quorum_set).into();
 
         // Manually put bp into Confirm phase with valid commit and high_ballot
         bp.phase = BallotPhase::Confirm;
@@ -5260,7 +5260,7 @@ mod tests {
                     quorum_set_hash: qs_hash.clone(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         let env_c = ScpEnvelope {
             statement: ScpStatement {
@@ -5277,7 +5277,7 @@ mod tests {
                     quorum_set_hash: qs_hash.clone(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         bp.latest_envelopes.insert(node_b.clone(), env_b);
         bp.latest_envelopes.insert(node_c.clone(), env_c);
@@ -5332,7 +5332,7 @@ mod tests {
         let mut bp = BallotProtocol::new();
 
         let value = make_value(&[42]);
-        let qs_hash: stellar_xdr::curr::Hash = hash_quorum_set(&quorum_set).into();
+        let qs_hash: stellar_xdr::Hash = hash_quorum_set(&quorum_set).into();
 
         bp.phase = BallotPhase::Confirm;
         bp.commit = Some(ScpBallot {
@@ -5369,7 +5369,7 @@ mod tests {
                     quorum_set_hash: qs_hash.clone(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         let env_c = ScpEnvelope {
             statement: ScpStatement {
@@ -5386,7 +5386,7 @@ mod tests {
                     quorum_set_hash: qs_hash.clone(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         bp.latest_envelopes.insert(node_b.clone(), env_b);
         bp.latest_envelopes.insert(node_c.clone(), env_c);

--- a/crates/scp/src/compare.rs
+++ b/crates/scp/src/compare.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ScpNomination, ScpStatement, ScpStatementConfirm, ScpStatementPledges, ScpStatementPrepare,
 };
 
@@ -147,7 +147,7 @@ pub(crate) fn is_newer_confirm(old: &ScpStatementConfirm, new: &ScpStatementConf
 mod tests {
     use super::*;
     use crate::test_utils::{make_node_id, make_quorum_set, make_value};
-    use stellar_xdr::curr::{ScpBallot, ScpNomination};
+    use stellar_xdr::{ScpBallot, ScpNomination};
 
     #[test]
     fn test_is_newer_nomination() {
@@ -282,7 +282,7 @@ mod tests {
         let externalize_st = ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
-            pledges: ScpStatementPledges::Externalize(stellar_xdr::curr::ScpStatementExternalize {
+            pledges: ScpStatementPledges::Externalize(stellar_xdr::ScpStatementExternalize {
                 commit: make_ballot(1, &[1]),
                 n_h: 1,
                 commit_quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
@@ -340,7 +340,7 @@ mod tests {
         let confirm_st = ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
-            pledges: ScpStatementPledges::Confirm(stellar_xdr::curr::ScpStatementConfirm {
+            pledges: ScpStatementPledges::Confirm(stellar_xdr::ScpStatementConfirm {
                 ballot: make_ballot(1, &[1]),
                 n_prepared: 1,
                 n_commit: 1,
@@ -352,7 +352,7 @@ mod tests {
         let externalize_st = ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
-            pledges: ScpStatementPledges::Externalize(stellar_xdr::curr::ScpStatementExternalize {
+            pledges: ScpStatementPledges::Externalize(stellar_xdr::ScpStatementExternalize {
                 commit: make_ballot(1, &[1]),
                 n_h: 1,
                 commit_quorum_set_hash: qs_hash.into(),
@@ -412,7 +412,7 @@ mod tests {
         let confirm_st = ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
-            pledges: ScpStatementPledges::Confirm(stellar_xdr::curr::ScpStatementConfirm {
+            pledges: ScpStatementPledges::Confirm(stellar_xdr::ScpStatementConfirm {
                 ballot: make_ballot(1, &[1]),
                 n_prepared: 1,
                 n_commit: 1,
@@ -527,7 +527,7 @@ mod tests {
         let advancing_confirm = ScpStatement {
             node_id: node,
             slot_index: 100,
-            pledges: ScpStatementPledges::Confirm(stellar_xdr::curr::ScpStatementConfirm {
+            pledges: ScpStatementPledges::Confirm(stellar_xdr::ScpStatementConfirm {
                 ballot: make_ballot(5, &[1]),
                 n_prepared: 3,
                 n_commit: 2,

--- a/crates/scp/src/driver.rs
+++ b/crates/scp/src/driver.rs
@@ -40,7 +40,7 @@
 use std::time::Duration;
 
 use henyey_common::Hash256;
-use stellar_xdr::curr::{NodeId, ScpBallot, ScpEnvelope, ScpQuorumSet, Value};
+use stellar_xdr::{NodeId, ScpBallot, ScpEnvelope, ScpQuorumSet, Value};
 
 /// Type of SCP timer.
 ///
@@ -184,7 +184,7 @@ impl ValidationLevel {
 /// which produces the exact wire bytes stellar-core's `xdr::xdr_to_opaque`
 /// produces for these types. Kept as a free function (not a trait method) so it
 /// does not widen the public trait surface.
-fn scp_xdr_bytes<T: stellar_xdr::curr::WriteXdr>(value: &T) -> Vec<u8> {
+fn scp_xdr_bytes<T: stellar_xdr::WriteXdr>(value: &T) -> Vec<u8> {
     henyey_common::xdr_stream::xdr_to_bytes(value)
 }
 
@@ -790,7 +790,7 @@ mod tests {
 #[cfg(test)]
 mod default_hash_tests {
     use super::*;
-    use stellar_xdr::curr::{BytesM, Limits, PublicKey, Uint256, WriteXdr};
+    use stellar_xdr::{BytesM, Limits, PublicKey, Uint256, WriteXdr};
 
     /// A minimal `SCPDriver` impl that does NOT override `compute_hash_node`
     /// or `compute_value_hash`, so it exercises the trait DEFAULTS.

--- a/crates/scp/src/format.rs
+++ b/crates/scp/src/format.rs
@@ -1,6 +1,6 @@
 //! Display formatting helpers for SCP types (nodes, ballots, envelopes, values).
 
-use stellar_xdr::curr::{NodeId, ScpBallot, ScpEnvelope, ScpStatementPledges, Value};
+use stellar_xdr::{NodeId, ScpBallot, ScpEnvelope, ScpStatementPledges, Value};
 
 /// Number of bytes to display for node IDs (8 hex chars).
 const NODE_ID_PREFIX_BYTES: usize = 4;
@@ -14,7 +14,7 @@ const VALUE_PREFIX_BYTES: usize = 8;
 /// Returns the first 8 hex characters of the public key.
 pub fn node_id_to_short_string(node_id: &NodeId) -> String {
     match &node_id.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(bytes)) => {
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => {
             hex::encode(&bytes[..NODE_ID_PREFIX_BYTES])
         }
     }
@@ -102,7 +102,7 @@ pub fn envelope_to_str(envelope: &ScpEnvelope) -> String {
 mod tests {
     use super::*;
     use crate::test_utils::{make_node_id, make_value};
-    use stellar_xdr::curr::{ScpNomination, ScpQuorumSet, ScpStatement};
+    use stellar_xdr::{ScpNomination, ScpQuorumSet, ScpStatement};
 
     #[test]
     fn test_node_id_to_short_string() {
@@ -152,7 +152,7 @@ mod tests {
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         let s = envelope_to_str(&envelope);

--- a/crates/scp/src/lib.rs
+++ b/crates/scp/src/lib.rs
@@ -230,7 +230,7 @@ impl EnvelopeState {
 }
 
 // Re-export XDR types commonly used with SCP
-pub use stellar_xdr::curr::{
+pub use stellar_xdr::{
     NodeId, ScpBallot, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement, ScpStatementConfirm,
     ScpStatementExternalize, ScpStatementPledges, ScpStatementPrepare, Value,
 };
@@ -352,7 +352,7 @@ mod tests {
                     slot_index: 1,
                     pledges: ScpStatementPledges::Nominate(nomination),
                 },
-                signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap()),
+                signature: stellar_xdr::Signature(Vec::new().try_into().unwrap()),
             }
         };
 

--- a/crates/scp/src/nomination.rs
+++ b/crates/scp/src/nomination.rs
@@ -33,7 +33,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     NodeId, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement, ScpStatementPledges, Value,
 };
 
@@ -736,7 +736,7 @@ impl NominationProtocol {
 
         let mut envelope = ScpEnvelope {
             statement: statement.clone(),
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         ctx.driver.sign_envelope(&mut envelope);
@@ -1225,7 +1225,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
-    use stellar_xdr::curr::{Hash, PublicKey, ScpBallot, Uint256};
+    use stellar_xdr::{Hash, PublicKey, ScpBallot, Uint256};
 
     /// Helper to construct a `SlotContext` from the old four-parameter pattern.
     macro_rules! ctx {
@@ -1300,7 +1300,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1769,9 +1769,9 @@ mod tests {
         let mut nom = NominationProtocol::new();
 
         // Create a prepare envelope (ballot protocol, not nomination)
-        let prep = stellar_xdr::curr::ScpStatementPrepare {
+        let prep = stellar_xdr::ScpStatementPrepare {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
-            ballot: stellar_xdr::curr::ScpBallot {
+            ballot: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: make_value(&[1]),
             },
@@ -1780,14 +1780,14 @@ mod tests {
             n_c: 0,
             n_h: 0,
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
-            pledges: stellar_xdr::curr::ScpStatementPledges::Prepare(prep),
+            pledges: stellar_xdr::ScpStatementPledges::Prepare(prep),
         };
-        let envelope = stellar_xdr::curr::ScpEnvelope {
+        let envelope = stellar_xdr::ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         assert!(!nom.set_state_from_envelope(&envelope));
@@ -2554,7 +2554,7 @@ mod tests {
                 slot_index: 0,
                 pledges: ScpStatementPledges::Nominate(nomination_pledge),
             },
-            signature: stellar_xdr::curr::Signature(vec![].try_into().unwrap()),
+            signature: stellar_xdr::Signature(vec![].try_into().unwrap()),
         };
         nom.latest_nominations.insert(remote_node.clone(), envelope);
 
@@ -2759,7 +2759,7 @@ mod tests {
                     accepted: vec![make_value(&[1]), make_value(&[2])].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         nom.last_envelope = Some(local_env);
 
@@ -2774,7 +2774,7 @@ mod tests {
                     accepted: vec![make_value(&[1])].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         nom.latest_nominations.insert(peer.clone(), peer_env);
 
@@ -2804,7 +2804,7 @@ mod tests {
                     accepted: vec![make_value(&[1])].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         nom.last_envelope = Some(local_env);
 
@@ -2819,7 +2819,7 @@ mod tests {
                     accepted: vec![make_value(&[2])].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         nom.latest_nominations.insert(peer.clone(), peer_env);
 
@@ -2851,7 +2851,7 @@ mod tests {
                     accepted: vec![val.clone()].try_into().unwrap(),
                 }),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         nom.last_envelope = Some(env.clone());
 

--- a/crates/scp/src/quorum.rs
+++ b/crates/scp/src/quorum.rs
@@ -47,7 +47,7 @@
 use std::collections::HashSet;
 
 use henyey_common::Hash256;
-use stellar_xdr::curr::{NodeId, ScpQuorumSet};
+use stellar_xdr::{NodeId, ScpQuorumSet};
 
 /// Maximum allowed nesting level for quorum sets.
 ///
@@ -428,9 +428,7 @@ fn normalize_quorum_set_simplify(quorum_set: &mut ScpQuorumSet, id_to_remove: Op
 
 fn node_id_bytes(node_id: &NodeId) -> [u8; 32] {
     match &node_id.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(bytes)) => {
-            *bytes
-        }
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(bytes)) => *bytes,
     }
 }
 
@@ -576,7 +574,7 @@ impl SingletonQuorumSetCache {
 mod tests {
     use super::*;
     use crate::test_utils::make_node_id;
-    use stellar_xdr::curr::{PublicKey, Uint256};
+    use stellar_xdr::{PublicKey, Uint256};
 
     fn make_simple_quorum_set(threshold: u32, node_ids: &[NodeId]) -> ScpQuorumSet {
         simple_quorum_set(threshold, node_ids.to_vec())

--- a/crates/scp/src/quorum_config.rs
+++ b/crates/scp/src/quorum_config.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use henyey_common::config::QuorumSetConfig;
-use stellar_xdr::curr::{NodeId, PublicKey, ScpQuorumSet, Uint256};
+use stellar_xdr::{NodeId, PublicKey, ScpQuorumSet, Uint256};
 
 use crate::is_valid_quorum_set;
 

--- a/crates/scp/src/quorum_intersection/checker.rs
+++ b/crates/scp/src/quorum_intersection/checker.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use stellar_xdr::curr::{NodeId, ScpQuorumSet};
+use stellar_xdr::{NodeId, ScpQuorumSet};
 use tracing::warn;
 
 use henyey_common::xdr_to_bytes;

--- a/crates/scp/src/quorum_intersection/mod.rs
+++ b/crates/scp/src/quorum_intersection/mod.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use henyey_common::xdr_to_bytes;
 use henyey_crypto::Sha256Hasher;
-use stellar_xdr::curr::{NodeId, ScpQuorumSet};
+use stellar_xdr::{NodeId, ScpQuorumSet};
 
 use crate::quorum::is_quorum_slice;
 use crate::Hash256;

--- a/crates/scp/src/scp.rs
+++ b/crates/scp/src/scp.rs
@@ -45,7 +45,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     NodeId, ScpBallot, ScpEnvelope, ScpQuorumSet, ScpStatement, ScpStatementPledges, Value,
 };
 
@@ -1139,11 +1139,9 @@ impl<D: SCPDriver> SCP<D> {
                 .latest_envelopes()
                 .get(node_id)
                 .and_then(|env| match &env.statement.pledges {
-                    stellar_xdr::curr::ScpStatementPledges::Prepare(p) => Some(p.ballot.counter),
-                    stellar_xdr::curr::ScpStatementPledges::Confirm(c) => Some(c.ballot.counter),
-                    stellar_xdr::curr::ScpStatementPledges::Externalize(e) => {
-                        Some(e.commit.counter)
-                    }
+                    stellar_xdr::ScpStatementPledges::Prepare(p) => Some(p.ballot.counter),
+                    stellar_xdr::ScpStatementPledges::Confirm(c) => Some(c.ballot.counter),
+                    stellar_xdr::ScpStatementPledges::Externalize(e) => Some(e.commit.counter),
                     _ => None,
                 });
 
@@ -1224,7 +1222,7 @@ mod tests {
     };
     use std::sync::atomic::Ordering;
     use std::time::Duration;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ScpBallot, ScpNomination, ScpStatement, ScpStatementPledges, ScpStatementPrepare,
     };
 
@@ -1259,7 +1257,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 
@@ -1281,7 +1279,7 @@ mod tests {
         };
         ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         }
     }
 

--- a/crates/scp/src/slot.rs
+++ b/crates/scp/src/slot.rs
@@ -31,7 +31,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use stellar_xdr::curr::{NodeId, ScpEnvelope, ScpQuorumSet, ScpStatementPledges, Value};
+use stellar_xdr::{NodeId, ScpEnvelope, ScpQuorumSet, ScpStatementPledges, Value};
 
 use crate::ballot::{BallotPhase, BallotProtocol};
 use crate::driver::SCPDriver;
@@ -237,14 +237,14 @@ impl Slot {
     /// Externalize phase so `get_externalizing_state()` returns it.
     #[cfg(any(test, feature = "test-helpers"))]
     pub fn test_inject_externalizing_envelope(&mut self, envelope: ScpEnvelope) {
-        use stellar_xdr::curr::ScpStatementPledges;
+        use stellar_xdr::ScpStatementPledges;
 
         // Ensure the ballot is in Externalize phase with a commit value.
         if self.ballot.phase() != crate::ballot::BallotPhase::Externalize {
             // Extract value from the envelope for force_externalize.
             let value = match &envelope.statement.pledges {
                 ScpStatementPledges::Externalize(ext) => ext.commit.value.clone(),
-                _ => stellar_xdr::curr::Value(vec![0u8].try_into().unwrap()),
+                _ => stellar_xdr::Value(vec![0u8].try_into().unwrap()),
             };
             self.ballot.force_externalize(value);
         }
@@ -777,7 +777,7 @@ impl Slot {
     /// Get values from a statement.
     ///
     /// Extracts all values referenced by a statement.
-    pub fn get_statement_values(statement: &stellar_xdr::curr::ScpStatement) -> Vec<Value> {
+    pub fn get_statement_values(statement: &stellar_xdr::ScpStatement) -> Vec<Value> {
         use ScpStatementPledges::*;
         let mut values = Vec::new();
 
@@ -1124,19 +1124,19 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), quorum_set.clone(), true);
 
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let nomination = stellar_xdr::curr::ScpNomination {
+        let nomination = stellar_xdr::ScpNomination {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
             votes: vec![value.clone()].try_into().unwrap(),
             accepted: vec![].try_into().unwrap(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Nominate(nomination),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
@@ -1151,13 +1151,13 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), quorum_set.clone(), true);
 
         let value: Value = vec![4, 5, 6].try_into().unwrap();
-        let prep = stellar_xdr::curr::ScpStatementPrepare {
+        let prep = stellar_xdr::ScpStatementPrepare {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
-            ballot: stellar_xdr::curr::ScpBallot {
+            ballot: stellar_xdr::ScpBallot {
                 counter: 3,
                 value: value.clone(),
             },
-            prepared: Some(stellar_xdr::curr::ScpBallot {
+            prepared: Some(stellar_xdr::ScpBallot {
                 counter: 2,
                 value: value.clone(),
             }),
@@ -1165,14 +1165,14 @@ mod tests {
             n_c: 0,
             n_h: 0,
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Prepare(prep),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
@@ -1187,22 +1187,22 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), quorum_set.clone(), true);
 
         let value: Value = vec![7, 8, 9].try_into().unwrap();
-        let ext = stellar_xdr::curr::ScpStatementExternalize {
-            commit: stellar_xdr::curr::ScpBallot {
+        let ext = stellar_xdr::ScpStatementExternalize {
+            commit: stellar_xdr::ScpBallot {
                 counter: 5,
                 value: value.clone(),
             },
             n_h: 7,
             commit_quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Externalize(ext),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
@@ -1222,9 +1222,9 @@ mod tests {
 
         // Set up initial ballot state
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let prep = stellar_xdr::curr::ScpStatementPrepare {
+        let prep = stellar_xdr::ScpStatementPrepare {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
-            ballot: stellar_xdr::curr::ScpBallot {
+            ballot: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: value.clone(),
             },
@@ -1233,14 +1233,14 @@ mod tests {
             n_c: 0,
             n_h: 0,
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Prepare(prep),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
@@ -1392,19 +1392,19 @@ mod tests {
 
         // Set up some state via set_state_from_envelope so there are messages
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let nomination = stellar_xdr::curr::ScpNomination {
+        let nomination = stellar_xdr::ScpNomination {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
             votes: vec![value.clone()].try_into().unwrap(),
             accepted: vec![].try_into().unwrap(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Nominate(nomination),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
@@ -1454,18 +1454,18 @@ mod tests {
         // Since set_state_from_envelope validates node_id == local_node_id,
         // we can only add our own envelope.
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let nomination = stellar_xdr::curr::ScpNomination {
+        let nomination = stellar_xdr::ScpNomination {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
             votes: vec![value.clone()].try_into().unwrap(),
             accepted: vec![].try_into().unwrap(),
         };
         let own_envelope = ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
+            statement: stellar_xdr::ScpStatement {
                 node_id: node1.clone(),
                 slot_index: 1,
                 pledges: ScpStatementPledges::Nominate(nomination.clone()),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&own_envelope, &Arc::new(MockDriver::bare()));
 
@@ -1502,22 +1502,22 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), quorum_set.clone(), true);
 
         let value: Value = vec![7, 8, 9].try_into().unwrap();
-        let ext = stellar_xdr::curr::ScpStatementExternalize {
-            commit: stellar_xdr::curr::ScpBallot {
+        let ext = stellar_xdr::ScpStatementExternalize {
+            commit: stellar_xdr::ScpBallot {
                 counter: 5,
                 value: value.clone(),
             },
             n_h: 7,
             commit_quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Externalize(ext),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
@@ -1538,22 +1538,22 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), quorum_set.clone(), false);
 
         let value: Value = vec![7, 8, 9].try_into().unwrap();
-        let ext = stellar_xdr::curr::ScpStatementExternalize {
-            commit: stellar_xdr::curr::ScpBallot {
+        let ext = stellar_xdr::ScpStatementExternalize {
+            commit: stellar_xdr::ScpBallot {
                 counter: 5,
                 value: value.clone(),
             },
             n_h: 7,
             commit_quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Externalize(ext),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         // Note: set_state_from_envelope for EXTERNALIZE sets fully_validated=true
@@ -1580,19 +1580,19 @@ mod tests {
 
         // Create envelope from wrong node
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let nomination = stellar_xdr::curr::ScpNomination {
+        let nomination = stellar_xdr::ScpNomination {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
             votes: vec![value.clone()].try_into().unwrap(),
             accepted: vec![].try_into().unwrap(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node2.clone(), // Wrong node!
             slot_index: 1,
             pledges: ScpStatementPledges::Nominate(nomination),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         assert!(
@@ -1609,19 +1609,19 @@ mod tests {
 
         // Create envelope for wrong slot
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let nomination = stellar_xdr::curr::ScpNomination {
+        let nomination = stellar_xdr::ScpNomination {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
             votes: vec![value.clone()].try_into().unwrap(),
             accepted: vec![].try_into().unwrap(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 999, // Wrong slot!
             pledges: ScpStatementPledges::Nominate(nomination),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         assert!(
@@ -1638,22 +1638,22 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), quorum_set.clone(), true);
 
         let value: Value = vec![7, 8, 9].try_into().unwrap();
-        let ext = stellar_xdr::curr::ScpStatementExternalize {
-            commit: stellar_xdr::curr::ScpBallot {
+        let ext = stellar_xdr::ScpStatementExternalize {
+            commit: stellar_xdr::ScpBallot {
                 counter: 5,
                 value: value.clone(),
             },
             n_h: 7,
             commit_quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Externalize(ext),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         assert!(slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare())));
@@ -1757,9 +1757,9 @@ mod tests {
 
         // Create a dummy hint statement
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let prep = stellar_xdr::curr::ScpStatementPrepare {
+        let prep = stellar_xdr::ScpStatementPrepare {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
-            ballot: stellar_xdr::curr::ScpBallot {
+            ballot: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: value.clone(),
             },
@@ -1768,7 +1768,7 @@ mod tests {
             n_c: 0,
             n_h: 0,
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Prepare(prep),
@@ -1796,18 +1796,18 @@ mod tests {
 
         // Add nomination envelope
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let nomination = stellar_xdr::curr::ScpNomination {
+        let nomination = stellar_xdr::ScpNomination {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
             votes: vec![value.clone()].try_into().unwrap(),
             accepted: vec![].try_into().unwrap(),
         };
         let nom_envelope = ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
+            statement: stellar_xdr::ScpStatement {
                 node_id: node.clone(),
                 slot_index: 1,
                 pledges: ScpStatementPledges::Nominate(nomination),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&nom_envelope, &Arc::new(MockDriver::bare()));
 
@@ -1823,9 +1823,9 @@ mod tests {
         );
 
         // Add ballot envelope - should prefer ballot over nomination
-        let prep = stellar_xdr::curr::ScpStatementPrepare {
+        let prep = stellar_xdr::ScpStatementPrepare {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
-            ballot: stellar_xdr::curr::ScpBallot {
+            ballot: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: value.clone(),
             },
@@ -1835,12 +1835,12 @@ mod tests {
             n_h: 0,
         };
         let ballot_envelope = ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
+            statement: stellar_xdr::ScpStatement {
                 node_id: node.clone(),
                 slot_index: 1,
                 pledges: ScpStatementPledges::Prepare(prep),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&ballot_envelope, &Arc::new(MockDriver::bare()));
 
@@ -1877,22 +1877,22 @@ mod tests {
         // Simulate externalization happening while not fully validated:
         // set_state_from_envelope with an EXTERNALIZE populates ballot state
         let value: Value = vec![42].try_into().unwrap();
-        let externalize = stellar_xdr::curr::ScpStatementExternalize {
-            commit: stellar_xdr::curr::ScpBallot {
+        let externalize = stellar_xdr::ScpStatementExternalize {
+            commit: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: value.clone(),
             },
             n_h: 1,
             commit_quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Externalize(externalize),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
 
@@ -1959,8 +1959,8 @@ mod tests {
         let qs = Arc::new(make_qs(vec![peer_node.clone()], 1));
         let value: Value = vec![42, 43, 44].try_into().unwrap();
 
-        let ext = stellar_xdr::curr::ScpStatementExternalize {
-            commit: stellar_xdr::curr::ScpBallot {
+        let ext = stellar_xdr::ScpStatementExternalize {
+            commit: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: value.clone(),
             },
@@ -1968,12 +1968,12 @@ mod tests {
             commit_quorum_set_hash: crate::quorum::hash_quorum_set(&qs).into(),
         };
         let envelope = ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
+            statement: stellar_xdr::ScpStatement {
                 node_id: peer_node.clone(),
                 slot_index: 10,
                 pledges: ScpStatementPledges::Externalize(ext),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
 
         // --- Slot A: MaybeValidDeferred (simulates missing tx_set fast-path) ---
@@ -2102,7 +2102,7 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), quorum_set.clone(), true);
 
         // Process a peer nomination envelope
-        let peer_nomination = stellar_xdr::curr::ScpNomination {
+        let peer_nomination = stellar_xdr::ScpNomination {
             quorum_set_hash: crate::quorum::hash_quorum_set(&quorum_set).into(),
             votes: vec![vec![1u8, 2, 3].try_into().unwrap()]
                 .try_into()
@@ -2110,12 +2110,12 @@ mod tests {
             accepted: vec![].try_into().unwrap(),
         };
         let peer_envelope = ScpEnvelope {
-            statement: stellar_xdr::curr::ScpStatement {
+            statement: stellar_xdr::ScpStatement {
                 node_id: peer1.clone(),
                 slot_index: 1,
                 pledges: ScpStatementPledges::Nominate(peer_nomination),
             },
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.process_envelope(peer_envelope, &driver);
 
@@ -2180,9 +2180,9 @@ mod tests {
         let mut slot = Slot::new(1, node.clone(), qs.clone(), true);
 
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let prep = stellar_xdr::curr::ScpStatementPrepare {
+        let prep = stellar_xdr::ScpStatementPrepare {
             quorum_set_hash: crate::quorum::hash_quorum_set(&qs).into(),
-            ballot: stellar_xdr::curr::ScpBallot {
+            ballot: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: value.clone(),
             },
@@ -2191,14 +2191,14 @@ mod tests {
             n_c: 0,
             n_h: 0,
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node.clone(),
             slot_index: 1,
             pledges: ScpStatementPledges::Prepare(prep),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
         assert!(
@@ -2353,9 +2353,9 @@ mod tests {
         let mut slot = Slot::new(1, node1.clone(), qs.clone(), true);
 
         let value: Value = vec![1, 2, 3].try_into().unwrap();
-        let prep = stellar_xdr::curr::ScpStatementPrepare {
+        let prep = stellar_xdr::ScpStatementPrepare {
             quorum_set_hash: crate::quorum::hash_quorum_set(&qs).into(),
-            ballot: stellar_xdr::curr::ScpBallot {
+            ballot: stellar_xdr::ScpBallot {
                 counter: 1,
                 value: value.clone(),
             },
@@ -2364,14 +2364,14 @@ mod tests {
             n_c: 0,
             n_h: 0,
         };
-        let statement = stellar_xdr::curr::ScpStatement {
+        let statement = stellar_xdr::ScpStatement {
             node_id: node1,
             slot_index: 1,
             pledges: ScpStatementPledges::Prepare(prep),
         };
         let envelope = ScpEnvelope {
             statement,
-            signature: stellar_xdr::curr::Signature(Vec::new().try_into().unwrap_or_default()),
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap_or_default()),
         };
         slot.set_state_from_envelope(&envelope, &Arc::new(MockDriver::bare()));
         assert!(slot.is_fully_validated());

--- a/crates/scp/src/test_utils.rs
+++ b/crates/scp/src/test_utils.rs
@@ -7,7 +7,7 @@
 use crate::driver::{SCPDriver, ValidationLevel};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
-use stellar_xdr::curr::{NodeId, PublicKey, ScpBallot, ScpEnvelope, ScpQuorumSet, Uint256, Value};
+use stellar_xdr::{NodeId, PublicKey, ScpBallot, ScpEnvelope, ScpQuorumSet, Uint256, Value};
 
 // ---------------------------------------------------------------------------
 // MockDriver — configurable mock for SCPDriver

--- a/crates/scp/tests/multi_node_simulation.rs
+++ b/crates/scp/tests/multi_node_simulation.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use henyey_scp::{
     hash_quorum_set, is_quorum_slice, EnvelopeState, SCPDriver, ValidationLevel, SCP,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     NodeId, PublicKey, ScpBallot, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement,
     ScpStatementConfirm, ScpStatementExternalize, ScpStatementPledges, ScpStatementPrepare,
     Signature, Uint256, Value,

--- a/crates/scp/tests/quorum_intersection_json.rs
+++ b/crates/scp/tests/quorum_intersection_json.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use henyey_scp::quorum_config::parse_node_id;
 use henyey_scp::{is_quorum, is_quorum_slice};
 use serde::Deserialize;
-use stellar_xdr::curr::{NodeId, ScpQuorumSet};
+use stellar_xdr::{NodeId, ScpQuorumSet};
 
 #[derive(Debug, Deserialize)]
 struct QuorumIntersectionJson {

--- a/crates/scp/tests/scp_parity_tests/main.rs
+++ b/crates/scp/tests/scp_parity_tests/main.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use henyey_common::Hash256;
 use henyey_scp::{EnvelopeState, SCPDriver, SCPTimerType, ValidationLevel, SCP};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     Hash, NodeId, PublicKey, ScpBallot, ScpEnvelope, ScpNomination, ScpQuorumSet, ScpStatement,
     ScpStatementConfirm, ScpStatementExternalize, ScpStatementPledges, ScpStatementPrepare,
     Signature, Uint256, Value,

--- a/crates/simulation/src/applyload.rs
+++ b/crates/simulation/src/applyload.rs
@@ -22,7 +22,7 @@ use henyey_app::App;
 use henyey_common::Hash256;
 use henyey_ledger::{LedgerCloseData, LedgerClosePerf, TransactionSetVariant};
 use henyey_tx::envelope_utils::envelope_soroban_data;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ConfigSettingEntry, ContractDataDurability, ContractId, ContractIdPreimage,
     ContractIdPreimageFromAddress, ExtensionPoint, Hash, LedgerEntry, LedgerEntryData,
     LedgerEntryExt, LedgerKey, LedgerUpgrade, Limits, OperationBody, ScAddress, ScVal,
@@ -30,7 +30,7 @@ use stellar_xdr::curr::{
 };
 // `LedgerKeyContractData` is only constructed in test fixtures below.
 #[cfg(test)]
-use stellar_xdr::curr::LedgerKeyContractData;
+use stellar_xdr::LedgerKeyContractData;
 use tracing::{debug, info, warn};
 
 use crate::loadgen::{ContractInstance, TxGenerator};
@@ -69,7 +69,7 @@ fn is_soroban_envelope(env: &TransactionEnvelope) -> bool {
     let ops = match env {
         TransactionEnvelope::Tx(v1) => &v1.tx.operations,
         TransactionEnvelope::TxFeeBump(fb) => match &fb.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(v1) => &v1.tx.operations,
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(v1) => &v1.tx.operations,
         },
         _ => return false,
     };
@@ -410,8 +410,8 @@ impl ApplyLoad {
         // Count successes/failures from the result.
         for tx_result in &result.tx_results {
             match &tx_result.result.result {
-                stellar_xdr::curr::TransactionResultResult::TxSuccess(_)
-                | stellar_xdr::curr::TransactionResultResult::TxFeeBumpInnerSuccess(_) => {
+                stellar_xdr::TransactionResultResult::TxSuccess(_)
+                | stellar_xdr::TransactionResultResult::TxFeeBumpInnerSuccess(_) => {
                     self.apply_soroban_success += 1;
                 }
                 other => {
@@ -796,7 +796,7 @@ impl ApplyLoad {
             self.app.ledger_manager().current_ledger_seq() + 1,
             self.root_account_id,
             &wasm_hash,
-            &stellar_xdr::curr::Uint256(salt.0),
+            &stellar_xdr::Uint256(salt.0),
             None,
         )?;
         self.close_ledger(vec![create_tx], Vec::new(), false)?;
@@ -842,7 +842,7 @@ impl ApplyLoad {
         let (_, create_tx) = self.tx_gen.create_sac_transaction(
             ledger_num,
             Some(self.root_account_id),
-            stellar_xdr::curr::Asset::Native,
+            stellar_xdr::Asset::Native,
             None,
         )?;
         self.close_ledger(vec![create_tx], Vec::new(), false)?;
@@ -859,7 +859,7 @@ impl ApplyLoad {
 
         // Construct the SAC ContractInstance.
         // The SAC contract ID is derived from the native asset preimage.
-        let preimage = ContractIdPreimage::Asset(stellar_xdr::curr::Asset::Native);
+        let preimage = ContractIdPreimage::Asset(stellar_xdr::Asset::Native);
         let network_passphrase = self.app.config().network.passphrase.clone();
         let sac_contract_id =
             crate::loadgen_soroban::compute_contract_id(&preimage, &network_passphrase)?;
@@ -935,12 +935,12 @@ impl ApplyLoad {
         // Prepare base live entry.
         let base_live_entry = LedgerEntry {
             last_modified_ledger_seq: 0,
-            data: LedgerEntryData::ContractData(stellar_xdr::curr::ContractDataEntry {
+            data: LedgerEntryData::ContractData(stellar_xdr::ContractDataEntry {
                 ext: ExtensionPoint::V0,
                 contract: contract_addr.clone(),
                 key: ScVal::U64(0),
                 durability: ContractDataDurability::Persistent,
-                val: ScVal::Bytes(stellar_xdr::curr::ScBytes::default()),
+                val: ScVal::Bytes(stellar_xdr::ScBytes::default()),
             }),
             ext: LedgerEntryExt::V0,
         };
@@ -1029,7 +1029,7 @@ impl ApplyLoad {
             lm.bucket_list_mut().add_batch(
                 header.ledger_seq,
                 header.ledger_version,
-                stellar_xdr::curr::BucketListType::Live,
+                stellar_xdr::BucketListType::Live,
                 Vec::new(), // init_entries
                 live_entries,
                 Vec::new(), // dead_entries
@@ -1078,7 +1078,7 @@ impl ApplyLoad {
     /// Matches stellar-core `ApplyLoad::warmAccountCache()`.
     fn warm_account_cache(&mut self) {
         // Collect account IDs and their ledger account IDs to avoid borrow conflict
-        let account_info: Vec<(u64, stellar_xdr::curr::AccountId)> = self
+        let account_info: Vec<(u64, stellar_xdr::AccountId)> = self
             .tx_gen
             .accounts()
             .iter()
@@ -1329,7 +1329,7 @@ impl ApplyLoad {
         tx_max_instructions: u64,
         ledger_max_tx_count: u32,
     ) -> Vec<ConfigSettingEntry> {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ConfigSettingContractBandwidthV0, ConfigSettingContractComputeV0,
             ConfigSettingContractEventsV0, ConfigSettingContractExecutionLanesV0,
             ConfigSettingContractLedgerCostV0, ConfigSettingContractParallelComputeV0,
@@ -1415,7 +1415,7 @@ impl ApplyLoad {
     /// by writing the ConfigUpgradeSet as a synthetic TEMPORARY CONTRACT_DATA
     /// entry directly into the LedgerManager's in-memory Soroban state.
     fn apply_config_upgrade_direct(&mut self, entries: Vec<ConfigSettingEntry>) -> Result<()> {
-        use stellar_xdr::curr::{ConfigUpgradeSet, ConfigUpgradeSetKey, ContractDataEntry};
+        use stellar_xdr::{ConfigUpgradeSet, ConfigUpgradeSetKey, ContractDataEntry};
 
         // Build the ConfigUpgradeSet
         let num_entries = entries.len();
@@ -1644,7 +1644,7 @@ fn generate_live_entries(
         );
         let ttl_entry = LedgerEntry {
             last_modified_ledger_seq: ledger_seq,
-            data: LedgerEntryData::Ttl(stellar_xdr::curr::TtlEntry {
+            data: LedgerEntryData::Ttl(stellar_xdr::TtlEntry {
                 key_hash: Hash(ttl_key_hash.0),
                 live_until_ledger_seq: 1_000_000_000,
             }),
@@ -1670,12 +1670,12 @@ fn generate_archived_entries(
         };
         let le = LedgerEntry {
             last_modified_ledger_seq: ledger_seq,
-            data: LedgerEntryData::ContractData(stellar_xdr::curr::ContractDataEntry {
+            data: LedgerEntryData::ContractData(stellar_xdr::ContractDataEntry {
                 ext: ExtensionPoint::V0,
                 contract: cd.contract.clone(),
                 key: cd.key.clone(),
                 durability: ContractDataDurability::Persistent,
-                val: ScVal::Bytes(stellar_xdr::curr::ScBytes::default()),
+                val: ScVal::Bytes(stellar_xdr::ScBytes::default()),
             }),
             ext: LedgerEntryExt::V0,
         };
@@ -1866,7 +1866,7 @@ mod tests {
 
     #[test]
     fn test_estimate_tx_resources_fee_bump_soroban() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractId, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx, HostFunction, InvokeContractArgs, InvokeHostFunctionOp,
             LedgerFootprint, Memo, MuxedAccount, Operation, Preconditions, ScSymbol,

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -16,7 +16,7 @@ use henyey_overlay::{
     AddPeerOutcome, ConnectionFactory, LoopbackConnectionFactory, OverlayError, PeerAddress,
     PeerId, TcpConnectionFactory,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, CreateAccountOp, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
     PublicKey, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt,
     TransactionV1Envelope, Uint256, VecM,
@@ -1667,7 +1667,7 @@ impl Simulation {
         let destination = self.destination_for_node(&generated.destination)?;
         let operation = Operation {
             source_account: None,
-            body: OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+            body: OperationBody::Payment(stellar_xdr::PaymentOp {
                 destination,
                 asset: Asset::Native,
                 amount: generated.amount,
@@ -2395,7 +2395,7 @@ mod genesis_freshness_tests {
     #[test]
     fn test_genesis_init_rejects_stale_headers_without_lcl() {
         use henyey_db::queries::LedgerQueries;
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Hash, LedgerHeader, LedgerHeaderExt, StellarValue, StellarValueExt, TimePoint, VecM,
         };
 
@@ -2427,8 +2427,7 @@ mod genesis_freshness_tests {
             ext: LedgerHeaderExt::V0,
         };
         let header_xdr =
-            stellar_xdr::curr::WriteXdr::to_xdr(&header, stellar_xdr::curr::Limits::none())
-                .unwrap();
+            stellar_xdr::WriteXdr::to_xdr(&header, stellar_xdr::Limits::none()).unwrap();
         db.with_connection(|conn| {
             conn.store_ledger_header(&header, &header_xdr)?;
             Ok::<_, henyey_db::DbError>(())
@@ -2517,11 +2516,9 @@ mod defense_layer_tests {
                 // Clone header with ledger_seq = 5
                 let mut seeded_header = header;
                 seeded_header.ledger_seq = 5;
-                let seeded_xdr = stellar_xdr::curr::WriteXdr::to_xdr(
-                    &seeded_header,
-                    stellar_xdr::curr::Limits::none(),
-                )
-                .unwrap();
+                let seeded_xdr =
+                    stellar_xdr::WriteXdr::to_xdr(&seeded_header, stellar_xdr::Limits::none())
+                        .unwrap();
 
                 conn.store_ledger_header(&seeded_header, &seeded_xdr)
                     .expect("store seeded header");

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -19,7 +19,7 @@ use henyey_common::{Hash256, NetworkId};
 use henyey_crypto::SecretKey;
 use henyey_herder::TxQueueResult;
 use henyey_tx::TxResultCode;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, ContractDataDurability, ContractId, ContractIdPreimage,
     ContractIdPreimageFromAddress, CreateAccountOp, Hash, LedgerKey, LedgerKeyContractData, Memo,
     MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions, PublicKey, ScAddress, ScVal,
@@ -2004,7 +2004,7 @@ fn envelope_seq_num(env: &TransactionEnvelope) -> i64 {
         TransactionEnvelope::TxV0(e) => e.tx.seq_num.0,
         TransactionEnvelope::Tx(e) => e.tx.seq_num.0,
         TransactionEnvelope::TxFeeBump(e) => match &e.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
         },
     }
 }

--- a/crates/simulation/src/loadgen_pregenerated.rs
+++ b/crates/simulation/src/loadgen_pregenerated.rs
@@ -17,7 +17,7 @@
 
 use std::path::Path;
 
-use stellar_xdr::curr::{Limits, ReadXdr, TransactionEnvelope};
+use stellar_xdr::{Limits, ReadXdr, TransactionEnvelope};
 
 /// Stateful reader over a record-marked file of `TransactionEnvelope`s.
 pub struct PregeneratedTxReader {
@@ -96,7 +96,7 @@ impl PregeneratedTxReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Memo, MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions, SequenceNumber,
         Transaction, TransactionExt, TransactionV1Envelope, Uint256, VecM, WriteXdr,
     };
@@ -109,7 +109,7 @@ mod tests {
             source_account: None,
             body: OperationBody::Payment(PaymentOp {
                 destination: MuxedAccount::Ed25519(Uint256([9u8; 32])),
-                asset: stellar_xdr::curr::Asset::Native,
+                asset: stellar_xdr::Asset::Native,
                 amount: 1,
             }),
         };

--- a/crates/simulation/src/loadgen_soroban.rs
+++ b/crates/simulation/src/loadgen_soroban.rs
@@ -6,7 +6,7 @@
 
 use henyey_common::{Hash256, NetworkId};
 use henyey_crypto::{sign_hash, SecretKey};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ContractDataDurability, ContractExecutable, ContractId, ContractIdPreimage,
     ContractIdPreimageFromAddress, CreateContractArgs, DecoratedSignature, Hash, HashIdPreimage,
     HashIdPreimageContractId, HostFunction, Int128Parts, InvokeContractArgs, InvokeHostFunctionOp,
@@ -291,10 +291,8 @@ impl SorobanTxBuilder {
         salt: &Uint256,
         inclusion_fee: u32,
     ) -> anyhow::Result<TransactionEnvelope> {
-        let deployer_address = ScAddress::Account(stellar_xdr::curr::AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(
-                *source.public_key().as_bytes(),
-            )),
+        let deployer_address = ScAddress::Account(stellar_xdr::AccountId(
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(*source.public_key().as_bytes())),
         ));
 
         let preimage = ContractIdPreimage::Address(ContractIdPreimageFromAddress {
@@ -715,7 +713,7 @@ impl SorobanTxBuilder {
         &self,
         source: &SecretKey,
         sequence: i64,
-        asset: stellar_xdr::curr::Asset,
+        asset: stellar_xdr::Asset,
         inclusion_fee: u32,
     ) -> anyhow::Result<TransactionEnvelope> {
         let preimage = ContractIdPreimage::Asset(asset);
@@ -1076,8 +1074,8 @@ pub fn make_i128(value: i128) -> ScVal {
 
 /// Construct an `ScAddress::Account` from a public key.
 pub fn make_account_address(public_key: &henyey_crypto::PublicKey) -> ScAddress {
-    ScAddress::Account(stellar_xdr::curr::AccountId(
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(*public_key.as_bytes())),
+    ScAddress::Account(stellar_xdr::AccountId(
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(Uint256(*public_key.as_bytes())),
     ))
 }
 
@@ -1116,7 +1114,7 @@ fn build_sac_transfer_rw_keys(
 
     // Source account key
     if let ScAddress::Account(ref aid) = from_address {
-        keys.push(LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        keys.push(LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: aid.clone(),
         }));
     }
@@ -1124,7 +1122,7 @@ fn build_sac_transfer_rw_keys(
     // Destination balance key
     match &to_address {
         ScAddress::Contract(_) => {
-            let balance_key = ScVal::Vec(Some(stellar_xdr::curr::ScVec(
+            let balance_key = ScVal::Vec(Some(stellar_xdr::ScVec(
                 vec![
                     ScVal::Symbol(ScSymbol("Balance".try_into().unwrap())),
                     ScVal::Address(to_address),
@@ -1133,15 +1131,15 @@ fn build_sac_transfer_rw_keys(
                 .unwrap_or_default(),
             )));
             keys.push(LedgerKey::ContractData(
-                stellar_xdr::curr::LedgerKeyContractData {
+                stellar_xdr::LedgerKeyContractData {
                     contract: make_contract_address(contract_id),
                     key: balance_key,
-                    durability: stellar_xdr::curr::ContractDataDurability::Persistent,
+                    durability: stellar_xdr::ContractDataDurability::Persistent,
                 },
             ));
         }
         ScAddress::Account(ref aid) => {
-            keys.push(LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+            keys.push(LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
                 account_id: aid.clone(),
             }));
         }
@@ -1719,7 +1717,7 @@ mod tests {
 
     #[test]
     fn test_compute_contract_id_deterministic() {
-        let preimage = ContractIdPreimage::Asset(stellar_xdr::curr::Asset::Native);
+        let preimage = ContractIdPreimage::Asset(stellar_xdr::Asset::Native);
         let id1 = compute_contract_id(&preimage, "Test SDF Network ; September 2015").unwrap();
         let id2 = compute_contract_id(&preimage, "Test SDF Network ; September 2015").unwrap();
         assert_eq!(id1, id2);

--- a/crates/simulation/tests/app_simulation.rs
+++ b/crates/simulation/tests/app_simulation.rs
@@ -703,10 +703,9 @@ async fn test_load_account_sequence_finds_root_account() {
     let network_id = henyey_common::NetworkId::from_passphrase("Test SDF Network ; September 2015");
     let root_sk = henyey_crypto::SecretKey::from_seed(network_id.as_bytes());
     let root_pk = root_sk.public_key();
-    let root_account_id =
-        stellar_xdr::curr::AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*root_pk.as_bytes()),
-        ));
+    let root_account_id = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+        stellar_xdr::Uint256(*root_pk.as_bytes()),
+    ));
 
     // This is the bug: load_account_sequence returns Ok(None) instead of
     // Ok(Some(0)) for the genesis root account.
@@ -792,10 +791,9 @@ async fn test_load_account_sequence_pair_topology() {
     let network_id = henyey_common::NetworkId::from_passphrase("Test SDF Network ; September 2015");
     let root_sk = henyey_crypto::SecretKey::from_seed(network_id.as_bytes());
     let root_pk = root_sk.public_key();
-    let root_account_id =
-        stellar_xdr::curr::AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*root_pk.as_bytes()),
-        ));
+    let root_account_id = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+        stellar_xdr::Uint256(*root_pk.as_bytes()),
+    ));
 
     // Check on both nodes.
     for node_id in ["node0", "node1"] {
@@ -1987,7 +1985,7 @@ async fn test_pair_tcp_scp_messages_exercise_pump_scp_intake() {
 /// Regression context: #2317, #2364, #2374.
 #[tokio::test]
 async fn test_self_echo_scp_reaches_pump_scp_intake() {
-    use stellar_xdr::curr::{NodeId, StellarMessage};
+    use stellar_xdr::{NodeId, StellarMessage};
 
     let mut sim = build_app_backed_topology(Topologies::pair(SimulationMode::OverTcp), 100).await;
 
@@ -1999,7 +1997,7 @@ async fn test_self_echo_scp_reaches_pump_scp_intake() {
 
     // Derive node0's NodeId (matches herder's node_id_from_public_key).
     let pk_0 = app_0.public_key();
-    let node0_id = NodeId(stellar_xdr::curr::PublicKey::from(&pk_0));
+    let node0_id = NodeId(stellar_xdr::PublicKey::from(&pk_0));
 
     // Find an envelope authored by node0 from node1's SCP state.
     // Node0's own SCP slot doesn't store self-authored envelopes (they're

--- a/crates/tx/src/apply.rs
+++ b/crates/tx/src/apply.rs
@@ -84,7 +84,7 @@
 //! }
 //! ```
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, LedgerEntry, LedgerEntryChange, LedgerEntryChanges, LedgerKey, TransactionMeta,
     TransactionResult,
 };
@@ -193,7 +193,7 @@ impl TxChangeLog {
 
     /// Record a created entry.
     pub fn record_create(&mut self, entry: LedgerEntry) {
-        if let stellar_xdr::curr::LedgerEntryData::Ttl(ttl) = &entry.data {
+        if let stellar_xdr::LedgerEntryData::Ttl(ttl) = &entry.data {
             tracing::debug!(
                 key_hash = ?ttl.key_hash,
                 "TxChangeLog::record_create for Ttl"
@@ -209,7 +209,7 @@ impl TxChangeLog {
     /// `pre_state` is the entry value BEFORE the modification.
     /// `post_state` is the entry value AFTER the modification.
     pub fn record_update(&mut self, pre_state: LedgerEntry, post_state: LedgerEntry) {
-        if let stellar_xdr::curr::LedgerEntryData::Ttl(ttl) = &post_state.data {
+        if let stellar_xdr::LedgerEntryData::Ttl(ttl) = &post_state.data {
             tracing::debug!(
                 key_hash = ?ttl.key_hash,
                 "TxChangeLog::record_update for Ttl"
@@ -228,17 +228,17 @@ impl TxChangeLog {
     /// a separate STATE+UPDATED pair.
     pub fn update_created_ttl(
         &mut self,
-        key_hash: &stellar_xdr::curr::Hash,
-        ttl_entry: &stellar_xdr::curr::TtlEntry,
+        key_hash: &stellar_xdr::Hash,
+        ttl_entry: &stellar_xdr::TtlEntry,
     ) {
-        use stellar_xdr::curr::LedgerEntryData;
+        use stellar_xdr::LedgerEntryData;
 
         // Find the TTL entry in created with matching key_hash
         for entry in &mut self.created {
             if let LedgerEntryData::Ttl(ttl) = &entry.data {
                 if ttl.key_hash == *key_hash {
                     // Update the TTL value in the created entry
-                    entry.data = LedgerEntryData::Ttl(stellar_xdr::curr::TtlEntry {
+                    entry.data = LedgerEntryData::Ttl(stellar_xdr::TtlEntry {
                         key_hash: key_hash.clone(),
                         live_until_ledger_seq: ttl_entry.live_until_ledger_seq,
                     });
@@ -325,7 +325,7 @@ impl TxChangeLog {
     /// or buying-liabilities violation (TransactionUtils.cpp:561-592).
     pub fn apply_refund_to_account(&mut self, account_id: &AccountId, refund: i64) -> bool {
         use henyey_common::asset::try_add_account_balance;
-        use stellar_xdr::curr::LedgerEntryData;
+        use stellar_xdr::LedgerEntryData;
 
         // Find the last update for this account and modify its balance
         for entry in self.updated.iter_mut().rev() {
@@ -542,7 +542,7 @@ fn apply_before_ops_after(
 mod tests {
     use super::*;
     use crate::state::asset_to_trustline_asset;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     #[test]
     fn test_ledger_delta_creation() {
@@ -798,7 +798,7 @@ mod tests {
     /// Regression test for AUDIT-H18: stellar-core checks newBalance > INT64_MAX - buyingLiabilities.
     #[test]
     fn test_ledger_delta_apply_refund_buying_liabilities() {
-        use stellar_xdr::curr::{AccountEntryExtensionV1, Liabilities};
+        use stellar_xdr::{AccountEntryExtensionV1, Liabilities};
 
         let mut delta = TxChangeLog::new(100);
 
@@ -820,7 +820,7 @@ mod tests {
                         buying: 500,
                         selling: 0,
                     },
-                    ext: stellar_xdr::curr::AccountEntryExtensionV1Ext::V0,
+                    ext: stellar_xdr::AccountEntryExtensionV1Ext::V0,
                 }),
             }),
             ext: LedgerEntryExt::V0,
@@ -893,13 +893,13 @@ mod tests {
     #[test]
     fn test_asset_to_trustline_asset_variants() {
         // Native
-        let native = stellar_xdr::curr::Asset::Native;
+        let native = stellar_xdr::Asset::Native;
         let key = asset_to_trustline_asset(&native);
         assert!(matches!(key, TrustLineAsset::Native));
 
         // CreditAlphanum4
         let issuer = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([5u8; 32])));
-        let alpha4 = stellar_xdr::curr::Asset::CreditAlphanum4(AlphaNum4 {
+        let alpha4 = stellar_xdr::Asset::CreditAlphanum4(AlphaNum4 {
             asset_code: AssetCode4(*b"USD\0"),
             issuer: issuer.clone(),
         });
@@ -912,7 +912,7 @@ mod tests {
         }
 
         // CreditAlphanum12
-        let alpha12 = stellar_xdr::curr::Asset::CreditAlphanum12(AlphaNum12 {
+        let alpha12 = stellar_xdr::Asset::CreditAlphanum12(AlphaNum12 {
             asset_code: AssetCode12(*b"LONGASSET123"),
             issuer: issuer.clone(),
         });

--- a/crates/tx/src/envelope_utils.rs
+++ b/crates/tx/src/envelope_utils.rs
@@ -13,7 +13,7 @@
 //! `TransactionFrame`.
 
 use henyey_common::Resource;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     FeeBumpTransactionInnerTx, Operation, OperationBody, SorobanResources, SorobanTransactionData,
     TransactionEnvelope, TransactionExt, VecM,
 };
@@ -137,7 +137,7 @@ pub fn resources_from_envelope(
     if is_soroban_envelope(env) {
         let data = envelope_soroban_data(env);
         let fallback_resources = SorobanResources {
-            footprint: stellar_xdr::curr::LedgerFootprint {
+            footprint: stellar_xdr::LedgerFootprint {
                 read_only: VecM::default(),
                 read_write: VecM::default(),
             },
@@ -188,7 +188,7 @@ pub fn resources_from_envelope(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_classic_v1(ops: Vec<Operation>) -> TransactionEnvelope {
         TransactionEnvelope::Tx(TransactionV1Envelope {

--- a/crates/tx/src/error.rs
+++ b/crates/tx/src/error.rs
@@ -79,7 +79,7 @@ pub enum TxError {
 
     /// XDR error.
     #[error("XDR error: {0}")]
-    Xdr(#[from] stellar_xdr::curr::Error),
+    Xdr(#[from] stellar_xdr::Error),
 
     /// Checked arithmetic error (balance overflow, underflow, etc.).
     #[error("balance error: {0}")]

--- a/crates/tx/src/events.rs
+++ b/crates/tx/src/events.rs
@@ -36,7 +36,7 @@
 
 use henyey_common::NetworkId;
 use henyey_crypto::PublicKey as StrKeyPublicKey;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, ClaimableBalanceId, ContractDataDurability, ContractEvent, ContractEventBody,
     ContractEventType, ContractEventV0, ContractId, ContractIdPreimage, Hash, HashIdPreimage,
     HashIdPreimageContractId, Int128Parts, LedgerEntry, LedgerEntryData, LedgerKey, Limits, Memo,
@@ -161,7 +161,7 @@ impl OpEventManager {
     pub fn events_for_claim_atoms(
         &mut self,
         source: &MuxedAccount,
-        claim_atoms: &[stellar_xdr::curr::ClaimAtom],
+        claim_atoms: &[stellar_xdr::ClaimAtom],
     ) {
         if !self.enabled || self.finalized {
             return;
@@ -169,7 +169,7 @@ impl OpEventManager {
         let source_addr = make_muxed_account_address(source);
         for atom in claim_atoms {
             match atom {
-                stellar_xdr::curr::ClaimAtom::OrderBook(claim) => {
+                stellar_xdr::ClaimAtom::OrderBook(claim) => {
                     let seller = make_account_address(&claim.seller_id);
                     self.event_for_transfer_with_issuer_check(
                         &claim.asset_bought,
@@ -186,7 +186,7 @@ impl OpEventManager {
                         false,
                     );
                 }
-                stellar_xdr::curr::ClaimAtom::LiquidityPool(claim) => {
+                stellar_xdr::ClaimAtom::LiquidityPool(claim) => {
                     let pool = ScAddress::LiquidityPool(claim.liquidity_pool_id.clone());
                     self.event_for_transfer_with_issuer_check(
                         &claim.asset_bought,
@@ -203,7 +203,7 @@ impl OpEventManager {
                         false,
                     );
                 }
-                stellar_xdr::curr::ClaimAtom::V0(claim) => {
+                stellar_xdr::ClaimAtom::V0(claim) => {
                     let seller = ScAddress::Account(AccountId::from(
                         XdrPublicKey::PublicKeyTypeEd25519(claim.seller_ed25519.clone()),
                     ));
@@ -743,7 +743,7 @@ pub fn make_claimable_balance_address(balance_id: &ClaimableBalanceId) -> ScAddr
 fn make_event(contract_id: ContractId, topics: Vec<ScVal>, data: ScVal) -> ContractEvent {
     let topics: Vec<ScVal> = topics;
     ContractEvent {
-        ext: stellar_xdr::curr::ExtensionPoint::V0,
+        ext: stellar_xdr::ExtensionPoint::V0,
         contract_id: Some(contract_id),
         type_: ContractEventType::Contract,
         body: ContractEventBody::V0(ContractEventV0 {
@@ -1201,22 +1201,22 @@ fn get_asset_from_event(event: &ContractEvent, network_id: &NetworkId) -> Option
         Asset::Native
     } else if let Some((code, issuer_str)) = asset_str.split_once(':') {
         let issuer_pk = StrKeyPublicKey::from_strkey(issuer_str).ok()?;
-        let issuer = AccountId::from(XdrPublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256(*issuer_pk.as_bytes()),
-        ));
+        let issuer = AccountId::from(XdrPublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(
+            *issuer_pk.as_bytes(),
+        )));
         let code_bytes = code.as_bytes();
         if code_bytes.len() <= 4 {
             let mut buf = [0u8; 4];
             buf[..code_bytes.len()].copy_from_slice(code_bytes);
-            Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-                asset_code: stellar_xdr::curr::AssetCode4(buf),
+            Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+                asset_code: stellar_xdr::AssetCode4(buf),
                 issuer,
             })
         } else if code_bytes.len() <= 12 {
             let mut buf = [0u8; 12];
             buf[..code_bytes.len()].copy_from_slice(code_bytes);
-            Asset::CreditAlphanum12(stellar_xdr::curr::AlphaNum12 {
-                asset_code: stellar_xdr::curr::AssetCode12(buf),
+            Asset::CreditAlphanum12(stellar_xdr::AlphaNum12 {
+                asset_code: stellar_xdr::AssetCode12(buf),
                 issuer,
             })
         } else {
@@ -1293,22 +1293,22 @@ fn backfill_event(event: &mut ContractEvent, network_id: &NetworkId) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{MuxedAccountMed25519, PublicKey, Uint256};
+    use stellar_xdr::{MuxedAccountMed25519, PublicKey, Uint256};
 
     fn test_account_id(seed: u8) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([seed; 32])))
     }
 
     fn test_asset_alphanum4(seed: u8) -> Asset {
-        Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-            asset_code: stellar_xdr::curr::AssetCode4([b'U', b'S', b'D', 0]),
+        Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+            asset_code: stellar_xdr::AssetCode4([b'U', b'S', b'D', 0]),
             issuer: test_account_id(seed),
         })
     }
 
     fn test_asset_alphanum12(seed: u8) -> Asset {
-        Asset::CreditAlphanum12(stellar_xdr::curr::AlphaNum12 {
-            asset_code: stellar_xdr::curr::AssetCode12([
+        Asset::CreditAlphanum12(stellar_xdr::AlphaNum12 {
+            asset_code: stellar_xdr::AssetCode12([
                 b'L', b'O', b'N', b'G', b'A', b'S', b'S', b'E', b'T', 0, 0, 0,
             ]),
             issuer: test_account_id(seed),
@@ -1668,7 +1668,7 @@ mod tests {
         );
 
         let event = ContractEvent {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             contract_id: None,
             type_: ContractEventType::Contract,
             body: ContractEventBody::V0(ContractEventV0 {
@@ -2260,7 +2260,7 @@ mod tests {
     // Protocol 23 SAC mint/burn event reconciler tests (issue #3126).
     // ====================================================================
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractDataEntry, ExtensionPoint, LedgerEntryExt, ScSymbol as XdrScSymbol, ScVec, WriteXdr,
     };
 
@@ -2415,17 +2415,17 @@ mod tests {
         // An account entry is not CONTRACT_DATA → None even if the key matched.
         let account_entry = LedgerEntry {
             last_modified_ledger_seq: 0,
-            data: LedgerEntryData::Account(stellar_xdr::curr::AccountEntry {
+            data: LedgerEntryData::Account(stellar_xdr::AccountEntry {
                 account_id: test_account_id(1),
                 balance: 0,
-                seq_num: stellar_xdr::curr::SequenceNumber(0),
+                seq_num: stellar_xdr::SequenceNumber(0),
                 num_sub_entries: 0,
                 inflation_dest: None,
                 flags: 0,
                 home_domain: Default::default(),
-                thresholds: stellar_xdr::curr::Thresholds([0; 4]),
+                thresholds: stellar_xdr::Thresholds([0; 4]),
                 signers: Default::default(),
-                ext: stellar_xdr::curr::AccountEntryExt::V0,
+                ext: stellar_xdr::AccountEntryExt::V0,
             }),
             ext: LedgerEntryExt::V0,
         };

--- a/crates/tx/src/fee_bump.rs
+++ b/crates/tx/src/fee_bump.rs
@@ -42,7 +42,7 @@
 
 use henyey_common::protocol::{protocol_version_starts_from, ProtocolVersion};
 use henyey_common::{Hash256, NetworkId};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, DecoratedSignature, FeeBumpTransaction, FeeBumpTransactionEnvelope,
     FeeBumpTransactionInnerTx, Hash, InnerTransactionResult, InnerTransactionResultExt,
     InnerTransactionResultPair, InnerTransactionResultResult, MuxedAccount, OperationResult,
@@ -538,9 +538,7 @@ impl FeeBumpMutableTransactionResult {
             inner_success: true,
             inner_op_results: vec![
                 OperationResult::OpInner(
-                    stellar_xdr::curr::OperationResultTr::Payment(
-                        stellar_xdr::curr::PaymentResult::Success,
-                    )
+                    stellar_xdr::OperationResultTr::Payment(stellar_xdr::PaymentResult::Success,)
                 );
                 op_count
             ],
@@ -827,7 +825,7 @@ pub fn extract_inner_hash_from_result(result: &TransactionResult) -> Option<Hash
 mod tests {
     use super::*;
     use henyey_common::NetworkId;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         Asset, FeeBumpTransactionExt, Memo, Operation, OperationBody, PaymentOp, Preconditions,
         SequenceNumber, Signature, SignatureHint, Transaction, TransactionExt, Uint256, VecM,
     };

--- a/crates/tx/src/frame.rs
+++ b/crates/tx/src/frame.rs
@@ -36,8 +36,8 @@ use henyey_common::protocol::{
 use henyey_common::{Hash256, NetworkId, Resource};
 use henyey_crypto::sha256;
 use soroban_env_host_p25::fees::TransactionResources;
-use stellar_xdr::curr::Limits;
-use stellar_xdr::curr::{
+use stellar_xdr::Limits;
+use stellar_xdr::{
     AccountId, DecoratedSignature, EnvelopeType, FeeBumpTransactionInnerTx, Hash,
     InvokeHostFunctionOp, LedgerKey, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
     SorobanTransactionData, SorobanTransactionDataExt, Transaction, TransactionEnvelope,
@@ -161,7 +161,7 @@ impl TransactionFrame {
     ///
     /// For V1, returns the envelope itself. For FeeBump, returns the inner
     /// envelope from `FeeBumpTransactionInnerTx`. Returns `None` for V0.
-    fn inner_envelope(&self) -> Option<&stellar_xdr::curr::TransactionV1Envelope> {
+    fn inner_envelope(&self) -> Option<&stellar_xdr::TransactionV1Envelope> {
         match &*self.envelope {
             TransactionEnvelope::TxV0(_) => None,
             TransactionEnvelope::Tx(env) => Some(env),
@@ -485,7 +485,7 @@ impl TransactionFrame {
 
     /// Collect all keys needed for fee processing (source accounts).
     pub fn keys_for_fee_processing(&self) -> Vec<LedgerKey> {
-        use stellar_xdr::curr::LedgerKeyAccount;
+        use stellar_xdr::LedgerKeyAccount;
 
         let mut keys = vec![LedgerKey::Account(LedgerKeyAccount {
             account_id: self.source_account_id(),
@@ -505,7 +505,7 @@ impl TransactionFrame {
     /// keys that can be determined from the operation data alone.
     pub fn keys_for_apply(&self) -> std::collections::HashSet<LedgerKey> {
         use crate::operations::execute::prefetch::collect_prefetch_keys;
-        use stellar_xdr::curr::LedgerKeyAccount;
+        use stellar_xdr::LedgerKeyAccount;
 
         let mut keys = std::collections::HashSet::new();
         let source = self.inner_source_account_id();
@@ -789,7 +789,7 @@ impl TransactionFrame {
     ///
     /// Parity: TransactionFrame.cpp:358-410 (`validateHostFn`)
     pub fn validate_host_fn(&self) -> bool {
-        use stellar_xdr::curr::{ContractExecutable, ContractIdPreimage, HostFunction};
+        use stellar_xdr::{ContractExecutable, ContractIdPreimage, HostFunction};
 
         if !self.is_soroban() {
             return true;
@@ -833,12 +833,12 @@ impl TransactionFrame {
 /// Convert a MuxedAccount to AccountId.
 pub fn muxed_to_account_id(muxed: &MuxedAccount) -> AccountId {
     match muxed {
-        MuxedAccount::Ed25519(key) => AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key.clone()),
-        ),
-        MuxedAccount::MuxedEd25519(m) => AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(m.ed25519.clone()),
-        ),
+        MuxedAccount::Ed25519(key) => {
+            AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(key.clone()))
+        }
+        MuxedAccount::MuxedEd25519(m) => AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            m.ed25519.clone(),
+        )),
     }
 }
 
@@ -859,13 +859,13 @@ pub fn envelope_sequence_number(envelope: &TransactionEnvelope) -> i64 {
         TransactionEnvelope::TxV0(env) => env.tx.seq_num.0,
         TransactionEnvelope::Tx(env) => env.tx.seq_num.0,
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.seq_num.0,
         },
     }
 }
 
 pub fn soroban_disk_read_entries(
-    resources: &stellar_xdr::curr::SorobanResources,
+    resources: &stellar_xdr::SorobanResources,
     ext: Option<&SorobanTransactionDataExt>,
     is_restore_footprint: bool,
     ledger_version: u32,
@@ -903,7 +903,7 @@ pub fn soroban_disk_read_entries(
 mod tests {
     use super::*;
     use henyey_common::ResourceType;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_transaction() -> TransactionEnvelope {
         // Create a minimal valid transaction
@@ -1227,7 +1227,7 @@ mod tests {
 
         // Should be AccountId with all zeros
         match account_id.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => {
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => {
                 assert_eq!(key.0, [0u8; 32]);
             }
         }
@@ -1252,7 +1252,7 @@ mod tests {
         let inner_source = frame.inner_source_account_id();
 
         match inner_source.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => {
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => {
                 assert_eq!(key.0, [0u8; 32]);
             }
         }

--- a/crates/tx/src/frozen_keys.rs
+++ b/crates/tx/src/frozen_keys.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 
 use henyey_common::Hash256;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, ChangeTrustAsset, Hash, LedgerFootprint, LedgerKey, Limits, MuxedAccount,
     Operation, OperationBody, RevokeSponsorshipOp, WriteXdr,
 };
@@ -76,36 +76,33 @@ impl Default for FrozenKeyConfig {
 }
 
 /// Helper to construct an account LedgerKey for frozen key checks.
-pub fn account_key(account_id: &stellar_xdr::curr::AccountId) -> LedgerKey {
-    LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+pub fn account_key(account_id: &stellar_xdr::AccountId) -> LedgerKey {
+    LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
         account_id: account_id.clone(),
     })
 }
 
 /// Helper to construct a trustline LedgerKey for frozen key checks.
-pub fn trustline_key(
-    account_id: &stellar_xdr::curr::AccountId,
-    asset: &stellar_xdr::curr::Asset,
-) -> LedgerKey {
-    LedgerKey::Trustline(stellar_xdr::curr::LedgerKeyTrustLine {
+pub fn trustline_key(account_id: &stellar_xdr::AccountId, asset: &stellar_xdr::Asset) -> LedgerKey {
+    LedgerKey::Trustline(stellar_xdr::LedgerKeyTrustLine {
         account_id: account_id.clone(),
         asset: asset_to_trustline_asset(asset),
     })
 }
 
 /// Convert an Asset to a TrustLineAsset (for trustline key construction).
-fn asset_to_trustline_asset(asset: &stellar_xdr::curr::Asset) -> stellar_xdr::curr::TrustLineAsset {
+fn asset_to_trustline_asset(asset: &stellar_xdr::Asset) -> stellar_xdr::TrustLineAsset {
     match asset {
-        stellar_xdr::curr::Asset::Native => {
+        stellar_xdr::Asset::Native => {
             // Native assets don't have trustlines — this shouldn't be called for native.
             // Return a dummy value; caller should guard against native.
-            stellar_xdr::curr::TrustLineAsset::Native
+            stellar_xdr::TrustLineAsset::Native
         }
-        stellar_xdr::curr::Asset::CreditAlphanum4(a4) => {
-            stellar_xdr::curr::TrustLineAsset::CreditAlphanum4(a4.clone())
+        stellar_xdr::Asset::CreditAlphanum4(a4) => {
+            stellar_xdr::TrustLineAsset::CreditAlphanum4(a4.clone())
         }
-        stellar_xdr::curr::Asset::CreditAlphanum12(a12) => {
-            stellar_xdr::curr::TrustLineAsset::CreditAlphanum12(a12.clone())
+        stellar_xdr::Asset::CreditAlphanum12(a12) => {
+            stellar_xdr::TrustLineAsset::CreditAlphanum12(a12.clone())
         }
     }
 }
@@ -321,16 +318,16 @@ fn manage_offer_accesses_frozen_key(
 }
 
 /// Construct an Asset from AllowTrust asset code + issuer.
-fn allow_trust_asset(issuer: &AccountId, asset_code: &stellar_xdr::curr::AssetCode) -> Asset {
+fn allow_trust_asset(issuer: &AccountId, asset_code: &stellar_xdr::AssetCode) -> Asset {
     match asset_code {
-        stellar_xdr::curr::AssetCode::CreditAlphanum4(code) => {
-            Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
+        stellar_xdr::AssetCode::CreditAlphanum4(code) => {
+            Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
                 asset_code: code.clone(),
                 issuer: issuer.clone(),
             })
         }
-        stellar_xdr::curr::AssetCode::CreditAlphanum12(code) => {
-            Asset::CreditAlphanum12(stellar_xdr::curr::AlphaNum12 {
+        stellar_xdr::AssetCode::CreditAlphanum12(code) => {
+            Asset::CreditAlphanum12(stellar_xdr::AlphaNum12 {
                 asset_code: code.clone(),
                 issuer: issuer.clone(),
             })
@@ -341,12 +338,12 @@ fn allow_trust_asset(issuer: &AccountId, asset_code: &stellar_xdr::curr::AssetCo
 /// Convert a MuxedAccount to AccountId.
 fn muxed_to_account_id(muxed: &MuxedAccount) -> AccountId {
     match muxed {
-        MuxedAccount::Ed25519(key) => AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key.clone()),
-        ),
-        MuxedAccount::MuxedEd25519(m) => AccountId(
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(m.ed25519.clone()),
-        ),
+        MuxedAccount::Ed25519(key) => {
+            AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(key.clone()))
+        }
+        MuxedAccount::MuxedEd25519(m) => AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            m.ed25519.clone(),
+        )),
     }
 }
 
@@ -358,27 +355,27 @@ fn muxed_to_account_id(muxed: &MuxedAccount) -> AccountId {
 /// - The selling asset's trustline is frozen (non-native only)
 /// - The buying asset's trustline is frozen (non-native only)
 pub fn offer_accesses_frozen_key(
-    offer: &stellar_xdr::curr::OfferEntry,
+    offer: &stellar_xdr::OfferEntry,
     config: &FrozenKeyConfig,
 ) -> bool {
     if !config.has_frozen_keys() {
         return false;
     }
     // Frozen seller account only matters when at least one side is native
-    if (matches!(offer.selling, stellar_xdr::curr::Asset::Native)
-        || matches!(offer.buying, stellar_xdr::curr::Asset::Native))
+    if (matches!(offer.selling, stellar_xdr::Asset::Native)
+        || matches!(offer.buying, stellar_xdr::Asset::Native))
         && config.is_key_frozen(&account_key(&offer.seller_id))
     {
         return true;
     }
     // Check selling asset trustline (if non-native)
-    if !matches!(offer.selling, stellar_xdr::curr::Asset::Native)
+    if !matches!(offer.selling, stellar_xdr::Asset::Native)
         && config.is_key_frozen(&trustline_key(&offer.seller_id, &offer.selling))
     {
         return true;
     }
     // Check buying asset trustline (if non-native)
-    if !matches!(offer.buying, stellar_xdr::curr::Asset::Native)
+    if !matches!(offer.buying, stellar_xdr::Asset::Native)
         && config.is_key_frozen(&trustline_key(&offer.seller_id, &offer.buying))
     {
         return true;
@@ -389,7 +386,7 @@ pub fn offer_accesses_frozen_key(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_account_id(seed: u8) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([seed; 32])))
@@ -589,12 +586,10 @@ mod tests {
     #[test]
     fn test_accesses_frozen_key_soroban_footprint() {
         let source = make_account_id(1);
-        let frozen_key = LedgerKey::ContractData(stellar_xdr::curr::LedgerKeyContractData {
-            contract: stellar_xdr::curr::ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(
-                [42u8; 32],
-            ))),
-            key: stellar_xdr::curr::ScVal::Void,
-            durability: stellar_xdr::curr::ContractDataDurability::Persistent,
+        let frozen_key = LedgerKey::ContractData(stellar_xdr::LedgerKeyContractData {
+            contract: stellar_xdr::ScAddress::Contract(stellar_xdr::ContractId(Hash([42u8; 32]))),
+            key: stellar_xdr::ScVal::Void,
+            durability: stellar_xdr::ContractDataDurability::Persistent,
         });
         let key_bytes = frozen_key.to_xdr(Limits::none()).unwrap();
         let config = FrozenKeyConfig::new(vec![key_bytes], vec![]);
@@ -616,12 +611,10 @@ mod tests {
     fn test_op_create_account_frozen_dest() {
         let tx_source = make_account_id(1);
         let config = freeze_account(2);
-        let op = make_op(OperationBody::CreateAccount(
-            stellar_xdr::curr::CreateAccountOp {
-                destination: make_account_id(2),
-                starting_balance: 1000,
-            },
-        ));
+        let op = make_op(OperationBody::CreateAccount(stellar_xdr::CreateAccountOp {
+            destination: make_account_id(2),
+            starting_balance: 1000,
+        }));
         assert!(operation_accesses_frozen_key(&op, &tx_source, &config));
     }
 
@@ -629,7 +622,7 @@ mod tests {
     fn test_op_payment_native_frozen_dest() {
         let tx_source = make_account_id(1);
         let config = freeze_account(2);
-        let op = make_op(OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        let op = make_op(OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
             asset: Asset::Native,
             amount: 100,
@@ -642,7 +635,7 @@ mod tests {
         let tx_source = make_account_id(1);
         let asset = make_credit_asset(b"USD\0", 3);
         let config = freeze_trustline(1, &asset);
-        let op = make_op(OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        let op = make_op(OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
             asset: asset.clone(),
             amount: 100,
@@ -655,7 +648,7 @@ mod tests {
         let tx_source = make_account_id(1);
         let asset = make_credit_asset(b"USD\0", 3);
         let config = freeze_trustline(2, &asset);
-        let op = make_op(OperationBody::Payment(stellar_xdr::curr::PaymentOp {
+        let op = make_op(OperationBody::Payment(stellar_xdr::PaymentOp {
             destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
             asset: asset.clone(),
             amount: 100,
@@ -669,7 +662,7 @@ mod tests {
         let selling = make_credit_asset(b"USD\0", 3);
         let config = freeze_trustline(1, &selling);
         let op = make_op(OperationBody::ManageSellOffer(
-            stellar_xdr::curr::ManageSellOfferOp {
+            stellar_xdr::ManageSellOfferOp {
                 selling: selling.clone(),
                 buying: Asset::Native,
                 amount: 100,
@@ -685,7 +678,7 @@ mod tests {
         let tx_source = make_account_id(1);
         let config = freeze_account(99); // freeze unrelated account
         let op = make_op(OperationBody::ManageSellOffer(
-            stellar_xdr::curr::ManageSellOfferOp {
+            stellar_xdr::ManageSellOfferOp {
                 selling: Asset::Native,
                 buying: make_credit_asset(b"USD\0", 3),
                 amount: 100,
@@ -701,15 +694,13 @@ mod tests {
         let tx_source = make_account_id(1);
         let asset = make_credit_asset(b"USD\0", 3);
         let config = freeze_trustline(1, &asset);
-        let op = make_op(OperationBody::ChangeTrust(
-            stellar_xdr::curr::ChangeTrustOp {
-                line: ChangeTrustAsset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-                    asset_code: AssetCode4(*b"USD\0"),
-                    issuer: make_account_id(3),
-                }),
-                limit: 1000,
-            },
-        ));
+        let op = make_op(OperationBody::ChangeTrust(stellar_xdr::ChangeTrustOp {
+            line: ChangeTrustAsset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+                asset_code: AssetCode4(*b"USD\0"),
+                issuer: make_account_id(3),
+            }),
+            limit: 1000,
+        }));
         assert!(operation_accesses_frozen_key(&op, &tx_source, &config));
     }
 
@@ -728,7 +719,7 @@ mod tests {
         let tx_source = make_account_id(1);
         let asset = make_credit_asset(b"USD\0", 1);
         let config = freeze_trustline(2, &asset);
-        let op = make_op(OperationBody::Clawback(stellar_xdr::curr::ClawbackOp {
+        let op = make_op(OperationBody::Clawback(stellar_xdr::ClawbackOp {
             asset: asset.clone(),
             from: MuxedAccount::Ed25519(Uint256([2u8; 32])),
             amount: 50,
@@ -742,7 +733,7 @@ mod tests {
         let asset = make_credit_asset(b"USD\0", 3);
         let config = freeze_trustline(1, &asset);
         let op = make_op(OperationBody::CreateClaimableBalance(
-            stellar_xdr::curr::CreateClaimableBalanceOp {
+            stellar_xdr::CreateClaimableBalanceOp {
                 asset: asset.clone(),
                 amount: 100,
                 claimants: vec![].try_into().unwrap(),
@@ -756,7 +747,7 @@ mod tests {
         let tx_source = make_account_id(1);
         let config = freeze_account(99);
         let op = make_op(OperationBody::CreateClaimableBalance(
-            stellar_xdr::curr::CreateClaimableBalanceOp {
+            stellar_xdr::CreateClaimableBalanceOp {
                 asset: Asset::Native,
                 amount: 100,
                 claimants: vec![].try_into().unwrap(),
@@ -771,7 +762,7 @@ mod tests {
         let asset = make_credit_asset(b"USD\0", 1);
         let config = freeze_trustline(2, &asset);
         let op = make_op(OperationBody::SetTrustLineFlags(
-            stellar_xdr::curr::SetTrustLineFlagsOp {
+            stellar_xdr::SetTrustLineFlagsOp {
                 trustor: make_account_id(2),
                 asset: asset.clone(),
                 clear_flags: 0,
@@ -799,9 +790,9 @@ mod tests {
         let config = freeze_account(5);
         let tx_source = make_account_id(1);
         let op = make_op(OperationBody::RevokeSponsorship(
-            RevokeSponsorshipOp::Signer(stellar_xdr::curr::RevokeSponsorshipOpSigner {
+            RevokeSponsorshipOp::Signer(stellar_xdr::RevokeSponsorshipOpSigner {
                 account_id: make_account_id(5),
-                signer_key: stellar_xdr::curr::SignerKey::Ed25519(Uint256([0u8; 32])),
+                signer_key: stellar_xdr::SignerKey::Ed25519(Uint256([0u8; 32])),
             }),
         ));
         assert!(operation_accesses_frozen_key(&op, &tx_source, &config));
@@ -824,8 +815,8 @@ mod tests {
         // These ops return false from doesAccessFrozenKey
         for body in [
             OperationBody::Inflation,
-            OperationBody::BumpSequence(stellar_xdr::curr::BumpSequenceOp {
-                bump_to: stellar_xdr::curr::SequenceNumber(100),
+            OperationBody::BumpSequence(stellar_xdr::BumpSequenceOp {
+                bump_to: stellar_xdr::SequenceNumber(100),
             }),
         ] {
             assert!(
@@ -842,7 +833,7 @@ mod tests {
         let send_asset = make_credit_asset(b"USD\0", 3);
         let config = freeze_trustline(1, &send_asset);
         let op = make_op(OperationBody::PathPaymentStrictReceive(
-            stellar_xdr::curr::PathPaymentStrictReceiveOp {
+            stellar_xdr::PathPaymentStrictReceiveOp {
                 send_asset: send_asset.clone(),
                 send_max: 100,
                 destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
@@ -859,7 +850,7 @@ mod tests {
         let tx_source = make_account_id(1);
         let config = freeze_account(2);
         let op = make_op(OperationBody::PathPaymentStrictReceive(
-            stellar_xdr::curr::PathPaymentStrictReceiveOp {
+            stellar_xdr::PathPaymentStrictReceiveOp {
                 send_asset: make_credit_asset(b"USD\0", 3),
                 send_max: 100,
                 destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
@@ -877,7 +868,7 @@ mod tests {
         let dest_asset = make_credit_asset(b"EUR\0", 4);
         let config = freeze_trustline(2, &dest_asset);
         let op = make_op(OperationBody::PathPaymentStrictSend(
-            stellar_xdr::curr::PathPaymentStrictSendOp {
+            stellar_xdr::PathPaymentStrictSendOp {
                 send_asset: Asset::Native,
                 send_amount: 100,
                 destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! ```ignore
 //! use henyey_tx::{TransactionFrame, apply_from_history, TxChangeLog};
-//! use stellar_xdr::curr::{TransactionEnvelope, TransactionResult, TransactionMeta};
+//! use stellar_xdr::{TransactionEnvelope, TransactionResult, TransactionMeta};
 //!
 //! // Parse transaction from archive
 //! let envelope: TransactionEnvelope = /* from archive */;
@@ -188,7 +188,7 @@ pub use operations::{
     validate_classic_op_structure, validate_operation, OperationTypeExt, OperationValidationError,
     ThresholdLevel,
 };
-pub use stellar_xdr::curr::OperationType;
+pub use stellar_xdr::OperationType;
 
 // Re-export state types
 pub use state::{AssetPair, LedgerStateManager, OfferDescriptor, OfferIndex, OfferKey};
@@ -219,7 +219,7 @@ pub type Result<T> = std::result::Result<T, TxError>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_envelope() -> TransactionEnvelope {
         let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));

--- a/crates/tx/src/live_execution.rs
+++ b/crates/tx/src/live_execution.rs
@@ -70,7 +70,7 @@ use henyey_common::protocol::{
     protocol_version_is_before, protocol_version_starts_from, ProtocolVersion,
 };
 use henyey_common::{Hash256, NetworkId};
-use stellar_xdr::curr::{AccountId, TransactionEventStage, TransactionResultCode};
+use stellar_xdr::{AccountId, TransactionEventStage, TransactionResultCode};
 
 use crate::events::TxEventManager;
 use crate::frame::{muxed_to_account_id, TransactionFrame};
@@ -329,7 +329,7 @@ fn update_sequence_number(
         .get_account_mut(account_id)
         .ok_or_else(|| TxError::AccountNotFound(format!("{:?}", account_id)))?;
 
-    account.seq_num = stellar_xdr::curr::SequenceNumber(tx_seq_num);
+    account.seq_num = stellar_xdr::SequenceNumber(tx_seq_num);
     Ok(())
 }
 
@@ -693,7 +693,7 @@ pub fn apply_transaction(
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, MuxedAccount, Operation, OperationBody,
         PaymentOp, Preconditions, PublicKey, SequenceNumber, Transaction, TransactionEnvelope,
         TransactionExt, TransactionV1Envelope, Uint256,
@@ -708,7 +708,7 @@ mod tests {
             inflation_dest: None,
             flags: 0,
             home_domain: Default::default(),
-            thresholds: stellar_xdr::curr::Thresholds([1, 0, 0, 0]),
+            thresholds: stellar_xdr::Thresholds([1, 0, 0, 0]),
             signers: vec![].try_into().unwrap(),
             ext: AccountEntryExt::V0,
         }
@@ -721,7 +721,7 @@ mod tests {
             source_account: None,
             body: OperationBody::Payment(PaymentOp {
                 destination: dest,
-                asset: stellar_xdr::curr::Asset::Native,
+                asset: stellar_xdr::Asset::Native,
                 amount: 1000,
             }),
         };
@@ -733,7 +733,7 @@ mod tests {
             fee,
             seq_num: SequenceNumber(seq_num),
             cond: Preconditions::None,
-            memo: stellar_xdr::curr::Memo::None,
+            memo: stellar_xdr::Memo::None,
             operations: vec![payment_op].try_into().unwrap(),
             ext: TransactionExt::V0,
         };
@@ -947,14 +947,13 @@ mod tests {
         // liability check: (i64::MAX-100+50) > i64::MAX - 200 -> (i64::MAX-50) > (i64::MAX-200) -> true -> skip
         let mut account = make_account_entry(account_id.clone(), i64::MAX - 100, 1);
         // Add buying liabilities via V1 extension
-        account.ext =
-            stellar_xdr::curr::AccountEntryExt::V1(stellar_xdr::curr::AccountEntryExtensionV1 {
-                liabilities: stellar_xdr::curr::Liabilities {
-                    buying: 200,
-                    selling: 0,
-                },
-                ext: stellar_xdr::curr::AccountEntryExtensionV1Ext::V0,
-            });
+        account.ext = stellar_xdr::AccountEntryExt::V1(stellar_xdr::AccountEntryExtensionV1 {
+            liabilities: stellar_xdr::Liabilities {
+                buying: 200,
+                selling: 0,
+            },
+            ext: stellar_xdr::AccountEntryExtensionV1Ext::V0,
+        });
 
         if let Some(state) = ctx.state_mut() {
             state.put_account(account);
@@ -1290,7 +1289,7 @@ mod tests {
     /// (inner ops + 1) for fee calculation, not plain operation_count().
     #[test]
     fn test_fee_to_charge_fee_bump() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DecoratedSignature, FeeBumpTransaction, FeeBumpTransactionEnvelope,
             FeeBumpTransactionExt, FeeBumpTransactionInnerTx,
         };
@@ -1304,12 +1303,12 @@ mod tests {
             fee: 100,
             seq_num: SequenceNumber(1),
             cond: Preconditions::None,
-            memo: stellar_xdr::curr::Memo::None,
+            memo: stellar_xdr::Memo::None,
             operations: vec![Operation {
                 source_account: None,
                 body: OperationBody::Payment(PaymentOp {
                     destination: MuxedAccount::Ed25519(Uint256([2u8; 32])),
-                    asset: stellar_xdr::curr::Asset::Native,
+                    asset: stellar_xdr::Asset::Native,
                     amount: 1000,
                 }),
             }]
@@ -1334,7 +1333,7 @@ mod tests {
 
         let envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
             tx: fee_bump_tx,
-            signatures: stellar_xdr::curr::VecM::<DecoratedSignature, 20>::default(),
+            signatures: stellar_xdr::VecM::<DecoratedSignature, 20>::default(),
         });
 
         let frame = TransactionFrame::from_owned(envelope);
@@ -1355,7 +1354,7 @@ mod tests {
     /// not the outer fee source.
     #[test]
     fn test_audit_051_fee_bump_seq_num_on_inner_source() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DecoratedSignature, FeeBumpTransaction, FeeBumpTransactionEnvelope,
             FeeBumpTransactionExt, FeeBumpTransactionInnerTx,
         };
@@ -1383,12 +1382,12 @@ mod tests {
             fee: 100,
             seq_num: SequenceNumber(6),
             cond: Preconditions::None,
-            memo: stellar_xdr::curr::Memo::None,
+            memo: stellar_xdr::Memo::None,
             operations: vec![Operation {
                 source_account: None,
                 body: OperationBody::Payment(PaymentOp {
                     destination: MuxedAccount::Ed25519(Uint256([99u8; 32])),
-                    asset: stellar_xdr::curr::Asset::Native,
+                    asset: stellar_xdr::Asset::Native,
                     amount: 1000,
                 }),
             }]
@@ -1413,7 +1412,7 @@ mod tests {
 
         let fee_bump_envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
             tx: fee_bump_tx,
-            signatures: stellar_xdr::curr::VecM::<DecoratedSignature, 20>::default(),
+            signatures: stellar_xdr::VecM::<DecoratedSignature, 20>::default(),
         });
 
         let frame = TransactionFrame::from_owned(fee_bump_envelope);
@@ -1447,7 +1446,7 @@ mod tests {
         inner_fee: u32,
         outer_fee: i64,
     ) -> TransactionFrame {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, DecoratedSignature, FeeBumpTransaction,
             FeeBumpTransactionEnvelope, FeeBumpTransactionExt, FeeBumpTransactionInnerTx, Hash,
             HostFunction, InvokeContractArgs, InvokeHostFunctionOp, LedgerFootprint, LedgerKey,
@@ -1513,7 +1512,7 @@ mod tests {
             fee: inner_fee,
             seq_num: SequenceNumber(1),
             cond: Preconditions::None,
-            memo: stellar_xdr::curr::Memo::None,
+            memo: stellar_xdr::Memo::None,
             operations: vec![op].try_into().unwrap(),
             ext: TransactionExt::V1(soroban_data),
         };
@@ -1546,7 +1545,7 @@ mod tests {
     /// and charges the fee source, not the inner source.
     #[test]
     fn test_process_fee_seq_num_fee_bump() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             DecoratedSignature, FeeBumpTransaction, FeeBumpTransactionEnvelope,
             FeeBumpTransactionExt, FeeBumpTransactionInnerTx,
         };
@@ -1574,12 +1573,12 @@ mod tests {
             fee: 100,
             seq_num: SequenceNumber(6),
             cond: Preconditions::None,
-            memo: stellar_xdr::curr::Memo::None,
+            memo: stellar_xdr::Memo::None,
             operations: vec![Operation {
                 source_account: None,
                 body: OperationBody::Payment(PaymentOp {
                     destination: MuxedAccount::Ed25519(Uint256([50u8; 32])),
-                    asset: stellar_xdr::curr::Asset::Native,
+                    asset: stellar_xdr::Asset::Native,
                     amount: 1000,
                 }),
             }]
@@ -1604,7 +1603,7 @@ mod tests {
 
         let envelope = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
             tx: fee_bump_tx,
-            signatures: stellar_xdr::curr::VecM::<DecoratedSignature, 20>::default(),
+            signatures: stellar_xdr::VecM::<DecoratedSignature, 20>::default(),
         });
 
         let frame = TransactionFrame::from_owned(envelope);
@@ -1770,7 +1769,7 @@ mod tests {
         // stays at TxSuccess (the initial state from process_fee_seq_num).
         assert_eq!(
             result.result_code(),
-            stellar_xdr::curr::TransactionResultCode::TxSuccess,
+            stellar_xdr::TransactionResultCode::TxSuccess,
             "partial fee must not produce an error — body application is not blocked"
         );
 

--- a/crates/tx/src/meta_builder.rs
+++ b/crates/tx/src/meta_builder.rs
@@ -29,7 +29,7 @@
 //! - V4: Modern Soroban with per-operation events and diagnostic events
 
 use henyey_common::NetworkId;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     ContractEvent, ContractEventBody, ContractEventType, ContractEventV0, DiagnosticEvent,
     ExtensionPoint, LedgerEntry, LedgerEntryChange, LedgerEntryChanges, Memo, OperationMeta,
     OperationMetaV2, ScError, ScMap, ScMapEntry, ScVal, SorobanTransactionMeta,
@@ -396,7 +396,7 @@ impl OperationMetaBuilder {
         if !self.enabled {
             return;
         }
-        if let stellar_xdr::curr::LedgerEntryData::Ttl(ttl) = &entry.data {
+        if let stellar_xdr::LedgerEntryData::Ttl(ttl) = &entry.data {
             tracing::debug!(
                 key_hash = ?ttl.key_hash,
                 "OperationMetaBuilder::record_create for Ttl"
@@ -412,7 +412,7 @@ impl OperationMetaBuilder {
         if !self.enabled {
             return;
         }
-        if let stellar_xdr::curr::LedgerEntryData::Ttl(ttl) = &post_state.data {
+        if let stellar_xdr::LedgerEntryData::Ttl(ttl) = &post_state.data {
             tracing::debug!(
                 key_hash = ?ttl.key_hash,
                 "OperationMetaBuilder::record_update for Ttl"
@@ -425,7 +425,7 @@ impl OperationMetaBuilder {
     /// Record a deleted entry with its pre-state.
     ///
     /// Emits STATE followed by REMOVED changes.
-    pub fn record_delete(&mut self, key: stellar_xdr::curr::LedgerKey, pre_state: LedgerEntry) {
+    pub fn record_delete(&mut self, key: stellar_xdr::LedgerKey, pre_state: LedgerEntry) {
         if !self.enabled {
             return;
         }
@@ -949,7 +949,7 @@ use crate::scval_utils::{make_string_scval, make_symbol_scval};
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_frame() -> TransactionFrame {
         let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));

--- a/crates/tx/src/operations/execute/account_merge.rs
+++ b/crates/tx/src/operations/execute/account_merge.rs
@@ -1,7 +1,7 @@
 //! AccountMerge operation execution.
 
 use henyey_common::protocol::{protocol_version_starts_from, ProtocolVersion};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, AccountFlags, AccountId,
     AccountMergeResult, AccountMergeResultCode, MuxedAccount, OperationResult, OperationResultTr,
 };
@@ -136,7 +136,7 @@ fn num_sponsoring(account: &AccountEntry) -> i64 {
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_muxed_account(seed: u8) -> MuxedAccount {
         MuxedAccount::Ed25519(Uint256([seed; 32]))

--- a/crates/tx/src/operations/execute/bump_sequence.rs
+++ b/crates/tx/src/operations/execute/bump_sequence.rs
@@ -1,6 +1,6 @@
 //! BumpSequence operation execution.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, BumpSequenceOp, BumpSequenceResult, BumpSequenceResultCode, OperationResult,
     OperationResultTr,
 };
@@ -54,7 +54,7 @@ fn make_result(code: BumpSequenceResultCode) -> OperationResult {
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64, seq_num: i64) -> AccountEntry {
         AccountEntry {

--- a/crates/tx/src/operations/execute/change_trust.rs
+++ b/crates/tx/src/operations/execute/change_trust.rs
@@ -1,6 +1,6 @@
 //! ChangeTrust operation execution.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountFlags, AccountId, Asset, ChangeTrustAsset, ChangeTrustOp, ChangeTrustResult,
     ChangeTrustResultCode, LedgerKey, LedgerKeyTrustLine, LiquidityPoolEntry,
     LiquidityPoolEntryBody, LiquidityPoolEntryConstantProduct, LiquidityPoolParameters,
@@ -277,22 +277,20 @@ fn create_trustline(
     Ok(None)
 }
 
-fn change_trust_asset_to_trust_line_asset(
-    asset: &ChangeTrustAsset,
-) -> stellar_xdr::curr::TrustLineAsset {
-    use stellar_xdr::curr::PoolId;
+fn change_trust_asset_to_trust_line_asset(asset: &ChangeTrustAsset) -> stellar_xdr::TrustLineAsset {
+    use stellar_xdr::PoolId;
 
     match asset {
-        ChangeTrustAsset::Native => stellar_xdr::curr::TrustLineAsset::Native,
+        ChangeTrustAsset::Native => stellar_xdr::TrustLineAsset::Native,
         ChangeTrustAsset::CreditAlphanum4(a) => {
-            stellar_xdr::curr::TrustLineAsset::CreditAlphanum4(a.clone())
+            stellar_xdr::TrustLineAsset::CreditAlphanum4(a.clone())
         }
         ChangeTrustAsset::CreditAlphanum12(a) => {
-            stellar_xdr::curr::TrustLineAsset::CreditAlphanum12(a.clone())
+            stellar_xdr::TrustLineAsset::CreditAlphanum12(a.clone())
         }
         ChangeTrustAsset::PoolShare(params) => {
             let pool_id = henyey_common::Hash256::hash_xdr(params).into();
-            stellar_xdr::curr::TrustLineAsset::PoolShare(PoolId(pool_id))
+            stellar_xdr::TrustLineAsset::PoolShare(PoolId(pool_id))
         }
     }
 }
@@ -516,7 +514,7 @@ mod tests {
         create_test_account_id, create_test_asset, create_test_trustline_asset,
     };
     use henyey_common::LIQUIDITY_POOL_FEE_V18;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {

--- a/crates/tx/src/operations/execute/claimable_balance.rs
+++ b/crates/tx/src/operations/execute/claimable_balance.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashSet;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountFlags, AccountId, Asset, ClaimClaimableBalanceOp, ClaimClaimableBalanceResult,
     ClaimClaimableBalanceResultCode, ClaimPredicate, ClaimableBalanceEntry,
     ClaimableBalanceEntryExt, ClaimableBalanceEntryExtensionV1,
@@ -262,7 +262,7 @@ pub(crate) fn execute_claim_claimable_balance(
 
     // Check if source is a valid claimant
     let is_valid_claimant = entry.claimants.iter().any(|c| match c {
-        stellar_xdr::curr::Claimant::ClaimantTypeV0(cv0) => {
+        stellar_xdr::Claimant::ClaimantTypeV0(cv0) => {
             &cv0.destination == source && check_predicate(&cv0.predicate, context)
         }
     });
@@ -377,7 +377,7 @@ fn asset_issuer(asset: &Asset) -> Option<AccountId> {
 }
 
 /// Check if a claim predicate is satisfied.
-fn check_predicate(predicate: &stellar_xdr::curr::ClaimPredicate, context: &LedgerContext) -> bool {
+fn check_predicate(predicate: &stellar_xdr::ClaimPredicate, context: &LedgerContext) -> bool {
     match predicate {
         ClaimPredicate::Unconditional => true,
         ClaimPredicate::And(predicates) => {
@@ -539,7 +539,7 @@ mod tests {
     use super::super::AUTHORIZED_FLAG;
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {
@@ -1352,7 +1352,7 @@ mod tests {
 
         // Find the op_source account in updated entries
         let op_source_in_delta = updated_entries.iter().any(|entry| {
-            if let stellar_xdr::curr::LedgerEntryData::Account(acc) = &entry.data {
+            if let stellar_xdr::LedgerEntryData::Account(acc) = &entry.data {
                 acc.account_id == op_source_id
             } else {
                 false
@@ -2322,8 +2322,7 @@ mod tests {
 
         // Freeze the claimant's USD trustline via CAP-77
         let frozen_key = crate::frozen_keys::trustline_key(&claimant_id, &asset);
-        let frozen_bytes =
-            stellar_xdr::curr::WriteXdr::to_xdr(&frozen_key, Limits::none()).unwrap();
+        let frozen_bytes = stellar_xdr::WriteXdr::to_xdr(&frozen_key, Limits::none()).unwrap();
 
         let mut context = create_test_context();
         context.frozen_key_config =

--- a/crates/tx/src/operations/execute/clawback.rs
+++ b/crates/tx/src/operations/execute/clawback.rs
@@ -4,7 +4,7 @@
 //! - Clawback (clawback from a trustline)
 //! - ClawbackClaimableBalance (clawback from a claimable balance)
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, ClaimableBalanceFlags, ClawbackClaimableBalanceOp,
     ClawbackClaimableBalanceResult, ClawbackClaimableBalanceResultCode, ClawbackOp, ClawbackResult,
     ClawbackResultCode, LedgerKey, LedgerKeyClaimableBalance, MuxedAccount, OperationResult,
@@ -35,7 +35,7 @@ pub(crate) fn execute_clawback(
     // stellar-core compares the full MuxedAccount XDR values, so a MuxedEd25519
     // with the same base key as the source Ed25519 is NOT considered "self".
     let source_as_muxed = MuxedAccount::Ed25519(match source.0 {
-        stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(ref k) => k.clone(),
+        stellar_xdr::PublicKey::PublicKeyTypeEd25519(ref k) => k.clone(),
     });
     if op.from == source_as_muxed {
         return Ok(make_clawback_result(ClawbackResultCode::Malformed));
@@ -145,7 +145,7 @@ pub(crate) fn execute_clawback_claimable_balance(
     // Check the claimable balance entry itself has CLAWBACK_ENABLED flag
     // (stellar-core checks isClawbackEnabledOnClaimableBalance, NOT the issuer account)
     let cb_clawback_enabled = match &entry.ext {
-        stellar_xdr::curr::ClaimableBalanceEntryExt::V1(v1) => {
+        stellar_xdr::ClaimableBalanceEntryExt::V1(v1) => {
             v1.flags & ClaimableBalanceFlags::ClaimableBalanceClawbackEnabledFlag as u32 != 0
         }
         _ => false,
@@ -216,7 +216,7 @@ mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
     use crate::TxError;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     const AUTHORIZED_FLAG: u32 = TrustLineFlags::AuthorizedFlag as u32;
 

--- a/crates/tx/src/operations/execute/create_account.rs
+++ b/crates/tx/src/operations/execute/create_account.rs
@@ -1,6 +1,6 @@
 //! CreateAccount operation execution.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountId, CreateAccountOp, CreateAccountResult,
     CreateAccountResultCode, LedgerKey, LedgerKeyAccount, OperationResult, OperationResultTr,
     SequenceNumber, String32, Thresholds,
@@ -150,7 +150,7 @@ fn make_result(code: CreateAccountResultCode) -> OperationResult {
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {

--- a/crates/tx/src/operations/execute/extend_footprint_ttl.rs
+++ b/crates/tx/src/operations/execute/extend_footprint_ttl.rs
@@ -6,7 +6,7 @@
 use henyey_common::protocol::{
     protocol_version_is_before, PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, ExtendFootprintTtlOp, ExtendFootprintTtlResult, ExtendFootprintTtlResultCode,
     OperationResult, OperationResultTr, SorobanTransactionData,
 };
@@ -187,7 +187,7 @@ mod tests {
 
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_context() -> LedgerContext {
         LedgerContext::testnet(1, 1000)
@@ -651,7 +651,7 @@ mod tests {
 
         // Insert a contract code entry with enough bytes to exceed disk_read_bytes=1
         let code_entry = ContractCodeEntry {
-            ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+            ext: stellar_xdr::ContractCodeEntryExt::V0,
             hash: contract_hash.clone(),
             code: vec![0u8; 500].try_into().unwrap(),
         };
@@ -659,7 +659,7 @@ mod tests {
 
         // Insert a TTL entry that needs extending
         let key_hash = crate::soroban::compute_key_hash(&contract_key);
-        let ttl_entry = stellar_xdr::curr::TtlEntry {
+        let ttl_entry = stellar_xdr::TtlEntry {
             key_hash: key_hash.clone(),
             live_until_ledger_seq: context.sequence + 10,
         };
@@ -729,14 +729,14 @@ mod tests {
         });
 
         let code_entry = ContractCodeEntry {
-            ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+            ext: stellar_xdr::ContractCodeEntryExt::V0,
             hash: contract_hash.clone(),
             code: vec![0u8; 500].try_into().unwrap(),
         };
         state.create_contract_code(code_entry);
 
         let key_hash = crate::soroban::compute_key_hash(&contract_key);
-        let ttl_entry = stellar_xdr::curr::TtlEntry {
+        let ttl_entry = stellar_xdr::TtlEntry {
             key_hash: key_hash.clone(),
             live_until_ledger_seq: context.sequence + 10,
         };
@@ -806,7 +806,7 @@ mod tests {
 
         // Insert a contract code entry into state so the lookup succeeds
         let code_entry = ContractCodeEntry {
-            ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+            ext: stellar_xdr::ContractCodeEntryExt::V0,
             hash: contract_hash.clone(),
             code: vec![0u8; 100].try_into().unwrap(),
         };
@@ -814,7 +814,7 @@ mod tests {
 
         // Insert a TTL entry that needs extending (live_until < current + extend_to)
         let key_hash = crate::soroban::compute_key_hash(&contract_key);
-        let ttl_entry = stellar_xdr::curr::TtlEntry {
+        let ttl_entry = stellar_xdr::TtlEntry {
             key_hash: key_hash.clone(),
             live_until_ledger_seq: context.sequence + 10, // live but needs extending
         };

--- a/crates/tx/src/operations/execute/inflation.rs
+++ b/crates/tx/src/operations/execute/inflation.rs
@@ -4,7 +4,7 @@
 //! Note: Inflation has been deprecated since Protocol 12 and always returns
 //! NOT_TIME on the public network, but we implement it for completeness.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, InflationPayout, InflationResult, InflationResultCode, OperationResult,
     OperationResultTr,
 };
@@ -65,7 +65,7 @@ fn make_inflation_result(
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {

--- a/crates/tx/src/operations/execute/invoke_host_function.rs
+++ b/crates/tx/src/operations/execute/invoke_host_function.rs
@@ -3,7 +3,7 @@
 //! This module implements the execution logic for the InvokeHostFunction operation,
 //! which executes Soroban smart contract functions.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, ContractEvent, DiagnosticEvent, Hash, InvokeHostFunctionOp,
     InvokeHostFunctionResult, InvokeHostFunctionResultCode, InvokeHostFunctionSuccessPreImage,
     LedgerEntry, LedgerKey, OperationResult, OperationResultTr, ScVal, SorobanTransactionData,
@@ -30,19 +30,19 @@ use crate::{Result, TxError};
 /// We can't use state.get_*().is_some() because archived entries are pre-loaded
 /// into state from InMemorySorobanState before Soroban execution.
 fn key_already_created_in_delta(delta: &crate::apply::TxChangeLog, key: &LedgerKey) -> bool {
-    use stellar_xdr::curr::LedgerEntryData;
+    use stellar_xdr::LedgerEntryData;
 
     for entry in delta.created_entries() {
         let entry_key = match &entry.data {
             LedgerEntryData::ContractData(cd) => {
-                LedgerKey::ContractData(stellar_xdr::curr::LedgerKeyContractData {
+                LedgerKey::ContractData(stellar_xdr::LedgerKeyContractData {
                     contract: cd.contract.clone(),
                     key: cd.key.clone(),
                     durability: cd.durability,
                 })
             }
             LedgerEntryData::ContractCode(cc) => {
-                LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+                LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
                     hash: cc.hash.clone(),
                 })
             }
@@ -58,9 +58,9 @@ fn key_already_created_in_delta(delta: &crate::apply::TxChangeLog, key: &LedgerK
 /// Check if a TTL entry with the given key hash was already created in the delta.
 fn ttl_already_created_in_delta(
     delta: &crate::apply::TxChangeLog,
-    key_hash: &stellar_xdr::curr::Hash,
+    key_hash: &stellar_xdr::Hash,
 ) -> bool {
-    use stellar_xdr::curr::LedgerEntryData;
+    use stellar_xdr::LedgerEntryData;
 
     for entry in delta.created_entries() {
         if let LedgerEntryData::Ttl(ttl) = &entry.data {
@@ -411,16 +411,16 @@ impl AddReadsContext<'_> {
                 .get_contract_data(&cd_key.contract, &cd_key.key, cd_key.durability)
                 .map(|cd| LedgerEntry {
                     last_modified_ledger_seq: 0,
-                    data: stellar_xdr::curr::LedgerEntryData::ContractData(cd.clone()),
-                    ext: stellar_xdr::curr::LedgerEntryExt::V0,
+                    data: stellar_xdr::LedgerEntryData::ContractData(cd.clone()),
+                    ext: stellar_xdr::LedgerEntryExt::V0,
                 }),
             LedgerKey::ContractCode(cc_key) => {
                 self.state
                     .get_contract_code(&cc_key.hash)
                     .map(|cc| LedgerEntry {
                         last_modified_ledger_seq: 0,
-                        data: stellar_xdr::curr::LedgerEntryData::ContractCode(cc.clone()),
-                        ext: stellar_xdr::curr::LedgerEntryExt::V0,
+                        data: stellar_xdr::LedgerEntryData::ContractCode(cc.clone()),
+                        ext: stellar_xdr::LedgerEntryExt::V0,
                     })
             }
             _ => None,
@@ -729,7 +729,7 @@ fn validate_and_compute_write_bytes(
     for change in storage_changes {
         if let crate::soroban::StorageChangeKind::Modified { entry, .. } = &change.kind {
             // Skip TTL entries - their write fees are handled separately
-            if matches!(entry.data, stellar_xdr::curr::LedgerEntryData::Ttl(_)) {
+            if matches!(entry.data, stellar_xdr::LedgerEntryData::Ttl(_)) {
                 continue;
             }
             // Compute XDR size without heap allocation.
@@ -894,7 +894,7 @@ fn extract_hot_archive_restored_keys(
 fn apply_soroban_storage_changes(
     state: &mut LedgerStateManager,
     changes: &[crate::soroban::StorageChange],
-    footprint: &stellar_xdr::curr::LedgerFootprint,
+    footprint: &stellar_xdr::LedgerFootprint,
     hot_archive_restored_keys: &std::collections::HashSet<LedgerKey>,
     ttl_key_cache: Option<&crate::soroban::TtlKeyCache>,
     protocol_version: u32,
@@ -955,7 +955,7 @@ fn apply_soroban_storage_changes(
         if henyey_common::is_soroban_key(key) {
             // Soroban entries must have a corresponding TTL entry also created
             let key_hash = crate::soroban::get_or_compute_key_hash(ttl_key_cache, key);
-            let ttl_key = LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl { key_hash });
+            let ttl_key = LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl { key_hash });
             assert!(
                 created_keys.contains(&ttl_key),
                 "Created Soroban entry {:?} missing TTL key",
@@ -1106,7 +1106,7 @@ fn apply_soroban_storage_change(
         } => {
             // Handle contract data and code entries.
             match &entry.data {
-                stellar_xdr::curr::LedgerEntryData::ContractData(cd) => {
+                stellar_xdr::LedgerEntryData::ContractData(cd) => {
                     let exists = state
                         .get_contract_data(&cd.contract, &cd.key, cd.durability)
                         .is_some();
@@ -1123,7 +1123,7 @@ fn apply_soroban_storage_change(
                         state.update_contract_data(cd.clone());
                     }
                 }
-                stellar_xdr::curr::LedgerEntryData::ContractCode(cc) => {
+                stellar_xdr::LedgerEntryData::ContractCode(cc) => {
                     let exists = state.get_contract_code(&cc.hash).is_some();
                     let already_in_delta = is_hot_archive_restore
                         && key_already_created_in_delta(state.delta(), &change.key);
@@ -1138,7 +1138,7 @@ fn apply_soroban_storage_change(
                         state.update_contract_code(cc.clone());
                     }
                 }
-                stellar_xdr::curr::LedgerEntryData::Ttl(ttl) => {
+                stellar_xdr::LedgerEntryData::Ttl(ttl) => {
                     let exists = state.get_ttl(&ttl.key_hash).is_some();
                     tracing::debug!(
                         key_hash = ?ttl.key_hash,
@@ -1150,7 +1150,7 @@ fn apply_soroban_storage_change(
                     create_or_update_ttl(state, ttl.clone(), exists);
                 }
                 // SAC (Stellar Asset Contract) can modify Account and Trustline entries
-                stellar_xdr::curr::LedgerEntryData::Account(acc) => {
+                stellar_xdr::LedgerEntryData::Account(acc) => {
                     if state.get_account(&acc.account_id).is_some() {
                         state.update_account(acc.clone());
                     } else {
@@ -1158,7 +1158,7 @@ fn apply_soroban_storage_change(
                         was_created = true;
                     }
                 }
-                stellar_xdr::curr::LedgerEntryData::Trustline(tl) => {
+                stellar_xdr::LedgerEntryData::Trustline(tl) => {
                     if state
                         .get_trustline_by_trustline_asset(&tl.account_id, &tl.asset)
                         .is_some()
@@ -1200,7 +1200,7 @@ fn apply_soroban_storage_change(
             //
             // Skip TTL emission for TTL entries themselves - they were already handled above
             // and computing key_hash of a TTL key would give the wrong hash.
-            if !matches!(entry.data, stellar_xdr::curr::LedgerEntryData::Ttl(_)) {
+            if !matches!(entry.data, stellar_xdr::LedgerEntryData::Ttl(_)) {
                 if let Some(live_until) = live_until {
                     if *live_until == 0 {
                         return was_created;
@@ -1223,7 +1223,7 @@ fn apply_soroban_storage_change(
                         // First restoration from hot archive - create TTL
                         tracing::debug!(?key_hash, live_until, "TTL emit: hot archive restore");
                         state.create_ttl(ttl);
-                        created_keys.insert(LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl {
+                        created_keys.insert(LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl {
                             key_hash: key_hash.clone(),
                         }));
                     } else if is_hot_archive_restore && ttl_already_restored {
@@ -1247,7 +1247,7 @@ fn apply_soroban_storage_change(
                             "TTL emit: data modified, TTL extended or new"
                         );
                         if !exists {
-                            created_keys.insert(LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl {
+                            created_keys.insert(LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl {
                                 key_hash: key_hash.clone(),
                             }));
                         }
@@ -1256,7 +1256,7 @@ fn apply_soroban_storage_change(
                         // New entry being created - emit TTL
                         tracing::debug!(?key_hash, live_until, "TTL emit: new TTL entry");
                         state.create_ttl(ttl);
-                        created_keys.insert(LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl {
+                        created_keys.insert(LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl {
                             key_hash: key_hash.clone(),
                         }));
                     } else {
@@ -1429,7 +1429,7 @@ mod tests {
     use super::*;
     use crate::soroban::{HotArchiveLookup, OperationContext, StorageChange};
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_context() -> LedgerContext {
         LedgerContext::testnet(1, 1000)
@@ -2012,8 +2012,8 @@ mod tests {
         };
         let hot_entry = LedgerEntry {
             last_modified_ledger_seq: 50,
-            data: stellar_xdr::curr::LedgerEntryData::ContractData(cd_entry),
-            ext: stellar_xdr::curr::LedgerEntryExt::V0,
+            data: stellar_xdr::LedgerEntryData::ContractData(cd_entry),
+            ext: stellar_xdr::LedgerEntryExt::V0,
         };
         let hot_entry_size = xdr_encoded_len(&hot_entry) as u32;
 
@@ -2033,8 +2033,7 @@ mod tests {
         }
         let hot_archive = TestHotArchive(key.clone(), hot_entry);
 
-        let account_key =
-            LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount { account_id: source });
+        let account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount { account_id: source });
 
         let footprint = LedgerFootprint {
             read_only: vec![account_key].try_into().unwrap(),
@@ -4289,21 +4288,21 @@ mod tests {
         HotArchiveRestore,
         ContractEvent,
     ) {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             Asset, ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, Hash,
             LedgerEntry, LedgerEntryData, LedgerEntryExt, Limits, ScAddress, ScMap, ScMapEntry,
             ScSymbol, ScVal, ScVec, WriteXdr,
         };
 
-        let asset = Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-            asset_code: stellar_xdr::curr::AssetCode4(*b"USDC"),
-            issuer: AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                stellar_xdr::curr::Uint256([7u8; 32]),
+        let asset = Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+            asset_code: stellar_xdr::AssetCode4(*b"USDC"),
+            issuer: AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([7u8; 32]),
             )),
         });
 
         // Compute the SAC contract id the same way events.rs does.
-        use stellar_xdr::curr::{ContractIdPreimage, HashIdPreimage, HashIdPreimageContractId};
+        use stellar_xdr::{ContractIdPreimage, HashIdPreimage, HashIdPreimageContractId};
         let preimage = HashIdPreimage::ContractId(HashIdPreimageContractId {
             network_id: Hash::from(net.0),
             contract_id_preimage: ContractIdPreimage::Asset(asset.clone()),
@@ -4322,7 +4321,7 @@ mod tests {
             )));
             let amt = {
                 let v = amount as i128;
-                ScVal::I128(stellar_xdr::curr::Int128Parts {
+                ScVal::I128(stellar_xdr::Int128Parts {
                     hi: (v >> 64) as i64,
                     lo: v as u64,
                 })
@@ -4396,12 +4395,10 @@ mod tests {
         // event so the diagnostic-channel assertion is meaningful), plus a
         // return value.
         let host_event = ContractEvent {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
-            contract_id: Some(stellar_xdr::curr::ContractId(stellar_xdr::curr::Hash(
-                [123u8; 32],
-            ))),
-            type_: stellar_xdr::curr::ContractEventType::Contract,
-            body: stellar_xdr::curr::ContractEventBody::V0(stellar_xdr::curr::ContractEventV0 {
+            ext: stellar_xdr::ExtensionPoint::V0,
+            contract_id: Some(stellar_xdr::ContractId(stellar_xdr::Hash([123u8; 32]))),
+            type_: stellar_xdr::ContractEventType::Contract,
+            body: stellar_xdr::ContractEventBody::V0(stellar_xdr::ContractEventV0 {
                 topics: vec![ScVal::U32(999)].try_into().unwrap(),
                 data: ScVal::U32(999),
             }),

--- a/crates/tx/src/operations/execute/liquidity_pool.rs
+++ b/crates/tx/src/operations/execute/liquidity_pool.rs
@@ -4,7 +4,7 @@
 //! - LiquidityPoolDeposit
 //! - LiquidityPoolWithdraw
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, LiquidityPoolDepositOp, LiquidityPoolDepositResult,
     LiquidityPoolDepositResultCode, LiquidityPoolWithdrawOp, LiquidityPoolWithdrawResult,
     LiquidityPoolWithdrawResultCode, OperationResult, OperationResultTr, Price, TrustLineAsset,
@@ -63,7 +63,7 @@ pub(crate) fn execute_liquidity_pool_deposit(
 
     // Get pool parameters
     let (asset_a, asset_b, reserve_a, reserve_b, total_shares, _fee) = match &pool.body {
-        stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
+        stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
             let params = &cp.params;
             (
                 params.asset_a.clone(),
@@ -222,7 +222,7 @@ pub(crate) fn execute_liquidity_pool_deposit(
     // Update pool reserves
     if let Some(pool_mut) = state.get_liquidity_pool_mut(&op.liquidity_pool_id) {
         match &mut pool_mut.body {
-            stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
+            stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
                 add_pool_reserve(&mut cp.reserve_a, deposit_a)?;
                 add_pool_reserve(&mut cp.reserve_b, deposit_b)?;
                 add_pool_shares(&mut cp.total_pool_shares, shares_received)?;
@@ -268,7 +268,7 @@ pub(crate) fn execute_liquidity_pool_withdraw(
 
     // Get pool parameters
     let (asset_a, asset_b, reserve_a, reserve_b, total_shares) = match &pool.body {
-        stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
+        stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
             let params = &cp.params;
             (
                 params.asset_a.clone(),
@@ -367,7 +367,7 @@ pub(crate) fn execute_liquidity_pool_withdraw(
     // Update pool reserves
     if let Some(pool_mut) = state.get_liquidity_pool_mut(&op.liquidity_pool_id) {
         match &mut pool_mut.body {
-            stellar_xdr::curr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
+            stellar_xdr::LiquidityPoolEntryBody::LiquidityPoolConstantProduct(cp) => {
                 add_pool_reserve(&mut cp.reserve_a, -withdraw_a)?;
                 add_pool_reserve(&mut cp.reserve_b, -withdraw_b)?;
                 add_pool_shares(&mut cp.total_pool_shares, -op.amount)?;
@@ -390,7 +390,7 @@ fn resolve_deposit_asset(
     state: &LedgerStateManager,
     context: &LedgerContext,
 ) -> std::result::Result<i64, LiquidityPoolDepositResultCode> {
-    use stellar_xdr::curr::TrustLineEntry;
+    use stellar_xdr::TrustLineEntry;
 
     let trustline: Option<&TrustLineEntry> =
         if matches!(asset, Asset::Native) || is_issuer(source, asset) {
@@ -839,7 +839,7 @@ mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
     use henyey_common::LIQUIDITY_POOL_FEE_V18;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64, flags: u32) -> AccountEntry {
         AccountEntry {
@@ -2547,8 +2547,7 @@ mod tests {
 
         // Freeze source's trustline for asset_a via CAP-77
         let frozen_key = crate::frozen_keys::trustline_key(&source_id, &asset_a);
-        let frozen_bytes =
-            stellar_xdr::curr::WriteXdr::to_xdr(&frozen_key, Limits::none()).unwrap();
+        let frozen_bytes = stellar_xdr::WriteXdr::to_xdr(&frozen_key, Limits::none()).unwrap();
 
         let mut context = create_test_context();
         context.frozen_key_config =
@@ -2647,8 +2646,7 @@ mod tests {
 
         // Freeze source's trustline for asset_b via CAP-77
         let frozen_key = crate::frozen_keys::trustline_key(&source_id, &asset_b);
-        let frozen_bytes =
-            stellar_xdr::curr::WriteXdr::to_xdr(&frozen_key, Limits::none()).unwrap();
+        let frozen_bytes = stellar_xdr::WriteXdr::to_xdr(&frozen_key, Limits::none()).unwrap();
 
         let mut context = create_test_context();
         context.frozen_key_config =

--- a/crates/tx/src/operations/execute/manage_data.rs
+++ b/crates/tx/src/operations/execute/manage_data.rs
@@ -3,7 +3,7 @@
 //! This module implements the execution logic for the ManageData operation,
 //! which allows accounts to attach arbitrary key-value data.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, DataEntry, DataEntryExt, LedgerKey, LedgerKeyData, ManageDataOp, ManageDataResult,
     ManageDataResultCode, OperationResult, OperationResultTr,
 };
@@ -190,7 +190,7 @@ fn is_string_valid(bytes: &[u8]) -> bool {
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {

--- a/crates/tx/src/operations/execute/manage_offer.rs
+++ b/crates/tx/src/operations/execute/manage_offer.rs
@@ -5,7 +5,7 @@
 
 use std::cmp::Ordering;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, CreatePassiveSellOfferOp, LedgerKey, LedgerKeyOffer, ManageBuyOfferOp,
     ManageOfferSuccessResult, ManageOfferSuccessResultOffer, ManageSellOfferOp,
     ManageSellOfferResult, ManageSellOfferResultCode, OfferEntry, OfferEntryExt, OfferEntryFlags,
@@ -951,10 +951,8 @@ fn create_offer_entry(
 }
 
 /// Convert ManageSellOfferResult to ManageBuyOfferResult.
-fn convert_sell_to_buy_result(
-    result: ManageSellOfferResult,
-) -> stellar_xdr::curr::ManageBuyOfferResult {
-    use stellar_xdr::curr::ManageBuyOfferResult;
+fn convert_sell_to_buy_result(result: ManageSellOfferResult) -> stellar_xdr::ManageBuyOfferResult {
+    use stellar_xdr::ManageBuyOfferResult;
 
     match result {
         ManageSellOfferResult::Success(s) => ManageBuyOfferResult::Success(s),
@@ -1002,7 +1000,7 @@ mod tests {
     use super::super::{AUTHORIZED_FLAG, AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG};
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {
@@ -2723,7 +2721,7 @@ mod tests {
         let result = execute_manage_buy_offer(&op, &source_id, &mut state, &context);
         match result.unwrap() {
             OperationResult::OpInner(OperationResultTr::ManageBuyOffer(
-                stellar_xdr::curr::ManageBuyOfferResult::Success(_),
+                stellar_xdr::ManageBuyOfferResult::Success(_),
             )) => {
                 // Success
             }
@@ -2893,7 +2891,7 @@ mod tests {
         // meaning it was recorded as accessed. This matches stellar-core behavior where
         // loadAccount is called before the exchange for new offers (V14+).
         let op_snapshots = state.end_op_snapshot();
-        let source_account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let source_account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: source_id.clone(),
         });
         assert!(
@@ -3059,7 +3057,7 @@ mod tests {
         // In stellar-core, createEntryWithPossibleSponsorship loads the sponsor (numSponsoring++),
         // and removeEntryWithPossibleSponsorship loads it again (numSponsoring--).
         // Net effect is zero but the sponsor gets lm stamped.
-        let sponsor_account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let sponsor_account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: sponsor_id.clone(),
         });
         assert!(
@@ -3068,7 +3066,7 @@ mod tests {
         );
 
         // Source account should also be in op snapshot
-        let source_account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let source_account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: source_id.clone(),
         });
         assert!(

--- a/crates/tx/src/operations/execute/mod.rs
+++ b/crates/tx/src/operations/execute/mod.rs
@@ -37,7 +37,7 @@ pub(super) use henyey_common::checked_types::{account_liabilities, trustline_lia
 use soroban_env_host_p24 as soroban_env_host24;
 use soroban_env_host_p25 as soroban_env_host25;
 use soroban_env_host_p26 as soroban_env_host26;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext, AccountId,
     Asset, ContractEvent, DiagnosticEvent, ExtendFootprintTtlResult, InvokeHostFunctionResult,
     LedgerKey, Liabilities, Operation, OperationBody, OperationResult, OperationResultTr,
@@ -316,11 +316,11 @@ fn apply_balance_delta(
 }
 
 /// Classify a ledger key for rent purposes: (is_persistent, is_code_entry).
-fn rent_classification(key: &stellar_xdr::curr::LedgerKey) -> (bool, bool) {
+fn rent_classification(key: &stellar_xdr::LedgerKey) -> (bool, bool) {
     match key {
-        stellar_xdr::curr::LedgerKey::ContractCode(_) => (true, true),
-        stellar_xdr::curr::LedgerKey::ContractData(cd) => (
-            cd.durability == stellar_xdr::curr::ContractDataDurability::Persistent,
+        stellar_xdr::LedgerKey::ContractCode(_) => (true, true),
+        stellar_xdr::LedgerKey::ContractData(cd) => (
+            cd.durability == stellar_xdr::ContractDataDurability::Persistent,
             false,
         ),
         _ => (false, false),
@@ -509,7 +509,7 @@ pub struct SorobanOperationMeta {
     /// Diagnostic events emitted during execution.
     pub diagnostic_events: Vec<DiagnosticEvent>,
     /// Return value for invoke host function (if any).
-    pub return_value: Option<stellar_xdr::curr::ScVal>,
+    pub return_value: Option<stellar_xdr::ScVal>,
     /// Contract events + return value size in bytes.
     pub event_size_bytes: u32,
     /// Rent fee charged for storage changes.
@@ -558,10 +558,10 @@ impl SorobanOperationMeta {
 /// in `processOpLedgerEntryChanges` to determine RESTORED vs RESTORED+UPDATED emission.
 #[derive(Debug, Clone)]
 pub struct HotArchiveRestore {
-    key: stellar_xdr::curr::LedgerKey,
-    entry: stellar_xdr::curr::LedgerEntry,
+    key: stellar_xdr::LedgerKey,
+    entry: stellar_xdr::LedgerEntry,
     /// Synthesized TTL entry at the time of restore. Used for meta comparison.
-    ttl_entry: stellar_xdr::curr::LedgerEntry,
+    ttl_entry: stellar_xdr::LedgerEntry,
 }
 
 impl HotArchiveRestore {
@@ -577,8 +577,8 @@ impl HotArchiveRestore {
     /// - `key` is not a persistent Soroban key (ContractCode or persistent ContractData)
     /// - `entry` does not correspond to `key`
     pub fn new(
-        key: stellar_xdr::curr::LedgerKey,
-        entry: stellar_xdr::curr::LedgerEntry,
+        key: stellar_xdr::LedgerKey,
+        entry: stellar_xdr::LedgerEntry,
         restored_live_until_ledger: u32,
     ) -> Self {
         assert!(
@@ -604,34 +604,31 @@ impl HotArchiveRestore {
     }
 
     /// The ledger key of the restored entry (ContractCode or persistent ContractData).
-    pub fn key(&self) -> &stellar_xdr::curr::LedgerKey {
+    pub fn key(&self) -> &stellar_xdr::LedgerKey {
         &self.key
     }
 
     /// The restored entry value.
-    pub fn entry(&self) -> &stellar_xdr::curr::LedgerEntry {
+    pub fn entry(&self) -> &stellar_xdr::LedgerEntry {
         &self.entry
     }
 
     /// The synthesized TTL entry at the time of restore.
-    pub fn ttl_entry(&self) -> &stellar_xdr::curr::LedgerEntry {
+    pub fn ttl_entry(&self) -> &stellar_xdr::LedgerEntry {
         &self.ttl_entry
     }
 
     /// Derive the TTL key from the data/code key.
-    pub fn ttl_key(&self) -> stellar_xdr::curr::LedgerKey {
+    pub fn ttl_key(&self) -> stellar_xdr::LedgerKey {
         let key_hash = crate::soroban::compute_key_hash(&self.key);
-        stellar_xdr::curr::LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl { key_hash })
+        stellar_xdr::LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl { key_hash })
     }
 }
 
 #[cfg(test)]
 impl HotArchiveRestore {
     /// Test helper: create with a default TTL target of 1000.
-    pub fn new_for_test(
-        key: stellar_xdr::curr::LedgerKey,
-        entry: stellar_xdr::curr::LedgerEntry,
-    ) -> Self {
+    pub fn new_for_test(key: stellar_xdr::LedgerKey, entry: stellar_xdr::LedgerEntry) -> Self {
         Self::new(key, entry, 1000)
     }
 }
@@ -660,12 +657,12 @@ pub struct RevokeEvent {
     /// The asset moving out of the pool.
     pub asset: Asset,
     /// The liquidity pool the asset is leaving (the event `from`).
-    pub pool_id: stellar_xdr::curr::PoolId,
+    pub pool_id: stellar_xdr::PoolId,
     /// The amount withdrawn from the pool for this asset.
     pub amount: i64,
     /// Some(cb) for a `transfer` to the claimable balance; None for a `burn`
     /// to the issuer (holder issues this asset).
-    pub claimable_balance_id: Option<stellar_xdr::curr::ClaimableBalanceId>,
+    pub claimable_balance_id: Option<stellar_xdr::ClaimableBalanceId>,
 }
 
 impl OperationExecutionResult {
@@ -709,7 +706,7 @@ enum OldRentState {
 }
 
 struct RentSnapshot {
-    key: stellar_xdr::curr::LedgerKey,
+    key: stellar_xdr::LedgerKey,
     is_persistent: bool,
     is_code_entry: bool,
     old_state: OldRentState,
@@ -736,15 +733,16 @@ struct RentChange {
 /// available.
 pub fn entry_size_for_rent_by_protocol_with_cost_params(
     protocol_version: u32,
-    entry: &stellar_xdr::curr::LedgerEntry,
+    entry: &stellar_xdr::LedgerEntry,
     entry_xdr_size: u32,
     cost_params: Option<(
-        &stellar_xdr::curr::ContractCostParams,
-        &stellar_xdr::curr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
     )>,
 ) -> u32 {
     use crate::soroban::convert::{
         try_convert_ledger_entry_to_p24, try_convert_ledger_entry_ws_to_p25,
+        try_convert_ledger_entry_ws_to_p26,
     };
     if protocol_version_is_before(protocol_version, ProtocolVersion::V25) {
         let budget = match cost_params {
@@ -781,20 +779,31 @@ pub fn entry_size_for_rent_by_protocol_with_cost_params(
             }
         }
     } else {
-        // Protocol >= 26: p26 host uses stellar-xdr 26.0.0 (same as workspace).
+        // Protocol >= 26: p26 host pins stellar-xdr 26.0.0, distinct from the
+        // workspace XDR, so the entry is byte-converted to the P26 type.
         let budget = match cost_params {
             Some((cpu, mem)) => build_budget_p26(cpu, mem),
             None => soroban_env_host26::budget::Budget::default(),
         };
-        soroban_env_host26::e2e_invoke::entry_size_for_rent(&budget, entry, entry_xdr_size)
-            .unwrap_or(entry_xdr_size)
+        match try_convert_ledger_entry_ws_to_p26(entry) {
+            Ok(p26_entry) => soroban_env_host26::e2e_invoke::entry_size_for_rent(
+                &budget,
+                &p26_entry,
+                entry_xdr_size,
+            )
+            .unwrap_or(entry_xdr_size),
+            Err(e) => {
+                tracing::warn!("entry_size_for_rent: {e}, falling back to XDR size");
+                entry_xdr_size
+            }
+        }
     }
 }
 
 /// Build a P24 Budget from on-chain cost parameters.
 fn build_budget_p24(
-    cpu_cost_params: &stellar_xdr::curr::ContractCostParams,
-    mem_cost_params: &stellar_xdr::curr::ContractCostParams,
+    cpu_cost_params: &stellar_xdr::ContractCostParams,
+    mem_cost_params: &stellar_xdr::ContractCostParams,
 ) -> soroban_env_host24::budget::Budget {
     use crate::soroban::convert::try_convert_cost_params_to_p24;
     match (
@@ -815,8 +824,8 @@ fn build_budget_p24(
 
 /// Build a P25 Budget from on-chain cost parameters.
 fn build_budget_p25(
-    cpu_cost_params: &stellar_xdr::curr::ContractCostParams,
-    mem_cost_params: &stellar_xdr::curr::ContractCostParams,
+    cpu_cost_params: &stellar_xdr::ContractCostParams,
+    mem_cost_params: &stellar_xdr::ContractCostParams,
 ) -> soroban_env_host25::budget::Budget {
     use crate::soroban::convert::try_convert_cost_params_ws_to_p25;
     match (
@@ -833,30 +842,33 @@ fn build_budget_p25(
 }
 
 /// Build a P26 Budget from on-chain cost parameters.
-///
-/// P26 host uses stellar-xdr 26.0.0 (same as workspace) — no conversion needed.
 fn build_budget_p26(
-    cpu_cost_params: &stellar_xdr::curr::ContractCostParams,
-    mem_cost_params: &stellar_xdr::curr::ContractCostParams,
+    cpu_cost_params: &stellar_xdr::ContractCostParams,
+    mem_cost_params: &stellar_xdr::ContractCostParams,
 ) -> soroban_env_host26::budget::Budget {
-    soroban_env_host26::budget::Budget::try_from_configs(
-        0,
-        0,
-        cpu_cost_params.clone(),
-        mem_cost_params.clone(),
-    )
-    .unwrap_or_else(|_| soroban_env_host26::budget::Budget::default())
+    use crate::soroban::convert::try_convert_cost_params_ws_to_p26;
+    match (
+        try_convert_cost_params_ws_to_p26(cpu_cost_params),
+        try_convert_cost_params_ws_to_p26(mem_cost_params),
+    ) {
+        (Ok(cpu), Ok(mem)) => soroban_env_host26::budget::Budget::try_from_configs(0, 0, cpu, mem)
+            .unwrap_or_else(|_| soroban_env_host26::budget::Budget::default()),
+        (Err(e), _) | (_, Err(e)) => {
+            tracing::warn!("build_budget_p26: {e}, using default budget");
+            soroban_env_host26::budget::Budget::default()
+        }
+    }
 }
 
 // Local conversion functions removed — use crate::soroban::convert::try_convert_* instead.
 
 fn rent_snapshot_for_keys(
-    keys: &[stellar_xdr::curr::LedgerKey],
+    keys: &[stellar_xdr::LedgerKey],
     state: &LedgerStateManager,
     protocol_version: u32,
     cost_params: Option<(
-        &stellar_xdr::curr::ContractCostParams,
-        &stellar_xdr::curr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
     )>,
     ttl_key_cache: Option<&crate::soroban::TtlKeyCache>,
 ) -> Vec<RentSnapshot> {
@@ -895,8 +907,8 @@ fn rent_changes_from_snapshots(
     state: &LedgerStateManager,
     protocol_version: u32,
     cost_params: Option<(
-        &stellar_xdr::curr::ContractCostParams,
-        &stellar_xdr::curr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
+        &stellar_xdr::ContractCostParams,
     )>,
     ttl_key_cache: Option<&crate::soroban::TtlKeyCache>,
 ) -> Vec<RentChange> {
@@ -1463,7 +1475,7 @@ pub fn execute_operation_with_soroban(
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {

--- a/crates/tx/src/operations/execute/offer_exchange.rs
+++ b/crates/tx/src/operations/execute/offer_exchange.rs
@@ -1,6 +1,6 @@
 //! Offer exchange math helpers (v10+).
 
-use stellar_xdr::curr::{AccountId, Asset, ClaimAtom, Price};
+use stellar_xdr::{AccountId, Asset, ClaimAtom, Price};
 
 use crate::frozen_keys::FrozenKeyConfig;
 use crate::state::LedgerStateManager;

--- a/crates/tx/src/operations/execute/offer_utils.rs
+++ b/crates/tx/src/operations/execute/offer_utils.rs
@@ -6,7 +6,7 @@
 //! - Crossing an offer (the v10 exchange path)
 //! - Deleting an offer with sponsorship/sub-entry cleanup
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, ClaimAtom, ClaimOfferAtom, LedgerKey, LedgerKeyOffer, OfferEntry, Price,
 };
 

--- a/crates/tx/src/operations/execute/path_payment.rs
+++ b/crates/tx/src/operations/execute/path_payment.rs
@@ -3,7 +3,7 @@
 //! This module implements the execution logic for PathPaymentStrictReceive
 //! and PathPaymentStrictSend operations, which transfer assets through a path.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, ClaimAtom, ClaimLiquidityAtom, LiquidityPoolEntryBody,
     LiquidityPoolParameters, OperationResult, OperationResultTr, PathPaymentStrictReceiveOp,
     PathPaymentStrictReceiveResult, PathPaymentStrictReceiveResultCode,
@@ -833,7 +833,7 @@ fn apply_pool_exchange(
 
 fn pool_id_for_assets(send_asset: &Asset, recv_asset: &Asset) -> PoolId {
     let params = LiquidityPoolParameters::LiquidityPoolConstantProduct(
-        stellar_xdr::curr::LiquidityPoolConstantProductParameters {
+        stellar_xdr::LiquidityPoolConstantProductParameters {
             asset_a: std::cmp::min(send_asset.clone(), recv_asset.clone()),
             asset_b: std::cmp::max(send_asset.clone(), recv_asset.clone()),
             fee: LIQUIDITY_POOL_FEE_V18 as i32,
@@ -1097,7 +1097,7 @@ mod tests {
     use crate::test_utils::{
         create_test_account_id, create_test_asset, create_test_trustline_asset,
     };
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_muxed_account(seed: u8) -> MuxedAccount {
         MuxedAccount::Ed25519(Uint256([seed; 32]))
@@ -3081,7 +3081,7 @@ mod tests {
     /// path payments must skip pool exchange and use order-book only.
     #[test]
     fn test_audit_011_pool_trading_disabled_flag_skips_pool_exchange() {
-        use stellar_xdr::curr::LedgerHeaderFlags;
+        use stellar_xdr::LedgerHeaderFlags;
 
         let mut state = LedgerStateManager::new(5_000_000, 100);
 

--- a/crates/tx/src/operations/execute/payment.rs
+++ b/crates/tx/src/operations/execute/payment.rs
@@ -3,7 +3,7 @@
 //! This module implements the execution logic for the Payment operation,
 //! which transfers assets between accounts.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, OperationResult, OperationResultTr, PathPaymentStrictReceiveOp,
     PathPaymentStrictReceiveResult, PaymentOp, PaymentResult, PaymentResultCode,
 };
@@ -117,7 +117,7 @@ mod tests {
     use crate::test_utils::{
         create_test_account_id, create_test_asset, create_test_trustline_asset,
     };
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     const AUTHORIZED_FLAG: u32 = 0x1; // TrustLineFlags::AuthorizedFlag
 

--- a/crates/tx/src/operations/execute/prefetch.rs
+++ b/crates/tx/src/operations/execute/prefetch.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, AllowTrustOp, Asset, AssetCode, BeginSponsoringFutureReservesOp, ChangeTrustAsset,
     ChangeTrustOp, ClaimClaimableBalanceOp, ClawbackClaimableBalanceOp, ClawbackOp,
     CreateAccountOp, CreateClaimableBalanceOp, CreatePassiveSellOfferOp, LedgerKey,
@@ -43,13 +43,13 @@ fn offer_key(seller: &AccountId, id: i64) -> LedgerKey {
     })
 }
 
-fn claimable_balance_key(id: &stellar_xdr::curr::ClaimableBalanceId) -> LedgerKey {
+fn claimable_balance_key(id: &stellar_xdr::ClaimableBalanceId) -> LedgerKey {
     LedgerKey::ClaimableBalance(LedgerKeyClaimableBalance {
         balance_id: id.clone(),
     })
 }
 
-fn data_key(account: &AccountId, name: &stellar_xdr::curr::String64) -> LedgerKey {
+fn data_key(account: &AccountId, name: &stellar_xdr::String64) -> LedgerKey {
     LedgerKey::Data(LedgerKeyData {
         account_id: account.clone(),
         data_name: name.clone(),
@@ -172,13 +172,13 @@ fn prefetch_keys_allow_trust(op: &AllowTrustOp, source: &AccountId, keys: &mut H
     // Build the trustline asset from the AllowTrust asset code + source (issuer)
     let tl_asset = match &op.asset {
         AssetCode::CreditAlphanum4(code) => {
-            TrustLineAsset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
+            TrustLineAsset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
                 asset_code: code.clone(),
                 issuer: source.clone(),
             })
         }
         AssetCode::CreditAlphanum12(code) => {
-            TrustLineAsset::CreditAlphanum12(stellar_xdr::curr::AlphaNum12 {
+            TrustLineAsset::CreditAlphanum12(stellar_xdr::AlphaNum12 {
                 asset_code: code.clone(),
                 issuer: source.clone(),
             })
@@ -244,7 +244,7 @@ fn prefetch_keys_liquidity_pool_deposit(
     keys: &mut HashSet<LedgerKey>,
 ) {
     keys.insert(LedgerKey::LiquidityPool(
-        stellar_xdr::curr::LedgerKeyLiquidityPool {
+        stellar_xdr::LedgerKeyLiquidityPool {
             liquidity_pool_id: op.liquidity_pool_id.clone(),
         },
     ));
@@ -256,7 +256,7 @@ fn prefetch_keys_liquidity_pool_withdraw(
     keys: &mut HashSet<LedgerKey>,
 ) {
     keys.insert(LedgerKey::LiquidityPool(
-        stellar_xdr::curr::LedgerKeyLiquidityPool {
+        stellar_xdr::LedgerKeyLiquidityPool {
             liquidity_pool_id: op.liquidity_pool_id.clone(),
         },
     ));
@@ -363,7 +363,7 @@ pub fn collect_prefetch_keys(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn test_account_id(seed: u8) -> AccountId {
         AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([seed; 32])))

--- a/crates/tx/src/operations/execute/restore_footprint.rs
+++ b/crates/tx/src/operations/execute/restore_footprint.rs
@@ -3,7 +3,7 @@
 //! This module implements the execution logic for the RestoreFootprint operation,
 //! which restores archived Soroban contract data entries.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, LedgerEntry, LedgerEntryData, LedgerKey, OperationResult, OperationResultTr,
     RestoreFootprintOp, RestoreFootprintResult, RestoreFootprintResultCode, SorobanTransactionData,
     TtlEntry,
@@ -325,7 +325,7 @@ fn make_result(code: RestoreFootprintResultCode) -> OperationResult {
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     /// Default min persistent TTL for tests (matches testnet config)
     const TEST_MIN_PERSISTENT_TTL: u32 = 120960;

--- a/crates/tx/src/operations/execute/set_options.rs
+++ b/crates/tx/src/operations/execute/set_options.rs
@@ -3,7 +3,7 @@
 //! This module implements the execution logic for the SetOptions operation,
 //! which modifies various account settings.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, AccountEntryExtensionV2,
     AccountFlags, AccountId, OperationResult, OperationResultTr, PublicKey, SetOptionsOp,
     SetOptionsResult, SetOptionsResultCode, Signer, SignerKey, SignerKeyEd25519SignedPayload,
@@ -287,7 +287,7 @@ struct AccountSnapshot {
 /// Apply a signer update (add, remove, or change weight) to the source account.
 /// Returns the sponsor delta to apply, or an error.
 fn apply_signer_update(
-    signer: &stellar_xdr::curr::Signer,
+    signer: &stellar_xdr::Signer,
     source: &AccountId,
     source_account: &mut AccountEntry,
     sponsor_info: Option<&SponsorInfo>,
@@ -328,7 +328,7 @@ fn apply_signer_update(
     let sponsor = sponsor_info.map(|info| info.sponsor_id.clone());
     let has_v2 = matches!(
         source_account.ext,
-        AccountEntryExt::V1(stellar_xdr::curr::AccountEntryExtensionV1 {
+        AccountEntryExt::V1(stellar_xdr::AccountEntryExtensionV1 {
             ext: AccountEntryExtensionV1Ext::V2(_),
             ..
         })
@@ -485,7 +485,7 @@ fn make_result(code: SetOptionsResultCode) -> OperationResult {
 mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn make_string32(s: &str) -> String32 {
         String32::try_from(s.as_bytes().to_vec()).unwrap()

--- a/crates/tx/src/operations/execute/sponsorship.rs
+++ b/crates/tx/src/operations/execute/sponsorship.rs
@@ -5,7 +5,7 @@
 //! - EndSponsoringFutureReserves
 //! - RevokeSponsorship
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, BeginSponsoringFutureReservesOp, BeginSponsoringFutureReservesResult,
     BeginSponsoringFutureReservesResultCode, EndSponsoringFutureReservesResult,
     EndSponsoringFutureReservesResultCode, LedgerEntryData, LedgerKey, LedgerKeyAccount,
@@ -109,7 +109,7 @@ pub(crate) fn execute_revoke_sponsorship(
     state: &mut LedgerStateManager,
     context: &LedgerContext,
 ) -> Result<OperationResult> {
-    use stellar_xdr::curr::RevokeSponsorshipOp as RSO;
+    use stellar_xdr::RevokeSponsorshipOp as RSO;
 
     // Check source account exists
     if state.get_account(source).is_none() {
@@ -494,7 +494,7 @@ mod tests {
         create_test_account_id, create_test_account_with_sponsorship, create_test_trustline,
         create_test_trustline_asset,
     };
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64) -> AccountEntry {
         AccountEntry {

--- a/crates/tx/src/operations/execute/trust_flags.rs
+++ b/crates/tx/src/operations/execute/trust_flags.rs
@@ -4,7 +4,7 @@
 //! - AllowTrust (deprecated, but still supported)
 //! - SetTrustLineFlags
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountFlags, AccountId, AllowTrustOp, AllowTrustResult, AllowTrustResultCode, Asset,
     ClaimPredicate, ClaimableBalanceEntry, ClaimableBalanceId, Claimant, ClaimantV0, Hash,
     HashIdPreimage, HashIdPreimageRevokeId, LedgerKey, LedgerKeyClaimableBalance,
@@ -44,12 +44,12 @@ pub(crate) fn execute_allow_trust(
 
     // Validate asset code content (defense-in-depth; also checked in validation layer).
     match &op.asset {
-        stellar_xdr::curr::AssetCode::CreditAlphanum4(code) => {
+        stellar_xdr::AssetCode::CreditAlphanum4(code) => {
             if !henyey_common::asset::is_asset_code4_valid(code) {
                 return Ok(make_allow_trust_result(AllowTrustResultCode::Malformed));
             }
         }
-        stellar_xdr::curr::AssetCode::CreditAlphanum12(code) => {
+        stellar_xdr::AssetCode::CreditAlphanum12(code) => {
             if !henyey_common::asset::is_asset_code12_valid(code) {
                 return Ok(make_allow_trust_result(AllowTrustResultCode::Malformed));
             }
@@ -310,16 +310,16 @@ pub(crate) fn execute_set_trust_line_flags(
 }
 
 /// Convert an AllowTrust asset code + issuer into a full Asset.
-fn asset_from_code(code: &stellar_xdr::curr::AssetCode, issuer: &AccountId) -> Asset {
+fn asset_from_code(code: &stellar_xdr::AssetCode, issuer: &AccountId) -> Asset {
     match code {
-        stellar_xdr::curr::AssetCode::CreditAlphanum4(c) => {
-            Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
+        stellar_xdr::AssetCode::CreditAlphanum4(c) => {
+            Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
                 asset_code: c.clone(),
                 issuer: issuer.clone(),
             })
         }
-        stellar_xdr::curr::AssetCode::CreditAlphanum12(c) => {
-            Asset::CreditAlphanum12(stellar_xdr::curr::AlphaNum12 {
+        stellar_xdr::AssetCode::CreditAlphanum12(c) => {
+            Asset::CreditAlphanum12(stellar_xdr::AlphaNum12 {
                 asset_code: c.clone(),
                 issuer: issuer.clone(),
             })
@@ -690,17 +690,19 @@ fn redeem_into_claimable_balance(
         claimants: vec![claimant].try_into().unwrap(),
         asset: asset.clone(),
         amount,
-        ext: stellar_xdr::curr::ClaimableBalanceEntryExt::V0,
+        ext: stellar_xdr::ClaimableBalanceEntryExt::V0,
     };
 
     // If asset is not native, check clawback flag
     if !matches!(asset, Asset::Native) {
         if let Some(asset_tl) = state.get_trustline(account_id, asset) {
             if asset_tl.flags & TRUSTLINE_CLAWBACK_ENABLED_FLAG != 0 {
-                cb_entry.ext = stellar_xdr::curr::ClaimableBalanceEntryExt::V1(
-                    stellar_xdr::curr::ClaimableBalanceEntryExtensionV1 {
-                        ext: stellar_xdr::curr::ClaimableBalanceEntryExtensionV1Ext::V0,
-                        flags: stellar_xdr::curr::ClaimableBalanceFlags::ClaimableBalanceClawbackEnabledFlag as u32,
+                cb_entry.ext = stellar_xdr::ClaimableBalanceEntryExt::V1(
+                    stellar_xdr::ClaimableBalanceEntryExtensionV1 {
+                        ext: stellar_xdr::ClaimableBalanceEntryExtensionV1Ext::V0,
+                        flags:
+                            stellar_xdr::ClaimableBalanceFlags::ClaimableBalanceClawbackEnabledFlag
+                                as u32,
                     },
                 );
             }
@@ -870,7 +872,7 @@ mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
     use henyey_common::LIQUIDITY_POOL_FEE_V18;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_test_account(account_id: AccountId, balance: i64, flags: u32) -> AccountEntry {
         AccountEntry {
@@ -1028,9 +1030,7 @@ mod tests {
 
         let op = AllowTrustOp {
             trustor: trustor_id.clone(),
-            asset: stellar_xdr::curr::AssetCode::CreditAlphanum4(AssetCode4([
-                b'U', b'S', b'D', b'C',
-            ])),
+            asset: stellar_xdr::AssetCode::CreditAlphanum4(AssetCode4([b'U', b'S', b'D', b'C'])),
             authorize: 0,
         };
 
@@ -1292,7 +1292,7 @@ mod tests {
         // The issuer account should NOT be in the updated entries
         // Only the trustline should be recorded as updated
         for entry in updated_entries {
-            if let stellar_xdr::curr::LedgerEntryData::Account(acc) = &entry.data {
+            if let stellar_xdr::LedgerEntryData::Account(acc) = &entry.data {
                 // Check this isn't the issuer account
                 assert_ne!(
                     acc.account_id, issuer_id,
@@ -1303,7 +1303,7 @@ mod tests {
 
         // The trustline SHOULD be in the updated entries (it was updated)
         let has_trustline = updated_entries.iter().any(|e| {
-            matches!(&e.data, stellar_xdr::curr::LedgerEntryData::Trustline(tl)
+            matches!(&e.data, stellar_xdr::LedgerEntryData::Trustline(tl)
                 if tl.account_id == trustor_id)
         });
         assert!(
@@ -1377,7 +1377,7 @@ mod tests {
 
         // The issuer account should NOT be in the updated entries
         for entry in updated_entries {
-            if let stellar_xdr::curr::LedgerEntryData::Account(acc) = &entry.data {
+            if let stellar_xdr::LedgerEntryData::Account(acc) = &entry.data {
                 assert_ne!(
                     acc.account_id, issuer_id,
                     "Issuer account should NOT be in updated_entries for AllowTrust"
@@ -1387,7 +1387,7 @@ mod tests {
 
         // The trustline SHOULD be in the updated entries
         let has_trustline = updated_entries.iter().any(|e| {
-            matches!(&e.data, stellar_xdr::curr::LedgerEntryData::Trustline(tl)
+            matches!(&e.data, stellar_xdr::LedgerEntryData::Trustline(tl)
                 if tl.account_id == trustor_id)
         });
         assert!(
@@ -3250,7 +3250,7 @@ mod tests {
             num_sub_entries: 0,
             inflation_dest: None,
             flags: AccountFlags::RevocableFlag as u32,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([1, 0, 0, 0]),
             signers: Vec::new().try_into().unwrap(),
             ext: AccountEntryExt::V0,
@@ -3260,7 +3260,7 @@ mod tests {
         let invalid_code = AssetCode4([b'U', 0, b'S', b'D']);
         let op = AllowTrustOp {
             trustor: trustor_id.clone(),
-            asset: stellar_xdr::curr::AssetCode::CreditAlphanum4(invalid_code),
+            asset: stellar_xdr::AssetCode::CreditAlphanum4(invalid_code),
             authorize: 1,
         };
 
@@ -3307,7 +3307,7 @@ mod tests {
             num_sub_entries: 0,
             inflation_dest: None,
             flags: AccountFlags::RevocableFlag as u32,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([1, 0, 0, 0]),
             signers: Vec::new().try_into().unwrap(),
             ext: AccountEntryExt::V0,

--- a/crates/tx/src/operations/mod.rs
+++ b/crates/tx/src/operations/mod.rs
@@ -12,7 +12,7 @@ use crate::frame::muxed_to_account_id;
 use henyey_common::asset::{
     is_asset_valid, is_change_trust_asset_valid, is_string_valid, is_trustline_asset_valid,
 };
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, AllowTrustOp, Asset, BeginSponsoringFutureReservesOp, BumpSequenceOp,
     ChangeTrustAsset, ChangeTrustOp, ClaimClaimableBalanceOp, ClaimPredicate, Claimant,
     ClawbackClaimableBalanceOp, ClawbackOp, CreateAccountOp, CreateClaimableBalanceOp,
@@ -24,7 +24,7 @@ use stellar_xdr::curr::{
     MASK_ACCOUNT_FLAGS_V17,
 };
 
-/// Extension trait for `stellar_xdr::curr::OperationType` providing Soroban classification
+/// Extension trait for `stellar_xdr::OperationType` providing Soroban classification
 /// and body-to-type conversion.
 pub trait OperationTypeExt {
     /// Check if this is a Soroban operation.
@@ -481,9 +481,8 @@ fn validate_set_options(
         // signer key must not be self
         if let Some(src) = source_account {
             if let SignerKey::Ed25519(key) = &signer.key {
-                let signer_acct = AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-                    key.clone(),
-                ));
+                let signer_acct =
+                    AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(key.clone()));
                 if &signer_acct == src {
                     return Err(OperationValidationError::InvalidSigner);
                 }
@@ -564,14 +563,14 @@ fn validate_allow_trust(
     // Asset must be a valid credit code. Mirrors stellar-core
     // AllowTrustOpFrame::doCheckValid() which calls isAssetValid().
     match &op.asset {
-        stellar_xdr::curr::AssetCode::CreditAlphanum4(code) => {
+        stellar_xdr::AssetCode::CreditAlphanum4(code) => {
             if !henyey_common::asset::is_asset_code4_valid(code) {
                 return Err(OperationValidationError::InvalidAsset(
                     "invalid asset code".into(),
                 ));
             }
         }
-        stellar_xdr::curr::AssetCode::CreditAlphanum12(code) => {
+        stellar_xdr::AssetCode::CreditAlphanum12(code) => {
             if !henyey_common::asset::is_asset_code12_valid(code) {
                 return Err(OperationValidationError::InvalidAsset(
                     "invalid asset code".into(),
@@ -752,7 +751,7 @@ fn validate_revoke_sponsorship(
                         "invalid trustline asset".into(),
                     ));
                 }
-                if matches!(tl.asset, stellar_xdr::curr::TrustLineAsset::Native) {
+                if matches!(tl.asset, stellar_xdr::TrustLineAsset::Native) {
                     return Err(OperationValidationError::InvalidAsset(
                         "trustline asset cannot be native".into(),
                     ));
@@ -805,7 +804,7 @@ fn validate_clawback(
     // with the same underlying key is considered different (clawback is allowed).
     if let Some(src) = source_account {
         let key = match &src.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(k) => k.clone(),
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(k) => k.clone(),
         };
         let src_muxed = MuxedAccount::Ed25519(key);
         if op.from == src_muxed {
@@ -1110,8 +1109,8 @@ pub fn validate_classic_op_structure(
 pub fn malformed_operation_result(
     body: &OperationBody,
     err: &OperationValidationError,
-) -> stellar_xdr::curr::OperationResult {
-    use stellar_xdr::curr::*;
+) -> stellar_xdr::OperationResult {
+    use stellar_xdr::*;
     let tr = match body {
         OperationBody::CreateAccount(_) => {
             OperationResultTr::CreateAccount(CreateAccountResult::Malformed)
@@ -1219,7 +1218,7 @@ pub fn malformed_operation_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     #[test]
     fn test_operation_type_from_body() {
@@ -1398,9 +1397,9 @@ mod tests {
             source_account: None,
             body: OperationBody::AllowTrust(AllowTrustOp {
                 trustor: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
-                asset: stellar_xdr::curr::AssetCode::CreditAlphanum4(
-                    stellar_xdr::curr::AssetCode4([b'U', b'S', b'D', 0]),
-                ),
+                asset: stellar_xdr::AssetCode::CreditAlphanum4(stellar_xdr::AssetCode4([
+                    b'U', b'S', b'D', 0,
+                ])),
                 authorize: 1,
             }),
         };
@@ -1410,7 +1409,7 @@ mod tests {
         let bump_seq_op = Operation {
             source_account: None,
             body: OperationBody::BumpSequence(BumpSequenceOp {
-                bump_to: stellar_xdr::curr::SequenceNumber(100),
+                bump_to: stellar_xdr::SequenceNumber(100),
             }),
         };
         assert_eq!(get_threshold_level(&bump_seq_op), ThresholdLevel::Low);
@@ -1419,8 +1418,8 @@ mod tests {
         let claim_op = Operation {
             source_account: None,
             body: OperationBody::ClaimClaimableBalance(ClaimClaimableBalanceOp {
-                balance_id: stellar_xdr::curr::ClaimableBalanceId::ClaimableBalanceIdTypeV0(
-                    stellar_xdr::curr::Hash([0u8; 32]),
+                balance_id: stellar_xdr::ClaimableBalanceId::ClaimableBalanceIdTypeV0(
+                    stellar_xdr::Hash([0u8; 32]),
                 ),
             }),
         };
@@ -1461,7 +1460,7 @@ mod tests {
         let change_trust_op = Operation {
             source_account: None,
             body: OperationBody::ChangeTrust(ChangeTrustOp {
-                line: stellar_xdr::curr::ChangeTrustAsset::Native,
+                line: stellar_xdr::ChangeTrustAsset::Native,
                 limit: 1000,
             }),
         };
@@ -1471,7 +1470,7 @@ mod tests {
         let manage_data_op = Operation {
             source_account: None,
             body: OperationBody::ManageData(ManageDataOp {
-                data_name: stellar_xdr::curr::String64::try_from(b"test".to_vec()).unwrap(),
+                data_name: stellar_xdr::String64::try_from(b"test".to_vec()).unwrap(),
                 data_value: Some(b"value".to_vec().try_into().unwrap()),
             }),
         };
@@ -1519,8 +1518,8 @@ mod tests {
                 med_threshold: None,
                 high_threshold: None,
                 home_domain: None,
-                signer: Some(stellar_xdr::curr::Signer {
-                    key: stellar_xdr::curr::SignerKey::Ed25519(Uint256([0u8; 32])),
+                signer: Some(stellar_xdr::Signer {
+                    key: stellar_xdr::SignerKey::Ed25519(Uint256([0u8; 32])),
                     weight: 10,
                 }),
             }),
@@ -1587,7 +1586,7 @@ mod tests {
                 med_threshold: None,
                 high_threshold: None,
                 home_domain: Some(
-                    stellar_xdr::curr::String32::try_from(b"example.com".to_vec()).unwrap(),
+                    stellar_xdr::String32::try_from(b"example.com".to_vec()).unwrap(),
                 ),
                 signer: None,
             }),
@@ -1673,8 +1672,8 @@ mod tests {
     fn test_validate_manage_sell_offer() {
         let valid = ManageSellOfferOp {
             selling: Asset::Native,
-            buying: Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-                asset_code: stellar_xdr::curr::AssetCode4([b'U', b'S', b'D', 0]),
+            buying: Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+                asset_code: stellar_xdr::AssetCode4([b'U', b'S', b'D', 0]),
                 issuer: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
             }),
             amount: 1000,
@@ -1733,8 +1732,8 @@ mod tests {
     fn test_validate_manage_buy_offer() {
         let valid = ManageBuyOfferOp {
             selling: Asset::Native,
-            buying: Asset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-                asset_code: stellar_xdr::curr::AssetCode4([b'U', b'S', b'D', 0]),
+            buying: Asset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+                asset_code: stellar_xdr::AssetCode4([b'U', b'S', b'D', 0]),
                 issuer: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
             }),
             buy_amount: 1000,
@@ -1806,11 +1805,11 @@ mod tests {
     /// Test validate_change_trust.
     #[test]
     fn test_validate_change_trust() {
-        use stellar_xdr::curr::ChangeTrustAsset;
+        use stellar_xdr::ChangeTrustAsset;
 
         let valid = ChangeTrustOp {
-            line: ChangeTrustAsset::CreditAlphanum4(stellar_xdr::curr::AlphaNum4 {
-                asset_code: stellar_xdr::curr::AssetCode4([b'U', b'S', b'D', 0]),
+            line: ChangeTrustAsset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+                asset_code: stellar_xdr::AssetCode4([b'U', b'S', b'D', 0]),
                 issuer: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
             }),
             limit: 1000,
@@ -1829,13 +1828,13 @@ mod tests {
     #[test]
     fn test_validate_bump_sequence() {
         let valid = BumpSequenceOp {
-            bump_to: stellar_xdr::curr::SequenceNumber(100),
+            bump_to: stellar_xdr::SequenceNumber(100),
         };
         assert!(validate_bump_sequence(&valid).is_ok());
 
         // Negative bump_to
         let negative = BumpSequenceOp {
-            bump_to: stellar_xdr::curr::SequenceNumber(-1),
+            bump_to: stellar_xdr::SequenceNumber(-1),
         };
         assert!(validate_bump_sequence(&negative).is_err());
     }
@@ -1844,21 +1843,21 @@ mod tests {
     #[test]
     fn test_validate_manage_data() {
         let valid = ManageDataOp {
-            data_name: stellar_xdr::curr::String64::try_from(b"test".to_vec()).unwrap(),
+            data_name: stellar_xdr::String64::try_from(b"test".to_vec()).unwrap(),
             data_value: Some(b"value".to_vec().try_into().unwrap()),
         };
         assert!(validate_manage_data(&valid, 21).is_ok());
 
         // Delete operation (None value) is also valid
         let delete = ManageDataOp {
-            data_name: stellar_xdr::curr::String64::try_from(b"test".to_vec()).unwrap(),
+            data_name: stellar_xdr::String64::try_from(b"test".to_vec()).unwrap(),
             data_value: None,
         };
         assert!(validate_manage_data(&delete, 21).is_ok());
 
         // Invalid string (contains null byte)
         let invalid_name = ManageDataOp {
-            data_name: stellar_xdr::curr::String64::try_from(b"te\x00st".to_vec()).unwrap(),
+            data_name: stellar_xdr::String64::try_from(b"te\x00st".to_vec()).unwrap(),
             data_value: None,
         };
         assert!(validate_manage_data(&invalid_name, 21).is_err());

--- a/crates/tx/src/result.rs
+++ b/crates/tx/src/result.rs
@@ -17,7 +17,7 @@
 //! The [`TxResultCode`] and [`OpResultCode`] type aliases provide typed access to
 //! XDR result codes with human-readable names.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     OperationResult, OperationResultTr, TransactionResult, TransactionResultCode,
     TransactionResultResult,
 };
@@ -71,7 +71,7 @@ impl TxResultWrapper {
             inner: TransactionResult {
                 fee_charged: 0,
                 result: TransactionResultResult::TxSuccess(vec![].try_into().unwrap()),
-                ext: stellar_xdr::curr::TransactionResultExt::V0,
+                ext: stellar_xdr::TransactionResultExt::V0,
             },
         }
     }
@@ -172,7 +172,7 @@ impl TransactionResultCodeExt for TransactionResultCode {
 }
 
 /// Operation result code — type alias for the XDR `OperationResultCode`.
-pub type OpResultCode = stellar_xdr::curr::OperationResultCode;
+pub type OpResultCode = stellar_xdr::OperationResultCode;
 
 // ============================================================================
 // Mutable Transaction Result Types (for live execution)
@@ -333,7 +333,7 @@ impl std::error::Error for RefundableFeeError {}
 ///
 // SECURITY: error result construction uses pre-validated operation results from execution
 /// Delegates to [`TransactionResultCodeExt::to_xdr_result`].
-fn code_to_result(code: stellar_xdr::curr::TransactionResultCode) -> TransactionResultResult {
+fn code_to_result(code: stellar_xdr::TransactionResultCode) -> TransactionResultResult {
     code.to_xdr_result()
 }
 
@@ -373,39 +373,39 @@ impl MutableTransactionResult {
             inner: TransactionResult {
                 fee_charged,
                 result: TransactionResultResult::TxSuccess(vec![].try_into().unwrap()),
-                ext: stellar_xdr::curr::TransactionResultExt::V0,
+                ext: stellar_xdr::TransactionResultExt::V0,
             },
             refundable_fee_tracker: None,
         }
     }
 
     /// Create a new error result with the given code.
-    pub fn create_error(code: stellar_xdr::curr::TransactionResultCode, fee_charged: i64) -> Self {
-        use stellar_xdr::curr::TransactionResultCode::*;
+    pub fn create_error(code: stellar_xdr::TransactionResultCode, fee_charged: i64) -> Self {
+        use stellar_xdr::TransactionResultCode::*;
 
         // Fee-bump codes need special handling with InnerTransactionResultPair.
         let result = match code {
             TxFeeBumpInnerSuccess => TransactionResultResult::TxFeeBumpInnerSuccess(
-                stellar_xdr::curr::InnerTransactionResultPair {
-                    transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                    result: stellar_xdr::curr::InnerTransactionResult {
+                stellar_xdr::InnerTransactionResultPair {
+                    transaction_hash: stellar_xdr::Hash([0u8; 32]),
+                    result: stellar_xdr::InnerTransactionResult {
                         fee_charged: 0,
-                        result: stellar_xdr::curr::InnerTransactionResultResult::TxSuccess(
+                        result: stellar_xdr::InnerTransactionResultResult::TxSuccess(
                             vec![].try_into().unwrap(),
                         ),
-                        ext: stellar_xdr::curr::InnerTransactionResultExt::V0,
+                        ext: stellar_xdr::InnerTransactionResultExt::V0,
                     },
                 },
             ),
             TxFeeBumpInnerFailed => TransactionResultResult::TxFeeBumpInnerFailed(
-                stellar_xdr::curr::InnerTransactionResultPair {
-                    transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                    result: stellar_xdr::curr::InnerTransactionResult {
+                stellar_xdr::InnerTransactionResultPair {
+                    transaction_hash: stellar_xdr::Hash([0u8; 32]),
+                    result: stellar_xdr::InnerTransactionResult {
                         fee_charged: 0,
-                        result: stellar_xdr::curr::InnerTransactionResultResult::TxFailed(
+                        result: stellar_xdr::InnerTransactionResultResult::TxFailed(
                             vec![].try_into().unwrap(),
                         ),
-                        ext: stellar_xdr::curr::InnerTransactionResultExt::V0,
+                        ext: stellar_xdr::InnerTransactionResultExt::V0,
                     },
                 },
             ),
@@ -416,7 +416,7 @@ impl MutableTransactionResult {
             inner: TransactionResult {
                 fee_charged,
                 result,
-                ext: stellar_xdr::curr::TransactionResultExt::V0,
+                ext: stellar_xdr::TransactionResultExt::V0,
             },
             refundable_fee_tracker: None,
         }
@@ -427,7 +427,7 @@ impl MutableTransactionResult {
     pub fn create_success(fee_charged: i64, op_count: usize) -> Self {
         let results = vec![
             OperationResult::OpInner(OperationResultTr::Payment(
-                stellar_xdr::curr::PaymentResult::Success,
+                stellar_xdr::PaymentResult::Success,
             ));
             op_count
         ];
@@ -436,7 +436,7 @@ impl MutableTransactionResult {
             inner: TransactionResult {
                 fee_charged,
                 result: TransactionResultResult::TxSuccess(results.try_into().unwrap_or_default()),
-                ext: stellar_xdr::curr::TransactionResultExt::V0,
+                ext: stellar_xdr::TransactionResultExt::V0,
             },
             refundable_fee_tracker: None,
         }
@@ -447,7 +447,7 @@ impl MutableTransactionResult {
     // SECURITY: fee refund values validated during tx validation; overflow not possible with valid fees
     /// This also resets any consumed refundable fees (for Soroban) so that
     /// the maximum refund is returned to the fee source.
-    pub fn set_error(&mut self, code: stellar_xdr::curr::TransactionResultCode) {
+    pub fn set_error(&mut self, code: stellar_xdr::TransactionResultCode) {
         // Mirror stellar-core MutableTransactionResultBase::setError monotonicity
         // (MutableTransactionResult.cpp:148-160): an error result may only be
         // re-set to the same code (idempotent) or set from a success state —
@@ -548,7 +548,7 @@ impl MutableTransactionResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     fn create_success_result() -> TransactionResult {
         TransactionResult {
@@ -681,7 +681,7 @@ mod tests {
         let mut result = MutableTransactionResult::new(100);
         assert!(result.is_success());
 
-        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        result.set_error(stellar_xdr::TransactionResultCode::TxBadSeq);
         assert!(!result.is_success());
         assert_eq!(result.result_code(), TxResultCode::TxBadSeq);
     }
@@ -696,17 +696,17 @@ mod tests {
     #[should_panic(expected = "set_error must be monotonic")]
     fn test_set_error_rejects_error_to_different_error() {
         let mut result = MutableTransactionResult::new(100);
-        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        result.set_error(stellar_xdr::TransactionResultCode::TxBadSeq);
         // Changing to a different error code must panic via the entry guard.
-        result.set_error(stellar_xdr::curr::TransactionResultCode::TxInsufficientFee);
+        result.set_error(stellar_xdr::TransactionResultCode::TxInsufficientFee);
     }
 
     #[test]
     fn test_set_error_idempotent_same_code_ok() {
         let mut result = MutableTransactionResult::new(100);
-        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        result.set_error(stellar_xdr::TransactionResultCode::TxBadSeq);
         // Re-setting the same error code is idempotent and must not panic.
-        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        result.set_error(stellar_xdr::TransactionResultCode::TxBadSeq);
         assert!(!result.is_success());
         assert_eq!(result.result_code(), TxResultCode::TxBadSeq);
     }
@@ -716,7 +716,7 @@ mod tests {
         let mut result = MutableTransactionResult::new(100);
         assert!(result.is_success());
         // Transitioning from a success state to an error is always allowed.
-        result.set_error(stellar_xdr::curr::TransactionResultCode::TxBadSeq);
+        result.set_error(stellar_xdr::TransactionResultCode::TxBadSeq);
         assert!(!result.is_success());
         assert_eq!(result.result_code(), TxResultCode::TxBadSeq);
     }
@@ -736,7 +736,7 @@ mod tests {
         );
 
         // Set error should reset consumed fees
-        result.set_error(stellar_xdr::curr::TransactionResultCode::TxFailed);
+        result.set_error(stellar_xdr::TransactionResultCode::TxFailed);
         assert_eq!(
             result.refundable_fee_tracker().unwrap().consumed_rent_fee(),
             0
@@ -783,7 +783,7 @@ mod tests {
     #[test]
     fn test_mutable_result_create_error() {
         let result = MutableTransactionResult::create_error(
-            stellar_xdr::curr::TransactionResultCode::TxNoAccount,
+            stellar_xdr::TransactionResultCode::TxNoAccount,
             50,
         );
         assert!(!result.is_success());
@@ -885,12 +885,12 @@ mod tests {
         let inner_result = TransactionResult {
             fee_charged: 100,
             result: TransactionResultResult::TxFeeBumpInnerSuccess(
-                stellar_xdr::curr::InnerTransactionResultPair {
-                    transaction_hash: stellar_xdr::curr::Hash([0u8; 32]),
-                    result: stellar_xdr::curr::InnerTransactionResult {
+                stellar_xdr::InnerTransactionResultPair {
+                    transaction_hash: stellar_xdr::Hash([0u8; 32]),
+                    result: stellar_xdr::InnerTransactionResult {
                         fee_charged: 50,
                         result: InnerTransactionResultResult::TxSuccess(vec![].try_into().unwrap()),
-                        ext: stellar_xdr::curr::InnerTransactionResultExt::V0,
+                        ext: stellar_xdr::InnerTransactionResultExt::V0,
                     },
                 },
             ),

--- a/crates/tx/src/scval_utils.rs
+++ b/crates/tx/src/scval_utils.rs
@@ -1,6 +1,6 @@
 //! Shared ScVal construction helpers for events and transaction meta.
 
-use stellar_xdr::curr::{ScString, ScSymbol, ScVal, StringM};
+use stellar_xdr::{ScString, ScSymbol, ScVal, StringM};
 
 /// Create a ScVal::Symbol from a string.
 pub(crate) fn make_symbol_scval(value: &str) -> ScVal {

--- a/crates/tx/src/signature_checker.rs
+++ b/crates/tx/src/signature_checker.rs
@@ -38,7 +38,7 @@
 use henyey_common::Hash256;
 use henyey_crypto::Signature;
 use std::collections::HashMap;
-use stellar_xdr::curr::{DecoratedSignature, Signer, SignerKey, SignerKeyType};
+use stellar_xdr::{DecoratedSignature, Signer, SignerKey, SignerKeyType};
 
 /// Signature checker that tracks which signatures have been used and
 /// accumulates weights when checking against account signers.
@@ -300,7 +300,7 @@ fn verify_ed25519_signed_payload(sig: &DecoratedSignature, signer: &Signer) -> b
 ///
 /// Creates a signer list from the account's explicit signers plus the master
 /// key (using the account's master weight from `thresholds[0]`).
-pub fn collect_signers_for_account(account: &stellar_xdr::curr::AccountEntry) -> Vec<Signer> {
+pub fn collect_signers_for_account(account: &stellar_xdr::AccountEntry) -> Vec<Signer> {
     let mut signers: Vec<Signer> = account.signers.to_vec();
 
     // Add the master key as a signer with weight from thresholds[0]
@@ -308,7 +308,7 @@ pub fn collect_signers_for_account(account: &stellar_xdr::curr::AccountEntry) ->
     if master_weight > 0 {
         // Extract the Ed25519 key bytes from the PublicKey
         let key_bytes = match &account.account_id.0 {
-            stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(key) => key.clone(),
+            stellar_xdr::PublicKey::PublicKeyTypeEd25519(key) => key.clone(),
         };
         signers.push(Signer {
             key: SignerKey::Ed25519(key_bytes),
@@ -323,7 +323,7 @@ pub fn collect_signers_for_account(account: &stellar_xdr::curr::AccountEntry) ->
 mod tests {
     use super::*;
     use henyey_crypto::{sign_hash, SecretKey};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, PublicKey as XdrPublicKey,
         Signature as XdrSignature, SignatureHint, Thresholds, Uint256,
     };
@@ -503,11 +503,11 @@ mod tests {
         let account = AccountEntry {
             account_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(master_key_bytes.clone())),
             balance: 1000,
-            seq_num: stellar_xdr::curr::SequenceNumber(1),
+            seq_num: stellar_xdr::SequenceNumber(1),
             num_sub_entries: 0,
             inflation_dest: None,
             flags: 0,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([10, 1, 2, 3]), // Master weight = 10
             signers: vec![extra_signer.clone()].try_into().unwrap(),
             ext: AccountEntryExt::V0,
@@ -554,11 +554,11 @@ mod tests {
         let account = AccountEntry {
             account_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(master_key_bytes.clone())),
             balance: 1000,
-            seq_num: stellar_xdr::curr::SequenceNumber(1),
+            seq_num: stellar_xdr::SequenceNumber(1),
             num_sub_entries: 0,
             inflation_dest: None,
             flags: 0,
-            home_domain: stellar_xdr::curr::String32::default(),
+            home_domain: stellar_xdr::String32::default(),
             thresholds: Thresholds([0, 1, 2, 3]), // Master weight = 0
             signers: vec![].try_into().unwrap(),
             ext: AccountEntryExt::V0,

--- a/crates/tx/src/soroban/budget.rs
+++ b/crates/tx/src/soroban/budget.rs
@@ -3,7 +3,7 @@
 //! Tracks CPU instructions and memory usage for contract execution.
 
 pub use soroban_env_host_p25::fees::{FeeConfiguration, RentFeeConfiguration};
-use stellar_xdr::curr::ContractCostParams;
+use stellar_xdr::ContractCostParams;
 
 /// Soroban network configuration for contract execution.
 ///

--- a/crates/tx/src/soroban/convert.rs
+++ b/crates/tx/src/soroban/convert.rs
@@ -1,11 +1,12 @@
 //! Cross-version XDR byte-level conversion helpers.
 //!
-//! Henyey uses workspace XDR types (`stellar_xdr::curr`, currently v26-aligned)
+//! Henyey uses workspace XDR types (`stellar_xdr`, currently v27-aligned)
 //! as its canonical representation, but must convert to protocol-specific
-//! `soroban-env-host` types (P24, P25) for execution and rent calculation.
+//! `soroban-env-host` types (P24, P25, P26) for execution and rent calculation.
 //!
-//! The P26 host uses stellar-xdr 26.0.0 (same as workspace), so types are
-//! identical and no conversion is needed for P26.
+//! Each `soroban-env-host` pins its own XDR (P24→v24, P25→v25, P26→v26), all
+//! distinct from the workspace XDR, so byte-level conversion is required for
+//! every host version.
 //!
 //! These conversions serialize to XDR bytes and deserialize into the target
 //! version's types. This works because the wire format is compatible across
@@ -17,7 +18,8 @@
 
 use soroban_env_host_p24 as soroban_env_host24;
 use soroban_env_host_p25 as soroban_env_host25;
-use stellar_xdr::curr::{ContractCostParams, LedgerEntry, Limits, WriteXdr};
+use soroban_env_host_p26 as soroban_env_host26;
+use stellar_xdr::{ContractCostParams, LedgerEntry, Limits, WriteXdr};
 
 /// Error from cross-version XDR byte-level conversion.
 ///
@@ -126,10 +128,53 @@ pub fn try_convert_ledger_entry_to_p24(
         })
 }
 
+/// Convert workspace `ContractCostParams` to P26 `ContractCostParams`.
+pub fn try_convert_cost_params_ws_to_p26(
+    params: &ContractCostParams,
+) -> Result<soroban_env_host26::xdr::ContractCostParams, XdrConversionError> {
+    let bytes = params
+        .to_xdr(Limits::none())
+        .map_err(|e| XdrConversionError {
+            phase: "serialize",
+            type_name: "ContractCostParams",
+            source: e.into(),
+        })?;
+    use soroban_env_host26::xdr::ReadXdr as ReadXdrP26;
+    soroban_env_host26::xdr::ContractCostParams::from_xdr(
+        &bytes,
+        soroban_env_host26::xdr::Limits::none(),
+    )
+    .map_err(|e| XdrConversionError {
+        phase: "deserialize",
+        type_name: "P26 ContractCostParams",
+        source: e.into(),
+    })
+}
+
+/// Convert workspace `LedgerEntry` to P26 `LedgerEntry`.
+pub fn try_convert_ledger_entry_ws_to_p26(
+    entry: &LedgerEntry,
+) -> Result<soroban_env_host26::xdr::LedgerEntry, XdrConversionError> {
+    let bytes = entry
+        .to_xdr(Limits::none())
+        .map_err(|e| XdrConversionError {
+            phase: "serialize",
+            type_name: "LedgerEntry",
+            source: e.into(),
+        })?;
+    use soroban_env_host26::xdr::ReadXdr as ReadXdrP26;
+    soroban_env_host26::xdr::LedgerEntry::from_xdr(&bytes, soroban_env_host26::xdr::Limits::none())
+        .map_err(|e| XdrConversionError {
+            phase: "deserialize",
+            type_name: "P26 LedgerEntry",
+            source: e.into(),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractCostParamEntry, ContractDataDurability, ContractDataEntry, ContractId,
         ExtensionPoint, Hash, LedgerEntryData, LedgerEntryExt, ScAddress, ScVal,
     };
@@ -193,6 +238,20 @@ mod tests {
         let entry = sample_ledger_entry();
         let p24 = try_convert_ledger_entry_to_p24(&entry).unwrap();
         assert_eq!(p24.last_modified_ledger_seq, 100);
+    }
+
+    #[test]
+    fn test_try_convert_cost_params_ws_to_p26_roundtrip() {
+        let params = sample_cost_params();
+        let p26 = try_convert_cost_params_ws_to_p26(&params).unwrap();
+        assert_eq!(p26.0.len(), 1);
+    }
+
+    #[test]
+    fn test_try_convert_ledger_entry_ws_to_p26_roundtrip() {
+        let entry = sample_ledger_entry();
+        let p26 = try_convert_ledger_entry_ws_to_p26(&entry).unwrap();
+        assert_eq!(p26.last_modified_ledger_seq, 100);
     }
 
     #[test]

--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -38,7 +38,7 @@ use soroban_env_host26::{
 // The P26 host is pinned to the stellar-core v26.0.1 submodule revision (b351f88)
 // which uses stellar-xdr 26.0.0 — the same as our workspace. Types are unified
 // by Cargo, so no XDR byte roundtrip is needed for P26 (unlike P24/P25).
-use stellar_xdr::curr::{
+use stellar_xdr::{
     DiagnosticEvent, LedgerEntry, LedgerKey, Limits, ReadXdr, ScVal, SorobanTransactionData,
     SorobanTransactionDataExt, WriteXdr,
 };
@@ -89,7 +89,7 @@ pub struct SorobanExecutionResult {
     /// Storage changes made during execution.
     pub storage_changes: Vec<StorageChange>,
     /// Contract and system events emitted during execution.
-    pub contract_events: Vec<stellar_xdr::curr::ContractEvent>,
+    pub contract_events: Vec<stellar_xdr::ContractEvent>,
     /// Diagnostic events emitted during execution.
     pub diagnostic_events: Vec<DiagnosticEvent>,
     /// CPU instructions consumed.
@@ -267,7 +267,7 @@ impl PersistentModuleCache {
     /// prevent unbounded growth of the module cache.
     ///
     /// Returns true if the module was found and removed, false otherwise.
-    pub fn remove_contract(&self, hash: &stellar_xdr::curr::Hash) -> bool {
+    pub fn remove_contract(&self, hash: &stellar_xdr::Hash) -> bool {
         match self {
             PersistentModuleCache::P24(cache) => {
                 let contract_id = soroban_env_host24::xdr::Hash(hash.0);
@@ -436,7 +436,7 @@ impl<'a> LedgerSnapshotAdapterP25<'a> {
                         // Get the TTL entry for the restore info
                         let key_hash =
                             super::get_or_compute_key_hash(self.ttl_key_cache, key.as_ref());
-                        let ttl_key = LedgerKey::Ttl(stellar_xdr::curr::LedgerKeyTtl { key_hash });
+                        let ttl_key = LedgerKey::Ttl(stellar_xdr::LedgerKeyTtl { key_hash });
                         let ttl_entry = self.state.get_entry(&ttl_key);
 
                         ttl_entry.map(|te| {
@@ -767,7 +767,7 @@ struct NormalizedLedgerChange {
 /// suitable for e2e_invoke::invoke_host_function().
 ///
 /// This is the shared logic between P24 and P25 execution paths. Both paths use
-/// workspace XDR types (`stellar_xdr::curr`) and the same `LedgerSnapshotAdapterP25`.
+/// workspace XDR types (`stellar_xdr`) and the same `LedgerSnapshotAdapterP25`.
 fn prepare_footprint_entries(
     snapshot: &LedgerSnapshotAdapterP25<'_>,
     soroban_data: &SorobanTransactionData,
@@ -787,13 +787,13 @@ fn prepare_footprint_entries(
         let needs_ttl = henyey_common::is_soroban_key(key);
         if let Some(lu) = live_until {
             let key_hash = super::get_or_compute_key_hash(ttl_key_cache, key);
-            henyey_common::xdr_to_bytes(&stellar_xdr::curr::TtlEntry {
+            henyey_common::xdr_to_bytes(&stellar_xdr::TtlEntry {
                 key_hash,
                 live_until_ledger_seq: lu,
             })
         } else if needs_ttl {
             let key_hash = super::get_or_compute_key_hash(ttl_key_cache, key);
-            henyey_common::xdr_to_bytes(&stellar_xdr::curr::TtlEntry {
+            henyey_common::xdr_to_bytes(&stellar_xdr::TtlEntry {
                 key_hash,
                 live_until_ledger_seq: context.sequence,
             })
@@ -913,10 +913,10 @@ fn prepare_footprint_entries(
 
 /// Encode the host function invocation inputs into XDR bytes.
 fn encode_invocation_inputs(
-    host_function: &stellar_xdr::curr::HostFunction,
+    host_function: &stellar_xdr::HostFunction,
     soroban_data: &SorobanTransactionData,
-    source: &stellar_xdr::curr::AccountId,
-    auth_entries: &[stellar_xdr::curr::SorobanAuthorizationEntry],
+    source: &stellar_xdr::AccountId,
+    auth_entries: &[stellar_xdr::SorobanAuthorizationEntry],
 ) -> Result<EncodedInvocationInputs, SorobanExecutionError> {
     let encoded_host_fn = host_function
         .to_xdr(Limits::none())
@@ -946,11 +946,11 @@ fn encode_invocation_inputs(
 fn decode_contract_events(
     encoded_events: &[Vec<u8>],
     make_error: &dyn Fn(&str) -> SorobanExecutionError,
-) -> Result<(Vec<stellar_xdr::curr::ContractEvent>, u32), SorobanExecutionError> {
+) -> Result<(Vec<stellar_xdr::ContractEvent>, u32), SorobanExecutionError> {
     let mut contract_events = Vec::new();
     let mut contract_events_size = 0u32;
     for encoded_event in encoded_events {
-        let event = stellar_xdr::curr::ContractEvent::from_xdr(encoded_event, Limits::none())
+        let event = stellar_xdr::ContractEvent::from_xdr(encoded_event, Limits::none())
             .map_err(|_| make_error("failed to decode ContractEvent"))?;
         contract_events_size = contract_events_size.saturating_add(encoded_event.len() as u32);
         contract_events.push(event);
@@ -1619,6 +1619,17 @@ fn convert_diagnostic_events_p24(
     })
 }
 
+fn convert_diagnostic_events_p26(
+    events: Vec<soroban_env_host26::xdr::DiagnosticEvent>,
+) -> Vec<DiagnosticEvent> {
+    convert_diagnostic_events_cross_version(events, "P26", |event| {
+        use soroban_env_host26::xdr::WriteXdr as WriteXdrP26;
+        event
+            .to_xdr(soroban_env_host26::xdr::Limits::none())
+            .map_err(|e| e.to_string())
+    })
+}
+
 fn rent_fee_config_p25_to_p24(
     config: &soroban_env_host25::fees::RentFeeConfiguration,
 ) -> soroban_env_host24::fees::RentFeeConfiguration {
@@ -1679,13 +1690,28 @@ fn execute_host_function_p26(
     let memory_limit = soroban_config.tx_max_memory_bytes;
 
     let budget = if soroban_config.has_valid_cost_params() {
-        Budget::try_from_configs(
-            instruction_limit,
-            memory_limit,
-            soroban_config.cpu_cost_params.clone(),
-            soroban_config.mem_cost_params.clone(),
-        )
-        .map_err(make_setup_error)?
+        let cost_params_error = || {
+            make_setup_error(HostErrorP26::from(
+                soroban_env_host26::Error::from_type_and_code(
+                    soroban_env_host26::xdr::ScErrorType::Context,
+                    soroban_env_host26::xdr::ScErrorCode::InternalError,
+                ),
+            ))
+        };
+        let p26_cpu =
+            super::convert::try_convert_cost_params_ws_to_p26(&soroban_config.cpu_cost_params)
+                .map_err(|e| {
+                    tracing::warn!("P26 cost params conversion failed: {e}");
+                    cost_params_error()
+                })?;
+        let p26_mem =
+            super::convert::try_convert_cost_params_ws_to_p26(&soroban_config.mem_cost_params)
+                .map_err(|e| {
+                    tracing::warn!("P26 cost params conversion failed: {e}");
+                    cost_params_error()
+                })?;
+        Budget::try_from_configs(instruction_limit, memory_limit, p26_cpu, p26_mem)
+            .map_err(make_setup_error)?
     } else {
         tracing::warn!("Using default Soroban budget - cost parameters not loaded from network.");
         Budget::default()
@@ -1787,7 +1813,8 @@ fn execute_host_function_p26(
                 "P26: e2e_invoke failed"
             );
             for (i, event) in diagnostic_events.iter().enumerate() {
-                if let Ok(encoded) = event.to_xdr(Limits::none()) {
+                use soroban_env_host26::xdr::WriteXdr as _;
+                if let Ok(encoded) = event.to_xdr(soroban_env_host26::xdr::Limits::none()) {
                     tracing::warn!(
                         event_idx = i,
                         event_hex = hex::encode(&encoded),
@@ -1799,13 +1826,14 @@ fn execute_host_function_p26(
                 host_error: convert_host_error_p26_to_p25(e),
                 cpu_insns_consumed,
                 mem_bytes_consumed,
-                diagnostic_events,
+                diagnostic_events: convert_diagnostic_events_p26(diagnostic_events),
             });
         }
     };
 
     // ── Decode result ──
-    let final_diagnostic_events = diagnostic_events;
+    // Convert diagnostic events before defining closures that borrow budget.
+    let final_diagnostic_events = convert_diagnostic_events_p26(diagnostic_events);
 
     let make_budget_error = |desc: &str| -> SorobanExecutionError {
         tracing::debug!(desc, "P26: XDR decode error in result processing");
@@ -1893,11 +1921,11 @@ fn execute_host_function_p26(
 mod tests {
     use super::*;
     use crate::soroban::compute_key_hash;
-    use stellar_xdr::curr::{Hash, LedgerEntryData};
+    use stellar_xdr::{Hash, LedgerEntryData};
 
     #[test]
     fn test_compute_key_hash() {
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([1u8; 32]),
         });
         let hash = compute_key_hash(&key);
@@ -1907,10 +1935,10 @@ mod tests {
     /// Test compute_key_hash produces different hashes for different keys.
     #[test]
     fn test_compute_key_hash_different_keys() {
-        let key1 = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key1 = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([1u8; 32]),
         });
-        let key2 = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key2 = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([2u8; 32]),
         });
 
@@ -1923,7 +1951,7 @@ mod tests {
     /// Test compute_key_hash is deterministic.
     #[test]
     fn test_compute_key_hash_deterministic() {
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([42u8; 32]),
         });
 
@@ -1936,10 +1964,10 @@ mod tests {
     /// Test compute_key_hash with ContractData key.
     #[test]
     fn test_compute_key_hash_contract_data() {
-        use stellar_xdr::curr::{ContractDataDurability, LedgerKeyContractData, ScAddress};
+        use stellar_xdr::{ContractDataDurability, LedgerKeyContractData, ScAddress};
 
         let key = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash([3u8; 32]))),
+            contract: ScAddress::Contract(stellar_xdr::ContractId(Hash([3u8; 32]))),
             key: ScVal::U32(100),
             durability: ContractDataDurability::Persistent,
         });
@@ -1952,18 +1980,18 @@ mod tests {
     #[test]
     fn test_storage_change_with_new_entry() {
         let change = StorageChange {
-            key: LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+            key: LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
                 hash: Hash([4u8; 32]),
             }),
             kind: StorageChangeKind::Modified {
                 entry: Box::new(LedgerEntry {
                     last_modified_ledger_seq: 100,
-                    data: LedgerEntryData::ContractCode(stellar_xdr::curr::ContractCodeEntry {
-                        ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+                    data: LedgerEntryData::ContractCode(stellar_xdr::ContractCodeEntry {
+                        ext: stellar_xdr::ContractCodeEntryExt::V0,
                         hash: Hash([4u8; 32]),
                         code: vec![0xDE, 0xAD].try_into().unwrap(),
                     }),
-                    ext: stellar_xdr::curr::LedgerEntryExt::V0,
+                    ext: stellar_xdr::LedgerEntryExt::V0,
                 }),
                 live_until: Some(1000),
                 ttl_extended: false,
@@ -1981,7 +2009,7 @@ mod tests {
     #[test]
     fn test_storage_change_ttl_extended() {
         let change = StorageChange {
-            key: LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+            key: LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
                 hash: Hash([5u8; 32]),
             }),
             kind: StorageChangeKind::TtlOnly {
@@ -2081,7 +2109,7 @@ mod tests {
     #[test]
     fn test_storage_change_delete() {
         let change = StorageChange {
-            key: LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+            key: LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
                 hash: Hash([6u8; 32]),
             }),
             kind: StorageChangeKind::Deleted,
@@ -2123,7 +2151,7 @@ mod tests {
     #[test]
     fn test_map_storage_changes_invalid_new_value_errors() {
         use crate::soroban::LedgerStateManager;
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
         let state = LedgerStateManager::new(5_000_000, 100);
         let make_error = |_desc: &str| -> SorobanExecutionError {
             SorobanExecutionError {
@@ -2137,7 +2165,7 @@ mod tests {
             }
         };
         // Valid key, invalid new_value
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([1u8; 32]),
         });
         let encoded_key = key.to_xdr(Limits::none()).unwrap();
@@ -2156,7 +2184,7 @@ mod tests {
     #[test]
     fn test_map_storage_changes_valid_data() {
         use crate::soroban::LedgerStateManager;
-        use stellar_xdr::curr::WriteXdr;
+        use stellar_xdr::WriteXdr;
         let state = LedgerStateManager::new(5_000_000, 100);
         let make_error = |_desc: &str| -> SorobanExecutionError {
             SorobanExecutionError {
@@ -2169,17 +2197,17 @@ mod tests {
                 diagnostic_events: vec![],
             }
         };
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([1u8; 32]),
         });
         let entry = LedgerEntry {
             last_modified_ledger_seq: 100,
-            data: LedgerEntryData::ContractCode(stellar_xdr::curr::ContractCodeEntry {
-                ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+            data: LedgerEntryData::ContractCode(stellar_xdr::ContractCodeEntry {
+                ext: stellar_xdr::ContractCodeEntryExt::V0,
                 hash: Hash([1u8; 32]),
                 code: vec![0xDE, 0xAD].try_into().unwrap(),
             }),
-            ext: stellar_xdr::curr::LedgerEntryExt::V0,
+            ext: stellar_xdr::LedgerEntryExt::V0,
         };
         let encoded_key = key.to_xdr(Limits::none()).unwrap();
         let encoded_value = entry.to_xdr(Limits::none()).unwrap();
@@ -2211,7 +2239,7 @@ mod tests {
         // TtlOnly: read-only entry with TTL extended
         // We need a TTL that is greater than ledger-start to trigger ttl_extended=true.
         // LedgerStateManager starts with no TTLs, so any live_until > 0 means extended.
-        let key2 = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key2 = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([2u8; 32]),
         });
         let encoded_key2 = key2.to_xdr(Limits::none()).unwrap();
@@ -2258,7 +2286,7 @@ mod tests {
         // Set ledger-start TTL to 6_000_000 so that live_until <= ledger_start_ttl.
         let key_hash = crate::soroban::compute_key_hash(&key2);
         let mut state_with_ttl = LedgerStateManager::new(5_000_000, 100);
-        state_with_ttl.create_ttl(stellar_xdr::curr::TtlEntry {
+        state_with_ttl.create_ttl(stellar_xdr::TtlEntry {
             key_hash: key_hash.clone(),
             live_until_ledger_seq: 6_000_000,
         });
@@ -2283,7 +2311,7 @@ mod tests {
     /// events.
     #[test]
     fn test_convert_diagnostic_events_cross_version_skip_corrupt() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractEvent, ContractEventBody, ContractEventType, ContractEventV0, DiagnosticEvent,
             ExtensionPoint, WriteXdr,
         };
@@ -2356,27 +2384,25 @@ mod tests {
                 key: &LedgerKey,
             ) -> std::result::Result<Option<LedgerEntry>, Box<dyn std::error::Error + Send + Sync>>
             {
-                let key_bytes =
-                    stellar_xdr::curr::WriteXdr::to_xdr(key, stellar_xdr::curr::Limits::none())?;
+                let key_bytes = stellar_xdr::WriteXdr::to_xdr(key, stellar_xdr::Limits::none())?;
                 Ok(self.entries.get(&key_bytes).cloned())
             }
         }
 
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([99u8; 32]),
         });
         let entry = LedgerEntry {
             last_modified_ledger_seq: 42,
-            data: LedgerEntryData::ContractCode(stellar_xdr::curr::ContractCodeEntry {
-                ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+            data: LedgerEntryData::ContractCode(stellar_xdr::ContractCodeEntry {
+                ext: stellar_xdr::ContractCodeEntryExt::V0,
                 hash: Hash([99u8; 32]),
                 code: vec![0xCA, 0xFE].try_into().unwrap(),
             }),
-            ext: stellar_xdr::curr::LedgerEntryExt::V0,
+            ext: stellar_xdr::LedgerEntryExt::V0,
         };
 
-        let key_bytes =
-            stellar_xdr::curr::WriteXdr::to_xdr(&key, stellar_xdr::curr::Limits::none()).unwrap();
+        let key_bytes = stellar_xdr::WriteXdr::to_xdr(&key, stellar_xdr::Limits::none()).unwrap();
         let mut ha_entries = HashMap::new();
         ha_entries.insert(key_bytes, entry);
         let hot_archive = TestHotArchive {

--- a/crates/tx/src/soroban/mod.rs
+++ b/crates/tx/src/soroban/mod.rs
@@ -94,7 +94,7 @@ pub(crate) use storage::StorageKey;
 pub(crate) use ttl::synthesize_ttl_entry;
 pub use ttl::{extend_ttl_target, restore_ttl_target};
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Hash, HostFunction, LedgerEntry, LedgerKey, SorobanAuthorizationEntry,
     SorobanTransactionData,
 };
@@ -267,7 +267,7 @@ impl<'a> GuardedHotArchive<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint, Hash,
         LedgerEntryData, LedgerEntryExt, LedgerKeyContractData, PublicKey, ScAddress, ScVal,
         Uint256,
@@ -313,7 +313,7 @@ mod tests {
         assert!(archive.get(&contract_key).unwrap().is_none());
 
         // Account key
-        let account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
         });
         assert!(archive.get(&account_key).unwrap().is_none());
@@ -334,8 +334,7 @@ mod tests {
                 key: &LedgerKey,
             ) -> std::result::Result<Option<LedgerEntry>, Box<dyn std::error::Error + Send + Sync>>
             {
-                let key_bytes =
-                    stellar_xdr::curr::WriteXdr::to_xdr(key, stellar_xdr::curr::Limits::none())?;
+                let key_bytes = stellar_xdr::WriteXdr::to_xdr(key, stellar_xdr::Limits::none())?;
                 Ok(self.entries.get(&key_bytes).cloned())
             }
         }
@@ -343,8 +342,7 @@ mod tests {
         let mut entries = HashMap::new();
         let key = test_contract_data_key();
         let entry = test_contract_data_entry();
-        let key_bytes =
-            stellar_xdr::curr::WriteXdr::to_xdr(&key, stellar_xdr::curr::Limits::none()).unwrap();
+        let key_bytes = stellar_xdr::WriteXdr::to_xdr(&key, stellar_xdr::Limits::none()).unwrap();
         entries.insert(key_bytes, entry.clone());
 
         let archive = TestHotArchive { entries };

--- a/crates/tx/src/soroban/protocol/p25.rs
+++ b/crates/tx/src/soroban/protocol/p25.rs
@@ -15,7 +15,7 @@ mod tests {
     use soroban_env_host_p25::xdr::{ReadXdr as ReadXdrP25, WriteXdr as WriteXdrP25};
     use soroban_env_host_p25::{storage::SnapshotSource, HostError};
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerKey, Limits, ReadXdr,
         WriteXdr,
     };
@@ -268,7 +268,7 @@ mod tests {
         }
     }
 
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractDataDurability, ContractDataEntry, ContractId, LedgerKeyContractData, ScAddress,
         ScVal, TtlEntry,
     };
@@ -289,7 +289,7 @@ mod tests {
         val: i32,
     ) -> ContractDataEntry {
         ContractDataEntry {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             contract: ScAddress::Contract(ContractId(Hash(contract_hash))),
             key: ScVal::I32(key_val),
             durability: ContractDataDurability::Persistent,
@@ -452,24 +452,24 @@ mod tests {
         let current_ledger = 1000u32;
 
         // Create an account
-        let account_id = AccountId(stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
-            stellar_xdr::curr::Uint256([5u8; 32]),
+        let account_id = AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256([5u8; 32]),
         ));
-        let account = stellar_xdr::curr::AccountEntry {
+        let account = stellar_xdr::AccountEntry {
             account_id: account_id.clone(),
             balance: 1_000_000_000,
-            seq_num: stellar_xdr::curr::SequenceNumber(1),
+            seq_num: stellar_xdr::SequenceNumber(1),
             num_sub_entries: 0,
             inflation_dest: None,
             flags: 0,
-            home_domain: stellar_xdr::curr::String32::default(),
-            thresholds: stellar_xdr::curr::Thresholds([1, 0, 0, 0]),
-            signers: stellar_xdr::curr::VecM::default(),
-            ext: stellar_xdr::curr::AccountEntryExt::V0,
+            home_domain: stellar_xdr::String32::default(),
+            thresholds: stellar_xdr::Thresholds([1, 0, 0, 0]),
+            signers: stellar_xdr::VecM::default(),
+            ext: stellar_xdr::AccountEntryExt::V0,
         };
         state.create_account(account);
 
-        let key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: account_id.clone(),
         });
 

--- a/crates/tx/src/soroban/protocol/types.rs
+++ b/crates/tx/src/soroban/protocol/types.rs
@@ -1,6 +1,6 @@
 //! Shared types for protocol-versioned host implementations.
 
-use stellar_xdr::curr::{LedgerEntry, LedgerEntryData, LedgerKey, LedgerKeyTtl};
+use stellar_xdr::{LedgerEntry, LedgerEntryData, LedgerKey, LedgerKeyTtl};
 
 /// An entry restored from the live BucketList (had expired TTL but wasn't yet evicted).
 ///
@@ -101,7 +101,7 @@ impl LiveBucketListRestore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         ContractCodeEntry, ContractDataDurability, ContractDataEntry, ContractId, ExtensionPoint,
         Hash, LedgerEntryExt, LedgerKeyContractCode, LedgerKeyContractData, ScAddress, ScVal,
         TtlEntry,
@@ -139,7 +139,7 @@ mod tests {
         LedgerEntry {
             last_modified_ledger_seq: 100,
             data: LedgerEntryData::ContractCode(ContractCodeEntry {
-                ext: stellar_xdr::curr::ContractCodeEntryExt::V0,
+                ext: stellar_xdr::ContractCodeEntryExt::V0,
                 hash: Hash([2u8; 32]),
                 code: vec![0u8; 10].try_into().unwrap(),
             }),
@@ -216,12 +216,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "key must be a persistent Soroban key")]
     fn test_new_panics_on_account_key() {
-        let account_key = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
-            account_id: stellar_xdr::curr::AccountId(
-                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
-                    [0u8; 32],
-                )),
-            ),
+        let account_key = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
+            account_id: stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                stellar_xdr::Uint256([0u8; 32]),
+            )),
         });
         let entry = persistent_data_entry();
         let data_key = persistent_data_key();

--- a/crates/tx/src/soroban/storage.rs
+++ b/crates/tx/src/soroban/storage.rs
@@ -4,8 +4,8 @@
 //! our LedgerStateManager.
 
 #[cfg(test)]
-use stellar_xdr::curr::ContractDataEntry;
-use stellar_xdr::curr::{
+use stellar_xdr::ContractDataEntry;
+use stellar_xdr::{
     ContractDataDurability, Hash, LedgerKey, LedgerKeyContractData, ScAddress, ScVal,
 };
 
@@ -76,7 +76,7 @@ impl StorageEntry {
     /// Convert to a ContractDataEntry.
     pub fn to_contract_data_entry(&self) -> ContractDataEntry {
         ContractDataEntry {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             contract: self.key.contract.clone(),
             key: self.key.key.clone(),
             durability: self.key.durability,
@@ -255,7 +255,7 @@ impl Footprint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{ContractId, LedgerKeyContractCode};
+    use stellar_xdr::{ContractId, LedgerKeyContractCode};
 
     fn make_contract_address(seed: u8) -> ScAddress {
         ScAddress::Contract(ContractId(Hash([seed; 32])))
@@ -494,7 +494,7 @@ mod tests {
             ContractDataDurability::Persistent,
         );
         // Use a simple ScVal type
-        let value = ScVal::I128(stellar_xdr::curr::Int128Parts { hi: 0, lo: 42 });
+        let value = ScVal::I128(stellar_xdr::Int128Parts { hi: 0, lo: 42 });
         let entry = StorageEntry::new(key, value.clone(), 5000);
 
         let contract_data = entry.to_contract_data_entry();

--- a/crates/tx/src/soroban/ttl.rs
+++ b/crates/tx/src/soroban/ttl.rs
@@ -35,16 +35,16 @@ pub fn restore_ttl_target(ledger_seq: u32, min_persistent_ttl: u32) -> u32 {
 /// data/code key hash and the restore target TTL at the time of restoration.
 #[must_use]
 pub(crate) fn synthesize_ttl_entry(
-    key_hash: stellar_xdr::curr::Hash,
+    key_hash: stellar_xdr::Hash,
     live_until_ledger_seq: u32,
-) -> stellar_xdr::curr::LedgerEntry {
-    stellar_xdr::curr::LedgerEntry {
+) -> stellar_xdr::LedgerEntry {
+    stellar_xdr::LedgerEntry {
         last_modified_ledger_seq: 0,
-        data: stellar_xdr::curr::LedgerEntryData::Ttl(stellar_xdr::curr::TtlEntry {
+        data: stellar_xdr::LedgerEntryData::Ttl(stellar_xdr::TtlEntry {
             key_hash,
             live_until_ledger_seq,
         }),
-        ext: stellar_xdr::curr::LedgerEntryExt::V0,
+        ext: stellar_xdr::LedgerEntryExt::V0,
     }
 }
 

--- a/crates/tx/src/state/entries.rs
+++ b/crates/tx/src/state/entries.rs
@@ -216,9 +216,9 @@ impl LedgerStateManager {
                     last_modified_ledger_seq: last_modified,
                     data: other,
                     ext: if has_sponsorship_ext {
-                        LedgerEntryExt::V1(stellar_xdr::curr::LedgerEntryExtensionV1 {
+                        LedgerEntryExt::V1(stellar_xdr::LedgerEntryExtensionV1 {
                             sponsoring_id: SponsorshipDescriptor(sponsor),
-                            ext: stellar_xdr::curr::LedgerEntryExtensionV1Ext::V0,
+                            ext: stellar_xdr::LedgerEntryExtensionV1Ext::V0,
                         })
                     } else {
                         LedgerEntryExt::V0

--- a/crates/tx/src/state/mod.rs
+++ b/crates/tx/src/state/mod.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext,
     AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountEntryExtensionV3, AccountId, Asset,
     ClaimableBalanceEntry, ClaimableBalanceId, ContractCodeEntry, ContractDataDurability,
@@ -1630,7 +1630,7 @@ impl LedgerStateManager {
 // ==================== Helper Functions ====================
 
 /// Convert a String64 data name to a String.
-fn data_name_to_string(name: &stellar_xdr::curr::String64) -> String {
+fn data_name_to_string(name: &stellar_xdr::String64) -> String {
     String::from_utf8_lossy(name.as_vec()).to_string()
 }
 
@@ -1758,7 +1758,7 @@ mod tests {
     use super::*;
     use crate::test_utils::create_test_account_id;
     use henyey_common::LIQUIDITY_POOL_FEE_V18;
-    use stellar_xdr::curr::*;
+    use stellar_xdr::*;
 
     /// Create a LedgerStateManager with a shared OfferStore pre-configured.
     fn new_manager_with_offers(base_reserve: i64, ledger_seq: u32) -> LedgerStateManager {
@@ -3661,7 +3661,7 @@ mod tests {
     /// (lower) TTL and compute higher rent fees.
     #[test]
     fn test_flush_ro_ttl_bumps_for_write_footprint() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             ContractDataDurability, LedgerKey, LedgerKeyContractData, ScAddress, ScVal,
         };
 
@@ -3711,7 +3711,7 @@ mod tests {
         // mechanism: create a real ContractData key, compute its actual hash,
         // and set up state accordingly.
         let contract_key = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash([99; 32]))),
+            contract: ScAddress::Contract(stellar_xdr::ContractId(Hash([99; 32]))),
             key: ScVal::Bool(true),
             durability: ContractDataDurability::Persistent,
         });
@@ -3719,11 +3719,9 @@ mod tests {
         // Compute the actual hash this key produces
         let actual_hash = {
             use sha2::{Digest, Sha256};
-            use stellar_xdr::curr::WriteXdr;
+            use stellar_xdr::WriteXdr;
             let mut hasher = Sha256::new();
-            let bytes = contract_key
-                .to_xdr(stellar_xdr::curr::Limits::none())
-                .unwrap();
+            let bytes = contract_key.to_xdr(stellar_xdr::Limits::none()).unwrap();
             hasher.update(&bytes);
             let result: [u8; 32] = hasher.finalize().into();
             Hash(result)
@@ -3780,7 +3778,7 @@ mod tests {
 
         // Flush with a non-Soroban key (Account)
         let account_key = LedgerKey::Account(LedgerKeyAccount {
-            account_id: AccountId(PublicKey::PublicKeyTypeEd25519(stellar_xdr::curr::Uint256(
+            account_id: AccountId(PublicKey::PublicKeyTypeEd25519(stellar_xdr::Uint256(
                 [1; 32],
             ))),
         });

--- a/crates/tx/src/state/offer_index.rs
+++ b/crates/tx/src/state/offer_index.rs
@@ -296,7 +296,7 @@ impl OfferIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountId, AlphaNum4, Asset, AssetCode4, OfferEntry, OfferEntryExt, Price, PublicKey,
         Uint256,
     };

--- a/crates/tx/src/state/offer_store.rs
+++ b/crates/tx/src/state/offer_store.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::offer_index::{OfferIndex, OfferKey};
 use super::{asset_to_trustline_asset, TrustlineKey};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, Asset, LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerEntryExtensionV1,
     LedgerEntryExtensionV1Ext, OfferEntry, SponsorshipDescriptor,
 };

--- a/crates/tx/src/state/signers.rs
+++ b/crates/tx/src/state/signers.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering;
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1Ext, AccountId, Signer, SignerKey,
     SponsorshipDescriptor, VecM,
 };
@@ -322,7 +322,7 @@ fn index_out_of_bounds(index: usize, len: usize) -> TxError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntryExtensionV1, AccountEntryExtensionV2, AccountEntryExtensionV2Ext, Liabilities,
         PublicKey, SignerKeyEd25519SignedPayload, String32, Thresholds, Uint256,
     };
@@ -331,7 +331,7 @@ mod tests {
         AccountEntry {
             account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([1; 32]))),
             balance: 100,
-            seq_num: stellar_xdr::curr::SequenceNumber(1),
+            seq_num: stellar_xdr::SequenceNumber(1),
             num_sub_entries: signers.len() as u32,
             inflation_dest: None,
             flags: 0,

--- a/crates/tx/src/state/sponsorship.rs
+++ b/crates/tx/src/state/sponsorship.rs
@@ -617,8 +617,7 @@ impl LedgerStateManager {
         }
 
         // Create the pre-auth TX signer key from the transaction hash
-        let signer_key =
-            stellar_xdr::curr::SignerKey::PreAuthTx(stellar_xdr::curr::Uint256(tx_hash.0));
+        let signer_key = stellar_xdr::SignerKey::PreAuthTx(stellar_xdr::Uint256(tx_hash.0));
 
         // Remove from each source account
         for account_id in source_accounts {
@@ -644,7 +643,7 @@ impl LedgerStateManager {
     pub fn remove_account_signer(
         &mut self,
         account_id: &AccountId,
-        signer_key: &stellar_xdr::curr::SignerKey,
+        signer_key: &stellar_xdr::SignerKey,
     ) -> Result<bool> {
         // ── Phase 1: Validate (fallible, no observable mutations) ────────
 
@@ -785,7 +784,7 @@ fn check_num_sponsoring_overflow(account: &AccountEntry, delta: i64) -> Result<(
 mod tests {
     use super::*;
     use crate::test_utils::{create_test_account_id, create_test_account_with_sponsorship};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntryExt, AccountEntryExtensionV1Ext, Signer, SignerKey, SponsorshipDescriptor,
         Uint256,
     };
@@ -1298,9 +1297,9 @@ mod tests {
         let mut state = LedgerStateManager::new(5_000_000, 100);
         let mut hash = [0u8; 32];
         hash[0] = 99;
-        let key = LedgerKey::ClaimableBalance(stellar_xdr::curr::LedgerKeyClaimableBalance {
-            balance_id: stellar_xdr::curr::ClaimableBalanceId::ClaimableBalanceIdTypeV0(
-                stellar_xdr::curr::Hash(hash),
+        let key = LedgerKey::ClaimableBalance(stellar_xdr::LedgerKeyClaimableBalance {
+            balance_id: stellar_xdr::ClaimableBalanceId::ClaimableBalanceIdTypeV0(
+                stellar_xdr::Hash(hash),
             ),
         });
         // No sponsor set for this key
@@ -1336,9 +1335,9 @@ mod tests {
         ));
 
         // Use a trustline key (a subentry type that requires num_sub_entries check)
-        let key = LedgerKey::Trustline(stellar_xdr::curr::LedgerKeyTrustLine {
+        let key = LedgerKey::Trustline(stellar_xdr::LedgerKeyTrustLine {
             account_id: owner_id.clone(),
-            asset: stellar_xdr::curr::TrustLineAsset::Native,
+            asset: stellar_xdr::TrustLineAsset::Native,
         });
         state.set_entry_sponsor(key.clone(), sponsor_id.clone());
 
@@ -1359,22 +1358,20 @@ mod tests {
 
     /// Helper: build a trustline ledger key for tests.
     fn trustline_key(owner: &AccountId, asset_seed: u8) -> LedgerKey {
-        LedgerKey::Trustline(stellar_xdr::curr::LedgerKeyTrustLine {
+        LedgerKey::Trustline(stellar_xdr::LedgerKeyTrustLine {
             account_id: owner.clone(),
-            asset: stellar_xdr::curr::TrustLineAsset::CreditAlphanum4(
-                stellar_xdr::curr::AlphaNum4 {
-                    asset_code: stellar_xdr::curr::AssetCode4([asset_seed, 0, 0, 0]),
-                    issuer: create_test_account_id(200),
-                },
-            ),
+            asset: stellar_xdr::TrustLineAsset::CreditAlphanum4(stellar_xdr::AlphaNum4 {
+                asset_code: stellar_xdr::AssetCode4([asset_seed, 0, 0, 0]),
+                issuer: create_test_account_id(200),
+            }),
         })
     }
 
     /// Helper: build a claimable balance ledger key for tests.
     fn cb_key(seed: u8) -> LedgerKey {
-        LedgerKey::ClaimableBalance(stellar_xdr::curr::LedgerKeyClaimableBalance {
-            balance_id: stellar_xdr::curr::ClaimableBalanceId::ClaimableBalanceIdTypeV0(
-                stellar_xdr::curr::Hash([seed; 32]),
+        LedgerKey::ClaimableBalance(stellar_xdr::LedgerKeyClaimableBalance {
+            balance_id: stellar_xdr::ClaimableBalanceId::ClaimableBalanceIdTypeV0(
+                stellar_xdr::Hash([seed; 32]),
             ),
         })
     }
@@ -1946,7 +1943,7 @@ mod tests {
     /// Post-fix: completes successfully, clears metadata, decrements all counts.
     #[test]
     fn test_l62759194_replay_subentry_removal_uses_phase1_sponsor_snapshot() {
-        use stellar_xdr::curr::{LedgerKeyOffer, OfferEntry, OfferEntryExt, Price};
+        use stellar_xdr::{LedgerKeyOffer, OfferEntry, OfferEntryExt, Price};
 
         let mut state = LedgerStateManager::new(5_000_000, 100);
 
@@ -2094,7 +2091,7 @@ mod tests {
     /// the Phase-1 captured sponsor snapshot.
     #[test]
     fn test_remove_sponsored_claimable_balance_uses_phase1_sponsor_snapshot() {
-        use stellar_xdr::curr::{ClaimableBalanceId, Hash, LedgerKeyClaimableBalance};
+        use stellar_xdr::{ClaimableBalanceId, Hash, LedgerKeyClaimableBalance};
 
         let mut state = LedgerStateManager::new(5_000_000, 100);
         let sponsor_id = create_test_account_id(240);
@@ -2131,7 +2128,7 @@ mod tests {
     /// must use the Phase-1 captured sponsor snapshot.
     #[test]
     fn test_remove_entry_sponsorship_and_update_counts_uses_phase1_sponsor_snapshot() {
-        use stellar_xdr::curr::{LedgerKeyOffer, OfferEntry, OfferEntryExt, Price};
+        use stellar_xdr::{LedgerKeyOffer, OfferEntry, OfferEntryExt, Price};
 
         let mut state = LedgerStateManager::new(5_000_000, 100);
 

--- a/crates/tx/src/test_utils.rs
+++ b/crates/tx/src/test_utils.rs
@@ -4,7 +4,7 @@
 //! and TestUtils patterns. It consolidates test utilities that were previously
 //! duplicated across individual operation test modules.
 
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext,
     AccountEntryExtensionV2, AccountEntryExtensionV2Ext, AccountFlags, AccountId, AlphaNum4, Asset,
     AssetCode4, Liabilities, PublicKey, SequenceNumber, String32, Thresholds, TrustLineAsset,
@@ -291,18 +291,18 @@ pub fn create_test_context_with_protocol(protocol_version: u32) -> LedgerContext
 
 /// Assert that an operation result is OpTooManySubentries.
 #[track_caller]
-pub fn assert_too_many_subentries(result: &stellar_xdr::curr::OperationResult) {
+pub fn assert_too_many_subentries(result: &stellar_xdr::OperationResult) {
     match result {
-        stellar_xdr::curr::OperationResult::OpTooManySubentries => {}
+        stellar_xdr::OperationResult::OpTooManySubentries => {}
         other => panic!("expected OpTooManySubentries, got {:?}", other),
     }
 }
 
 /// Assert that an operation result is OpTooManySponsoring.
 #[track_caller]
-pub fn assert_too_many_sponsoring(result: &stellar_xdr::curr::OperationResult) {
+pub fn assert_too_many_sponsoring(result: &stellar_xdr::OperationResult) {
     match result {
-        stellar_xdr::curr::OperationResult::OpTooManySponsoring => {}
+        stellar_xdr::OperationResult::OpTooManySponsoring => {}
         other => panic!("expected OpTooManySponsoring, got {:?}", other),
     }
 }

--- a/crates/tx/src/tx_set_xdr.rs
+++ b/crates/tx/src/tx_set_xdr.rs
@@ -9,7 +9,7 @@
 //! construction should carry an `// Intentionally invalid` comment and exist
 //! only in tests verifying validation of malformed inputs.
 
-use stellar_xdr::curr::{ParallelTxExecutionStage, ParallelTxsComponent, TransactionPhase, VecM};
+use stellar_xdr::{ParallelTxExecutionStage, ParallelTxsComponent, TransactionPhase, VecM};
 
 /// Construct a `ParallelTxsComponent` enforcing the base-fee/empty-stages
 /// invariant (stellar-core `parallelPhaseToXdr()`, TxSetFrame.cpp:286-300).
@@ -78,7 +78,7 @@ pub fn soroban_phase_with_stages(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stellar_xdr::curr::{DependentTxCluster, ParallelTxExecutionStage, TransactionEnvelope};
+    use stellar_xdr::{DependentTxCluster, ParallelTxExecutionStage, TransactionEnvelope};
 
     fn make_dummy_stages() -> VecM<ParallelTxExecutionStage> {
         // A minimal non-empty execution_stages: one stage with one cluster

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -40,7 +40,7 @@
 
 use henyey_common::{asset::is_asset_valid, Hash256, NetworkId};
 use henyey_crypto::{PublicKey, Signature};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountEntry, DecoratedSignature, Limits, OperationBody, Preconditions, SignerKey,
     TransactionEnvelope, WriteXdr,
 };
@@ -83,9 +83,9 @@ fn check_xdr_depth(frame: &TransactionFrame) -> std::result::Result<(), PreSeqNu
 ///
 /// - `DepthLimitExceeded` → includes the configured limit value.
 /// - Any other XDR error → preserves the underlying error text.
-fn format_xdr_depth_error(err: stellar_xdr::curr::Error) -> PreSeqNumError {
+fn format_xdr_depth_error(err: stellar_xdr::Error) -> PreSeqNumError {
     match err {
-        stellar_xdr::curr::Error::DepthLimitExceeded => PreSeqNumError::Malformed(format!(
+        stellar_xdr::Error::DepthLimitExceeded => PreSeqNumError::Malformed(format!(
             "XDR depth limit exceeded (limit: {XDR_DEPTH_LIMIT})"
         )),
         other => PreSeqNumError::Malformed(format!("XDR depth check failed: {other}")),
@@ -244,7 +244,7 @@ impl LedgerContext {
     /// Whether liquidity pool trading is disabled by the ledger header flags.
     /// Mirrors stellar-core's `isPoolTradingDisabled()`.
     pub fn is_pool_trading_disabled(&self) -> bool {
-        use stellar_xdr::curr::LedgerHeaderFlags;
+        use stellar_xdr::LedgerHeaderFlags;
         self.ledger_flags & (LedgerHeaderFlags::TradingFlag as u32) != 0
     }
 }
@@ -654,7 +654,7 @@ fn validate_soroban_resources(
     }
 
     let footprint = &data.resources.footprint;
-    if let stellar_xdr::curr::SorobanTransactionDataExt::V1(resource_ext) = &data.ext {
+    if let stellar_xdr::SorobanTransactionDataExt::V1(resource_ext) = &data.ext {
         let mut prev: Option<u32> = None;
         for index in resource_ext.archived_soroban_entries.iter() {
             if let Some(prev_index) = prev {
@@ -697,10 +697,10 @@ fn validate_soroban_resources(
             // Valid: Account, Trustline, ContractData, ContractCode.
             // Invalid: Offer, Data, ClaimableBalance, LiquidityPool, ConfigSetting, Ttl.
             match key {
-                stellar_xdr::curr::LedgerKey::Account(_)
-                | stellar_xdr::curr::LedgerKey::Trustline(_)
-                | stellar_xdr::curr::LedgerKey::ContractData(_)
-                | stellar_xdr::curr::LedgerKey::ContractCode(_) => {}
+                stellar_xdr::LedgerKey::Account(_)
+                | stellar_xdr::LedgerKey::Trustline(_)
+                | stellar_xdr::LedgerKey::ContractData(_)
+                | stellar_xdr::LedgerKey::ContractCode(_) => {}
                 _ => {
                     return Err(ValidationError::InvalidStructure(
                         "unsupported ledger key type in Soroban footprint".to_string(),
@@ -829,7 +829,7 @@ fn available_balance_for_fee(
     base_reserve: u32,
     protocol_version: u32,
 ) -> i64 {
-    use stellar_xdr::curr::{AccountEntryExt, AccountEntryExtensionV1Ext};
+    use stellar_xdr::{AccountEntryExt, AccountEntryExtensionV1Ext};
 
     // minBalance = (2 + numSubEntries + numSponsoring − numSponsored) * base_reserve,
     // matching stellar-core `getMinBalance` / `henyey_ledger::fees::minimum_balance`.
@@ -946,7 +946,7 @@ fn fee_bump_inner_hash(
 ) -> std::result::Result<Hash256, String> {
     match frame.envelope() {
         TransactionEnvelope::TxFeeBump(env) => match &env.tx.inner_tx {
-            stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => {
                 let inner_env = TransactionEnvelope::Tx(inner.clone());
                 let inner_frame = TransactionFrame::from_owned_with_network(inner_env, *network_id);
                 inner_frame
@@ -991,10 +991,7 @@ fn has_ed25519_signature(
         .any(|sig| verify_signature_with_key(tx_hash, sig, pk))
 }
 
-fn has_hashx_signature(
-    signatures: &[DecoratedSignature],
-    key: &stellar_xdr::curr::Uint256,
-) -> bool {
+fn has_hashx_signature(signatures: &[DecoratedSignature], key: &stellar_xdr::Uint256) -> bool {
     signatures.iter().any(|sig| {
         // No length restriction on HashX preimages — stellar-core accepts any
         // length allowed by XDR and checks only sha256(preimage) == key.
@@ -1010,7 +1007,7 @@ fn has_hashx_signature(
 fn has_signed_payload_signature(
     _tx_hash: &Hash256,
     signatures: &[DecoratedSignature],
-    signed_payload: &stellar_xdr::curr::SignerKeyEd25519SignedPayload,
+    signed_payload: &stellar_xdr::SignerKeyEd25519SignedPayload,
 ) -> bool {
     signatures
         .iter()
@@ -1072,8 +1069,8 @@ pub enum PreSeqNumError {
 
 impl PreSeqNumError {
     /// Map to the corresponding `TransactionResultCode`.
-    pub fn to_tx_result_code(&self) -> stellar_xdr::curr::TransactionResultCode {
-        use stellar_xdr::curr::TransactionResultCode;
+    pub fn to_tx_result_code(&self) -> stellar_xdr::TransactionResultCode {
+        use stellar_xdr::TransactionResultCode;
         match self {
             Self::MissingOperation => TransactionResultCode::TxMissingOperation,
             Self::Malformed(_) => TransactionResultCode::TxMalformed,
@@ -1136,10 +1133,7 @@ pub fn check_valid_pre_seq_num_with_config(
     // (stellar-core: TransactionFrame.cpp commonValidPreSeqNum rejects
     // ENVELOPE_TYPE_TX_V0 with txNOT_SUPPORTED for protocol >= 13)
     if protocol_version >= 13 {
-        if matches!(
-            frame.envelope(),
-            stellar_xdr::curr::TransactionEnvelope::TxV0(_)
-        ) {
+        if matches!(frame.envelope(), stellar_xdr::TransactionEnvelope::TxV0(_)) {
             return Err(PreSeqNumError::OpNotSupported);
         }
     }
@@ -1268,7 +1262,7 @@ pub fn check_valid_pre_seq_num_with_config(
                         // 4e-i. WASM size gate
                         // stellar-core: InvokeHostFunctionOpFrame.cpp:1290-1299
                         if let Some(max_size) = soroban_limits.map(|l| l.max_contract_size_bytes) {
-                            if let stellar_xdr::curr::HostFunction::UploadContractWasm(wasm) =
+                            if let stellar_xdr::HostFunction::UploadContractWasm(wasm) =
                                 &invoke.host_function
                             {
                                 if wasm.len() > max_size as usize {
@@ -1282,10 +1276,10 @@ pub fn check_valid_pre_seq_num_with_config(
                         }
                         // 4e-ii. CreateContract fromAsset: validate asset code
                         // stellar-core: InvokeHostFunctionOpFrame.cpp:1301-1309
-                        if let stellar_xdr::curr::HostFunction::CreateContract(args) =
+                        if let stellar_xdr::HostFunction::CreateContract(args) =
                             &invoke.host_function
                         {
-                            if let stellar_xdr::curr::ContractIdPreimage::Asset(asset) =
+                            if let stellar_xdr::ContractIdPreimage::Asset(asset) =
                                 &args.contract_id_preimage
                             {
                                 if !is_asset_valid(asset, protocol_version) {
@@ -1312,7 +1306,7 @@ pub fn check_valid_pre_seq_num_with_config(
         // so fee-bump-wrapped classic txs with V1 extensions are correctly rejected.
         if protocol_version >= 21 {
             if let Some(tx) = frame.inner_tx() {
-                if tx.ext != stellar_xdr::curr::TransactionExt::V0 {
+                if tx.ext != stellar_xdr::TransactionExt::V0 {
                     return Err(PreSeqNumError::Malformed(
                         "classic transaction must not carry extension data".to_string(),
                     ));
@@ -1422,7 +1416,7 @@ fn check_soroban_resource_limits(
 
     // 8. Archived entry extension validation (protocol version check)
     // Parity: stellar-core TransactionFrame.cpp:990-1041
-    if let stellar_xdr::curr::SorobanTransactionDataExt::V1(_) = &data.ext {
+    if let stellar_xdr::SorobanTransactionDataExt::V1(_) = &data.ext {
         if protocol_version < 23 {
             return Err(PreSeqNumError::SorobanInvalid(
                 "SorobanResourcesExtV0 not supported before protocol 23".to_string(),
@@ -1440,8 +1434,8 @@ fn check_soroban_resource_limits(
 /// For other ops, only classic (non-Soroban) entries plus archived Soroban
 /// entries require disk reads.
 fn get_num_disk_read_entries(
-    resources: &stellar_xdr::curr::SorobanResources,
-    ext: &stellar_xdr::curr::SorobanTransactionDataExt,
+    resources: &stellar_xdr::SorobanResources,
+    ext: &stellar_xdr::SorobanTransactionDataExt,
     frame: &TransactionFrame,
 ) -> u64 {
     let is_restore = frame
@@ -1467,7 +1461,7 @@ fn get_num_disk_read_entries(
     }
 
     // Add archived Soroban entries (on-disk by definition)
-    if let stellar_xdr::curr::SorobanTransactionDataExt::V1(resource_ext) = ext {
+    if let stellar_xdr::SorobanTransactionDataExt::V1(resource_ext) = ext {
         count += resource_ext.archived_soroban_entries.len() as u64;
     }
 
@@ -1478,18 +1472,18 @@ fn get_num_disk_read_entries(
 ///
 /// Parity: stellar-core `footprintKeyIsValid` lambda (TransactionFrame.cpp:916-962).
 fn validate_footprint_key(
-    key: &stellar_xdr::curr::LedgerKey,
+    key: &stellar_xdr::LedgerKey,
     protocol_version: u32,
     limits: &SorobanResourceLimits,
 ) -> std::result::Result<(), PreSeqNumError> {
     match key {
-        stellar_xdr::curr::LedgerKey::Account(_)
-        | stellar_xdr::curr::LedgerKey::ContractData(_)
-        | stellar_xdr::curr::LedgerKey::ContractCode(_) => {}
-        stellar_xdr::curr::LedgerKey::Trustline(tl) => {
+        stellar_xdr::LedgerKey::Account(_)
+        | stellar_xdr::LedgerKey::ContractData(_)
+        | stellar_xdr::LedgerKey::ContractCode(_) => {}
+        stellar_xdr::LedgerKey::Trustline(tl) => {
             // stellar-core: reject native, self-issued, and invalid trustline assets
             if !henyey_common::asset::is_trustline_asset_valid(&tl.asset, protocol_version)
-                || matches!(tl.asset, stellar_xdr::curr::TrustLineAsset::Native)
+                || matches!(tl.asset, stellar_xdr::TrustLineAsset::Native)
                 || henyey_common::asset::is_trustline_asset_issuer(&tl.account_id, &tl.asset)
             {
                 return Err(PreSeqNumError::SorobanInvalid(
@@ -1520,7 +1514,7 @@ fn validate_footprint_key(
 mod tests {
     use super::*;
     use henyey_crypto::{sign_hash, SecretKey};
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         AccountEntry, AccountEntryExt, AccountId, Asset, ContractDataDurability, ContractId,
         DecoratedSignature, Duration, Hash, HostFunction, InvokeContractArgs, InvokeHostFunctionOp,
         LedgerBounds, LedgerFootprint, LedgerKey, LedgerKeyContractData, ManageDataOp, Memo,
@@ -1741,7 +1735,7 @@ mod tests {
 
     #[test]
     fn test_validate_soroban_archived_index_out_of_bounds() {
-        let key = LedgerKey::ContractCode(stellar_xdr::curr::LedgerKeyContractCode {
+        let key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
             hash: Hash([3u8; 32]),
         });
         let envelope = create_soroban_envelope(vec![key], Some(vec![1]), true);
@@ -2004,7 +1998,7 @@ mod tests {
     /// After the fix it PASSES because available balance < fee.
     #[test]
     fn test_validate_full_rejects_insufficient_available_balance() {
-        use stellar_xdr::curr::{AccountEntryExtensionV1, AccountEntryExtensionV1Ext, Liabilities};
+        use stellar_xdr::{AccountEntryExtensionV1, AccountEntryExtensionV1Ext, Liabilities};
 
         let secret = SecretKey::from_seed(&[42u8; 32]);
         let account_id: AccountId = (&secret.public_key()).into();
@@ -2067,7 +2061,7 @@ mod tests {
     /// fee, `validate_full` must NOT push `InsufficientBalance`.
     #[test]
     fn test_validate_full_accepts_sufficient_available_balance() {
-        use stellar_xdr::curr::{AccountEntryExtensionV1, AccountEntryExtensionV1Ext, Liabilities};
+        use stellar_xdr::{AccountEntryExtensionV1, AccountEntryExtensionV1Ext, Liabilities};
 
         let secret = SecretKey::from_seed(&[43u8; 32]);
         let account_id: AccountId = (&secret.public_key()).into();
@@ -2124,9 +2118,7 @@ mod tests {
         // Build a deeply nested ScVal to exceed the 500-depth XDR limit.
         let mut val = ScVal::U32(42);
         for _ in 0..501 {
-            val = ScVal::Vec(Some(stellar_xdr::curr::ScVec(
-                vec![val].try_into().unwrap(),
-            )));
+            val = ScVal::Vec(Some(stellar_xdr::ScVec(vec![val].try_into().unwrap())));
         }
 
         let source = MuxedAccount::Ed25519(Uint256([1u8; 32]));
@@ -3091,11 +3083,10 @@ mod tests {
     fn test_check_valid_pre_seq_num_empty_signed_payload_extra_signer() {
         let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));
         let dest = MuxedAccount::Ed25519(Uint256([1u8; 32]));
-        let signer =
-            SignerKey::Ed25519SignedPayload(stellar_xdr::curr::SignerKeyEd25519SignedPayload {
-                ed25519: Uint256([42u8; 32]),
-                payload: vec![].try_into().unwrap(),
-            });
+        let signer = SignerKey::Ed25519SignedPayload(stellar_xdr::SignerKeyEd25519SignedPayload {
+            ed25519: Uint256([42u8; 32]),
+            payload: vec![].try_into().unwrap(),
+        });
         let tx = Transaction {
             source_account: source,
             fee: 100,
@@ -3216,7 +3207,7 @@ mod tests {
         // Regression for #2059: a fee-bump envelope wrapping a classic inner tx
         // with TransactionExt::V1 must also be rejected on p21+, matching
         // stellar-core's inner-tx revalidation in FeeBumpTransactionFrame.cpp:307-309.
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -3285,7 +3276,7 @@ mod tests {
     fn test_check_valid_pre_seq_num_soroban_duplicate_footprint_key() {
         let source = MuxedAccount::Ed25519(Uint256([0u8; 32]));
         let dup_key = LedgerKey::ContractData(LedgerKeyContractData {
-            contract: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash([99u8; 32]))),
+            contract: ScAddress::Contract(stellar_xdr::ContractId(Hash([99u8; 32]))),
             key: ScVal::Symbol(ScSymbol("test".try_into().unwrap())),
             durability: ContractDataDurability::Persistent,
         });
@@ -3312,7 +3303,7 @@ mod tests {
                 source_account: None,
                 body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
                     host_function: HostFunction::InvokeContract(InvokeContractArgs {
-                        contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash(
+                        contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash(
                             [1u8; 32],
                         ))),
                         function_name: ScSymbol("test".try_into().unwrap()),
@@ -3341,7 +3332,7 @@ mod tests {
     #[test]
     fn test_audit_074_hashx_extra_signer_non_32_byte_preimage() {
         use henyey_common::Hash256;
-        use stellar_xdr::curr::{DecoratedSignature, Signature, SignatureHint, Uint256};
+        use stellar_xdr::{DecoratedSignature, Signature, SignatureHint, Uint256};
 
         // 5-byte preimage "hello"
         let preimage = b"hello";
@@ -3390,7 +3381,7 @@ mod tests {
         // Regression: check_valid_pre_seq_num must validate ops against the inner
         // tx source, not the outer fee source. A payment from inner→dest is valid
         // when the inner source differs from the outer fee source.
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -3463,7 +3454,7 @@ mod tests {
     /// in the apply path and produce txFAILED with per-op results.
     #[test]
     fn test_pre_seq_num_does_not_reject_malformed_classic_ops() {
-        use stellar_xdr::curr::*;
+        use stellar_xdr::*;
 
         let source_key = Uint256([1u8; 32]);
         // ManageBuyOffer with same selling/buying asset: structurally invalid
@@ -3603,7 +3594,7 @@ mod tests {
     /// Fee-bump wrapping a Soroban inner tx with zero outer inclusion fee → rejected.
     #[test]
     fn test_validate_fee_fee_bump_soroban_zero_inclusion_fee() {
-        use stellar_xdr::curr::{
+        use stellar_xdr::{
             FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
             FeeBumpTransactionInnerTx,
         };
@@ -3946,7 +3937,7 @@ mod tests {
 
     #[test]
     fn test_validate_footprint_key_unsupported_type() {
-        use stellar_xdr::curr::LedgerKeyOffer;
+        use stellar_xdr::LedgerKeyOffer;
         let key = LedgerKey::Offer(LedgerKeyOffer {
             seller_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
             offer_id: 1,
@@ -3961,7 +3952,7 @@ mod tests {
         let limits = permissive_limits();
 
         // Account key
-        let acct = LedgerKey::Account(stellar_xdr::curr::LedgerKeyAccount {
+        let acct = LedgerKey::Account(stellar_xdr::LedgerKeyAccount {
             account_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]))),
         });
         assert!(validate_footprint_key(&acct, 23, &limits).is_ok());
@@ -3986,7 +3977,7 @@ mod tests {
 
     #[test]
     fn test_validate_footprint_key_trustline_native_rejected() {
-        use stellar_xdr::curr::{LedgerKeyTrustLine, TrustLineAsset};
+        use stellar_xdr::{LedgerKeyTrustLine, TrustLineAsset};
         let key = LedgerKey::Trustline(LedgerKeyTrustLine {
             account_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]))),
             asset: TrustLineAsset::Native,
@@ -3997,7 +3988,7 @@ mod tests {
 
     #[test]
     fn test_validate_footprint_key_trustline_self_issued_rejected() {
-        use stellar_xdr::curr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine, TrustLineAsset};
+        use stellar_xdr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine, TrustLineAsset};
         let issuer_bytes = [7u8; 32];
         let key = LedgerKey::Trustline(LedgerKeyTrustLine {
             account_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(Uint256(issuer_bytes))),
@@ -4012,7 +4003,7 @@ mod tests {
 
     #[test]
     fn test_validate_footprint_key_trustline_valid() {
-        use stellar_xdr::curr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine, TrustLineAsset};
+        use stellar_xdr::{AlphaNum4, AssetCode4, LedgerKeyTrustLine, TrustLineAsset};
         let key = LedgerKey::Trustline(LedgerKeyTrustLine {
             account_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([1u8; 32]))),
             asset: TrustLineAsset::CreditAlphanum4(AlphaNum4 {
@@ -4026,7 +4017,7 @@ mod tests {
 
     #[test]
     fn test_get_num_disk_read_entries_restore_footprint() {
-        use stellar_xdr::curr::RestoreFootprintOp;
+        use stellar_xdr::RestoreFootprintOp;
         let rw = vec![
             contract_data_key(1),
             contract_data_key(2),
@@ -4040,7 +4031,7 @@ mod tests {
             rw,
             SorobanTransactionDataExt::V0,
             OperationBody::RestoreFootprint(RestoreFootprintOp {
-                ext: stellar_xdr::curr::ExtensionPoint::V0,
+                ext: stellar_xdr::ExtensionPoint::V0,
             }),
         );
         let data = frame.soroban_data().unwrap();
@@ -4073,7 +4064,7 @@ mod tests {
 
     #[test]
     fn test_get_num_disk_read_entries_classic_keys_counted() {
-        use stellar_xdr::curr::LedgerKeyAccount;
+        use stellar_xdr::LedgerKeyAccount;
         // Account keys are classic (non-Soroban) → counted as disk reads at v23+
         let acct_key = LedgerKey::Account(LedgerKeyAccount {
             account_id: AccountId(XdrPublicKey::PublicKeyTypeEd25519(Uint256([5u8; 32]))),
@@ -4100,7 +4091,7 @@ mod tests {
 
     #[test]
     fn test_xdr_depth_error_message_includes_limit() {
-        let err = stellar_xdr::curr::Error::DepthLimitExceeded;
+        let err = stellar_xdr::Error::DepthLimitExceeded;
         let result = format_xdr_depth_error(err);
         assert_eq!(
             result,
@@ -4122,7 +4113,7 @@ mod tests {
 
     #[test]
     fn test_xdr_depth_error_message_preserves_non_depth_xdr_error() {
-        let err = stellar_xdr::curr::Error::LengthLimitExceeded;
+        let err = stellar_xdr::Error::LengthLimitExceeded;
         let expected_inner = format!("{err}");
         let result = format_xdr_depth_error(err);
         let msg = match &result {

--- a/crates/tx/tests/validation_parity.rs
+++ b/crates/tx/tests/validation_parity.rs
@@ -11,7 +11,7 @@ use henyey_tx::validation::{
     check_valid_pre_seq_num, check_valid_pre_seq_num_with_config, PreSeqNumError,
 };
 use henyey_tx::{validate_operation, TransactionFrame};
-use stellar_xdr::curr::{
+use stellar_xdr::{
     AccountId, AlphaNum4, Asset, AssetCode4, ClawbackOp, ContractDataDurability, ContractId,
     ContractIdPreimage, CreateContractArgs, ExtendFootprintTtlOp, FeeBumpTransaction,
     FeeBumpTransactionEnvelope, FeeBumpTransactionExt, FeeBumpTransactionInnerTx, Hash,
@@ -71,10 +71,10 @@ fn make_soroban_frame(
 /// Build a minimal InvokeHostFunction operation body (invoke contract no-op).
 fn invoke_host_noop() -> OperationBody {
     OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-        host_function: HostFunction::InvokeContract(stellar_xdr::curr::InvokeContractArgs {
+        host_function: HostFunction::InvokeContract(stellar_xdr::InvokeContractArgs {
             contract_address: ScAddress::Contract(ContractId(Hash([9u8; 32]))),
-            function_name: stellar_xdr::curr::ScSymbol(
-                stellar_xdr::curr::StringM::<32>::try_from("noop".to_string()).unwrap(),
+            function_name: stellar_xdr::ScSymbol(
+                stellar_xdr::StringM::<32>::try_from("noop".to_string()).unwrap(),
             ),
             args: VecM::default(),
         }),
@@ -128,7 +128,7 @@ fn test_reject_restore_footprint_nonempty_readonly() {
 
     let frame = make_soroban_frame(
         OperationBody::RestoreFootprint(RestoreFootprintOp {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
         }),
         footprint,
         50,
@@ -155,7 +155,7 @@ fn test_reject_restore_footprint_non_persistent_readwrite() {
 
     let frame = make_soroban_frame(
         OperationBody::RestoreFootprint(RestoreFootprintOp {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
         }),
         footprint,
         50,
@@ -187,7 +187,7 @@ fn test_reject_extend_footprint_ttl_nonempty_readwrite() {
 
     let frame = make_soroban_frame(
         OperationBody::ExtendFootprintTtl(ExtendFootprintTtlOp {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             extend_to: 1000,
         }),
         footprint,
@@ -213,7 +213,7 @@ fn test_reject_extend_footprint_ttl_non_soroban_key() {
 
     let frame = make_soroban_frame(
         OperationBody::ExtendFootprintTtl(ExtendFootprintTtlOp {
-            ext: stellar_xdr::curr::ExtensionPoint::V0,
+            ext: stellar_xdr::ExtensionPoint::V0,
             extend_to: 1000,
         }),
         footprint,
@@ -336,7 +336,7 @@ fn test_reject_clawback_muxed_from_not_self_clawback() {
 /// Regression test for #1486 — CreateContract fromAsset with invalid asset code.
 #[test]
 fn test_reject_create_contract_from_invalid_asset() {
-    use stellar_xdr::curr::ContractExecutable;
+    use stellar_xdr::ContractExecutable;
 
     // All-zero asset code is invalid per isAssetValid
     let invalid_asset = Asset::CreditAlphanum4(AlphaNum4 {
@@ -494,19 +494,17 @@ fn make_over_depth_soroban_envelope() -> TransactionEnvelope {
     // Each ScVal::Vec layer adds XDR depth. We need >500 layers.
     let mut val = ScVal::U32(42);
     for _ in 0..501 {
-        val = ScVal::Vec(Some(stellar_xdr::curr::ScVec(
-            vec![val].try_into().unwrap(),
-        )));
+        val = ScVal::Vec(Some(stellar_xdr::ScVec(vec![val].try_into().unwrap())));
     }
 
     let source = MuxedAccount::Ed25519(Uint256([1u8; 32]));
     let op = Operation {
         source_account: None,
         body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
-            host_function: HostFunction::InvokeContract(stellar_xdr::curr::InvokeContractArgs {
+            host_function: HostFunction::InvokeContract(stellar_xdr::InvokeContractArgs {
                 contract_address: ScAddress::Contract(ContractId(Hash([9u8; 32]))),
-                function_name: stellar_xdr::curr::ScSymbol(
-                    stellar_xdr::curr::StringM::<32>::try_from("deep".to_string()).unwrap(),
+                function_name: stellar_xdr::ScSymbol(
+                    stellar_xdr::StringM::<32>::try_from("deep".to_string()).unwrap(),
                 ),
                 args: vec![val].try_into().unwrap(),
             }),
@@ -589,7 +587,7 @@ fn test_validate_basic_rejects_transaction_exceeding_xdr_depth_limit() {
 /// the XDR depth limit. Parity: stellar-core FeeBumpTransactionFrame.cpp:278.
 #[test]
 fn test_reject_fee_bump_transaction_exceeding_xdr_depth_limit() {
-    use stellar_xdr::curr::{
+    use stellar_xdr::{
         DecoratedSignature, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
         FeeBumpTransactionInnerTx, Signature, SignatureHint,
     };


### PR DESCRIPTION
Closes #3531

## Summary

stellar-xdr 27.0.0 removed the `curr` module (types now live at the crate root) and dropped the `curr`/`next` Cargo features. This PR mechanically migrates all 3849 `stellar_xdr::curr::` references across 290 files to `stellar_xdr::` (scripted literal prefix-collapse), applies 3 manual non-`::` fixups (one `use ... as xdr` alias in overlay/peer.rs + two doc comments), and bumps the workspace `stellar-xdr` dep to `=27.0.0`.

The feature set settled empirically to `["std", "serde", "serde_json", "base64"]`: `curr` is gone, and `base64` is now its own feature in 27.0.0 (no longer pulled in transitively via std/serde) — dropping it breaks `from_xdr_base64`/`to_xdr_base64`.

The bump surfaced a version skew the old code had masked: workspace XDR was 26.0.0, identical to `soroban_env_host_p26`'s pinned XDR, so the P26 host path passed workspace types straight into the host with no conversion. With workspace XDR now 27.0.0 but the P26 host still pinned to 26.0.0, the P26 path needs the same byte-level cross-version conversion the P24/P25 paths already use. Added `try_convert_cost_params_ws_to_p26` / `try_convert_ledger_entry_ws_to_p26` / `convert_diagnostic_events_p26` (XDR byte round-trips, behavior-preserving, mirroring the existing P24/P25 converters) and wired them into the P26 budget / entry-size / diagnostic-event call sites in henyey-tx and henyey-ledger.

This is the **behavior-free prerequisite** that unblocks #3526 (Enable Protocol 27). It changes zero observable behavior: a path rename, a feature-list fix, and a 1:1 extension of an existing cross-version conversion pattern.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3531#issuecomment-4763875116)

## Self-checks (post-rename)

- `git grep stellar_xdr::curr` → **0 hits**
- `git diff` actual changed `soroban_env_host` lines → **none** beyond the intentional P26 converter additions (the `soroban_env_host_pNN::xdr` re-export paths are untouched)
- `git grep stellar_xdr::next` → **0 hits**

## Test plan

- [x] `cargo fmt --all -- --check` (rename-induced rewraps applied via `cargo fmt`; only rename-adjacent lines changed)
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build --all` under `-Dwarnings` — PASS
- [x] `cargo build --all --all-targets` under `-Dwarnings` — PASS
- [x] `cargo build --profile release-ci --all` — PASS
- [x] `cargo test --workspace --all-targets` — **7446 passed, 0 failed**
- [x] `cargo test -p henyey-herder --features test-support --tests` — PASS
- [x] `cargo test --workspace --doc` — PASS
- [x] Parity tripwires all green: `ledger_close_meta_vectors` (2), `tx_meta_hash_vectors` (1), `validation_parity` (12), `scp_parity_tests` (124), `txset_mixed_equivalence` (1), `transaction_execution` (108) — meta/hash vectors byte-identical, confirming behavior-free

## Deviations from plan

- Plan started the feature list from `["serde","serde_json","base64"]` and said to settle empirically; the settled set keeps `std` (gated trait methods need it) → `["std","serde","serde_json","base64"]`.
- Plan anticipated possible "type/variant renames" requiring 1:1 fixups. The only build-surfaced non-rename work was the P26 cross-version conversion described above — a pure mechanical extension of the already-established P24/P25 byte-conversion pattern, not a semantic/protocol change. Added 2 unit tests for the new P26 converters mirroring the existing P24/P25 roundtrip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)