### PR TITLE
Bump overlay max protocol version 40 -> 41 for Protocol 27

### DIFF
--- a/crates/overlay/SPEC_ADHERENCE.md
+++ b/crates/overlay/SPEC_ADHERENCE.md
@@ -1,8 +1,8 @@
 # OVERLAY_SPEC Adherence — henyey-overlay
 
-**Spec version:** 26 (Overlay Protocol v38–v39)
+**Spec version:** 26 (Overlay Protocol v38–v41)
 **Crate:** crates/overlay
-**Last updated:** 2026-06-03
+**Last updated:** 2026-06-22
 **Overall adherence:** 83%
 
 Counts (excluding Drift and N/A from denominator):

--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -936,6 +936,51 @@ mod tests {
         );
     }
 
+    /// Parity guard: henyey must advertise the stellar-core v27.0.0 overlay
+    /// protocol range — max 41 (`OVERLAY_PROTOCOL_VERSION`), min 38
+    /// (`OVERLAY_PROTOCOL_MIN_VERSION`). Behavior-flip test: FAILS on
+    /// origin/main (max still 40), PASSES after the bump.
+    #[test]
+    fn test_advertised_overlay_version_is_41_min_38() {
+        let secret = SecretKey::generate();
+        let local_node = LocalNode::new_testnet(secret);
+        let ctx = AuthContext::new(local_node, true);
+
+        let hello = ctx.create_hello();
+        assert_eq!(
+            hello.overlay_version, 41,
+            "advertised max overlay version must match stellar-core v27.0.0 (41)"
+        );
+        assert_eq!(
+            hello.overlay_min_version, 38,
+            "advertised min overlay version must stay 38"
+        );
+    }
+
+    /// A v27 peer advertising `[38, 41]` must negotiate successfully against
+    /// our raised ceiling, while a peer entirely above our max (`[42, 45]`)
+    /// must still be rejected.
+    #[test]
+    fn test_negotiation_with_v41_peer_succeeds() {
+        let secret = SecretKey::generate();
+        let local_node = LocalNode::new_testnet(secret);
+        let ctx = AuthContext::new(local_node.clone(), true);
+
+        // v27 peer: range [38, 41] — overlaps our [38, 41], accepted.
+        let v41_peer = make_hello_with_versions(41, 38, &local_node);
+        assert!(
+            ctx.validate_overlay_version(&v41_peer).is_ok(),
+            "a v27 peer advertising [38,41] must negotiate against our ceiling of 41"
+        );
+
+        // Peer entirely above our max: range [42, 45] — no overlap, rejected.
+        let too_new = make_hello_with_versions(45, 42, &local_node);
+        assert!(
+            ctx.validate_overlay_version(&too_new).is_err(),
+            "a peer whose min (42) exceeds our max (41) must be rejected"
+        );
+    }
+
     // ---- G14: receiver auth state (not the wire bit-31 flag) gates MAC verification in unwrap_message ----
 
     /// Helper: Complete a full handshake between two AuthContexts.

--- a/crates/overlay/src/auth.rs
+++ b/crates/overlay/src/auth.rs
@@ -928,7 +928,7 @@ mod tests {
         let ctx = AuthContext::new(local_node, true);
 
         let hello = ctx.create_hello();
-        assert_eq!(hello.overlay_version, 40);
+        assert_eq!(hello.overlay_version, 41);
         assert_eq!(hello.overlay_min_version, 38);
         assert_eq!(
             hello.ledger_version,
@@ -1478,13 +1478,13 @@ mod tests {
 
     #[test]
     fn test_process_hello_rejects_peer_too_new() {
-        // Peer's min version is above our max (40)
+        // Peer's min version is above our max (41)
         let secret = SecretKey::generate();
         let local_node = LocalNode::new_testnet(secret);
         let mut ctx = AuthContext::new(local_node.clone(), true);
         ctx.hello_sent();
 
-        let hello = make_hello_with_versions(43, 41, &local_node);
+        let hello = make_hello_with_versions(45, 42, &local_node);
         let result = ctx.process_hello(&hello);
         assert!(result.is_err());
         assert!(
@@ -1903,10 +1903,10 @@ mod tests {
             r
         );
 
-        // Peer too new.
+        // Peer too new (min 42 is above our max of 41).
         let mut ctx = AuthContext::new(local_node.clone(), false);
         ctx.hello_sent();
-        let hello = make_hello_with_versions(43, 41, &local_node);
+        let hello = make_hello_with_versions(45, 42, &local_node);
         ctx.process_hello_phase1(&hello).unwrap();
         let r = ctx.validate_hello_post_send(&hello);
         assert!(

--- a/crates/overlay/src/lib.rs
+++ b/crates/overlay/src/lib.rs
@@ -819,9 +819,9 @@ pub struct LocalNode {
 }
 
 const LEDGER_VERSION: u32 = henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION;
-// Parity: stellar-core/src/main/Config.cpp:164-165 (v26.0.0)
-// OVERLAY_PROTOCOL_VERSION = 40, OVERLAY_PROTOCOL_MIN_VERSION = 38
-const OVERLAY_VERSION: u32 = 40;
+// Parity: stellar-core/src/main/Config.cpp:163-164 (v27.0.0)
+// OVERLAY_PROTOCOL_MIN_VERSION = 38, OVERLAY_PROTOCOL_VERSION = 41
+const OVERLAY_VERSION: u32 = 41;
 const OVERLAY_MIN_VERSION: u32 = 38;
 const DEFAULT_LISTENING_PORT: u16 = 11625;
 


### PR DESCRIPTION
Closes #3529

## Summary

stellar-core v27.0.0 raised `OVERLAY_PROTOCOL_VERSION` from 40 to 41 (min stays 38). henyey advertised 40, so it negotiated a stale max overlay version against v27 peers. This bumps the advertised max to 41 and refreshes the parity comment, the version-range tests, and the overlay SPEC_ADHERENCE.md header.

The bump carries **no new wire obligation**: the overlay XDR (`Stellar-overlay.x`) is byte-identical v26.0.1 -> v27.0.0, there are zero `>= 41` overlay-version gates in stellar-core's `src/overlay` tree, and the commit that raised the constant (`6536a04f`) only reorders an already-existing `AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED` check earlier in `Peer::recvAuth` for initiator-side metrics/backoff. henyey already sends that flag as the sole valid auth flag and drops peers whose auth flag differs, so it already satisfies the v41 contract. `validate_overlay_version` is a version-agnostic `[min,max]` overlap check; raising our max widens the accepted ceiling with no logic change.

Parity confirmed against the **v27.0.0 tag** (`git show v27.0.0:src/main/Config.cpp` -> `OVERLAY_PROTOCOL_MIN_VERSION = 38; OVERLAY_PROTOCOL_VERSION = 41`), not the v26.0.1-pinned submodule checkout.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3529#issuecomment-4764389708)

## Test plan

- [x] cargo fmt --check
- [x] cargo build -p henyey-overlay --all-targets (RUSTFLAGS=-Dwarnings)
- [x] cargo build --all (RUSTFLAGS=-Dwarnings)
- [x] cargo test -p henyey-overlay (470 lib tests pass)
- [x] cargo test --all (green)

## Behavior-flip test (feature)

- **Test:** `crates/overlay/src/auth.rs::test_advertised_overlay_version_is_41_min_38`
- **Pre-bump:** committed as `7babf37c` — verified FAILED with `assertion left == right failed ... left: 40, right: 41`.
- **Post-bump:** verified PASSES after `72df5f7f`.
- Companion `test_negotiation_with_v41_peer_succeeds` asserts a `[38,41]` v27 peer negotiates while `[42,45]` is rejected.

## Deviations from plan

- The plan listed `test_validate_hello_post_send_rejects_version_and_network` under "existing tests preserved", but its "peer too new" fixture used `(43, 41)` — min 41 was above the old max 40 but is valid under the new max 41. Bumped that fixture (and the analogous `test_process_hello_rejects_peer_too_new`) to `(45, 42)` so the rejection case stays meaningful. Mechanical fixture update within the plan's named test scope; no semantic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)