### PR TITLE
Deploy latest-green Verify-Execution sha; allowlist stellar-core submodule

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -1626,22 +1626,77 @@ fi
 
 Report `deployed_sha_status` in the tick's status line.
 
-**Gate comparison:**
+**Deploy-target selection — latest green `Verify Execution (Mainnet)` (#3351):**
+
+The deploy target is NOT `origin/main` HEAD. On a busy `main` the heavyweight
+`CI` workflow is cancel-per-head (structurally never green at HEAD), and
+`Verify Execution (Mainnet)` — the hash-parity correctness suite that catches
+consensus hash-mismatch regressions — runs only on `schedule` (daily 06:00 UTC)
++ `workflow_dispatch`, so it is green only on the specific heads that were HEAD
+at a cron/dispatch run, never on the racing tip. A "deploy HEAD iff its CI is
+green" gate therefore never fires. Per operator option 3, we deploy the
+**latest commit whose `Verify Execution (Mainnet)` run completed `success`**,
+decoupling the deploy target from the racing tip while never shipping a binary
+the parity suite has not validated.
 
 ```bash
 origin_sha=$(git rev-parse origin/main)
 
+# Query Verify-Execution runs on main, newest-first, as headSha|status|conclusion.
+# The run-level workflow `name:` is literally "Verify Execution (Mainnet)".
+ve_records=$(gh run list --repo stellar-experimental/henyey \
+  --workflow "Verify Execution (Mainnet)" --branch main --limit 30 \
+  --json headSha,status,conclusion,createdAt \
+  --jq '.[] | "\(.headSha)|\(.status)|\(.conclusion)"' 2>/dev/null)
+
+# Pure selector (scripts/lib/monitor-decisions.sh). Prints the chosen target sha
+# to stdout (empty if none) and a reason token to stderr. FAIL-CLOSED: empty
+# stdout ⇒ never deploy (no validated target). Guardrails: on-main ancestor of
+# HEAD, deployed-or-ahead (never backwards), within MAX_DEPLOY_WALK commits;
+# an oracle error / locally-unresolvable sha is a skip-this-candidate, never an
+# abort, never a deploy.
+source "$(git rev-parse --show-toplevel)/scripts/lib/monitor-decisions.sh"
+deploy_target_sha=$(printf '%s\n' "$ve_records" \
+  | select_latest_green_deploy_target "$deployed_sha" "$origin_sha" 2>/tmp/ve_reason)
+ve_reason=$(cat /tmp/ve_reason 2>/dev/null)
+```
+
+**Gate comparison** (keys on `deploy_target_sha`, NOT `origin/main` HEAD):
+
+```bash
 case "$deployed_sha_status" in
   ok|missing-fresh)
-    [ "$deployed_sha" = "$origin_sha" ] && gate_action="up-to-date" || gate_action="proceed"
+    if [ -z "$deploy_target_sha" ]; then
+      # No validated target. green-equals-deployed ⇒ up-to-date no-op;
+      # any other reason ⇒ DEFER (fail-closed — never deploy unvalidated).
+      if [ "$ve_reason" = "green-equals-deployed" ]; then
+        gate_action="up-to-date"
+      else
+        gate_action="defer-no-green"
+      fi
+    else
+      gate_action="proceed"   # deploy_target_sha is the validated target
+    fi
     ;;
   invalid)
-    gate_action="proceed-force-rebuild"
+    # Corrupt build_sha. Still require a validated target to deploy to.
+    if [ -z "$deploy_target_sha" ]; then
+      gate_action="defer-no-green"
+    else
+      gate_action="proceed-force-rebuild"
+    fi
     ;;
 esac
 ```
 
-If `gate_action="up-to-date"`: no action (already up to date).
+If `gate_action="up-to-date"`: no action (already running the latest green sha).
+
+If `gate_action="defer-no-green"`: SKIP DEPLOY this tick (fail-closed — no green
+`Verify Execution` target ahead of what's deployed). Report:
+`DEPLOY DEFERRED (no green Verify Execution target ahead of deployed ${deployed_sha:0:8}: $ve_reason)`.
+Do NOT build or restart. (This is the correct, safe behavior on a busy main
+between schedule runs: the node keeps running its last parity-validated binary
+rather than deploying an unvalidated HEAD.)
 
 Otherwise enter the deploy path:
 
@@ -1666,7 +1721,7 @@ Otherwise enter the deploy path:
    if [ "$gate_action" = "proceed-force-rebuild" ]; then
      # invalid build_sha — skip heuristic, force rebuild
      needs_rebuild="yes"
-   elif changed_paths=$(git diff --name-only "$deployed_sha" origin/main 2>/dev/null); then
+   elif changed_paths=$(git diff --name-only "$deployed_sha" "$deploy_target_sha" 2>/dev/null); then
      # ok or missing-fresh: classify every changed path. needs_rebuild stays
      # "no" only if EVERY path is provably non-binary-affecting; ANY ambiguity
      # flips to "yes" (fail-safe). skip_kind tracks the strongest skip reason
@@ -1682,7 +1737,7 @@ Otherwise enter the deploy path:
            # crates/**/src/**.rs: test-only ONLY if every changed line in THIS
            # file's diff is inside a #[cfg(test)]/mod tests region. Any ambiguity
            # (zero-context hunk, module deletion, boundary edit) → rebuild.
-           if git diff "$deployed_sha" origin/main -- "$p" | diff_is_test_only; then
+           if git diff "$deployed_sha" "$deploy_target_sha" -- "$p" | diff_is_test_only; then
              skip_kind="test-only"
            else
              needs_rebuild="yes"; break
@@ -1703,7 +1758,9 @@ Otherwise enter the deploy path:
      `.github/`, `.claude/`, `scripts/`, `docs/`, `metrics/`, root-level `*.md`
      (e.g. `README.md`, `CLAUDE.md`), root-level git metadata dotfiles
      (`.gitignore`, `.gitattributes`, `.gitmodules`), `stellar-specs` /
-     `stellar-specs/` submodule pointer changes, and container-image files
+     `stellar-specs/` and `stellar-core` / `stellar-core/` reference-submodule
+     pointer changes (parity-reference submodules per CLAUDE.md, never in the
+     `cargo build --release -p henyey` graph — #3530), and container-image files
      (`Dockerfile`, `.dockerignore`, `*.dockerfile`) — `cargo` never reads them,
      so they cannot change the compiled binary; safe ONLY because the monitor
      runs the locally-compiled `release/henyey`, not the Docker image (the
@@ -1722,7 +1779,7 @@ Otherwise enter the deploy path:
 2a. **Authoritative binary byte-compare** (only when `needs_rebuild="no"`): the
     heuristic has marked the changeset a skip CANDIDATE, but shell-based Rust
     region parsing is brittle, so it does NOT by itself authorize a skip. Build
-    `henyey` at BOTH `deployed_sha` and `origin/main` into the SAME scratch
+    `henyey` at BOTH `deployed_sha` and `deploy_target_sha` into the SAME scratch
     target dir with identical flags, then byte-compare the two produced
     binaries. Skip the rebuild+restart ONLY if the bytes are identical;
     otherwise fall through to the normal rebuild+restart path (step 3+).
@@ -1735,12 +1792,12 @@ Otherwise enter the deploy path:
       BIN_OLD="/home/tomer/data/$MONITOR_SESSION_ID/binrel-old"
       BIN_NEW="/home/tomer/data/$MONITOR_SESSION_ID/binrel-new"
       rm -rf "$CMP_TARGET"; mkdir -p "$CMP_TARGET"
-      # Build at deployed_sha, then at origin/main, into the SAME target dir.
+      # Build at deployed_sha, then at deploy_target_sha, into the SAME target dir.
       git stash --include-untracked >/dev/null 2>&1 || true
       git checkout --quiet "$deployed_sha" \
         && CARGO_TARGET_DIR="$CMP_TARGET" cargo build --release -p henyey \
         && cp "$CMP_TARGET/release/henyey" "$BIN_OLD"
-      git checkout --quiet origin/main \
+      git checkout --quiet "$deploy_target_sha" \
         && CARGO_TARGET_DIR="$CMP_TARGET" cargo build --release -p henyey \
         && cp "$CMP_TARGET/release/henyey" "$BIN_NEW"
       if [ -f "$BIN_OLD" ] && [ -f "$BIN_NEW" ] && cmp -s "$BIN_OLD" "$BIN_NEW"; then
@@ -1752,18 +1809,20 @@ Otherwise enter the deploy path:
     fi
     ```
     On a **confirmed skip** (`needs_rebuild="no"` AND `binary_identical="yes"`):
-    run `git pull --rebase` only, then advance `BUILD_SHA_FILE` to the new sha:
+    check out `deploy_target_sha` (the latest-green target, NOT HEAD), then
+    advance `BUILD_SHA_FILE` to it:
     ```bash
-    new_sha=$(git rev-parse origin/main)
+    git checkout --quiet "$deploy_target_sha"
+    new_sha="$deploy_target_sha"
     printf '%s\n' "$new_sha" > "${BUILD_SHA_FILE}.tmp"
     mv "${BUILD_SHA_FILE}.tmp" "$BUILD_SHA_FILE"
     ```
     The bytes are confirmed byte-identical, so the running binary IS the
-    origin/main binary — advancing `BUILD_SHA_FILE` is correct and fixes the
-    per-tick re-trip (the gate no longer re-evaluates this same changeset every
-    tick). Report:
-    - `DEPLOY SYNCED (test-only: binary byte-identical — pulled <N> commits, no restart)` when `skip_kind="test-only"`;
-    - `DEPLOY SYNCED (no-binary-impact: allowlisted paths only — pulled <N> commits, no restart)` when `skip_kind="no-binary-impact"`.
+    `deploy_target_sha` binary — advancing `BUILD_SHA_FILE` is correct and fixes
+    the per-tick re-trip (the gate no longer re-evaluates this same changeset
+    every tick). Report:
+    - `DEPLOY SYNCED (test-only: binary byte-identical — advanced to green ${deploy_target_sha:0:8}, no restart)` when `skip_kind="test-only"`;
+    - `DEPLOY SYNCED (no-binary-impact: allowlisted paths only — advanced to green ${deploy_target_sha:0:8}, no restart)` when `skip_kind="no-binary-impact"`.
 
     If `binary_identical="no"` (a heuristic false-positive OR a
     non-reproducible build): set `needs_rebuild="yes"` and fall through to the
@@ -1818,21 +1877,30 @@ Otherwise enter the deploy path:
    Consequence: a normal `git revert` (which adds a revert commit but leaves
    the quarantined SHA in ancestry) auto-clears the gate on the next tick.
    Operator no longer needs to manually `quarantine_remove` reverted SHAs.
-4. Check CI status on origin/main: `gh run list --branch main --limit 3 --json conclusion --jq '.[].conclusion'`.
-   If any recent run has conclusion `failure`, do NOT deploy — route the failure
-   through check (11) and wait.
-5. If all conclusions are `success` (ignore `""` for in-progress and `cancelled`):
-   `git pull --rebase`, `CARGO_TARGET_DIR=/home/tomer/data/$MONITOR_SESSION_ID/cargo-target cargo build --release -p henyey`.
-6. If build succeeds:
+4. **Deploy target is already parity-validated.** `deploy_target_sha` was
+   selected precisely because its `Verify Execution (Mainnet)` run completed
+   `success` (operator option 3). The legacy "scan origin/main `CI` conclusions
+   and defer on `failure`" gate is REMOVED from the per-head deploy signal: on a
+   busy main `CI` is cancel-per-head (never a clean `success` at HEAD), so it
+   carried no usable signal, and every commit was already branch-protection-gated
+   pre-merge. Build the validated target:
    ```bash
-   # Persist the just-built sha BEFORE Stop-PID. Atomic via tmp + mv.
-   new_sha=$(git rev-parse HEAD)
+   git checkout --quiet "$deploy_target_sha"
+   CARGO_TARGET_DIR=/home/tomer/data/$MONITOR_SESSION_ID/cargo-target \
+     cargo build --release -p henyey
+   ```
+   (Independently, check (11) still observes main CI failures for the status
+   report and alarming — it just no longer gates this deploy.)
+5. If build succeeds:
+   ```bash
+   # Persist the just-built target sha BEFORE Stop-PID. Atomic via tmp + mv.
+   new_sha="$deploy_target_sha"
    printf '%s\n' "$new_sha" > "${BUILD_SHA_FILE}.tmp"
    mv "${BUILD_SHA_FILE}.tmp" "$BUILD_SHA_FILE"
    ```
    Then: Stop-PID, Rotate-log suffix `preredeploy`, Relaunch.
-   Report: `DEPLOY — pulled <N> commits (<old-sha>..<new-sha>), rebuilt, restarted at L<ledger>`.
-7. If build fails: report `BUILD FAILED`, do NOT restart — the old binary is
+   Report: `DEPLOY — to green Verify-Execution sha ${deploy_target_sha:0:8} (${deployed_sha:0:8}..${deploy_target_sha:0:8}), N commits behind origin HEAD ${origin_sha:0:8}, rebuilt, restarted at L<ledger>`.
+6. If build fails: report `BUILD FAILED`, do NOT restart — the old binary is
    still running. Do NOT update `BUILD_SHA_FILE`. Route the build error through
    check (11).
 

--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -704,6 +704,16 @@ classify_path_binary_relevance() {
       echo "no-impact"; return 0 ;;
     stellar-specs|stellar-specs/*)
       echo "no-impact"; return 0 ;;
+    # stellar-core is a parity-reference submodule (CLAUDE.md: "available as a
+    # git submodule … for parity checks"); it is NEVER in the
+    # `cargo build --release -p henyey` build graph, so a submodule-pointer bump
+    # cannot change the compiled binary. Mirror the stellar-specs arm (#3530): a
+    # `stellar-core`-pointer-only changeset becomes a skip *candidate*, while the
+    # authoritative restart-skip is still independently gated by the §10-step-2a
+    # release-binary byte-compare. So this arm can never on its own suppress a
+    # real deploy — it only lets the byte-compare carve-out fire.
+    stellar-core|stellar-core/*)
+      echo "no-impact"; return 0 ;;
     # Container-image files (#3307): never read by `cargo build --release -p
     # henyey`, so they cannot change the compiled binary. Routing them through
     # no-impact makes a Dockerfile-only delta a skip *candidate* that the
@@ -743,6 +753,136 @@ classify_path_binary_relevance() {
 
   # --- Everything else: fail-safe rebuild. ---
   echo "rebuild"
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# select_latest_green_deploy_target DEPLOYED_SHA ORIGIN_SHA   (issue #3351)
+#
+# Pure deploy-target selector for the monitor-tick §10 deploy gate. On a busy
+# `main` the heavyweight `CI` workflow is cancel-per-head (structurally never
+# green at HEAD) and `Verify Execution (Mainnet)` runs only on schedule /
+# workflow_dispatch — so it is green only on the specific heads that were HEAD
+# at a cron/dispatch run, never on the racing tip. The legacy "deploy origin
+# HEAD iff its CI is green" gate therefore never fires. This selector instead
+# picks the NEWEST commit whose `Verify Execution (Mainnet)` run completed
+# `success` and that is safe to deploy (operator option 3: deploy latest-green).
+#
+# Reads Verify-Execution run records on stdin, one per line, newest-first
+# (exactly the `gh run list … --json headSha,status,conclusion --jq` order):
+#     <headSha>|<status>|<conclusion>
+#
+# Prints the chosen deploy-target sha to STDOUT (empty if none), and a single
+# reason token to STDERR. Reason tokens:
+#     (sha printed)        — a valid newer green target was selected
+#     no-green-run         — no record is completed/success
+#     green-equals-deployed— newest valid green sha == deployed (up-to-date)
+#     green-behind-deployed— only green sha(s) are ancestors of deployed (no
+#                            backwards deploy)
+#     green-not-on-main    — only green sha(s) are not ancestors of ORIGIN_SHA
+#                            (off-main / force-pushed / unresolvable locally)
+#     walk-exceeded        — newest valid green sha is > MAX_DEPLOY_WALK commits
+#                            ahead of deployed (defensive staleness bound)
+#
+# FAIL-CLOSED contract (DEPLOY-SAFETY):
+#   - empty stdout  ⇒ caller MUST NOT deploy (no validated target). Never emits
+#     a sha that is unvalidated, off-main, equal-to/behind deployed, or beyond
+#     the walk bound.
+#   - the ancestry oracle is injected as the overridable shell functions
+#     `is_ancestor A B` (0 iff A is ancestor-or-equal of B) and
+#     `commits_ahead DEP SHA` (count of DEP..SHA), defaulting to git. An oracle
+#     ERROR or a sha unresolvable locally is treated as "skip THIS candidate"
+#     (reason green-not-on-main) — it never aborts the tick and never deploys.
+#   - records are consumed newest-first; the FIRST candidate satisfying every
+#     guardrail wins. `green-equals-deployed` short-circuits as up-to-date the
+#     moment the newest valid-on-main green sha is the deployed sha (so we never
+#     redeploy the running binary, and never look past it to an older green).
+#
+# Returns 0 always (the reason token + empty/non-empty stdout carry the result).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Defensive staleness bound: refuse to jump more than this many commits in one
+# deploy, even to a green sha (guards against a weeks-lapsed schedule yielding a
+# wildly stale "green"). Single documented constant; env-overridable for tests.
+: "${MAX_DEPLOY_WALK:=200}"
+
+# Ancestry oracle (overridable for hermetic tests). Default: real git.
+# is_ancestor A B → 0 iff A is an ancestor-or-equal of B (A reachable from B).
+if ! declare -F is_ancestor >/dev/null 2>&1; then
+  is_ancestor() { git merge-base --is-ancestor "$1" "$2" 2>/dev/null; }
+fi
+# commits_ahead DEP SHA → number of commits in DEP..SHA (reachable from SHA,
+# not from DEP). Prints 0 on any error so the caller's numeric compare is safe.
+if ! declare -F commits_ahead >/dev/null 2>&1; then
+  commits_ahead() { git rev-list --count "$1".."$2" 2>/dev/null || echo 0; }
+fi
+
+select_latest_green_deploy_target() {
+  local deployed_sha="$1" origin_sha="$2"
+  local line sha status conclusion
+  local saw_green=0           # any completed/success record at all
+  local saw_on_main=0         # any green record that is on main (ancestor of HEAD)
+
+  while IFS='|' read -r sha status conclusion; do
+    # Skip blank lines.
+    [[ -z "$sha" ]] && continue
+    # Only completed/success records are deploy candidates.
+    [[ "$status" == "completed" && "$conclusion" == "success" ]] || continue
+    saw_green=1
+
+    # Guardrail 1 — on main: the green sha must be an ancestor-or-equal of the
+    # origin HEAD. An oracle error / locally-unresolvable sha lands here too
+    # (is_ancestor returns non-zero) → skip THIS candidate, never abort.
+    if ! is_ancestor "$sha" "$origin_sha"; then
+      continue
+    fi
+    saw_on_main=1
+
+    # Up-to-date: the newest valid-on-main green sha IS the deployed sha. This is
+    # a distinct, terminal outcome — report up-to-date and stop (never redeploy
+    # the running binary, never fall through to an older green).
+    if [[ "$sha" == "$deployed_sha" ]]; then
+      echo "green-equals-deployed" >&2
+      return 0
+    fi
+
+    # Guardrail 2 — not backwards: the green sha must be deployed-or-descendant.
+    # If deployed_sha is NOT an ancestor of sha, this green is behind/diverged
+    # from what's running → never deploy backwards. Skip this candidate.
+    if ! is_ancestor "$deployed_sha" "$sha"; then
+      continue
+    fi
+
+    # Guardrail 3 — walk bound: refuse a green sha more than MAX_DEPLOY_WALK
+    # commits ahead of deployed (defensive against a long-lapsed schedule).
+    local ahead
+    ahead="$(commits_ahead "$deployed_sha" "$sha")"
+    [[ "$ahead" =~ ^[0-9]+$ ]] || ahead=0
+    if (( ahead > MAX_DEPLOY_WALK )); then
+      echo "walk-exceeded" >&2
+      return 0
+    fi
+
+    # All guardrails passed — this is the newest valid green target.
+    echo "$sha"
+    return 0
+  done
+
+  # No candidate selected — emit the most specific reason. Any green sha that
+  # reached the walk-bound or up-to-date checks already returned inline above, so
+  # reaching here means every green record failed an earlier guardrail.
+  if (( saw_on_main == 1 )); then
+    # Green sha(s) exist on main but every one is an ancestor of deployed_sha
+    # (behind what's running) → no backwards deploy.
+    echo "green-behind-deployed" >&2
+  elif (( saw_green == 1 )); then
+    # Green sha(s) exist but none are ancestors of origin HEAD (off-main /
+    # force-pushed / unresolvable locally).
+    echo "green-not-on-main" >&2
+  else
+    # No completed/success record at all.
+    echo "no-green-run" >&2
+  fi
   return 0
 }
 

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=406
+TAP_PLAN=418
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -9790,6 +9790,21 @@ BOARDEOF
   else
     tap_not_ok "classify_path: stellar-specs submodule → no-impact" "got '$(_cls "stellar-specs")'"
   fi
+  # #3530: stellar-core is a parity-reference submodule (CLAUDE.md), never in the
+  # `cargo build --release -p henyey` graph — a pointer-only bump cannot change
+  # the binary. Mirror the stellar-specs arm so a submodule-pin-only commit is a
+  # skip CANDIDATE; the §10-step-2a byte-compare still independently gates the
+  # actual restart-skip.
+  if [[ "$(_cls "stellar-core")" == "no-impact" ]]; then
+    tap_ok "classify_path: stellar-core submodule → no-impact (#3530)"
+  else
+    tap_not_ok "classify_path: stellar-core submodule → no-impact (#3530)" "got '$(_cls "stellar-core")'"
+  fi
+  if [[ "$(_cls "stellar-core/src/foo")" == "no-impact" ]]; then
+    tap_ok "classify_path: stellar-core/* path → no-impact (#3530)"
+  else
+    tap_not_ok "classify_path: stellar-core/* path → no-impact (#3530)" "got '$(_cls "stellar-core/src/foo")'"
+  fi
   # Container-image files (#3307): Dockerfile / .dockerignore / *.dockerfile are
   # never read by `cargo build --release -p henyey`, so they cannot change the
   # compiled binary. Route them through no-impact so a Dockerfile-only delta hits
@@ -9862,6 +9877,142 @@ BOARDEOF
   else
     tap_not_ok "classify_path: non-.rs under crates/src → rebuild (fail-safe)" "got '$(_cls "crates/app/src/fixtures/data.json")'"
   fi
+
+  # ── #3351: select_latest_green_deploy_target ────────────────────────────────
+  # The selector picks the newest Verify-Execution-green sha that is on main,
+  # at-or-ahead of the deployed sha, and within MAX_DEPLOY_WALK commits. It is
+  # fail-closed: empty stdout (+ a stderr reason) on no valid target, so the
+  # SKILL never deploys an unvalidated binary. The git ancestry oracle is
+  # injected as overridable functions (is_ancestor / commits_ahead) so these
+  # tests are hermetic — no on-disk repo needed.
+  #
+  # Hermetic ancestry model used by the stub oracle below. We define a simple
+  # linear main history (oldest → newest):
+  #     DEP  →  G_OLD  →  G  →  HEAD
+  # plus an off-main sha (FORK) that is NOT an ancestor of HEAD, and a far-ahead
+  # green sha (FAR) used to exercise the walk bound. The stub answers ancestry
+  # from a fixed table so the selector logic is exercised without real git.
+  _order_of() {
+    # echo a monotonic rank for each known sha; unknown → empty (unresolvable).
+    case "$1" in
+      DEP)   echo 0 ;;
+      G_OLD) echo 1 ;;
+      G)     echo 2 ;;
+      HEAD)  echo 3 ;;
+      FAR)   echo 9999 ;;   # far ahead of DEP on main
+      *)     echo "" ;;     # FORK / unknown → not resolvable on main
+    esac
+  }
+  # is_ancestor A B : 0 iff A is an ancestor-or-equal of B on the linear main.
+  # FORK is off-main: never an ancestor of anything, and HEAD is never its anc.
+  is_ancestor() {
+    local a="$1" b="$2" ra rb
+    if [[ "$a" == "FORK" || "$b" == "FORK" ]]; then return 1; fi
+    ra="$(_order_of "$a")"; rb="$(_order_of "$b")"
+    [[ -n "$ra" && -n "$rb" && "$ra" -le "$rb" ]]
+  }
+  # commits_ahead DEP SHA : count of commits in DEP..SHA (reachable from SHA, not DEP).
+  commits_ahead() {
+    local dep="$1" sha="$2" rd rs
+    rd="$(_order_of "$dep")"; rs="$(_order_of "$sha")"
+    if [[ -z "$rd" || -z "$rs" ]]; then echo 0; return 0; fi
+    if [[ "$rs" -le "$rd" ]]; then echo 0; return 0; fi
+    echo $(( rs - rd ))
+  }
+
+  # Case 1: HEAD has no green Verify Execution (CI cancelled); older sha G is
+  # completed/success, on main, ahead of deployed → selector picks G.
+  _records_head_cancelled() {
+    printf '%s\n' \
+      "HEAD|completed|cancelled" \
+      "G|completed|success" \
+      "G_OLD|completed|success"
+  }
+  _sel1="$(_records_head_cancelled | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null)"
+  if [[ "$_sel1" == "G" ]]; then
+    tap_ok "select_latest_green: picks newest green ancestor when HEAD CI cancelled (#3351)"
+  else
+    tap_not_ok "select_latest_green: picks newest green ancestor when HEAD CI cancelled (#3351)" "got '$_sel1'"
+  fi
+
+  # Case 2: no green record at all → empty stdout + reason no-green-run.
+  _records_none_green() {
+    printf '%s\n' \
+      "HEAD|completed|cancelled" \
+      "G|in_progress|" \
+      "G_OLD|completed|failure"
+  }
+  _err2="$(_records_none_green | select_latest_green_deploy_target "DEP" "HEAD" 2>&1 >/dev/null)"
+  _out2="$(_records_none_green | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null)"
+  if [[ -z "$_out2" && "$_err2" == *"no-green-run"* ]]; then
+    tap_ok "select_latest_green: no green run → empty + reason no-green-run (#3351)"
+  else
+    tap_not_ok "select_latest_green: no green run → empty + reason no-green-run (#3351)" "out='$_out2' err='$_err2'"
+  fi
+
+  # Case 3: only green sha == deployed → up-to-date no-op (empty + green-equals-deployed),
+  # NOT a redeploy of the running sha.
+  _records_green_eq_dep() {
+    printf '%s\n' \
+      "HEAD|completed|cancelled" \
+      "DEP|completed|success"
+  }
+  _err3="$(_records_green_eq_dep | select_latest_green_deploy_target "DEP" "HEAD" 2>&1 >/dev/null)"
+  _out3="$(_records_green_eq_dep | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null)"
+  if [[ -z "$_out3" && "$_err3" == *"green-equals-deployed"* ]]; then
+    tap_ok "select_latest_green: green == deployed → empty + green-equals-deployed (#3351)"
+  else
+    tap_not_ok "select_latest_green: green == deployed → empty + green-equals-deployed (#3351)" "out='$_out3' err='$_err3'"
+  fi
+
+  # Case 4: only green sha is BEHIND deployed (ancestor of DEP) → no backwards
+  # deploy (empty + green-behind-deployed). Deploy DEP_AHEAD where green G_OLD is
+  # behind it: deployed=G, green=G_OLD (G_OLD is an ancestor of G).
+  _records_green_behind() {
+    printf '%s\n' \
+      "HEAD|completed|cancelled" \
+      "G_OLD|completed|success"
+  }
+  _err4="$(_records_green_behind | select_latest_green_deploy_target "G" "HEAD" 2>&1 >/dev/null)"
+  _out4="$(_records_green_behind | select_latest_green_deploy_target "G" "HEAD" 2>/dev/null)"
+  if [[ -z "$_out4" && "$_err4" == *"green-behind-deployed"* ]]; then
+    tap_ok "select_latest_green: green behind deployed → empty + green-behind-deployed (#3351)"
+  else
+    tap_not_ok "select_latest_green: green behind deployed → empty + green-behind-deployed (#3351)" "out='$_out4' err='$_err4'"
+  fi
+
+  # Case 5: green sha is off-main (not an ancestor of HEAD) → skip candidate,
+  # reason green-not-on-main; with no other green → empty.
+  _records_green_offmain() {
+    printf '%s\n' \
+      "HEAD|completed|cancelled" \
+      "FORK|completed|success"
+  }
+  _err5="$(_records_green_offmain | select_latest_green_deploy_target "DEP" "HEAD" 2>&1 >/dev/null)"
+  _out5="$(_records_green_offmain | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null)"
+  if [[ -z "$_out5" && "$_err5" == *"green-not-on-main"* ]]; then
+    tap_ok "select_latest_green: off-main green → empty + green-not-on-main (#3351)"
+  else
+    tap_not_ok "select_latest_green: off-main green → empty + green-not-on-main (#3351)" "out='$_out5' err='$_err5'"
+  fi
+
+  # Case 6: green sha exceeds MAX_DEPLOY_WALK commits ahead of deployed →
+  # reject (empty + walk-exceeded). FAR is 9999 commits ahead of DEP.
+  _records_far_green() {
+    printf '%s\n' \
+      "HEAD|completed|cancelled" \
+      "FAR|completed|success"
+  }
+  _err6="$(_records_far_green | select_latest_green_deploy_target "DEP" "FAR" 2>&1 >/dev/null)"
+  _out6="$(_records_far_green | select_latest_green_deploy_target "DEP" "FAR" 2>/dev/null)"
+  if [[ -z "$_out6" && "$_err6" == *"walk-exceeded"* ]]; then
+    tap_ok "select_latest_green: green > MAX_DEPLOY_WALK ahead → empty + walk-exceeded (#3351)"
+  else
+    tap_not_ok "select_latest_green: green > MAX_DEPLOY_WALK ahead → empty + walk-exceeded (#3351)" "out='$_out6' err='$_err6'"
+  fi
+
+  # Restore real git oracles so no later test sees the stubs.
+  unset -f is_ancestor commits_ahead _order_of
 
   # --- diff_is_test_only: hunk-level ---
   # PASS case: a src/*.rs diff whose every changed line is strictly inside a


### PR DESCRIPTION
Closes #3351
Closes #3530

> ## ⚠️ DEPLOY-CRITICAL monitor-pipeline — DO NOT AUTO-MERGE, operator merge required
>
> This PR changes the monitor-tick deploy gate, which controls **which binary
> ships to the production mainnet validator**. It MUST be merged by the operator
> after review. **No auto-merge.**

## Summary

Two coupled monitor-pipeline (deploy-gate) changes, both in `scripts/lib/monitor-decisions.sh` + the monitor-tick SKILL.md §10 + the bash test harness, shipped as ONE PR (the operator picked the options in-session):

- **#3351 (operator option 3 — deploy latest-green):** On a busy `main` the heavyweight `CI` workflow is cancel-per-head (never green at HEAD) and `Verify Execution (Mainnet)` runs only on schedule/dispatch, so the legacy "deploy HEAD iff its CI is green" gate never fires and the validator falls arbitrarily behind. New pure selector `select_latest_green_deploy_target DEPLOYED_SHA ORIGIN_SHA` picks the newest `Verify Execution (Mainnet)` `completed/success` sha that is (a) an ancestor of origin HEAD, (b) at-or-ahead of the deployed sha, (c) within `MAX_DEPLOY_WALK=200` commits. §10 steps 4–6 are rewritten to checkout+build+persist THAT sha (not HEAD).
- **#3530 (allowlist add):** add a `stellar-core|stellar-core/*) echo "no-impact"` `case` arm next to the existing `stellar-specs` arm. `stellar-core` is a parity-reference submodule, never in the `cargo build --release -p henyey` graph, so a pointer-only bump cannot change the binary. This only makes such a changeset a skip CANDIDATE; the §10-step-2a byte-compare still independently gates the actual restart-skip. (The commit-hash-byte-compare-defeat concern is explicitly OUT OF SCOPE per operator.)

## Fail-closed guardrails (DEPLOY-SAFETY)

The selector is provably fail-closed — no path deploys an unvalidated or regressing binary:
- Empty stdout ⇒ caller MUST NOT deploy. Reason tokens on stderr: `no-green-run`, `green-equals-deployed` (→ up-to-date no-op, never a redeploy of the running sha), `green-behind-deployed` (never deploy backwards), `green-not-on-main`, `walk-exceeded`.
- Oracle error / locally-unresolvable sha ⇒ skip-this-candidate, never abort the tick, never deploy.
- The chosen sha is, by construction, a commit whose `Verify Execution (Mainnet)` parity suite completed `success`, is on main, and is deployed-or-ahead.
- The git ancestry oracle (`is_ancestor` / `commits_ahead`) is injected as overridable functions so the selector is tested hermetically.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3351#issuecomment-4771992891)

## Test plan

- [x] `bash -n scripts/lib/monitor-decisions.sh` + `bash -n scripts/test-monitor-skill-snippets.sh`
- [x] `shellcheck scripts/lib/monitor-decisions.sh` — no new findings (15 pre-existing, unchanged)
- [x] Full monitor test harness `bash scripts/test-monitor-skill-snippets.sh` — 418/418 pass, exit 0
- [x] cargo fmt --check + cargo clippy (pre-commit hook, both commits)

## Regression test (kind: bug-fix)

- **Tests:** `scripts/test-monitor-skill-snippets.sh` — `classify_path: stellar-core* → no-impact` (#3530, ×2) and `select_latest_green: …` (#3351, ×6 incl. all guardrail reason branches).
- **Pre-fix:** committed as `d1e993d5` — verified RED on origin/main: #3530 cases `not ok` (falls through to `rebuild`); #3351 cases abort with exit 127 (function absent).
- **Post-fix:** verified GREEN after `c2bc321d` — all 8 pass, full harness 418/418.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)