### PR TITLE
Enable Protocol 27: add ProtocolVersion::V27 and native p27 soroban host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 # They are referenced as workspace dependencies with version pins below.
 
 [workspace.package]
-version = "26.0.0-alpha.1"
+version = "27.0.0-alpha.1"
 edition = "2021"
 authors = ["Stellar Contributors"]
 license = "Apache-2.0"
@@ -42,10 +42,11 @@ stellar-strkey = "0.0.11"
 # submodule's recorded gitlinks for rs-soroban-env.
 # Verify alignment: bash scripts/check-soroban-pins.sh
 # When bumping the stellar-core submodule, update these revs to match:
-#   git -C stellar-core ls-tree HEAD src/rust/soroban/p24 src/rust/soroban/p25 src/rust/soroban/p26
+#   git -C stellar-core ls-tree HEAD src/rust/soroban/p24 src/rust/soroban/p25 src/rust/soroban/p26 src/rust/soroban/p27
 soroban-env-host-p24 = { package = "soroban-env-host", git = "https://github.com/stellar/rs-soroban-env", rev = "a37eeda815e626f416eff13f2eacb32a8b0c3729" }
 soroban-env-host-p25 = { package = "soroban-env-host", git = "https://github.com/stellar/rs-soroban-env", rev = "6323c1fc03ecb9f53b7c1e42fd62c1bbd3aebc2c" }
 soroban-env-host-p26 = { package = "soroban-env-host", git = "https://github.com/stellar/rs-soroban-env", rev = "b351f88a468d3b9e1d6de53d5b0ca585f6b7dadb" }
+soroban-env-host-p27 = { package = "soroban-env-host", git = "https://github.com/stellar/rs-soroban-env", rev = "b03d2563f3a08d51095a19bdbb6d90364b8ce04a" }
 
 # Workspace crates
 henyey-common = { path = "crates/common" }

--- a/crates/app/src/app/bootstrap.rs
+++ b/crates/app/src/app/bootstrap.rs
@@ -43,14 +43,15 @@ pub struct GenesisConfig {
 
 impl Default for GenesisConfig {
     fn default() -> Self {
-        // Matches stellar-core Config.cpp defaults (false / 26 / 100 /
-        // 100_000_000 / 50). With `use_config_for_genesis = false` these
-        // overrides are inert and genesis is byte-identical to the pre-change
+        // Matches stellar-core Config.cpp defaults (false / CURRENT_PROTOCOL / 100 /
+        // 100_000_000 / 50; stellar-core ties TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION
+        // to CURRENT_LEDGER_PROTOCOL_VERSION). With `use_config_for_genesis = false`
+        // these overrides are inert and genesis is byte-identical to the pre-change
         // behavior (the genesis header still uses the hardcoded 0 / 100 /
         // 100_000_000 / 100 values below).
         Self {
             use_config_for_genesis: false,
-            protocol_version: 26,
+            protocol_version: henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION,
             base_fee: 100,
             base_reserve: 100_000_000,
             max_tx_set_size: 50,

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -2185,7 +2185,8 @@ mod tests {
 
     #[test]
     fn test_use_config_for_genesis_defaults() {
-        // Absent keys ⇒ stellar-core defaults (false / 26 / 100 / 100_000_000 / 50).
+        // Absent keys ⇒ stellar-core defaults (false / CURRENT_PROTOCOL / 100 / 100_000_000 / 50).
+        // stellar-core sets TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION.
         let core_toml: toml::Value = toml::from_str(
             r#"
             NETWORK_PASSPHRASE = "Test SDF Network ; September 2015"
@@ -2194,7 +2195,10 @@ mod tests {
         .unwrap();
         let config = translate_stellar_core_config(&core_toml).unwrap();
         assert!(!config.testing.use_config_for_genesis);
-        assert_eq!(config.testing.testing_upgrade_ledger_protocol_version, 26);
+        assert_eq!(
+            config.testing.testing_upgrade_ledger_protocol_version,
+            henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION
+        );
         assert_eq!(config.testing.testing_upgrade_desired_fee, 100);
         assert_eq!(config.testing.testing_upgrade_reserve, 100_000_000);
         assert_eq!(config.testing.testing_upgrade_max_tx_set_size, 50);

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -623,8 +623,9 @@ impl Default for DiagnosticsConfig {
 /// accelerate_time = true  # 1s ledger close, checkpoint frequency 8
 /// ```
 fn default_testing_upgrade_protocol_version() -> u32 {
-    // stellar-core CURRENT_LEDGER_PROTOCOL_VERSION (Config.cpp:36).
-    26
+    // stellar-core sets TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION
+    // (Config.cpp:34/232). Mirror our CURRENT_LEDGER_PROTOCOL_VERSION (= 27).
+    henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION
 }
 
 fn default_testing_upgrade_desired_fee() -> u32 {

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -378,6 +378,28 @@ mod tests {
     }
 
     #[test]
+    fn test_protocol_version_v27_value() {
+        assert_eq!(ProtocolVersion::V27 as u32, 27);
+        assert_eq!(ProtocolVersion::V27.as_u32(), 27);
+    }
+
+    #[test]
+    fn test_current_ledger_protocol_version_is_27() {
+        assert_eq!(CURRENT_LEDGER_PROTOCOL_VERSION, 27);
+    }
+
+    #[test]
+    fn test_protocol_version_starts_from_v27() {
+        // A v27 ledger is at or after V27; a v26 ledger is before V27.
+        assert!(protocol_version_starts_from(27, ProtocolVersion::V27));
+        assert!(!protocol_version_starts_from(26, ProtocolVersion::V27));
+        assert!(protocol_version_is_before(26, ProtocolVersion::V27));
+        assert!(!protocol_version_is_before(27, ProtocolVersion::V27));
+        // V27 is strictly after V26.
+        assert!(ProtocolVersion::V27 > ProtocolVersion::V26);
+    }
+
+    #[test]
     fn test_protocol_version_starts_from() {
         assert!(!protocol_version_starts_from(19, ProtocolVersion::V20));
         assert!(protocol_version_starts_from(20, ProtocolVersion::V20));

--- a/crates/common/src/protocol.rs
+++ b/crates/common/src/protocol.rs
@@ -39,7 +39,7 @@
 
 /// Protocol version enumeration for type-safe version comparisons.
 ///
-/// This enum represents all known Stellar protocol versions from V0 to V26.
+/// This enum represents all known Stellar protocol versions from V0 to V27.
 /// It is used with the version-checking functions to enable compile-time
 /// verification of version comparisons.
 ///
@@ -77,6 +77,7 @@ pub enum ProtocolVersion {
     V24 = 24,
     V25 = 25,
     V26 = 26,
+    V27 = 27,
 }
 
 impl ProtocolVersion {
@@ -133,7 +134,7 @@ pub const MIN_LEDGER_PROTOCOL_VERSION: u32 = 24;
 ///
 /// This represents the highest protocol version that this implementation
 /// can process. Ledgers with higher versions will be rejected.
-pub const CURRENT_LEDGER_PROTOCOL_VERSION: u32 = 26;
+pub const CURRENT_LEDGER_PROTOCOL_VERSION: u32 = 27;
 
 /// The minimum supported ledger protocol version for Soroban execution.
 ///
@@ -386,6 +387,51 @@ mod tests {
     #[test]
     fn test_current_ledger_protocol_version_is_27() {
         assert_eq!(CURRENT_LEDGER_PROTOCOL_VERSION, 27);
+    }
+
+    #[test]
+    fn test_ledger_header_version_27_xdr_roundtrip() {
+        // A protocol-27 LedgerHeader must round-trip through the workspace XDR
+        // (stellar-xdr 27.0.0), confirming the toolchain recognizes ledger_version 27.
+        use stellar_xdr::{Limits, ReadXdr, WriteXdr};
+        let header = stellar_xdr::LedgerHeader {
+            ledger_version: 27,
+            previous_ledger_hash: stellar_xdr::Hash([0u8; 32]),
+            scp_value: stellar_xdr::StellarValue {
+                tx_set_hash: stellar_xdr::Hash([0u8; 32]),
+                close_time: stellar_xdr::TimePoint(0),
+                upgrades: vec![].try_into().unwrap(),
+                ext: stellar_xdr::StellarValueExt::Basic,
+            },
+            tx_set_result_hash: stellar_xdr::Hash([0u8; 32]),
+            bucket_list_hash: stellar_xdr::Hash([0u8; 32]),
+            ledger_seq: 1,
+            total_coins: 0,
+            fee_pool: 0,
+            inflation_seq: 0,
+            id_pool: 0,
+            base_fee: 100,
+            base_reserve: 5_000_000,
+            max_tx_set_size: 1000,
+            skip_list: [
+                stellar_xdr::Hash([0u8; 32]),
+                stellar_xdr::Hash([0u8; 32]),
+                stellar_xdr::Hash([0u8; 32]),
+                stellar_xdr::Hash([0u8; 32]),
+            ],
+            ext: stellar_xdr::LedgerHeaderExt::V0,
+        };
+        let bytes = header.to_xdr(Limits::none()).expect("encode v27 header");
+        let decoded =
+            stellar_xdr::LedgerHeader::from_xdr(&bytes, Limits::none()).expect("decode v27 header");
+        assert_eq!(decoded.ledger_version, 27);
+
+        // ScVal round-trip (smoke).
+        let sv = stellar_xdr::ScVal::U32(27);
+        let sv_bytes = sv.to_xdr(Limits::none()).expect("encode scval");
+        let sv_decoded =
+            stellar_xdr::ScVal::from_xdr(&sv_bytes, Limits::none()).expect("decode scval");
+        assert_eq!(sv_decoded, stellar_xdr::ScVal::U32(27));
     }
 
     #[test]

--- a/crates/ledger/Cargo.toml
+++ b/crates/ledger/Cargo.toml
@@ -15,6 +15,7 @@ henyey-tx.workspace = true
 henyey-invariant.workspace = true
 soroban-env-host-p25.workspace = true
 soroban-env-host-p26.workspace = true
+soroban-env-host-p27.workspace = true
 
 # Serialization
 serde.workspace = true

--- a/crates/ledger/src/execution/apply.rs
+++ b/crates/ledger/src/execution/apply.rs
@@ -1854,6 +1854,39 @@ mod tests {
         }
     }
 
+    /// P27 module cache: warming a V1-ext entry derives V1 cost inputs from the
+    /// wasm (mirrors the P26 behavior) and the rebuild caller (`new_for_protocol(27)`)
+    /// routes to a P27 cache.
+    #[test]
+    fn test_warm_module_cache_v1_entry_uses_derived_v1_cost_inputs_p27() {
+        let cache = PersistentModuleCache::new_for_protocol(27)
+            .expect("P27 module cache should be available");
+        let (entry, hash_bytes) = make_v1_contract_code_ledger_entry(WASM_A);
+        super::super::warm_module_cache_from_entries(Some(&cache), &[entry], 27);
+
+        let host_hash = soroban_env_host_p27::xdr::Hash(hash_bytes);
+        let module = cache
+            .as_p27()
+            .expect("protocol 27 must produce a P27 cache")
+            .get_module(&host_hash)
+            .expect("get_module should not error")
+            .expect("V1-ext entry should be in cache");
+
+        match &module.cost_inputs {
+            soroban_env_host_p27::vm::VersionedContractCodeCostInputs::V1(inputs) => {
+                assert_ne!(
+                    inputs.n_instructions, 10,
+                    "cost inputs should be derived from wasm, not copied from entry ext"
+                );
+            }
+            soroban_env_host_p27::vm::VersionedContractCodeCostInputs::V0 { .. } => {
+                panic!(
+                    "P27 should derive V1 cost inputs from wasm via parse_and_cache_module_simple"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_warm_module_cache_v0_cost_inputs_p24() {
         let cache = PersistentModuleCache::new_for_protocol(24)

--- a/crates/ledger/src/soroban_state.rs
+++ b/crates/ledger/src/soroban_state.rs
@@ -183,6 +183,7 @@ use soroban_env_host25::budget::Budget as BudgetP25;
 use soroban_env_host25::e2e_invoke::entry_size_for_rent as entry_size_for_rent_p25;
 use soroban_env_host_p25 as soroban_env_host25;
 use soroban_env_host_p26 as soroban_env_host26;
+use soroban_env_host_p27 as soroban_env_host27;
 use stellar_xdr::{
     ConfigSettingId, ContractCostParams, Hash, LedgerEntry, LedgerEntryData, LedgerKey,
     LedgerKeyConfigSetting, LedgerKeyContractCode, LedgerKeyContractData, LedgerKeyTtl, TtlEntry,
@@ -322,6 +323,31 @@ fn build_rent_budget_p26(
         mem_params,
     )
     .unwrap_or_else(|_| soroban_env_host26::budget::Budget::default())
+}
+
+/// Build a p27 Budget from on-chain cost parameters (for protocol 27+).
+///
+/// NATIVE: the P27 host shares stellar-xdr 27.0.0 with the workspace, so the
+/// workspace `ContractCostParams` are passed straight through (no conversion).
+fn build_rent_budget_p27(
+    rent_config: Option<&SorobanRentConfig>,
+) -> soroban_env_host27::budget::Budget {
+    let Some(config) = rent_config else {
+        return soroban_env_host27::budget::Budget::default();
+    };
+    if !config.has_valid_cost_params() {
+        return soroban_env_host27::budget::Budget::default();
+    }
+
+    let instruction_limit = config.tx_max_instructions.saturating_mul(2);
+    let memory_limit = config.tx_max_memory_bytes.saturating_mul(2);
+    soroban_env_host27::budget::Budget::try_from_configs(
+        instruction_limit,
+        memory_limit,
+        config.cpu_cost_params.clone(),
+        config.mem_cost_params.clone(),
+    )
+    .unwrap_or_else(|_| soroban_env_host27::budget::Budget::default())
 }
 
 /// Compute the XDR-encoded byte length of a `LedgerEntry` as a `u32`.
@@ -1060,20 +1086,28 @@ impl InMemorySorobanState {
                 }
             };
         }
-        // Protocol >= 26: use p26 host (86 cost types).
-        // P26 host pins stellar-xdr 26.0.0, distinct from the workspace XDR, so
-        // the entry is byte-converted to the P26 type.
-        let budget = build_rent_budget_p26(rent_config);
-        match try_convert_ledger_entry_ws_to_p26(entry) {
-            Ok(p26_entry) => {
-                soroban_env_host26::e2e_invoke::entry_size_for_rent(&budget, &p26_entry, xdr_size)
-                    .unwrap_or(xdr_size)
-            }
-            Err(e) => {
-                tracing::warn!("calculate_code_size: {e}, falling back to XDR size");
-                xdr_size
-            }
+        if protocol_version_is_before(protocol_version, ProtocolVersion::V27) {
+            // Protocol 26: use p26 host (86 cost types).
+            // P26 host pins stellar-xdr 26.0.0, distinct from the workspace XDR, so
+            // the entry is byte-converted to the P26 type.
+            let budget = build_rent_budget_p26(rent_config);
+            return match try_convert_ledger_entry_ws_to_p26(entry) {
+                Ok(p26_entry) => soroban_env_host26::e2e_invoke::entry_size_for_rent(
+                    &budget, &p26_entry, xdr_size,
+                )
+                .unwrap_or(xdr_size),
+                Err(e) => {
+                    tracing::warn!("calculate_code_size: {e}, falling back to XDR size");
+                    xdr_size
+                }
+            };
         }
+        // Protocol >= 27: use p27 host.
+        // P27 host shares stellar-xdr 27.0.0 with the workspace, so the entry is
+        // passed NATIVELY (no byte conversion).
+        let budget = build_rent_budget_p27(rent_config);
+        soroban_env_host27::e2e_invoke::entry_size_for_rent(&budget, entry, xdr_size)
+            .unwrap_or(xdr_size)
     }
 
     /// Update state with new entries from a ledger close.

--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -929,7 +929,10 @@ mod tests {
         let hello = ctx.create_hello();
         assert_eq!(hello.overlay_version, 40);
         assert_eq!(hello.overlay_min_version, 38);
-        assert_eq!(hello.ledger_version, 26);
+        assert_eq!(
+            hello.ledger_version,
+            henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION
+        );
     }
 
     // ---- G14: receiver auth state (not the wire bit-31 flag) gates MAC verification in unwrap_message ----

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -16,6 +16,7 @@ henyey-db.workspace = true
 soroban-env-host-p24.workspace = true
 soroban-env-host-p25.workspace = true
 soroban-env-host-p26.workspace = true
+soroban-env-host-p27.workspace = true
 
 # Error handling
 thiserror.workspace = true

--- a/crates/tx/src/operations/execute/mod.rs
+++ b/crates/tx/src/operations/execute/mod.rs
@@ -37,6 +37,7 @@ pub(super) use henyey_common::checked_types::{account_liabilities, trustline_lia
 use soroban_env_host_p24 as soroban_env_host24;
 use soroban_env_host_p25 as soroban_env_host25;
 use soroban_env_host_p26 as soroban_env_host26;
+use soroban_env_host_p27 as soroban_env_host27;
 use stellar_xdr::{
     AccountEntry, AccountEntryExt, AccountEntryExtensionV1, AccountEntryExtensionV1Ext, AccountId,
     Asset, ContractEvent, DiagnosticEvent, ExtendFootprintTtlResult, InvokeHostFunctionResult,
@@ -778,8 +779,8 @@ pub fn entry_size_for_rent_by_protocol_with_cost_params(
                 entry_xdr_size
             }
         }
-    } else {
-        // Protocol >= 26: p26 host pins stellar-xdr 26.0.0, distinct from the
+    } else if protocol_version_is_before(protocol_version, ProtocolVersion::V27) {
+        // Protocol 26: p26 host pins stellar-xdr 26.0.0, distinct from the
         // workspace XDR, so the entry is byte-converted to the P26 type.
         let budget = match cost_params {
             Some((cpu, mem)) => build_budget_p26(cpu, mem),
@@ -797,6 +798,15 @@ pub fn entry_size_for_rent_by_protocol_with_cost_params(
                 entry_xdr_size
             }
         }
+    } else {
+        // Protocol >= 27: p27 host pins stellar-xdr 27.0.0 — the SAME as the
+        // workspace XDR — so the entry is passed NATIVELY (no byte conversion).
+        let budget = match cost_params {
+            Some((cpu, mem)) => build_budget_p27(cpu, mem),
+            None => soroban_env_host27::budget::Budget::default(),
+        };
+        soroban_env_host27::e2e_invoke::entry_size_for_rent(&budget, entry, entry_xdr_size)
+            .unwrap_or(entry_xdr_size)
     }
 }
 
@@ -858,6 +868,24 @@ fn build_budget_p26(
             soroban_env_host26::budget::Budget::default()
         }
     }
+}
+
+/// Build a P27 Budget from on-chain cost parameters.
+///
+/// NATIVE: the P27 host shares stellar-xdr 27.0.0 with the workspace, so the
+/// workspace `ContractCostParams` are passed straight through (no conversion).
+fn build_budget_p27(
+    cpu_cost_params: &stellar_xdr::ContractCostParams,
+    mem_cost_params: &stellar_xdr::ContractCostParams,
+) -> soroban_env_host27::budget::Budget {
+    // Use limits of 0 — we only need the cost model, not actual metering.
+    soroban_env_host27::budget::Budget::try_from_configs(
+        0,
+        0,
+        cpu_cost_params.clone(),
+        mem_cost_params.clone(),
+    )
+    .unwrap_or_else(|_| soroban_env_host27::budget::Budget::default())
 }
 
 // Local conversion functions removed — use crate::soroban::convert::try_convert_* instead.

--- a/crates/tx/src/soroban/error.rs
+++ b/crates/tx/src/soroban/error.rs
@@ -249,4 +249,22 @@ mod tests {
             _ => panic!("Expected Context error"),
         }
     }
+
+    #[test]
+    fn test_convert_host_error_p27_to_p25() {
+        use soroban_env_host_p27 as soroban_env_host27;
+        let p27_sc_error = soroban_env_host27::xdr::ScError::Storage(
+            soroban_env_host27::xdr::ScErrorCode::ExceededLimit,
+        );
+        let p27_host_error = soroban_env_host27::HostError::from(p27_sc_error);
+        let p25_host_error = convert_host_error_p27_to_p25(p27_host_error);
+
+        let p25_sc_error: ScError25 = (&p25_host_error)
+            .try_into()
+            .unwrap_or(ScError25::Context(ScErrorCode25::InternalError));
+        match p25_sc_error {
+            ScError25::Storage(code) => assert_eq!(code, ScErrorCode25::ExceededLimit),
+            other => panic!("Expected Storage error, got {other:?}"),
+        }
+    }
 }

--- a/crates/tx/src/soroban/error.rs
+++ b/crates/tx/src/soroban/error.rs
@@ -3,6 +3,7 @@
 use soroban_env_host_p24 as soroban_env_host24;
 use soroban_env_host_p25 as soroban_env_host25;
 use soroban_env_host_p26 as soroban_env_host26;
+use soroban_env_host_p27 as soroban_env_host27;
 
 /// Convert a P24 HostError to P25 HostError.
 ///
@@ -91,6 +92,51 @@ fn convert_sc_error_p26_to_p25(
         ScError26::Budget(code) => ScError25::Budget(convert_sc_error_code_p26_to_p25(code)),
         ScError26::Value(code) => ScError25::Value(convert_sc_error_code_p26_to_p25(code)),
         ScError26::Auth(code) => ScError25::Auth(convert_sc_error_code_p26_to_p25(code)),
+    }
+}
+
+/// Convert a P27 HostError to P25 HostError.
+///
+/// P25 is our canonical internal error type for `SorobanExecutionError`. Even
+/// though soroban-env-host-p27 shares stellar-xdr 27.0.0 with the workspace, the
+/// P25 host type is a distinct crate, so a real (integer-preserving) conversion
+/// is still required. The ScError variants and codes are stable across versions.
+pub(crate) fn convert_host_error_p27_to_p25(
+    err: soroban_env_host27::HostError,
+) -> soroban_env_host25::HostError {
+    let sc_error = soroban_env_host27::xdr::ScError::try_from(&err).unwrap_or(
+        soroban_env_host27::xdr::ScError::Context(
+            soroban_env_host27::xdr::ScErrorCode::InternalError,
+        ),
+    );
+    let sc_error = convert_sc_error_p27_to_p25(sc_error);
+    soroban_env_host25::HostError::from(sc_error)
+}
+
+fn convert_sc_error_code_p27_to_p25(
+    code: soroban_env_host27::xdr::ScErrorCode,
+) -> soroban_env_host25::xdr::ScErrorCode {
+    soroban_env_host25::xdr::ScErrorCode::try_from(code as i32)
+        .unwrap_or(soroban_env_host25::xdr::ScErrorCode::InternalError)
+}
+
+fn convert_sc_error_p27_to_p25(
+    sc_error: soroban_env_host27::xdr::ScError,
+) -> soroban_env_host25::xdr::ScError {
+    use soroban_env_host25::xdr::ScError as ScError25;
+    use soroban_env_host27::xdr::ScError as ScError27;
+
+    match sc_error {
+        ScError27::Contract(code) => ScError25::Contract(code),
+        ScError27::WasmVm(code) => ScError25::WasmVm(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Context(code) => ScError25::Context(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Storage(code) => ScError25::Storage(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Object(code) => ScError25::Object(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Crypto(code) => ScError25::Crypto(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Events(code) => ScError25::Events(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Budget(code) => ScError25::Budget(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Value(code) => ScError25::Value(convert_sc_error_code_p27_to_p25(code)),
+        ScError27::Auth(code) => ScError25::Auth(convert_sc_error_code_p27_to_p25(code)),
     }
 }
 

--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -19,6 +19,7 @@ use soroban_env_host25::HostError as HostErrorP25;
 use soroban_env_host_p24 as soroban_env_host24;
 use soroban_env_host_p25 as soroban_env_host25;
 use soroban_env_host_p26 as soroban_env_host26;
+use soroban_env_host_p27 as soroban_env_host27;
 
 // P25 module cache types
 use soroban_env_host25::{
@@ -26,24 +27,33 @@ use soroban_env_host25::{
     ErrorHandler as ErrorHandlerP25, ModuleCache as ModuleCacheP25,
 };
 
-// P26 module cache types
-// soroban-env-host-p26 uses stellar-xdr 26.0.0 — the same version as our workspace.
-// This means P26 XDR types ARE the workspace types — no XDR byte roundtrip needed.
+// P26 module cache types.
+// soroban-env-host-p26 pins stellar-xdr 26.0.0, distinct from the workspace XDR
+// (now 27.0.0), so P26 XDR types are byte-converted to the workspace types (#3533).
 use soroban_env_host26::HostError as HostErrorP26;
 use soroban_env_host26::{
     budget::AsBudget as AsBudgetP26, CompilationContext as CompilationContextP26,
     ErrorHandler as ErrorHandlerP26, ModuleCache as ModuleCacheP26,
 };
 
-// The P26 host is pinned to the stellar-core v26.0.1 submodule revision (b351f88)
-// which uses stellar-xdr 26.0.0 — the same as our workspace. Types are unified
-// by Cargo, so no XDR byte roundtrip is needed for P26 (unlike P24/P25).
+// P27 module cache types.
+// soroban-env-host-p27 is pinned to the stellar-core v27.0.0 gitlink (b03d2563)
+// which uses stellar-xdr 27.0.0 — the SAME version as our workspace. This means
+// P27 XDR types ARE the workspace types; Cargo unifies them, so the P27 path is
+// NATIVE — no XDR byte roundtrip (unlike P24/P25/P26).
+use soroban_env_host27::HostError as HostErrorP27;
+use soroban_env_host27::{
+    budget::AsBudget as AsBudgetP27, CompilationContext as CompilationContextP27,
+    ErrorHandler as ErrorHandlerP27, ModuleCache as ModuleCacheP27,
+};
 use stellar_xdr::{
     DiagnosticEvent, LedgerEntry, LedgerKey, Limits, ReadXdr, ScVal, SorobanTransactionData,
     SorobanTransactionDataExt, WriteXdr,
 };
 
-use super::error::{convert_host_error_p24_to_p25, convert_host_error_p26_to_p25};
+use super::error::{
+    convert_host_error_p24_to_p25, convert_host_error_p26_to_p25, convert_host_error_p27_to_p25,
+};
 use super::HostFunctionInvocation;
 use crate::state::LedgerStateManager;
 use crate::validation::LedgerContext;
@@ -187,8 +197,10 @@ pub enum PersistentModuleCache {
     P24(ModuleCache),
     /// Protocol 25 module cache
     P25(ModuleCacheP25),
-    /// Protocol 26+ module cache
+    /// Protocol 26 module cache
     P26(ModuleCacheP26),
+    /// Protocol 27+ module cache
+    P27(ModuleCacheP27),
 }
 
 impl PersistentModuleCache {
@@ -214,9 +226,21 @@ impl PersistentModuleCache {
             .map(PersistentModuleCache::P26)
     }
 
+    /// Create a new empty P27 cache.
+    pub fn new_p27() -> Option<Self> {
+        let ctx = WasmCompilationContextP27::new();
+        ModuleCacheP27::new(&ctx)
+            .ok()
+            .map(PersistentModuleCache::P27)
+    }
+
     /// Create a new cache for the given protocol version.
     pub fn new_for_protocol(protocol_version: u32) -> Option<Self> {
-        if protocol_version_starts_from(protocol_version, ProtocolVersion::V26) {
+        // V27-first: protocol_version_starts_from(_, V26) is also true at v27, so
+        // the V27 branch MUST precede the V26 branch to route v27 ledgers correctly.
+        if protocol_version_starts_from(protocol_version, ProtocolVersion::V27) {
+            Self::new_p27()
+        } else if protocol_version_starts_from(protocol_version, ProtocolVersion::V26) {
             Self::new_p26()
         } else if protocol_version_starts_from(protocol_version, ProtocolVersion::V25) {
             Self::new_p25()
@@ -258,6 +282,12 @@ impl PersistentModuleCache {
                     .parse_and_cache_module_simple(&ctx, protocol_version, wasm)
                     .is_ok()
             }
+            PersistentModuleCache::P27(cache) => {
+                let ctx = WasmCompilationContextP27::new();
+                cache
+                    .parse_and_cache_module_simple(&ctx, protocol_version, wasm)
+                    .is_ok()
+            }
         }
     }
 
@@ -279,6 +309,10 @@ impl PersistentModuleCache {
             }
             PersistentModuleCache::P26(cache) => {
                 let contract_id = soroban_env_host26::xdr::Hash(hash.0);
+                cache.remove_module(&contract_id).ok().flatten().is_some()
+            }
+            PersistentModuleCache::P27(cache) => {
+                let contract_id = soroban_env_host27::xdr::Hash(hash.0);
                 cache.remove_module(&contract_id).ok().flatten().is_some()
             }
         }
@@ -304,6 +338,14 @@ impl PersistentModuleCache {
     pub fn as_p26(&self) -> Option<&ModuleCacheP26> {
         match self {
             PersistentModuleCache::P26(cache) => Some(cache),
+            _ => None,
+        }
+    }
+
+    /// Get the P27 cache if this is a P27 cache.
+    pub fn as_p27(&self) -> Option<&ModuleCacheP27> {
+        match self {
+            PersistentModuleCache::P27(cache) => Some(cache),
             _ => None,
         }
     }
@@ -671,6 +713,16 @@ define_wasm_compilation_context!(
     HostErrorP26
 );
 
+// P27 version of the compilation context.
+define_wasm_compilation_context!(
+    WasmCompilationContextP27,
+    soroban_env_host27,
+    ErrorHandlerP27,
+    AsBudgetP27,
+    CompilationContextP27,
+    HostErrorP27
+);
+
 /// Execute a Soroban host function with an optional pre-populated module cache.
 ///
 /// This is the same as `execute_host_function` but accepts an optional persistent
@@ -683,6 +735,21 @@ pub(crate) fn execute_host_function_with_cache(
     request: HostFunctionInvocation<'_>,
 ) -> Result<SorobanExecutionResult, SorobanExecutionError> {
     let protocol_version = request.context.protocol_version;
+    // V27-first: starts_from(_, V26) is also true at v27, so the V27 branch MUST
+    // precede the V26 branch — otherwise a v27 ledger mis-routes to the P26 host.
+    if protocol_version_starts_from(protocol_version, ProtocolVersion::V27) {
+        // INVARIANT: module cache always present and correct protocol type during Soroban execution
+        let cache = request
+            .module_cache
+            .unwrap_or_else(|| panic!("Module cache must be provided for Soroban TX execution"));
+        let p27_cache = cache.as_p27().unwrap_or_else(|| {
+            panic!(
+                "Module cache is not P27 but protocol version is {}",
+                protocol_version
+            )
+        });
+        return execute_host_function_p27(request, Some(p27_cache));
+    }
     if protocol_version_starts_from(protocol_version, ProtocolVersion::V26) {
         // INVARIANT: module cache always present and correct protocol type during Soroban execution
         let cache = request
@@ -1660,6 +1727,33 @@ fn rent_fee_config_p25_to_p26(
     }
 }
 
+fn convert_diagnostic_events_p27(
+    events: Vec<soroban_env_host27::xdr::DiagnosticEvent>,
+) -> Vec<DiagnosticEvent> {
+    convert_diagnostic_events_cross_version(events, "P27", |event| {
+        use soroban_env_host27::xdr::WriteXdr as WriteXdrP27;
+        event
+            .to_xdr(soroban_env_host27::xdr::Limits::none())
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Convert the SorobanConfig's (P25-typed) RentFeeConfiguration to the P27 type.
+///
+/// The SorobanConfig stores RentFeeConfiguration as P25 types. The P27 host has an
+/// independent struct with the same fields, so we copy field by field.
+fn rent_fee_config_p25_to_p27(
+    config: &soroban_env_host25::fees::RentFeeConfiguration,
+) -> soroban_env_host27::fees::RentFeeConfiguration {
+    soroban_env_host27::fees::RentFeeConfiguration {
+        fee_per_write_1kb: config.fee_per_write_1kb,
+        fee_per_rent_1kb: config.fee_per_rent_1kb,
+        fee_per_write_entry: config.fee_per_write_entry,
+        persistent_rent_rate_denominator: config.persistent_rent_rate_denominator,
+        temporary_rent_rate_denominator: config.temporary_rent_rate_denominator,
+    }
+}
+
 fn execute_host_function_p26(
     request: HostFunctionInvocation<'_>,
     existing_cache: Option<&ModuleCacheP26>,
@@ -1882,6 +1976,256 @@ fn execute_host_function_p26(
     let rent_changes = e2e_invoke::extract_rent_changes(&result.ledger_changes);
     let p26_rent_config = rent_fee_config_p25_to_p26(&soroban_config.rent_fee_config);
     let rent_fee = compute_rent_fee(&rent_changes, &p26_rent_config, context.sequence);
+
+    // ── Storage changes ──
+    let normalized_changes: Vec<NormalizedLedgerChange> = result
+        .ledger_changes
+        .into_iter()
+        .map(|c| NormalizedLedgerChange {
+            encoded_key: c.encoded_key,
+            read_only: c.read_only,
+            encoded_new_value: c.encoded_new_value,
+            old_entry_size_bytes_for_rent: c.old_entry_size_bytes_for_rent,
+            ttl_new_live_until_ledger: c.ttl_change.map(|t| t.new_live_until_ledger),
+        })
+        .collect();
+    let storage_changes =
+        map_storage_changes(normalized_changes, state, ttl_key_cache, &make_budget_error)?;
+
+    let cpu_insns = budget.get_cpu_insns_consumed().unwrap_or(0);
+    let mem_bytes = budget.get_mem_bytes_consumed().unwrap_or(0);
+    let contract_events_and_return_value_size =
+        contract_events_size.saturating_add(return_value_size);
+
+    Ok(SorobanExecutionResult {
+        return_value,
+        storage_changes,
+        contract_events,
+        diagnostic_events: final_diagnostic_events,
+        cpu_insns,
+        mem_bytes,
+        contract_events_and_return_value_size,
+        rent_fee,
+        live_bucket_list_restores: footprint.live_bl_restores,
+        actual_restored_indices: footprint.actual_restored_indices,
+    })
+}
+
+/// Execute a Soroban host function on the P27 host (protocol 27+).
+///
+/// This is a NATIVE clone of `execute_host_function_p26`: soroban-env-host-p27
+/// pins stellar-xdr 27.0.0 — the SAME version as our workspace — so the P27 XDR
+/// types ARE the workspace types. There is NO byte roundtrip: the on-chain cost
+/// params and ledger entries are passed straight through. Only the canonical
+/// internal error type (P25, for `SorobanExecutionError`) requires a conversion,
+/// done via `convert_host_error_p27_to_p25`.
+fn execute_host_function_p27(
+    request: HostFunctionInvocation<'_>,
+    existing_cache: Option<&ModuleCacheP27>,
+) -> Result<SorobanExecutionResult, SorobanExecutionError> {
+    use soroban_env_host27::{budget::Budget, e2e_invoke, fees::compute_rent_fee};
+
+    let HostFunctionInvocation {
+        host_function,
+        auth_entries,
+        source,
+        state,
+        context,
+        soroban_data,
+        soroban_config,
+        guarded_hot_archive,
+        ttl_key_cache,
+        ..
+    } = request;
+
+    let make_setup_error = |e: HostErrorP27| SorobanExecutionError {
+        host_error: convert_host_error_p27_to_p25(e),
+        cpu_insns_consumed: 0,
+        mem_bytes_consumed: 0,
+        diagnostic_events: Vec::new(),
+    };
+
+    let instruction_limit = soroban_data.resources.instructions as u64;
+    let memory_limit = soroban_config.tx_max_memory_bytes;
+
+    let budget = if soroban_config.has_valid_cost_params() {
+        // NATIVE: workspace ContractCostParams == soroban_env_host27::xdr::ContractCostParams.
+        // Pass them straight through — no ws_to_pNN conversion.
+        Budget::try_from_configs(
+            instruction_limit,
+            memory_limit,
+            soroban_config.cpu_cost_params.clone(),
+            soroban_config.mem_cost_params.clone(),
+        )
+        .map_err(make_setup_error)?
+    } else {
+        tracing::warn!("Using default Soroban budget - cost parameters not loaded from network.");
+        Budget::default()
+    };
+
+    let ledger_info = soroban_env_host27::LedgerInfo {
+        protocol_version: context.protocol_version,
+        sequence_number: context.sequence,
+        timestamp: context.close_time,
+        network_id: context.network_id.0 .0,
+        base_reserve: context.base_reserve,
+        min_temp_entry_ttl: soroban_config.min_temp_entry_ttl,
+        min_persistent_entry_ttl: soroban_config.min_persistent_entry_ttl,
+        max_entry_ttl: soroban_config.max_entry_ttl,
+    };
+
+    tracing::debug!(
+        protocol_version = context.protocol_version,
+        sequence_number = context.sequence,
+        timestamp = context.close_time,
+        instruction_limit,
+        memory_limit,
+        has_cost_params = soroban_config.has_valid_cost_params(),
+        "P27: Soroban host ledger info configured"
+    );
+
+    // SECURITY: PRNG seed always Some in production Soroban execution path
+    let base_prng_seed: [u8; 32] = if let Some(prng_seed) = context.soroban_prng_seed {
+        prng_seed
+    } else {
+        tracing::warn!("P27: Using fallback PRNG seed - results may differ from stellar-core");
+        derive_fallback_prng_seed(context)
+    };
+
+    let snapshot = LedgerSnapshotAdapterP25::with_hot_archive(
+        state,
+        context.sequence,
+        guarded_hot_archive,
+        ttl_key_cache,
+    );
+
+    // ── Gather footprint entries ──
+    let footprint = prepare_footprint_entries(
+        &snapshot,
+        soroban_data,
+        context,
+        soroban_config,
+        ttl_key_cache,
+        "P27",
+    )?;
+
+    // Use existing module cache — it must always be provided.
+    let module_cache = existing_cache
+        .unwrap_or_else(|| {
+            panic!(
+                "P27: Module cache is not available — this is a bug. \
+                The persistent module cache should always be initialized before TX execution."
+            )
+        })
+        .clone();
+    let module_cache = Some(module_cache);
+
+    // ── Encode inputs and call non-typed invoke_host_function() ──
+    let inputs = encode_invocation_inputs(host_function, soroban_data, source, auth_entries)?;
+
+    let mut diagnostic_events: Vec<soroban_env_host27::xdr::DiagnosticEvent> = Vec::new();
+
+    let result = match e2e_invoke::invoke_host_function(
+        &budget,
+        true, // enable_diagnostics
+        inputs.encoded_host_fn,
+        inputs.encoded_resources,
+        &footprint.actual_restored_indices,
+        inputs.encoded_source,
+        inputs.encoded_auth.into_iter(),
+        ledger_info,
+        footprint.encoded_ledger_entries.into_iter(),
+        footprint.encoded_ttl_entries.into_iter(),
+        base_prng_seed.to_vec(),
+        &mut diagnostic_events,
+        None, // trace_hook
+        module_cache,
+    ) {
+        Ok(r) => {
+            tracing::debug!(
+                cpu_consumed = budget.get_cpu_insns_consumed().unwrap_or(0),
+                mem_consumed = budget.get_mem_bytes_consumed().unwrap_or(0),
+                "P27: e2e_invoke completed successfully"
+            );
+            r
+        }
+        Err(e) => {
+            let cpu_insns_consumed = budget.get_cpu_insns_consumed().unwrap_or(0);
+            let mem_bytes_consumed = budget.get_mem_bytes_consumed().unwrap_or(0);
+            tracing::debug!(
+                cpu_consumed = cpu_insns_consumed,
+                mem_consumed = mem_bytes_consumed,
+                error = %e,
+                "P27: e2e_invoke failed"
+            );
+            for (i, event) in diagnostic_events.iter().enumerate() {
+                use soroban_env_host27::xdr::WriteXdr as _;
+                if let Ok(encoded) = event.to_xdr(soroban_env_host27::xdr::Limits::none()) {
+                    tracing::warn!(
+                        event_idx = i,
+                        event_hex = hex::encode(&encoded),
+                        "P27: Diagnostic event"
+                    );
+                }
+            }
+            return Err(SorobanExecutionError {
+                host_error: convert_host_error_p27_to_p25(e),
+                cpu_insns_consumed,
+                mem_bytes_consumed,
+                diagnostic_events: convert_diagnostic_events_p27(diagnostic_events),
+            });
+        }
+    };
+
+    // ── Decode result ──
+    // Convert diagnostic events before defining closures that borrow budget.
+    let final_diagnostic_events = convert_diagnostic_events_p27(diagnostic_events);
+
+    let make_budget_error = |desc: &str| -> SorobanExecutionError {
+        tracing::debug!(desc, "P27: XDR decode error in result processing");
+        SorobanExecutionError {
+            host_error: HostErrorP25::from(soroban_env_host25::Error::from_type_and_code(
+                soroban_env_host25::xdr::ScErrorType::Context,
+                soroban_env_host25::xdr::ScErrorCode::InternalError,
+            )),
+            cpu_insns_consumed: budget.get_cpu_insns_consumed().unwrap_or(0),
+            mem_bytes_consumed: budget.get_mem_bytes_consumed().unwrap_or(0),
+            diagnostic_events: final_diagnostic_events.clone(),
+        }
+    };
+
+    let (return_value, return_value_size) = match result.encoded_invoke_result {
+        Ok(ref bytes) => {
+            let val = ScVal::from_xdr(bytes, Limits::none())
+                .map_err(|_| make_budget_error("failed to decode ScVal"))?;
+            (val, bytes.len() as u32)
+        }
+        Err(ref e) => {
+            let cpu_insns_consumed = budget.get_cpu_insns_consumed().unwrap_or(0);
+            let mem_bytes_consumed = budget.get_mem_bytes_consumed().unwrap_or(0);
+            tracing::debug!(
+                cpu_consumed = cpu_insns_consumed,
+                mem_consumed = mem_bytes_consumed,
+                error = %e,
+                "P27: e2e_invoke result contained error"
+            );
+            return Err(SorobanExecutionError {
+                host_error: convert_host_error_p27_to_p25(e.clone()),
+                cpu_insns_consumed,
+                mem_bytes_consumed,
+                diagnostic_events: final_diagnostic_events.clone(),
+            });
+        }
+    };
+
+    // ── Contract events ──
+    let (contract_events, contract_events_size) =
+        decode_contract_events(&result.encoded_contract_events, &make_budget_error)?;
+
+    // ── Rent: use P27 host's compute_rent_fee ──
+    let rent_changes = e2e_invoke::extract_rent_changes(&result.ledger_changes);
+    let p27_rent_config = rent_fee_config_p25_to_p27(&soroban_config.rent_fee_config);
+    let rent_fee = compute_rent_fee(&rent_changes, &p27_rent_config, context.sequence);
 
     // ── Storage changes ──
     let normalized_changes: Vec<NormalizedLedgerChange> = result

--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -1932,6 +1932,32 @@ mod tests {
         assert_ne!(hash.0, [0u8; 32]);
     }
 
+    /// V27 protocol routes to a P27 module cache; V26 still routes to P26.
+    #[test]
+    fn test_new_for_protocol_v27_routes_to_p27() {
+        let cache27 = PersistentModuleCache::new_for_protocol(27)
+            .expect("P27 module cache should be available");
+        assert!(
+            cache27.as_p27().is_some(),
+            "protocol 27 must produce a P27 cache"
+        );
+        assert!(
+            cache27.as_p26().is_none(),
+            "protocol 27 must NOT produce a P26 cache"
+        );
+
+        let cache26 = PersistentModuleCache::new_for_protocol(26)
+            .expect("P26 module cache should be available");
+        assert!(
+            cache26.as_p26().is_some(),
+            "protocol 26 must still produce a P26 cache"
+        );
+        assert!(
+            cache26.as_p27().is_none(),
+            "protocol 26 must NOT produce a P27 cache"
+        );
+    }
+
     /// Test compute_key_hash produces different hashes for different keys.
     #[test]
     fn test_compute_key_hash_different_keys() {

--- a/scripts/check-soroban-pins.sh
+++ b/scripts/check-soroban-pins.sh
@@ -13,7 +13,7 @@ if [ ! -d "stellar-core/.git" ] && [ ! -f "stellar-core/.git" ]; then
 fi
 
 errors=0
-for proto in p24 p25 p26; do
+for proto in p24 p25 p26 p27; do
     # Extract recorded gitlink SHA from stellar-core's tree
     submodule_sha=$(git -C stellar-core ls-tree HEAD "src/rust/soroban/$proto" | awk '{print $3}')
     if [ -z "$submodule_sha" ]; then
@@ -46,7 +46,7 @@ if [ $errors -gt 0 ]; then
     echo ""
     echo "FAIL: $errors soroban pin(s) out of sync with stellar-core submodule."
     echo "Update Cargo.toml revs to match:"
-    echo "  git -C stellar-core ls-tree HEAD src/rust/soroban/p24 src/rust/soroban/p25 src/rust/soroban/p26"
+    echo "  git -C stellar-core ls-tree HEAD src/rust/soroban/p24 src/rust/soroban/p25 src/rust/soroban/p26 src/rust/soroban/p27"
     exit 1
 fi
 echo ""


### PR DESCRIPTION
Closes #3526

## Summary

Enables Protocol 27 — the keystone unblocking #3527/#3528/#3529. Adds `ProtocolVersion::V27 = 27`, bumps `CURRENT_LEDGER_PROTOCOL_VERSION` 26→27 (and the workspace version 26→27 to satisfy the version/protocol startup invariant), and wires a 5th soroban host `soroban-env-host-p27` pinned to the stellar-core v27.0.0 gitlink `b03d2563` (= rs-soroban-env v27.0.0), vendored exactly like p24/p25/p26.

Because `soroban-env-host-p27` shares stellar-xdr 27.0.0 with the workspace, the P27 path is **native**: `execute_host_function_p27` is a clone of the p26 path *minus* the `ws_to_pNN` conversions — cost params and ledger entries pass straight through. A **V27-first** routing branch is inserted ahead of the V26 branch in every router (`new_for_protocol`, `execute_host_function_with_cache`, and the two rent-size routers), since `protocol_version_starts_from(27, V26)` is also true. p26-and-below keep the merged #3533 byte-roundtrip paths unchanged. `convert_host_error_p27_to_p25` mirrors the existing error converters (P25 stays the canonical internal error type).

Depends on the now-merged #3531/#3533 migration base (`stellar-xdr = =27.0.0`, the `stellar_xdr::curr`→`stellar_xdr` rename, and the p26 byte-roundtrip converters), which is already on `main`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3526#issuecomment-4764088180)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] `cargo build --all` and `cargo build -p henyey-tx -p henyey-ledger -p henyey-common --all-targets` under `-Dwarnings`
- [x] `bash scripts/check-soroban-pins.sh` — all four pins (p24/p25/p26/p27) match the stellar-core submodule
- [x] `cargo test --all` — 7551 passed, 0 failed; parity tripwires green (ledger_close_meta_vectors, tx_meta_hash_vectors, validation_parity, scp_parity_tests, txset equivalence)

## New coverage (feature)

Failing-test-first (#3461): the regression tests were committed first (`c64715b5`) and verified to **fail to compile** on the pre-P27 base (`V27` / `as_p27` / `convert_host_error_p27_to_p25` / `soroban_env_host_p27` did not exist), then made green by the implementation (`efb6601b`):

- `crates/common/src/protocol.rs`: `test_protocol_version_v27_value`, `test_current_ledger_protocol_version_is_27`, `test_protocol_version_starts_from_v27`, `test_ledger_header_version_27_xdr_roundtrip`
- `crates/tx/src/soroban/host.rs`: `test_new_for_protocol_v27_routes_to_p27`
- `crates/tx/src/soroban/error.rs`: `test_convert_host_error_p27_to_p25`
- `crates/ledger/src/execution/apply.rs`: `test_warm_module_cache_v1_entry_uses_derived_v1_cost_inputs_p27` (rebuild caller routes to P27)

## Parity-rev sanity

stellar-core v27.0.0 compiles its p27 host from rs-soroban-env **v26.1.2** (Cargo rev `c0e58f94`) while its gitlink is **v27.0.0** (`b03d2563`); henyey pins the gitlink — the same gitlink-vs-Cargo split as p25, parity-clean to date. The v26.1.2→v27.0.0 cost/budget source delta is a single additive `impl MeteredClone for usize` (no `ContractCostType` / `fees.rs` / budget cost-model change), so cost/budget/rent parity holds and the green tripwires are the evidence. Protocol-27 behavioral features (CAP-0071, DEX V_27 cross-limit, overlay 40→41) remain out of scope (#3527/#3528/#3529); this PR only makes V27 exist and execute.

## Deviations from plan

- The plan named the rent-size router `compute_entry_size_for_rent`; the actual function is `entry_size_for_rent_by_protocol_with_cost_params` (in `crates/tx/src/operations/execute/mod.rs`) — the V27-first branch was added there.
- Required (in-scope) protocol-bump follow-through beyond the file list: bumped the workspace `version` 26→27 (the `check_version_protocol_invariant` startup gate), and aligned the stellar-core-mirroring defaults `default_testing_upgrade_protocol_version()` / `GenesisConfig::default().protocol_version` to `CURRENT_LEDGER_PROTOCOL_VERSION` (stellar-core v27.0.0 sets `TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION = 27`). The `Hello.ledger_version` test assertion was anchored to the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)