### PR TITLE
Auto-archive done section to keep ≤10 most recent in project-loop

### DIFF
--- a/.claude/skills/project-loop/SKILL.md
+++ b/.claude/skills/project-loop/SKILL.md
@@ -23,6 +23,7 @@ It reuses `/project-tick`'s board query (Step 1), actionability filter (Step 2 +
 ## Configuration
 
 - **`N` = max parallel sub-agents = 3** (override with `--max-parallel=N`). Never dispatch more than `N` specialists concurrently.
+- **`KEEP_RECENT_DONE` = 10** — the loop keeps at most this many closed items in the `done` section, archiving the rest each pass (Step F2). Override with `--keep-recent-done=N`; set `--no-archive` to disable the trim entirely.
 - **`--no-reflect`** — skip the self-reflection / self-improvement pass entirely (operator off-switch).
 - Repo / project / field IDs: see `/project-tick` "Project board" section.
 
@@ -159,7 +160,22 @@ Then handle these special cases before the next pass:
 
 - **Force-converge:** you do **not** implement force-converge — `/review-pr` owns the lifetime bounce-cap force-converge behavior (at the cap, green CI auto-merges and residual reviewer concerns become follow-up issues; only red/pending CI still blocks). Just let `/review-pr` handle it and record an anomaly when an issue hits the cap.
 
-If actionable work remains and slots are free → go back to **Step C** immediately (same pass continues picking). Otherwise → **Step G**.
+If actionable work remains and slots are free → go back to **Step C** immediately (same pass continues picking). Otherwise → **Step F2**.
+
+### Step F2 — Trim the `done` section (keep ≤ `KEEP_RECENT_DONE` most recent)
+
+Once per pass (after dispatch handling, before idle), keep the `done` column from growing without bound: archive every closed item except the **`KEEP_RECENT_DONE` (=10)** most-recently-closed. Best-effort — never block a pass; skip on error and record an anomaly:
+
+```bash
+[ "${NO_ARCHIVE:-0}" = "1" ] || \
+  bash .github/skills/shared/scripts/archive-stale-done.sh --keep-recent "${KEEP_RECENT_DONE:-10}" \
+  || anomaly_log_append "done-trim archive-stale-done.sh failed (non-fatal)"
+```
+
+Notes:
+- Selection is by `closedAt` recency over CLOSED project items (which is what populates `done`); it uses GitHub's `archiveProjectV2Item` mutation, which is **reversible** (items can be unarchived). Idempotent — a no-op once ≤ `KEEP_RECENT_DONE` closed items remain, so the steady-state cost is one paginated query per pass.
+- The same script's age-based mode (`[days]`, default 2) remains available for cron use; `/project-loop` uses the count-based `--keep-recent` mode so the visible `done` section stays bounded regardless of churn.
+- Requires a token with org Projects scope (the script pre-flights and fails loudly otherwise — see its header); on a token-less run the step just logs the anomaly and the pass continues.
 
 ### Step G — Idle / backoff
 

--- a/.github/skills/shared/scripts/archive-stale-done.sh
+++ b/.github/skills/shared/scripts/archive-stale-done.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
-# archive-stale-done.sh — archive closed project items older than N days.
+# archive-stale-done.sh — archive closed project items, by age or by count.
 #
 # Usage:
-#   archive-stale-done.sh [--dry-run] [days]
+#   archive-stale-done.sh [--dry-run] [days]            # age-based  (default)
+#   archive-stale-done.sh [--dry-run] --keep-recent N   # count-based
 #
-# Default days = 2.
+# Two selection policies (mutually exclusive):
+#   * age-based (default, default days = 2): archive every project #2 item
+#     whose underlying Issue/PR is CLOSED and was closed at least N days ago.
+#   * count-based (--keep-recent N): keep only the N most-recently-closed
+#     items; archive every other CLOSED item regardless of age. This is what
+#     /project-loop uses to keep the `done` column trimmed to ~10 items.
 #
-# Archives every project #2 item whose underlying Issue/PR is in state
-# CLOSED and was closed at least N days ago, unless already archived.
-# Idempotent and safe to run from cron / a scheduled GitHub Action /
-# the plan-do-review-loop tick.
+# In both cases only un-archived items with Issue/PR content (not drafts) are
+# touched. Idempotent and safe to run from cron / a scheduled GitHub Action /
+# the project-loop tick. Archiving is reversible (items can be unarchived).
 #
 # Why not use the built-in "Auto-archive items" project workflow?
 #   GitHub does not expose the workflow's filter/action via the public
@@ -19,11 +24,25 @@
 set -euo pipefail
 
 DRY_RUN=false
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN=true
-  shift
+KEEP_RECENT=""
+DAYS=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)        DRY_RUN=true; shift ;;
+    --keep-recent)    KEEP_RECENT="${2:?--keep-recent requires a count N}"; shift 2 ;;
+    --keep-recent=*)  KEEP_RECENT="${1#*=}"; shift ;;
+    --*)              echo "ERROR: unknown flag: $1" >&2; exit 2 ;;
+    *)                DAYS="$1"; shift ;;
+  esac
+done
+DAYS="${DAYS:-2}"
+
+if [ -n "$KEEP_RECENT" ]; then
+  if ! [[ "$KEEP_RECENT" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --keep-recent requires a non-negative integer, got: $KEEP_RECENT" >&2
+    exit 2
+  fi
 fi
-DAYS="${1:-2}"
 
 OWNER="stellar-experimental"
 PROJECT_NUM=2
@@ -81,20 +100,39 @@ items_json=$(gh api graphql --paginate -f query='
     }
   }' -f org="$OWNER" -F proj="$PROJECT_NUM")
 
-# Eligible: not yet archived, has issue/PR content (skip drafts), state CLOSED,
-# closedAt older than the cutoff.
-to_archive=$(jq -rs --argjson days "$DAYS" '
-  .[].data.organization.projectV2.items.nodes[]
-  | select(.isArchived == false)
-  | select(.content != null)
-  | select(.content.state == "CLOSED")
-  | select(.content.closedAt != null)
-  | select((.content.closedAt | fromdateiso8601) < (now - ($days * 86400)))
-  | "\(.id) \(.content.number) \(.content.closedAt)"
-' <<<"$items_json")
+# Eligible base set: not yet archived, has issue/PR content (skip drafts),
+# state CLOSED, with a closedAt. The two policies differ only in which of the
+# eligible items they then select for archiving.
+if [ -n "$KEEP_RECENT" ]; then
+  # Count-based: sort eligible items most-recent-first by closedAt, keep the
+  # first $KEEP_RECENT, archive the rest.
+  to_archive=$(jq -rs --argjson keep "$KEEP_RECENT" '
+    [ .[].data.organization.projectV2.items.nodes[]
+      | select(.isArchived == false)
+      | select(.content != null)
+      | select(.content.state == "CLOSED")
+      | select(.content.closedAt != null) ]
+    | sort_by(.content.closedAt) | reverse
+    | .[$keep:]
+    | .[] | "\(.id) \(.content.number) \(.content.closedAt)"
+  ' <<<"$items_json")
+  empty_msg="No surplus items to archive (≤${KEEP_RECENT} closed item(s) present)."
+else
+  # Age-based: archive eligible items whose closedAt is older than the cutoff.
+  to_archive=$(jq -rs --argjson days "$DAYS" '
+    .[].data.organization.projectV2.items.nodes[]
+    | select(.isArchived == false)
+    | select(.content != null)
+    | select(.content.state == "CLOSED")
+    | select(.content.closedAt != null)
+    | select((.content.closedAt | fromdateiso8601) < (now - ($days * 86400)))
+    | "\(.id) \(.content.number) \(.content.closedAt)"
+  ' <<<"$items_json")
+  empty_msg="No items to archive (closed > ${DAYS} day(s) ago)."
+fi
 
 if [ -z "$to_archive" ]; then
-  echo "No items to archive (closed > ${DAYS} day(s) ago)."
+  echo "$empty_msg"
   exit 0
 fi
 

--- a/.github/skills/shared/scripts/tests/test-archive-keep-recent.sh
+++ b/.github/skills/shared/scripts/tests/test-archive-keep-recent.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# test-archive-keep-recent.sh — regression tests for the count-based
+# `--keep-recent N` selection mode of archive-stale-done.sh.
+#
+# Tests (all use SKIP_PREFLIGHT=1 + --dry-run + a mocked `gh`, so no network
+# call and no real archive mutation is made):
+#   1. test_keep_recent_archives_all_but_n
+#        Mock returns 13 CLOSED items with distinct closedAt. With
+#        --keep-recent 10, asserts exactly the 3 OLDEST are selected (the 10
+#        most-recently-closed are kept) — regardless of age cutoff.
+#   2. test_keep_recent_noop_when_within_limit
+#        Mock returns 5 CLOSED items. With --keep-recent 10, asserts nothing
+#        is archived and the script exits 0 with the "No surplus" message.
+#   3. test_keep_recent_rejects_non_integer
+#        --keep-recent abc → exit 2 with a structured error (arg validation).
+#
+# Usage:
+#   bash .github/skills/shared/scripts/tests/test-archive-keep-recent.sh
+#
+# Exits 0 if all tests pass, non-zero on any failure.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_SCRIPT="$SCRIPT_DIR/../archive-stale-done.sh"
+
+if [ ! -x "$TARGET_SCRIPT" ]; then
+  echo "FAIL: target script not found or not executable: $TARGET_SCRIPT" >&2
+  exit 1
+fi
+
+FAILED=0
+PASSED=0
+
+# Build a mock `gh` that returns a single items page with the given number of
+# CLOSED items, numbered 1..N with closedAt = 2026-06-<DD>T00:00:00Z so item
+# #N is the most-recently-closed. Writes the mock to $1/gh.
+make_mock_gh_with_n_items() {
+  local dir="$1" n="$2" i dd nodes=""
+  for ((i = 1; i <= n; i++)); do
+    printf -v dd '%02d' "$i"
+    nodes+="{\"id\":\"I_${i}\",\"isArchived\":false,\"content\":{\"number\":${i},\"state\":\"CLOSED\",\"closedAt\":\"2026-06-${dd}T00:00:00Z\"}}"
+    [ "$i" -lt "$n" ] && nodes+=","
+  done
+  cat >"$dir/gh" <<EOF
+#!/usr/bin/env bash
+# Mock gh: return one items page with ${n} CLOSED items for the main fetch.
+if [[ "\$1" == "api" && "\$2" == "graphql" ]]; then
+  cat <<'JSON'
+{"data":{"organization":{"projectV2":{"items":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[${nodes}]}}}}}
+JSON
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$dir/gh"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: 13 items, keep 10 → archive the 3 oldest (#1,#2,#3) only.
+# ---------------------------------------------------------------------------
+test_keep_recent_archives_all_but_n() {
+  local name="test_keep_recent_archives_all_but_n"
+  local tmpdir; tmpdir="$(mktemp -d)"; trap 'rm -rf "$tmpdir"' RETURN
+  make_mock_gh_with_n_items "$tmpdir" 13
+
+  local output exit_code
+  output=$(PATH="$tmpdir:$PATH" GH_TOKEN="dummy" SKIP_PREFLIGHT=1 \
+           bash "$TARGET_SCRIPT" --dry-run --keep-recent 10 2>&1)
+  exit_code=$?
+
+  if [ "$exit_code" -ne 0 ]; then
+    echo "FAIL: $name — expected exit 0, got $exit_code"; echo "  output: $output"
+    FAILED=$((FAILED + 1)); return
+  fi
+  if ! grep -q "Dry-run complete: 3 item(s) would be archived." <<<"$output"; then
+    echo "FAIL: $name — expected exactly 3 items archived"; echo "  output: $output"
+    FAILED=$((FAILED + 1)); return
+  fi
+  # The 3 oldest must be selected; the newest (and the boundary #4) must NOT.
+  local must_have=("#1 " "#2 " "#3 ") must_not=("#4 " "#13 ")
+  local tok
+  for tok in "${must_have[@]}"; do
+    if ! grep -q "would archive ${tok}" <<<"$output"; then
+      echo "FAIL: $name — expected '${tok}' to be archived"; echo "  output: $output"
+      FAILED=$((FAILED + 1)); return
+    fi
+  done
+  for tok in "${must_not[@]}"; do
+    if grep -q "would archive ${tok}" <<<"$output"; then
+      echo "FAIL: $name — '${tok}' must be KEPT, not archived"; echo "  output: $output"
+      FAILED=$((FAILED + 1)); return
+    fi
+  done
+  echo "PASS: $name"; PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: 5 items, keep 10 → no-op, exit 0.
+# ---------------------------------------------------------------------------
+test_keep_recent_noop_when_within_limit() {
+  local name="test_keep_recent_noop_when_within_limit"
+  local tmpdir; tmpdir="$(mktemp -d)"; trap 'rm -rf "$tmpdir"' RETURN
+  make_mock_gh_with_n_items "$tmpdir" 5
+
+  local output exit_code
+  output=$(PATH="$tmpdir:$PATH" GH_TOKEN="dummy" SKIP_PREFLIGHT=1 \
+           bash "$TARGET_SCRIPT" --dry-run --keep-recent 10 2>&1)
+  exit_code=$?
+
+  if [ "$exit_code" -ne 0 ]; then
+    echo "FAIL: $name — expected exit 0, got $exit_code"; echo "  output: $output"
+    FAILED=$((FAILED + 1)); return
+  fi
+  if ! grep -q "No surplus items to archive" <<<"$output"; then
+    echo "FAIL: $name — expected 'No surplus items to archive'"; echo "  output: $output"
+    FAILED=$((FAILED + 1)); return
+  fi
+  echo "PASS: $name"; PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: non-integer --keep-recent → exit 2 with structured error.
+# ---------------------------------------------------------------------------
+test_keep_recent_rejects_non_integer() {
+  local name="test_keep_recent_rejects_non_integer"
+  local tmpdir; tmpdir="$(mktemp -d)"; trap 'rm -rf "$tmpdir"' RETURN
+  make_mock_gh_with_n_items "$tmpdir" 1
+
+  local output exit_code
+  output=$(PATH="$tmpdir:$PATH" GH_TOKEN="dummy" SKIP_PREFLIGHT=1 \
+           bash "$TARGET_SCRIPT" --dry-run --keep-recent abc 2>&1)
+  exit_code=$?
+
+  if [ "$exit_code" -ne 2 ]; then
+    echo "FAIL: $name — expected exit 2, got $exit_code"; echo "  output: $output"
+    FAILED=$((FAILED + 1)); return
+  fi
+  if ! grep -q "ERROR: --keep-recent requires a non-negative integer" <<<"$output"; then
+    echo "FAIL: $name — expected structured validation error"; echo "  output: $output"
+    FAILED=$((FAILED + 1)); return
+  fi
+  echo "PASS: $name"; PASSED=$((PASSED + 1))
+}
+
+test_keep_recent_archives_all_but_n
+test_keep_recent_noop_when_within_limit
+test_keep_recent_rejects_non_integer
+
+echo
+echo "Results: ${PASSED} passed, ${FAILED} failed"
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Make `/project-loop` automatically keep the board's `done` section trimmed to the **10 most-recently-closed** items, archiving the rest each pass. Operator-requested.

## Changes
- **`archive-stale-done.sh`** — add a count-based `--keep-recent N` mode alongside the existing age-based (`[days]`, default 2) mode. Count mode sorts eligible CLOSED items most-recent-first by `closedAt`, keeps the first N, archives the rest (regardless of age). Robust arg parsing (`--keep-recent N` / `--keep-recent=N` / non-integer rejected with exit 2). Age mode unchanged.
- **`project-loop/SKILL.md`** — new **Step F2** (runs once per pass, after dispatch, before idle): `archive-stale-done.sh --keep-recent ${KEEP_RECENT_DONE:-10}`, best-effort (skip+anomaly on error). New `KEEP_RECENT_DONE=10` config; `--no-archive` / `--keep-recent-done=N` overrides.
- **`tests/test-archive-keep-recent.sh`** — regression tests: archive-all-but-N selection (13 items → 3 oldest archived, 10 newest kept), within-limit no-op, non-integer validation.

## Notes
- Archiving uses the **reversible** `archiveProjectV2Item` mutation (items can be unarchived). Idempotent — a no-op once ≤10 closed items remain; steady-state cost is one paginated query per pass.
- Selection is by `closedAt` over CLOSED items (which is what populates `done`); GitHub's built-in Auto-archive workflow can't be configured via the API, so this CLI step is the config-as-code path.
- **Self-modifying** pipeline change (`.claude/skills/project-loop/`, shared script) — operator-approved in-session.

## Tests run
- New: `test-archive-keep-recent.sh` → 3/3 pass.
- Existing (no regression): `test-archive-stale-done-auth.sh` → 3/3 pass.
- Pre-commit fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)