### PR TITLE
Drop deleted lumen_reconciler.rs rows from tx README file map

### DIFF
--- a/crates/tx/README.md
+++ b/crates/tx/README.md
@@ -106,7 +106,6 @@ assert!(delta.fee_charged() >= 0);
 | `fee_bump.rs` | Fee-bump helpers, validation, and result wrapping. |
 | `signature_checker.rs` | Multi-signer verification and signer collection. |
 | `events.rs` | Classic and SAC event construction helpers. |
-| `lumen_reconciler.rs` | XLM event reconciliation for mint/burn/transfer edge cases. |
 | `meta_builder.rs` | Transaction metadata builders and diagnostic event plumbing; current finalize path emits V4 metadata. |
 | `scval_utils.rs` | `ScVal` conversion helpers used by event code. |
 | `operations/mod.rs` | Operation-level validation helpers, thresholds, and prefetch key collection. |
@@ -171,7 +170,6 @@ Soroban execution is protocol-versioned. `soroban-env-host-p24` is used for prot
 | `result.rs` | `src/transactions/MutableTransactionResult.cpp` |
 | `meta_builder.rs` | `src/transactions/TransactionMeta.cpp`, `src/transactions/TransactionMeta.h` |
 | `events.rs` | `src/transactions/EventManager.cpp` |
-| `lumen_reconciler.rs` | `src/transactions/LumenEventReconciler.cpp` |
 | `operations/mod.rs` | `src/transactions/OperationFrame.cpp` |
 | `operations/execute/*.rs` | `src/transactions/*OpFrame.cpp`, `src/transactions/OfferExchange.cpp` |
 | `state/mod.rs` | `src/ledger/LedgerTxn.cpp`, `src/ledger/LedgerTxn.h` |


### PR DESCRIPTION
Closes #3474

## Summary

`crates/tx/README.md` listed `lumen_reconciler.rs` in two tables — the file-list table and the stellar-core mapping table — but that source file was deleted as net-dead in #3471 (commit `5acf0549`). The `LumenEventReconciler` / `reconcile_events` path is only reachable below protocol 8, and henyey's supported protocol floor is 24+, so it was removed entirely (no replacement file). This corrects the README to match the current `crates/tx/src/` layout. Docs-only; no code or behavior change.

## Plan reference

Trivial short-circuit — Triage Report `## Implementation Notes` on #3474 (verified against the actual `origin/main` src tree, which confirmed the file is deleted with no successor). Triage flagged the mapping-table row; the identical file-list row referencing the same deleted file was removed alongside it per the same correct-the-map-to-reality scope.

## Test plan

- [x] cargo fmt --check (pre-commit hook)
- [x] cargo clippy --all -- -D warnings (pre-commit hook)
- [x] `cargo build -p henyey-tx` passes (README is not wired as a doctest via `include_str!`, so no `--doc` run applies)

## Deviations from plan

- Triage named only the stellar-core mapping row (line 174). The README also referenced the same deleted `lumen_reconciler.rs` in the file-list table (line 109); both stale rows were removed to keep the file map consistent with the current src tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)