### PR TITLE
Track CURRENT_LEDGER_PROTOCOL_VERSION in default_protocol_version()

### DIFF
--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -4936,4 +4936,64 @@ name = "test"
         assert_eq!(meta.commit_hash(), Some("a".repeat(40).as_str()));
         assert_eq!(meta.build_timestamp(), Some("2024-01-01T00:00:00Z"));
     }
+
+    // #3550: `default_protocol_version()` must track the compiled
+    // `CURRENT_LEDGER_PROTOCOL_VERSION` constant, not a stale literal. A
+    // non-pinned node otherwise under-advertises its max protocol in compat
+    // `/info` and caps operator upgrade proposals below what it can actually
+    // apply, mirroring stellar-core's
+    // `LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION` default
+    // (Config.cpp:160).
+    #[test]
+    fn test_default_protocol_version_tracks_current_constant() {
+        assert_eq!(
+            default_protocol_version(),
+            henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION,
+            "default_protocol_version() must track CURRENT_LEDGER_PROTOCOL_VERSION, not a literal"
+        );
+        // Anti-drift: pin the current expected value so a stale literal is caught.
+        assert_eq!(default_protocol_version(), 27);
+    }
+
+    #[test]
+    fn test_network_config_default_max_protocol_is_current() {
+        // The non-pinned default (used by compat `/info` advertisement, a
+        // verbatim passthrough at compat_http/handlers/info.rs:39) must equal
+        // the compiled current protocol.
+        let config = AppConfig::default();
+        assert_eq!(
+            config.network.max_protocol_version,
+            henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION
+        );
+
+        // A TOML that names `[network]` but omits `max_protocol_version` must
+        // deserialize to the current constant via `#[serde(default = ...)]`.
+        let toml_str = r#"
+[network]
+passphrase = "Test SDF Network ; September 2015"
+"#;
+        let parsed: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            parsed.network.max_protocol_version,
+            henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION,
+            "absent max_protocol_version must default to CURRENT_LEDGER_PROTOCOL_VERSION"
+        );
+    }
+
+    #[test]
+    fn test_explicit_max_protocol_version_overrides_default() {
+        // Override guardrail: an explicit pin (as in all shipped mainnet *.toml)
+        // must win over the now-current default. This is what keeps mainnet
+        // advertising the pinned 25 while the default auto-tracks the constant.
+        let toml_str = r#"
+[network]
+passphrase = "Public Global Stellar Network ; September 2015"
+max_protocol_version = 25
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.network.max_protocol_version, 25,
+            "an explicit TOML max_protocol_version must override the default"
+        );
+    }
 }

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -1714,7 +1714,12 @@ fn default_base_reserve() -> u32 {
 }
 
 fn default_protocol_version() -> u32 {
-    25
+    // Track the compiled current protocol so a non-pinned node advertises (and
+    // caps operator upgrade proposals at) its real max, mirroring stellar-core's
+    // `LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION` default
+    // (Config.cpp:160). Shipped mainnet *.toml pin this explicitly and override
+    // the default. See #3550.
+    henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION
 }
 
 fn default_db_path() -> PathBuf {


### PR DESCRIPTION
Closes #3550

## Summary

`default_protocol_version()` (crates/app/src/config.rs) returned a hardcoded `25` while henyey compiles at protocol 27, so a non-pinned node under-advertised its max protocol in compat `/info` and capped operator upgrade proposals one version below what it can actually apply. It now returns `henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION` (the same import path already used by `default_testing_upgrade_protocol_version()`), so the default auto-tracks the compiled current protocol — mirroring stellar-core's `LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION` default (`Config.cpp:160`). The constant is tracked, not a literal 27, so future protocol bumps carry automatically.

This is **advertisement + operator-proposal-cap only, NOT live consensus**. The only consumers of `config.network.max_protocol_version` are: (1) compat `/info` advertisement (`info.rs:39`, the bug), (2) the herder operator `set_upgrade_parameters` cap (`herder.rs:948`/`:2875` → `upgrades.rs:388`, byte-identical to stellar-core `Upgrades.cpp:263`), and (3) a cosmetic `PROTOCOL_VERSION` metrics gauge. Re-grepped on the fresh branch: the live SCP nomination/apply validity path (`scp_driver.rs:1926`) already hardcodes `CURRENT_LEDGER_PROTOCOL_VERSION`, independent of config — so this REMOVES a henyey-only internal inconsistency rather than altering consensus. Shipped mainnet `*.toml` pin `max_protocol_version = 25` explicitly and override the default, so mainnet advertising is unaffected.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3550#issuecomment-4769844170)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-app --all-targets (RUSTFLAGS=-Dwarnings)
- [x] cargo build --all
- [x] cargo test --all (exit 0, 0 failed across all summary lines)

## Regression test (kind: bug-fix)

- **Tests:** `crates/app/src/config.rs`::`test_default_protocol_version_tracks_current_constant`, `test_network_config_default_max_protocol_is_current` (invariant), plus `test_explicit_max_protocol_version_overrides_default` (override guardrail).
- **Pre-fix:** committed as `50374bd2` — the two invariant tests verified FAILED with `assertion left == right failed: left: 25, right: 27`; the override-guard test passed (pins explicit TOML `max_protocol_version = 25` still overrides).
- **Post-fix:** all three verified PASS after `b6ff831d`.

## Parity considerations

No parity tripwire vector reads `config.network.max_protocol_version` — `validation_parity`, `ledger_close_meta_vectors`, and `scp_parity_tests` live in crates that do not depend on henyey-app's config; byte-identity unaffected (confirmed by green `cargo test --all`).

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)