### PR TITLE
Mandate empirical build-verify for dead-code/visibility narrowing in plan + review-pr critics

### DIFF
--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -150,6 +150,28 @@ Run three lens passes in sequence (correctness / parity / scope), each as its ow
 >   preserved" list must name the integration tests in that crate that exercise
 >   the touched behavior.
 >
+> **Visibility-narrowing / dead-code build-verify gate (REVISE-MAJOR):**
+>
+> For ANY plan that narrows visibility (`pub`→`pub(crate)`/`pub(super)`/private)
+> or removes "dead" code: the plan MUST specify applying the narrowing/removal in
+> a scratch worktree and verifying it with `cargo build -p <crate> --all-targets`
+> (plus the workspace build) under `-Dwarnings`. A grep for callers is
+> INSUFFICIENT — only a build determines reachability (this repo sets `-Dwarnings`
+> globally in `.cargo/config.toml`, so an unused item is a hard error, and a
+> `#[cfg(test)]`-only caller does NOT keep an item alive in a normal `cargo build`).
+> The plan must classify each affected symbol:
+>
+> - **(a) in-crate non-test caller exists** → narrowing to `pub(crate)` is safe.
+> - **(b) only `#[cfg(test)]` callers, or no callers** → the item is DEAD: delete
+>   it, or keep it `pub` / `#[cfg(test)]` — never blind `pub(crate)` (that trips
+>   `dead_code`). A crate-root `pub use` re-export can be the sole keep-alive. An
+>   external integration-test-crate caller (`crates/<c>/tests/*.rs` is a SEPARATE
+>   crate) blocks `pub(crate)` with E0624.
+>
+> Return **REVISE-MAJOR** if a plan asserts a symbol is "safe to narrow" / "dead"
+> from a caller grep alone with no scratch build-verify step specified for `/do`,
+> or if it blind-narrows a (b)-class symbol to `pub(crate)`.
+>
 > You may read the issue body, the plan, and any source files the plan references.
 > Post your verdict as a PR-style comment with this exact structure:
 >
@@ -443,3 +465,7 @@ gh issue edit $ISSUE --repo stellar-experimental/henyey --remove-assignee @me
 - Round 1: C: REVISE-MAJOR ("too broad — splits across 3 crates") → refute pass: `STANDS` (genuinely 3 crates).
 - → File sub-issues, narrow plan. Round 2: A: REVISE-MAJOR ("narrowed plan no longer addresses original problem"), B: APPROVE, C: APPROVE → refute pass on A's concern: `STANDS`.
 - → Force-converge (Step 5-bis): file follow-up issue capturing A's surviving "narrowed plan misses original problem" concern, post `## ⚠️ Plan: Force-Converged (Round 2 Cap)` with the round-2 plan body and a reference to the follow-up, advance to `ready-for-doing`. The operator triages the follow-up — close as won't-fix if the original problem is genuinely covered by the narrowed plan + sub-issues, or schedule a follow-up PR if A was right.
+
+**Visibility-narrowing dead-code trap (Critic A REVISE-MAJOR):**
+- Plan: "narrow `ScpDriver::foo`/`bar` from `pub` to `pub(crate)`; grep shows zero callers outside the crate."
+- → Critic A: grep is insufficient under `-Dwarnings`. The symbols' only callers are `#[cfg(test)]` → they are DEAD, not "internal." `pub(crate)` would trip `dead_code` (this is exactly #3365 scp: 15 dead-code errors across 6 files). REVISE-MAJOR: the plan must specify a scratch build (`cargo build -p henyey-scp --all-targets` under `-Dwarnings`) and choose delete-or-keep-`pub`, not blind narrow.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -393,6 +393,25 @@ Post via `gh pr comment $PR_NUM --repo stellar-experimental/henyey --body-file <
 >    pass (CI will catch this) and the plan's "Existing tests preserved" list
 >    must all be green in CI.
 >
+> **Visibility-narrowing / dead-code build-verify gate (CHANGES_REQUESTED):**
+>
+> For ANY PR diff that narrows visibility (`pub`→`pub(crate)`/`pub(super)`/private)
+> or removes "dead" code: green CI proves the change COMPILES under this repo's
+> global `-Dwarnings`, but a green build alone is NOT enough — you MUST verify the
+> diff's per-symbol classification rationale, not rubber-stamp a grep-only
+> justification. For each affected symbol, confirm the diff's choice matches:
+> **(a)** in-crate non-test caller exists → `pub(crate)` is correct; **(b)** only
+> `#[cfg(test)]` callers or none → the symbol is DEAD and the diff must delete it
+> or keep it `pub` / `#[cfg(test)]` (a crate-root `pub use` re-export can be the
+> sole keep-alive; an integration-test-crate caller blocks `pub(crate)` with
+> E0624) — a blind `pub(crate)` on a (b)-class symbol would not have compiled, so
+> if CI is green the live question is whether the (a)/(b) classification the diff
+> assumed is actually the reason it compiles. Return **CHANGES_REQUESTED** if the
+> PR's narrowing/deletion justification rests on a caller grep with no evidence the
+> (a)/(b) classification was reasoned through. (Full worked trap: the `/plan`
+> SKILL "Examples (verdict patterns)" → "Visibility-narrowing dead-code trap",
+> the #3365 scp cfg(test) case.)
+>
 > Then evaluate logic, error handling, readability per usual.
 >
 > Post your verdict as a single PR-level comment using \`gh pr comment\`,


### PR DESCRIPTION
Closes #3384

## ⚠️ SELF-MODIFYING — DO NOT AUTO-MERGE, operator approval required for merge

This PR edits `.claude/skills/plan/SKILL.md` and `.claude/skills/review-pr/SKILL.md` (matches review-pr Step 5.5's self-modifying pattern). Per the operator's explicit in-session direction for this self-improvement work, **`/review-pr` must NOT fire `attempt_merge`** — the operator performs the final merge. Hold in `in-review`.

## Summary

Adds a **"Visibility-narrowing / dead-code build-verify gate"** to the correctness critic in both pipeline stages so the pipeline stops converging on grep-only "safe to narrow" conclusions that only fail at `/do` build time (regressions #3363, #3365).

Root cause: critic reasoning distinguished only "external vs internal" callers via grep, but under this repo's global `-Dwarnings` (`.cargo/config.toml`) a `#[cfg(test)]`-only caller does NOT keep an item alive in a normal `cargo build`, and "zero external callers" does not separate "has in-crate non-test callers" (safe to narrow) from "genuinely dead" (narrowing → `dead_code` error). Only a build with the change applied reveals this.

## Changes

- **`.claude/skills/plan/SKILL.md`** — Critic A (correctness) brief gains a REVISE-MAJOR gate: any plan narrowing visibility or removing dead code MUST specify applying it in a scratch worktree and running `cargo build -p <crate> --all-targets` under `-Dwarnings`; grep is INSUFFICIENT. Per-symbol classification: (a) in-crate non-test caller → `pub(crate)` safe; (b) only `#[cfg(test)]` callers or none → DEAD: delete or keep-`pub`/`#[cfg(test)]`, never blind `pub(crate)`; crate-root re-export can be a sole keep-alive; integration-test-crate caller blocks `pub(crate)` (E0624). Adds the #3365 scp cfg(test)-trap worked example to "Examples (verdict patterns)".
- **`.claude/skills/review-pr/SKILL.md`** — Reviewer A (correctness) brief mirrors the gate as a CHANGES_REQUESTED criterion: green CI proves it COMPILES, but the reviewer must verify the (a)/(b) classification rationale, not rubber-stamp a grep-only justification. One-line cross-reference to the plan example (not duplicated).

Scope: ONLY these two SKILL files. No /do, /triage, scripts, or ci.yml touched.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3384#issuecomment-4771964430)

## Test plan

This is a docs/guidance change — SKILL.md is not compiled, so there is no failing-on-main cargo test (correctly, none was fabricated). The gate is reviewer-read consistency plus the skill-snippet validators staying green. The change adds **no** new bash snippets (only inline backtick code spans), so the snippet harnesses (which validate shell library functions) are unaffected.

- [x] `bash scripts/test-project-loop-skill-snippets.sh` — 6/6 green
- [x] `bash scripts/test-spec-adhere-skill-snippets.sh` — 8/8 green
- [x] `bash scripts/test-review-pr-skill-snippets.sh` — 49/49 green
- [x] Code fences balanced in both SKILL files; no new fenced bash blocks in the diff
- [x] `cargo` workspace unaffected (pre-commit build hook passed)

## Out of scope / possible follow-up

There is intentionally **no** prose-level CI gate for the plan/review-pr SKILL guidance (no `test-plan-skill-snippets.sh`, and `test-review-pr-skill-snippets.sh` is not wired into `ci.yml`). This change adds no bash snippets, so the relevant assurance is reviewer-read consistency, not a CI prose-gate. Adding such a gate is a separate effort, not done here.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)