### PR TITLE
Swap hand-rolled constant_time_eq for subtle::ConstantTimeEq in overlay MAC verify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ henyey-rpc = { path = "crates/rpc" }
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core", "zeroize"] }
 x25519-dalek = { version = "2", default-features = false, features = ["static_secrets", "zeroize"] }
 sha2 = { version = "0.10", default-features = false, features = ["std"] }
+subtle = "2"
 blake2 = "0.10"
 hmac = "0.12"
 crypto_secretbox = "0.1"

--- a/crates/overlay/Cargo.toml
+++ b/crates/overlay/Cargo.toml
@@ -22,6 +22,7 @@ async-trait.workspace = true
 x25519-dalek.workspace = true
 hmac.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 blake2.workspace = true
 
 # Serialization

--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -115,14 +115,15 @@ pub trait AuthCertExt {
 /// Returns `true` if `a` and `b` are equal, without leaking information about
 /// which bytes differ through timing.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+    // Length differs only on non-secret, fixed-size MAC operands ([u8; 32]); the
+    // early return never leaks information about attacker-influenced lengths.
     if a.len() != b.len() {
         return false;
     }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
+    // Delegate the byte comparison to `subtle`, whose audited optimization
+    // barriers prevent a compiler from short-circuiting the constant-time loop.
+    a.ct_eq(b).into()
 }
 
 impl AuthCertExt for AuthCert {
@@ -1282,6 +1283,17 @@ mod tests {
         let mut b = [0u8; 32];
         b[31] = 1; // differ in only the last byte's lowest bit
         assert!(!constant_time_eq(&a, &b));
+
+        // Pin the real MAC operand shape: a 32-byte (`HmacSha256Mac.mac: [u8; 32]`)
+        // buffer with a single-bit flip in the last byte. This is exactly the
+        // operand size used at the MAC-verify call site in `unwrap_message`, so the
+        // boolean contract (equal -> true, single-bit-different -> false) is pinned
+        // for the security-critical shape.
+        let mac_a: [u8; 32] = [0xA5; 32];
+        let mut mac_b = mac_a;
+        assert!(constant_time_eq(&mac_a, &mac_b)); // identical MACs -> true
+        mac_b[31] ^= 0x01; // flip the lowest bit of the last byte
+        assert!(!constant_time_eq(&mac_a, &mac_b)); // single-bit-different -> false
     }
 
     #[test]


### PR DESCRIPTION
Closes #3518

## Summary

Replaces the hand-rolled `constant_time_eq` byte-fold in the overlay auth MAC-verification path (`crates/overlay/src/auth.rs`) with the audited `subtle::ConstantTimeEq` primitive. `subtle` v2.6.1 is already a transitive lockfile dependency (via the x25519-dalek / sha2 / dalek stack), so it is declared directly — `subtle = "2"` in `[workspace.dependencies]` and `subtle.workspace = true` in the overlay crate — keeping exactly one resolved `subtle` version (verified `cargo tree -i subtle` → single `subtle v2.6.1`). The function signature, name, and the single security-critical call site (`unwrap_message` MAC verify) are unchanged; the explicit non-secret length guard is retained. This buys `subtle`'s audited compiler optimization barriers and removes the self-audit burden, without changing any observable behavior.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3518#issuecomment-4764352419)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build -p henyey-overlay --all-targets` (-Dwarnings)
- [x] `cargo build --all` (-Dwarnings)
- [x] `cargo test --all` — 7551 tests pass, 0 failures
- [x] MAC/auth suite green: `test_constant_time_eq_*`, `test_unwrap_*_g14`, `test_audit_c1_mac_bypass_rejected`, `test_audit_004_auth_msg_mac_must_be_verified`, `test_bad_mac_does_not_advance_recv_sequence`
- [x] `cargo tree -i subtle` → exactly one version (`subtle v2.6.1`); no version split

The existing `test_constant_time_eq_*` tests are the semantic-preservation regression — they assert the boolean contract (equal→true, unequal/length-mismatch/single-bit-flip→false) and pass identically on the swapped impl. A 32-byte MAC-shaped (`HmacSha256Mac.mac: [u8; 32]`) single-bit-flip assertion was added to `test_constant_time_eq_single_bit_difference` to pin the real operand shape.

## Parity

Timing-safety hardening only — internal impl detail, not protocol. The MAC-verify decision (accept iff byte-equal, reject otherwise), sequence-counter ordering (`recv_sequence += 1` only after a passing compare), wire format, and `MacVerificationFailed` error path are all byte-identical before/after. stellar-core also performs constant-time MAC verification via libsodium `crypto_auth_hmacsha256_verify`, so intent already matches upstream.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)