### PR TITLE
Suppress duplicate added-peer count on mutual-dial replacement

### DIFF
--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -323,9 +323,20 @@ impl OverlayManager {
             }
         };
         shared.peer_info_cache.insert(peer_id.clone(), peer_info);
-        shared
-            .added_authenticated_peers
-            .fetch_add(1, Ordering::Relaxed);
+        // Only count a NEWLY-occupied authenticated slot. When this registration
+        // REPLACED an existing authenticated handle (the mutual-dial "new wins"
+        // tiebreaker above), the slot was already counted at the displaced peer's
+        // original registration, so re-counting would double-bump (+2 add / 0 drop
+        // for a single surviving peer). stellar-core v27.0.0 resolves the same
+        // collision pre-auth at HELLO (Peer::recvHello ERR_CONF "already-connected"),
+        // dropping the loser while still pending — never ++mAddedAuthenticatedPeers,
+        // never recordDroppedPeer. Suppressing the duplicate add (NOT bumping a drop)
+        // matches core's absolute counters: +1 add / 0 drop. (#3500)
+        if replaced.is_none() {
+            shared
+                .added_authenticated_peers
+                .fetch_add(1, Ordering::Relaxed);
+        }
         Ok(RegisterResult {
             outbound_rx,
             flow_control,

--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -2849,5 +2849,130 @@ mod tests {
             shared.cleanup_peer(&remote, new_gen);
             assert!(!shared.peers.contains_key(&remote));
         }
+
+        #[tokio::test]
+        async fn test_mutual_dial_replacement_does_not_double_count_added_peers() {
+            // Regression for #3500: the mutual-dial "new wins" replacement branch
+            // reuses an already-counted authenticated slot, so it must NOT bump the
+            // `added_authenticated_peers` atomic again. stellar-core v27.0.0 resolves
+            // the same collision pre-auth at HELLO (Peer::recvHello ERR_CONF
+            // "already-connected") so the loser is dropped while still pending —
+            // never counted as added, never recordDroppedPeer'd. Net core: +1/0.
+            // henyey must match: a winning replacement adds 0 (the slot was counted
+            // at the displaced peer's original registration) and the stale-generation
+            // cleanup drops 0.
+            let local = low_id();
+            let remote = high_id();
+            let shared = make_shared(local);
+            // Seed an existing authenticated outbound peer at generation 0. NOTE:
+            // insert_fake does NOT bump the add atomic, so we sample the baseline
+            // immediately before the replacing call and assert the *delta* across it.
+            insert_fake(&shared, &remote, ConnectionDirection::Outbound);
+
+            let added_before = shared.added_authenticated_peers.load(Ordering::Relaxed);
+            let dropped_before = shared.dropped_authenticated_peers.load(Ordering::Relaxed);
+
+            // Winning cross-direction inbound registration (local < remote ⇒ accept
+            // inbound ⇒ new wins ⇒ replaced.is_some()).
+            let peer = crate::peer::Peer::new_test_inbound(
+                remote.clone(),
+                false,
+                Arc::clone(&shared.metrics),
+            );
+            let reg = OverlayManager::try_register_peer(
+                &peer,
+                &remote,
+                peer.info().clone(),
+                &shared,
+                1024,
+            )
+            .expect("replacement should succeed");
+            assert!(
+                reg.replaced.is_some(),
+                "this case must be a replacement to exercise the double-count path"
+            );
+
+            // The replacement reused an already-counted slot: the add atomic must
+            // not have moved. On origin/main this is +1 (the bug) — the test fails.
+            assert_eq!(
+                shared.added_authenticated_peers.load(Ordering::Relaxed),
+                added_before,
+                "mutual-dial replacement must not bump added_authenticated_peers (double count)"
+            );
+
+            // Stale-generation cleanup of the displaced peer (the caller drops the
+            // old handle; its peer_loop calls cleanup_peer with the old generation):
+            // the new generation is installed, so this is a no-op and must not bump
+            // the drop atomic.
+            shared.cleanup_peer(&remote, 0);
+            assert_eq!(
+                shared.dropped_authenticated_peers.load(Ordering::Relaxed),
+                dropped_before,
+                "stale-generation cleanup must not bump dropped_authenticated_peers"
+            );
+            assert!(shared.peers.contains_key(&remote));
+        }
+
+        #[tokio::test]
+        async fn test_normal_registration_still_counts_added_peer() {
+            // Guard against over-correcting the fix: a non-replacing registration
+            // (vacant entry ⇒ replaced.is_none()) must still bump the add atomic by
+            // exactly 1.
+            let local = low_id();
+            let remote = high_id();
+            let shared = make_shared(local);
+
+            let added_before = shared.added_authenticated_peers.load(Ordering::Relaxed);
+            let peer = crate::peer::Peer::new_test_inbound(
+                remote.clone(),
+                false,
+                Arc::clone(&shared.metrics),
+            );
+            let reg = OverlayManager::try_register_peer(
+                &peer,
+                &remote,
+                peer.info().clone(),
+                &shared,
+                1024,
+            )
+            .expect("vacant entry should succeed");
+            assert!(reg.replaced.is_none());
+            assert_eq!(
+                shared.added_authenticated_peers.load(Ordering::Relaxed),
+                added_before + 1,
+                "a normal (non-replacement) registration must still count the added peer"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_mutual_dial_loser_does_not_count() {
+            // The mutual-dial "existing wins" branch returns Err(AlreadyConnected)
+            // BEFORE the add bump, so a rejected duplicate must leave the add atomic
+            // unchanged. local > remote ⇒ keep existing outbound ⇒ reject new inbound.
+            let local = high_id();
+            let remote = low_id();
+            let shared = make_shared(local);
+            insert_fake(&shared, &remote, ConnectionDirection::Outbound);
+
+            let added_before = shared.added_authenticated_peers.load(Ordering::Relaxed);
+            let peer = crate::peer::Peer::new_test_inbound(
+                remote.clone(),
+                false,
+                Arc::clone(&shared.metrics),
+            );
+            let result = OverlayManager::try_register_peer(
+                &peer,
+                &remote,
+                peer.info().clone(),
+                &shared,
+                1024,
+            );
+            assert!(result.is_err());
+            assert_eq!(
+                shared.added_authenticated_peers.load(Ordering::Relaxed),
+                added_before,
+                "a rejected mutual-dial loser must not bump added_authenticated_peers"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #3500

## Summary

The mutual-dial "new wins" tiebreaker in `OverlayManager::try_register_peer` (`crates/overlay/src/manager/connection.rs`) replaces an existing authenticated `PeerHandle` in place but then unconditionally bumped `added_authenticated_peers` again. Because the displaced peer's slot was already counted at its original registration, a single surviving steady-state peer was reported as `+2 add / 0 drop`, diverging from stellar-core v27.0.0, which reports `+1 add / 0 drop` (it resolves the same collision pre-authentication at HELLO — `Peer::recvHello` `ERR_CONF` "already-connected", Peer.cpp:1883-1896 — so the loser is dropped while still pending: no `++mAddedAuthenticatedPeers`, no `recordDroppedPeer`).

Fix: gate the `added_authenticated_peers.fetch_add(1, ..)` on `replaced.is_none()`, so a replacement (which reuses an already-counted slot) does not double-count. Suppressing the duplicate add (rather than bumping a drop) is the absolute-counter match to stellar-core: `+1 add / 0 drop`. The drop-counter path (`cleanup_peer`'s authenticated-only `removed.is_some()` gate) is untouched; the stale-generation cleanup of the displaced peer remains a no-op.

This is non-consensus, observability-only: `added_authenticated_peers` feeds only the survey-response XDR (`TimeSlicedNodeData.added_authenticated_peers`) via the app delta path in `crates/app/src/app/survey_impl.rs` (confirmed sole consumer). No consensus, ledger, herder, or SCP path changes.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3500#issuecomment-4765460760)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] RUSTFLAGS="-Dwarnings" cargo build -p henyey-overlay -p henyey-app --all-targets
- [x] cargo test --all (green)
- [x] cargo test -p henyey-overlay tiebreaker:: (11 passed)

## Regression test (kind: bug-fix)

- **Test:** `crates/overlay/src/manager/connection.rs::test_mutual_dial_replacement_does_not_double_count_added_peers`
- **Pre-fix:** committed as `5a8d8a412df0cffe89536d102e4dd63204ad50d4` — verified FAILED with `assertion left == right failed ... left: 1, right: 0` (the replacement double-counted the add atomic).
- **Post-fix:** verified PASSES after `d1bdf2619df128037c577c3bd74e41e3a27e8048`.
- Two guard tests also added: `test_normal_registration_still_counts_added_peer` (vacant entry still +1) and `test_mutual_dial_loser_does_not_count` (rejected duplicate stays +0).

## Deviations from plan

- The converged plan also re-pointed two rows in `crates/overlay/PARITY_STATUS.md`. Per operator direction (#3543 owns ALL survey-row PARITY_STATUS edits and is being implemented in parallel), this PR is scoped to `connection.rs` + tests ONLY to remain file-disjoint from #3543. No PARITY_STATUS.md edits here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)