### PR TITLE
Implement CAP-0071 Soroban authorization delegation protocol boundary (V_27)

### DIFF
--- a/crates/tx/src/operations/execute/invoke_host_function.rs
+++ b/crates/tx/src/operations/execute/invoke_host_function.rs
@@ -507,7 +507,27 @@ fn execute_contract_invocation(
         p23_sac_reconciler,
     } = request;
 
-    // Convert auth entries to a slice
+    // Convert auth entries to a slice.
+    //
+    // Auth entries are passed OPAQUELY to the protocol-routed Soroban host
+    // (`encode_invocation_inputs` in soroban/host.rs serializes them with the
+    // workspace XDR; the host decodes and verifies them with its own bundled
+    // XDR). ALL credential verification — including the CAP-0071 / V_27
+    // variants `SorobanCredentials::{AddressV2, AddressWithDelegates}`, the
+    // recursive `SorobanDelegateSignature` trees, and the new
+    // `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` preimage hashing — is
+    // owned by the host (soroban-env-host-p27), NEVER reimplemented here.
+    // Reimplementing it in henyey-tx would diverge from the host's metered
+    // hashing and fork consensus auth.
+    //
+    // Version gating is host-routing, not a validation-time gate: V_27+ ledgers
+    // run the p27 host (native CAP-0071 verification); pre-V27 ledgers run the
+    // p26 host, whose stellar-xdr 26.0.0 cannot decode credential discriminants
+    // 2/3, yielding a host error → `INVOKE_HOST_FUNCTION_TRAPPED` (a failed
+    // invocation), NOT a synthesized txMALFORMED. This matches stellar-core v27
+    // exactly: `InvokeHostFunctionOpFrame::doCheckValidForSoroban` performs no
+    // credential-type validation. See `crates/tx/tests/cap0071_auth_credentials.rs`
+    // and the `cap0071` unit tests in soroban/host.rs (#3527).
     let auth_entries: Vec<_> = op.auth.to_vec();
 
     // Run all pre-execution footprint checks in a single per-entry pass, mirroring

--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -2302,6 +2302,210 @@ mod tests {
         );
     }
 
+    // ====================================================================
+    // CAP-0071 Soroban authorization delegation (#3527)
+    //
+    // henyey-tx passes Soroban auth entries to the protocol-routed host as
+    // opaque XDR bytes via `encode_invocation_inputs` (host.rs:982). The
+    // host then decodes those bytes with ITS OWN bundled stellar-xdr and
+    // performs ALL credential verification. henyey-tx reimplements none of
+    // it (that would fork consensus auth). These tests pin the protocol
+    // boundary that gates the new credential variants:
+    //
+    //   * The P27 host pins stellar-xdr 27.0.0 (== workspace XDR), so it
+    //     decodes `SorobanCredentials::AddressV2` / `AddressWithDelegates`
+    //     (discriminants 2 / 3) and verifies them natively at V_27+.
+    //   * The pre-V27 P26 host pins stellar-xdr 26.0.0, which has no
+    //     knowledge of discriminants 2 / 3, so decoding an entry carrying
+    //     them FAILS. In the live apply path that decode failure surfaces
+    //     as a non-internal host error → `INVOKE_HOST_FUNCTION_TRAPPED`
+    //     (an op-level failed invocation), NOT a synthesized txMALFORMED.
+    //
+    // This mirrors stellar-core v27.0.0 exactly: `doCheckValidForSoroban`
+    // (InvokeHostFunctionOpFrame.cpp:1282) performs NO credential-type
+    // validation, and `get_host_module_for_protocol`
+    // (soroban_proto_all.rs) routes by ledger protocol version to the same
+    // p26 / p27 hosts. Pre-V27 rejection is therefore host-routing, not a
+    // validation-time gate — so henyey-tx adds no explicit version gate.
+    // ====================================================================
+
+    /// Build an `AddressV2` credential auth entry (discriminant 2) using the
+    /// workspace XDR (== P27 XDR), exactly as henyey-tx would hand it to the
+    /// host boundary.
+    fn cap0071_address_v2_entry() -> stellar_xdr::SorobanAuthorizationEntry {
+        use stellar_xdr::*;
+        SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::AddressV2(SorobanAddressCredentials {
+                address: ScAddress::Contract(ContractId(Hash([7u8; 32]))),
+                nonce: 42,
+                signature_expiration_ledger: 1000,
+                signature: ScVal::Void,
+            }),
+            root_invocation: SorobanAuthorizedInvocation {
+                function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                    contract_address: ScAddress::Contract(ContractId(Hash([8u8; 32]))),
+                    function_name: ScSymbol("f".try_into().unwrap()),
+                    args: VecM::default(),
+                }),
+                sub_invocations: VecM::default(),
+            },
+        }
+    }
+
+    /// Build an `AddressWithDelegates` credential auth entry (discriminant 3)
+    /// carrying a recursive `SorobanDelegateSignature` tree (a nested delegate
+    /// under a top-level delegate), exercising the full CAP-0071 surface.
+    fn cap0071_address_with_delegates_entry() -> stellar_xdr::SorobanAuthorizationEntry {
+        use stellar_xdr::*;
+        let nested = SorobanDelegateSignature {
+            address: ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+                [3u8; 32],
+            )))),
+            signature: ScVal::Void,
+            nested_delegates: VecM::default(),
+        };
+        let top = SorobanDelegateSignature {
+            address: ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+                [4u8; 32],
+            )))),
+            signature: ScVal::Void,
+            nested_delegates: vec![nested].try_into().unwrap(),
+        };
+        SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::AddressWithDelegates(
+                SorobanAddressCredentialsWithDelegates {
+                    address_credentials: SorobanAddressCredentials {
+                        address: ScAddress::Contract(ContractId(Hash([7u8; 32]))),
+                        nonce: 42,
+                        signature_expiration_ledger: 1000,
+                        signature: ScVal::Void,
+                    },
+                    delegates: vec![top].try_into().unwrap(),
+                },
+            ),
+            root_invocation: SorobanAuthorizedInvocation {
+                function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                    contract_address: ScAddress::Contract(ContractId(Hash([8u8; 32]))),
+                    function_name: ScSymbol("f".try_into().unwrap()),
+                    args: VecM::default(),
+                }),
+                sub_invocations: VecM::default(),
+            },
+        }
+    }
+
+    /// V_27+: the P27 host (stellar-xdr 27.0.0) decodes an `AddressV2` auth
+    /// entry — the discriminant the workspace serializes flows straight into
+    /// the host for native verification.
+    #[test]
+    fn test_address_v2_credentials_at_v27_routes_to_host() {
+        use soroban_env_host27::xdr::ReadXdr as ReadXdrP27;
+        let bytes = encode_one_auth_entry(&cap0071_address_v2_entry());
+        let decoded = soroban_env_host27::xdr::SorobanAuthorizationEntry::from_xdr(
+            &bytes,
+            soroban_env_host27::xdr::Limits::none(),
+        );
+        assert!(
+            decoded.is_ok(),
+            "P27 host (stellar-xdr 27.0.0) must decode AddressV2 credentials so it can verify them natively at V_27+: {decoded:?}"
+        );
+    }
+
+    /// V_27+: the P27 host decodes an `AddressWithDelegates` entry carrying a
+    /// recursive `SorobanDelegateSignature` tree — the full CAP-0071 surface
+    /// flows through opaquely for the host to verify.
+    #[test]
+    fn test_address_with_delegates_at_v27_routes_to_host() {
+        use soroban_env_host27::xdr::ReadXdr as ReadXdrP27;
+        let bytes = encode_one_auth_entry(&cap0071_address_with_delegates_entry());
+        let decoded = soroban_env_host27::xdr::SorobanAuthorizationEntry::from_xdr(
+            &bytes,
+            soroban_env_host27::xdr::Limits::none(),
+        );
+        assert!(
+            decoded.is_ok(),
+            "P27 host must decode AddressWithDelegates (recursive delegates) for native verification at V_27+: {decoded:?}"
+        );
+    }
+
+    /// Pre-V27: the P26 host (stellar-xdr 26.0.0) CANNOT decode an `AddressV2`
+    /// entry — discriminant 2 is unknown to it. This is the exact reject
+    /// mechanism: a host decode failure → non-internal host error →
+    /// `INVOKE_HOST_FUNCTION_TRAPPED` in the live path. NOT a txMALFORMED.
+    #[test]
+    fn test_address_v2_credentials_rejected_before_v27() {
+        use soroban_env_host26::xdr::ReadXdr as ReadXdrP26;
+        let bytes = encode_one_auth_entry(&cap0071_address_v2_entry());
+        let decoded = soroban_env_host26::xdr::SorobanAuthorizationEntry::from_xdr(
+            &bytes,
+            soroban_env_host26::xdr::Limits::none(),
+        );
+        assert!(
+            decoded.is_err(),
+            "P26 host (stellar-xdr 26.0.0) must REJECT AddressV2 credentials (unknown discriminant 2) — this is the pre-V27 host-routing reject path"
+        );
+    }
+
+    /// Pre-V27: the P26 host CANNOT decode an `AddressWithDelegates` entry —
+    /// discriminant 3 is unknown to it (host-routing rejection).
+    #[test]
+    fn test_address_with_delegates_rejected_before_v27() {
+        use soroban_env_host26::xdr::ReadXdr as ReadXdrP26;
+        let bytes = encode_one_auth_entry(&cap0071_address_with_delegates_entry());
+        let decoded = soroban_env_host26::xdr::SorobanAuthorizationEntry::from_xdr(
+            &bytes,
+            soroban_env_host26::xdr::Limits::none(),
+        );
+        assert!(
+            decoded.is_err(),
+            "P26 host must REJECT AddressWithDelegates (unknown discriminant 3) — pre-V27 host-routing reject path"
+        );
+    }
+
+    /// Regression guard: the legacy `Address` credential (discriminant 1) is
+    /// UNAFFECTED before V27 — the P26 host still decodes it. Confirms the
+    /// pre-V27 reject path is specific to the new variants and introduces no
+    /// regression for existing Soroban auth.
+    #[test]
+    fn test_legacy_address_credentials_unaffected_before_v27() {
+        use soroban_env_host26::xdr::ReadXdr as ReadXdrP26;
+        use stellar_xdr::*;
+        let entry = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: ScAddress::Contract(ContractId(Hash([7u8; 32]))),
+                nonce: 42,
+                signature_expiration_ledger: 1000,
+                signature: ScVal::Void,
+            }),
+            root_invocation: SorobanAuthorizedInvocation {
+                function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                    contract_address: ScAddress::Contract(ContractId(Hash([8u8; 32]))),
+                    function_name: ScSymbol("f".try_into().unwrap()),
+                    args: VecM::default(),
+                }),
+                sub_invocations: VecM::default(),
+            },
+        };
+        let bytes = encode_one_auth_entry(&entry);
+        let decoded = soroban_env_host26::xdr::SorobanAuthorizationEntry::from_xdr(
+            &bytes,
+            soroban_env_host26::xdr::Limits::none(),
+        );
+        assert!(
+            decoded.is_ok(),
+            "P26 host must STILL decode legacy Address credentials (discriminant 1) — no regression: {decoded:?}"
+        );
+    }
+
+    /// Encode a single auth entry to XDR via the workspace serializer — the
+    /// exact `to_xdr` path `encode_invocation_inputs` (host.rs:998) uses to
+    /// hand auth entries to the host boundary.
+    fn encode_one_auth_entry(entry: &stellar_xdr::SorobanAuthorizationEntry) -> Vec<u8> {
+        entry
+            .to_xdr(Limits::none())
+            .expect("workspace XDR (27.0.0) must serialize CAP-0071 auth entries")
+    }
+
     /// Test compute_key_hash produces different hashes for different keys.
     #[test]
     fn test_compute_key_hash_different_keys() {

--- a/crates/tx/tests/cap0071_auth_credentials.rs
+++ b/crates/tx/tests/cap0071_auth_credentials.rs
@@ -1,0 +1,246 @@
+//! CAP-0071 Soroban authorization delegation — protocol-boundary tests (#3527).
+//!
+//! Protocol 27 (CAP-0071) adds two new `SorobanCredentials` variants —
+//! `AddressV2` (discriminant 2) and `AddressWithDelegates` (discriminant 3,
+//! carrying a recursive `SorobanDelegateSignature` tree) — plus a new
+//! `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` signature preimage.
+//!
+//! henyey-tx's ONLY obligation is the protocol boundary: it passes `op.auth`
+//! opaquely to the protocol-routed Soroban host (`encode_invocation_inputs`),
+//! which decodes and verifies it with its own bundled XDR. ALL CAP-0071
+//! verification (credential routing, recursive delegate signatures, the new
+//! preimage + metered hashing) lives in `soroban-env-host-p27` — the same
+//! crate stellar-core v27 uses. henyey-tx reimplements none of it, because
+//! that would fork consensus auth.
+//!
+//! Pre-V27 rejection is *host-routing*, not a validation-time gate: stellar-core
+//! v27's `InvokeHostFunctionOpFrame::doCheckValidForSoroban` performs NO
+//! credential-type validation, and routes by ledger protocol version to the
+//! matching host. A pre-V27 ledger runs the P26 host (stellar-xdr 26.0.0), which
+//! cannot decode discriminants 2/3 → host error → `INVOKE_HOST_FUNCTION_TRAPPED`
+//! (a failed invocation), NOT a synthesized `txMALFORMED`. henyey mirrors this
+//! exactly via `PersistentModuleCache::new_for_protocol` (V27-first routing).
+//!
+//! The byte-level decode behavior of each host (P26 rejects, P27 accepts) is
+//! pinned by the unit tests in `crates/tx/src/soroban/host.rs`, which have the
+//! host crates in scope. These integration tests pin the henyey public-API
+//! boundary: version routing and that fee-bump inner-tx auth ops are reached.
+
+use henyey_tx::soroban::PersistentModuleCache;
+use henyey_tx::TransactionFrame;
+use stellar_xdr::{
+    AccountId, ContractId, FeeBumpTransaction, FeeBumpTransactionEnvelope, FeeBumpTransactionExt,
+    FeeBumpTransactionInnerTx, Hash, HostFunction, InvokeContractArgs, InvokeHostFunctionOp, Memo,
+    MuxedAccount, Operation, OperationBody, Preconditions, PublicKey, ScAddress, ScSymbol, ScVal,
+    SequenceNumber, SorobanAddressCredentials, SorobanAddressCredentialsWithDelegates,
+    SorobanAuthorizationEntry, SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+    SorobanCredentials, SorobanCredentialsType, SorobanDelegateSignature, Transaction,
+    TransactionEnvelope, TransactionExt, TransactionV1Envelope, Uint256, VecM,
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn account_id(b: u8) -> AccountId {
+    AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([b; 32])))
+}
+
+fn contract_addr(b: u8) -> ScAddress {
+    ScAddress::Contract(ContractId(Hash([b; 32])))
+}
+
+fn root_invocation() -> SorobanAuthorizedInvocation {
+    SorobanAuthorizedInvocation {
+        function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+            contract_address: contract_addr(8),
+            function_name: ScSymbol("f".try_into().unwrap()),
+            args: VecM::default(),
+        }),
+        sub_invocations: VecM::default(),
+    }
+}
+
+fn address_v2_entry() -> SorobanAuthorizationEntry {
+    SorobanAuthorizationEntry {
+        credentials: SorobanCredentials::AddressV2(SorobanAddressCredentials {
+            address: contract_addr(7),
+            nonce: 42,
+            signature_expiration_ledger: 1000,
+            signature: ScVal::Void,
+        }),
+        root_invocation: root_invocation(),
+    }
+}
+
+/// `AddressWithDelegates` with a recursive `SorobanDelegateSignature` tree
+/// (a nested delegate under a top-level delegate).
+fn address_with_delegates_entry() -> SorobanAuthorizationEntry {
+    let nested = SorobanDelegateSignature {
+        address: ScAddress::Account(account_id(3)),
+        signature: ScVal::Void,
+        nested_delegates: VecM::default(),
+    };
+    let top = SorobanDelegateSignature {
+        address: ScAddress::Account(account_id(4)),
+        signature: ScVal::Void,
+        nested_delegates: vec![nested].try_into().unwrap(),
+    };
+    SorobanAuthorizationEntry {
+        credentials: SorobanCredentials::AddressWithDelegates(
+            SorobanAddressCredentialsWithDelegates {
+                address_credentials: SorobanAddressCredentials {
+                    address: contract_addr(7),
+                    nonce: 42,
+                    signature_expiration_ledger: 1000,
+                    signature: ScVal::Void,
+                },
+                delegates: vec![top].try_into().unwrap(),
+            },
+        ),
+        root_invocation: root_invocation(),
+    }
+}
+
+fn invoke_op_with_auth(auth: Vec<SorobanAuthorizationEntry>) -> Operation {
+    Operation {
+        source_account: None,
+        body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+            host_function: HostFunction::InvokeContract(InvokeContractArgs {
+                contract_address: contract_addr(9),
+                function_name: ScSymbol("noop".try_into().unwrap()),
+                args: VecM::default(),
+            }),
+            auth: auth.try_into().unwrap(),
+        }),
+    }
+}
+
+fn inner_tx_envelope(op: Operation) -> TransactionEnvelope {
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256([1u8; 32])),
+        fee: 1000,
+        seq_num: SequenceNumber(1),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: vec![op].try_into().unwrap(),
+        ext: TransactionExt::V0,
+    };
+    TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx,
+        signatures: vec![].try_into().unwrap(),
+    })
+}
+
+// ============================================================================
+// XDR type surface (confirms the workspace pins stellar-xdr 27.0.0 with CAP-0071)
+// ============================================================================
+
+/// The CAP-0071 credential discriminants are exactly 2 and 3, matching the XDR
+/// `SOROBAN_CREDENTIALS_ADDRESS_V2 = 2` / `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES = 3`.
+#[test]
+fn test_cap0071_credential_discriminants() {
+    assert_eq!(SorobanCredentialsType::AddressV2 as i32, 2);
+    assert_eq!(SorobanCredentialsType::AddressWithDelegates as i32, 3);
+    assert_eq!(
+        SorobanCredentials::AddressV2(SorobanAddressCredentials {
+            address: contract_addr(7),
+            nonce: 0,
+            signature_expiration_ledger: 0,
+            signature: ScVal::Void,
+        })
+        .discriminant(),
+        SorobanCredentialsType::AddressV2
+    );
+    assert_eq!(
+        address_with_delegates_entry().credentials.discriminant(),
+        SorobanCredentialsType::AddressWithDelegates
+    );
+}
+
+// ============================================================================
+// Version routing — the pre-V27 reject mechanism is host-routing
+// ============================================================================
+
+/// V_27 routes to the P27 host (which verifies CAP-0071 credentials natively);
+/// pre-V27 routes to the P26 host (which cannot decode them). This is the
+/// version gate — no explicit credential validation gate exists, matching
+/// stellar-core v27 (`doCheckValidForSoroban` does no credential validation).
+#[test]
+fn test_version_routing_gates_cap0071_credentials() {
+    let cache27 =
+        PersistentModuleCache::new_for_protocol(27).expect("P27 module cache should be available");
+    assert!(
+        cache27.as_p27().is_some(),
+        "protocol 27 must route to the P27 host (native CAP-0071 verification)"
+    );
+    assert!(
+        cache27.as_p26().is_none(),
+        "protocol 27 must NOT route to the P26 host"
+    );
+
+    let cache26 =
+        PersistentModuleCache::new_for_protocol(26).expect("P26 module cache should be available");
+    assert!(
+        cache26.as_p26().is_some(),
+        "pre-V27 protocol 26 must route to the P26 host (which rejects discriminants 2/3)"
+    );
+    assert!(
+        cache26.as_p27().is_none(),
+        "protocol 26 must NOT route to the P27 host"
+    );
+}
+
+// ============================================================================
+// Fee-bump inner-tx ops are reached
+// ============================================================================
+
+/// `invoke_host_function_ops()` unwraps the fee-bump inner transaction, so the
+/// new credential auth entries on an inner Soroban op are reached by the host
+/// boundary even when wrapped in a fee-bump envelope (pre-V27, that inner op
+/// then fails the host decode → trapped invocation).
+#[test]
+fn test_fee_bump_inner_invoke_host_function_ops_reached() {
+    let inner = inner_tx_envelope(invoke_op_with_auth(vec![address_with_delegates_entry()]));
+    let fee_bump_env = TransactionEnvelope::TxFeeBump(FeeBumpTransactionEnvelope {
+        tx: FeeBumpTransaction {
+            fee_source: MuxedAccount::Ed25519(Uint256([2u8; 32])),
+            fee: 2000,
+            inner_tx: FeeBumpTransactionInnerTx::Tx(match inner {
+                TransactionEnvelope::Tx(e) => e,
+                _ => unreachable!(),
+            }),
+            ext: FeeBumpTransactionExt::V0,
+        },
+        signatures: vec![].try_into().unwrap(),
+    });
+    let frame = TransactionFrame::from_owned(fee_bump_env);
+
+    let ihf_ops = frame.invoke_host_function_ops();
+    assert_eq!(
+        ihf_ops.len(),
+        1,
+        "fee-bump inner InvokeHostFunction op must be reached via invoke_host_function_ops()"
+    );
+    let auth = &ihf_ops[0].auth;
+    assert_eq!(auth.len(), 1, "the inner op's auth entry must be present");
+    assert_eq!(
+        auth[0].credentials.discriminant(),
+        SorobanCredentialsType::AddressWithDelegates,
+        "the AddressWithDelegates credential must survive fee-bump unwrapping intact"
+    );
+}
+
+/// Sanity: a plain (non-fee-bump) Soroban tx carrying an `AddressV2` auth entry
+/// is reached the same way, with the credential intact for the host boundary.
+#[test]
+fn test_plain_invoke_host_function_ops_reached() {
+    let env = inner_tx_envelope(invoke_op_with_auth(vec![address_v2_entry()]));
+    let frame = TransactionFrame::from_owned(env);
+    let ihf_ops = frame.invoke_host_function_ops();
+    assert_eq!(ihf_ops.len(), 1);
+    assert_eq!(
+        ihf_ops[0].auth[0].credentials.discriminant(),
+        SorobanCredentialsType::AddressV2
+    );
+}


### PR DESCRIPTION
Closes #3527

## Summary

Protocol 27 (CAP-0071) adds Soroban authorization delegation: the new `SorobanCredentials::{AddressV2, AddressWithDelegates}` variants (the latter carrying a recursive `SorobanDelegateSignature` tree) and the `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` signature preimage.

henyey-tx's only obligation is the protocol boundary, and it is already provided by host-version routing (landed with #3526/#3534). henyey-tx passes `op.auth` opaquely to the protocol-routed Soroban host (`encode_invocation_inputs`), which decodes and verifies it with its own bundled XDR. **All** CAP-0071 verification — credential routing, recursive delegate signatures, and the new preimage + metered hashing — lives in `soroban-env-host-p27` (the same crate stellar-core v27 uses) and is never reimplemented in henyey-tx (that would fork consensus auth).

This PR adds the version-gating + accept tests (the planned primary deliverable) and a clarifying comment at the pass-through site. **No functional henyey-tx change** — the host-routing boundary already gates the new variants correctly.

### Pre-V27 reject mechanism (verified against stellar-core v27.0.0)

Confirmed against the v27.0.0 submodule (`git submodule update --init`): `InvokeHostFunctionOpFrame::doCheckValidForSoroban` performs **no** credential-type validation, and `get_host_module_for_protocol` routes by ledger protocol version. A pre-V27 ledger runs the p26 host whose stellar-xdr 26.0.0 cannot decode credential discriminants 2/3 → non-internal host error → `INVOKE_HOST_FUNCTION_TRAPPED` (a failed invocation), **not** a synthesized `txMALFORMED`. henyey mirrors this exactly via `PersistentModuleCache::new_for_protocol` (V27-first routing) — so no explicit validation gate is added (plan default path #1).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3527#issuecomment-4764411513)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-tx --all-targets -- -D warnings`
- [x] `cargo build -p henyey-tx --all-targets` and `RUSTFLAGS=-Dwarnings cargo build --all`
- [x] `cargo test --all` — green (0 failed across 83 test binaries)
- [x] Parity tripwires byte-identical: `tx_meta_hash_vectors`, `transaction_execution` (108), `validation_parity` (12)

### New coverage

Cross-host decode unit tests (`crates/tx/src/soroban/host.rs`) prove the exact reject/accept mechanism:
- `test_address_v2_credentials_at_v27_routes_to_host` / `test_address_with_delegates_at_v27_routes_to_host` — P27 host (xdr 27.0.0) decodes discriminants 2/3.
- `test_address_v2_credentials_rejected_before_v27` / `test_address_with_delegates_rejected_before_v27` — P26 host (xdr 26.0.0) rejects them.
- `test_legacy_address_credentials_unaffected_before_v27` — legacy `Address` (discriminant 1) still decodes pre-V27 (no regression).

Public-API boundary tests (`crates/tx/tests/cap0071_auth_credentials.rs`): credential discriminants (2/3), version routing (`new_for_protocol`), and fee-bump inner-tx auth-op reach via `invoke_host_function_ops()`.

## Deviations from plan

- **No explicit `validation.rs` credential gate** — the plan's conditional path #2 is omitted because /do confirmed stellar-core v27 does **no** credential-type validation at `doCheckValidForSoroban`; rejection is host-routing only (plan default path #1).
- **Failing-test-first nuance:** because path #1 requires no new henyey public surface, there was no pre-existing henyey defect to turn red. The tests lock the existing host-routing boundary; the parity value is the contrast within the same suite — identical bytes are *rejected* by the p26 host and *accepted* by the p27 host (`..._rejected_before_v27` vs `..._at_v27_routes_to_host`), which would break if routing or the xdr pins regressed. This is documented honestly rather than fabricating a red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)