### PR TITLE
Gate hot-archive merge metaentry on output version to fix L16 bucketListHash divergence

### DIFF
--- a/crates/bucket/PARITY_STATUS.md
+++ b/crates/bucket/PARITY_STATUS.md
@@ -110,6 +110,7 @@ Corresponds to: `HotArchiveBucket.h`, `HotArchiveBucketList.h`, `HotArchiveBucke
 | `fresh()` | `HotArchiveBucket::fresh()` | Full |
 | `isTombstoneEntry()` / `maybePut()` | `is_hot_archive_tombstone()` / merge helpers | Full |
 | `mergeCasesWithEqualKeys()` | `merge_hot_archive_buckets()` | Full |
+| `BucketOutputIterator` metaentry gate (`meta.ledgerVersion >= V11`) | `merge_hot_archive_buckets()` output-version gate | Full — empty-input spill (output version 0) emits NO metaentry and collapses to the empty bucket, matching core's `getBucket` empty-output path; previously emitted a `{v0,void}` meta-only bucket (`d15ebeb4…`), flipping the hot-archive hash and the header `bucketListHash` at the L16 level-1→2 spill (#3552) |
 | `bucketEntryToLoadResult()` / `convertToBucketEntry()` | `get()` / `HotArchiveBucket::fresh()` conversion | Full |
 | `countOldEntryType()` / `countNewEntryType()` / `checkProtocolLegality()` | No-ops consistent with upstream | Full |
 | `HotArchiveBucketList::addBatch()` | `HotArchiveBucketList::add_batch()` | Full |

--- a/crates/bucket/src/hot_archive.rs
+++ b/crates/bucket/src/hot_archive.rs
@@ -1842,16 +1842,32 @@ pub fn merge_hot_archive_buckets(
     // memory for the HashMap AND a subsequent O((n+m) log(n+m)) sort.
     let mut result_entries = Vec::with_capacity(1 + curr.len() + snap.len());
 
-    // Add metadata - hot archive buckets always use V1 with BucketListType::HotArchive
-    // for Protocol 23+.
-    let mut meta = BucketMetadata {
-        ledger_version: output_version,
-        ext: BucketMetadataExt::V0,
-    };
-    if protocol_version_starts_from(output_version, ProtocolVersion::V23) {
-        meta.ext = BucketMetadataExt::V1(BucketListType::HotArchive);
+    // Emit the metaentry only when the derived output version supports it
+    // (>= V11), mirroring stellar-core's `BucketOutputIterator` constructor,
+    // which writes the METAENTRY only when `meta.ledgerVersion >=
+    // FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY` (V11)
+    // (BucketOutputIterator.cpp:45-72). When both inputs are empty/meta-less,
+    // `output_version` is 0 (BucketInputIterator defaults a meta-less bucket to
+    // protocol 0; BucketInputIterator.cpp:35-42) and core emits NO metaentry,
+    // so `getBucket` sees `mObjectsPut == 0` and returns an EMPTY bucket
+    // (BucketOutputIterator.cpp:182-191). Henyey previously pushed a
+    // `{ledgerVersion: 0, ext: V0}` metaentry unconditionally, producing the
+    // meta-only bucket `d15ebeb4…` where core has an empty bucket — flipping the
+    // hot-archive bucket-list hash and (via the live+hot-archive combine) the
+    // header `bucketListHash` (#3552 residual L16 divergence). Hot-archive
+    // buckets exist only at V23+, so a populated merge always uses the V1
+    // extension; the V0/no-meta branch is reachable only for the empty-input
+    // spill, which must collapse to the canonical empty bucket.
+    if protocol_version_starts_from(output_version, ProtocolVersion::V11) {
+        let mut meta = BucketMetadata {
+            ledger_version: output_version,
+            ext: BucketMetadataExt::V0,
+        };
+        if protocol_version_starts_from(output_version, ProtocolVersion::V23) {
+            meta.ext = BucketMetadataExt::V1(BucketListType::HotArchive);
+        }
+        result_entries.push(HotArchiveBucketEntry::Metaentry(meta));
     }
-    result_entries.push(HotArchiveBucketEntry::Metaentry(meta));
 
     // Sorted merge-join: iterate both iterators in lock-step.
     // Snap (newer) wins on equal keys.
@@ -1913,6 +1929,16 @@ pub fn merge_hot_archive_buckets(
                 }
             }
         }
+    }
+
+    // If the merge produced no entries at all (no metaentry because
+    // output_version < V11, and no surviving data entries), collapse to the
+    // canonical empty bucket (hash zero), mirroring stellar-core's
+    // `getBucket` empty-output path (BucketOutputIterator.cpp:182-191) rather
+    // than materializing a zero-entry bucket.
+    if result_entries.is_empty() {
+        tracing::trace!("hot_archive merge: empty result, returning empty bucket");
+        return Ok(HotArchiveBucket::empty());
     }
 
     let result = HotArchiveBucket::from_entries(result_entries)?;

--- a/crates/bucket/src/hot_archive.rs
+++ b/crates/bucket/src/hot_archive.rs
@@ -3283,4 +3283,64 @@ mod tests {
             err_msg
         );
     }
+
+    /// Regression for #3552 (residual L16 `bucketListHash` divergence).
+    ///
+    /// At the ledger-16 hot-archive level-1→2 spill, both merge inputs are
+    /// empty (no entries, no metaentry ⇒ `get_protocol_version()` == 0), but the
+    /// merge is invoked with the CURRENT protocol (e.g. 27) as `maxProtocolVersion`.
+    /// stellar-core's `BucketOutputIterator` gates the metaentry on
+    /// `meta.ledgerVersion >= FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY`
+    /// (V11) (`BucketOutputIterator.cpp:45-72`). With the derived output version
+    /// 0 (< V11) it emits NO metaentry, so `mObjectsPut == 0` ⇒ a truly EMPTY
+    /// bucket (`getBucket`, `BucketOutputIterator.cpp:182-191`).
+    ///
+    /// Henyey instead unconditionally pushed a `{ledgerVersion: 0, ext: V0}`
+    /// metaentry, producing the meta-only bucket `d15ebeb4…` where core has an
+    /// empty bucket. That flips the hot-archive bucket-list hash, which combines
+    /// with the live hash into the header `bucketListHash` ⇒ the L16 consensus
+    /// divergence (henyey `759a1bbe…` vs core `9f58962b…`).
+    ///
+    /// Pre-fix this produced a non-empty `{v0,void}` meta-only bucket
+    /// (`d15ebeb4f9249d16…`); post-fix it is the canonical empty bucket.
+    #[test]
+    fn test_hot_archive_empty_input_merge_at_v27_yields_empty_not_v0_meta() {
+        // The d15ebeb4 divergent bucket: a single `{ledgerVersion:0, ext:V0}`
+        // HOT_ARCHIVE_METAENTRY (the exact 16-byte payload captured live).
+        let v0_meta_only = HotArchiveBucket::from_entries(vec![HotArchiveBucketEntry::Metaentry(
+            BucketMetadata {
+                ledger_version: 0,
+                ext: BucketMetadataExt::V0,
+            },
+        )])
+        .unwrap();
+        let v0_meta_only_hash = v0_meta_only.hash();
+
+        // Spill of two empty hot-archive buckets at the current protocol (27),
+        // exactly as the L16 level-1→2 hot-archive spill invokes it.
+        let merged = merge_hot_archive_buckets(
+            &HotArchiveBucket::empty(),
+            &HotArchiveBucket::empty(),
+            27,
+            true,
+        )
+        .unwrap();
+
+        assert_ne!(
+            merged.hash(),
+            v0_meta_only_hash,
+            "empty-input merge must NOT produce the {{v0,void}} meta-only bucket (d15ebeb4)"
+        );
+        assert!(
+            merged.is_empty(),
+            "empty-input merge at protocol 27 must yield an EMPTY hot-archive bucket (parity \
+             with stellar-core: output version 0 < V11 ⇒ no metaentry ⇒ empty), got hash {}",
+            merged.hash().to_hex()
+        );
+        assert!(
+            merged.hash().is_zero(),
+            "empty hot-archive bucket hash must be zero, got {}",
+            merged.hash().to_hex()
+        );
+    }
 }


### PR DESCRIPTION
Closes #3552

## Summary

Fixes the **residual** ledger-16 `bucketListHash` consensus divergence that survived the #3553 EvictionIterator-emission fix. At the L16 hot-archive level-1→2 spill, `merge_hot_archive_buckets` merges two empty inputs at the current protocol (27). It derived the output meta version from the input buckets (`max(curr, snap)` = 0 for empty/meta-less inputs, per `get_protocol_version`) and then **unconditionally pushed a `{ledgerVersion: 0, ext: V0}` metaentry**, producing the meta-only bucket `d15ebeb4…` where stellar-core produces an **empty** bucket.

stellar-core's `BucketOutputIterator` writes the METAENTRY only when `meta.ledgerVersion >= FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY` (V11) (`BucketOutputIterator.cpp:45-72`); for an empty-input merge the derived version is 0 (< V11) so **no metaentry is emitted** and `getBucket` returns an empty bucket (`mObjectsPut == 0`, `BucketOutputIterator.cpp:182-191`). The spurious `{v0,void}` bucket flipped henyey's hot-archive bucket-list hash, which combines `SHA256(live_hash || hot_archive_hash)` into the header `bucketListHash` — so henyey's L16 diverged (`759a1bbe…` vs core `9f58962b…`) and the node got stuck unable to externalize L17.

**Fix (parity-faithful, no new semantics):** emit the hot-archive merge metaentry only when `output_version >= V11`, and collapse a zero-entry merge result to the canonical empty bucket — mirroring core exactly. The #3553 EvictionIterator fix stays (necessary and correct); this is the disjoint residual.

## Pinned divergence (offline, deterministic)

Localization category: **(b/c)** — the tx-bearing level-1→2 boundary merge, specifically in the **hot-archive** sub-list, NOT the live bucket list and NOT the EvictionIterator value (candidate (a) was refuted: the iterator value is a stable `{level=6, is_curr=true, offset=0}` that matches core).

Decoded from the captured oracle (`ssc-v27-cap2` run, same bug): henyey's L16 bucket set = core's 14 buckets **+ one extra** `d15ebeb4f9249d16…` = a single `HOT_ARCHIVE_METAENTRY { ledgerVersion: 0, ext: V0 }` (16-byte payload `8000000c ffffffff 00000000 00000000`). Core's empty hot-archive bucket is `8559d8bc…` = `METAENTRY { ledgerVersion: 27, ext: V1(HotArchive) }` — present (shared, byte-identical) in both. The divergent bucket sits at hot-archive level-2 curr after the L16 spill.

## Validation — offline from-genesis close-ledger replay

Reproduced the plan's offline replay against the preserved SSC v27 archive (`ssc-3552-verify-archive.tar.gz`): 100-account genesis (passphrase `Private test network 'ssc-2346z-574ca2'`) **gated on L1 `bucketListHash == 1f2c1920…`** (matches core), then `close_ledger` L2→L16 with the archive's real generalized tx sets, decoded close times, `Version(27)@L6` + `MaxTxSetSize(1000)@L11`, disk-backed merges, inline eviction scan.

- **Pre-fix (origin/main `3ab671c8`):** L16 `bucketListHash = 759a1bbe…` ❌ (header `469d3f8f…` live).
- **Post-fix:** L16 `bucketListHash = 9f58962b4ef703fb…` ✅ and full header `header_hash = 46531748…` ✅ — matches core's authoritative L16. The **entire L1–L15 chain** matches core byte-for-byte.

## Regression test (kind: bug-fix)

- **Test:** `crates/bucket/src/hot_archive.rs::test_hot_archive_empty_input_merge_at_v27_yields_empty_not_v0_meta`
- **Pre-fix:** committed as `47b376cc` — verified FAILED with `left != right` producing the exact live-captured `d15ebeb4f9249d16…` `{v0,void}` meta-only bucket.
- **Post-fix:** verified PASSES after `bf4e823d` — the empty-input merge at protocol 27 yields the canonical empty bucket (zero hash).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3552#issuecomment-4774385369)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo build -p henyey-ledger -p henyey-bucket --all-targets` with `RUSTFLAGS=-Dwarnings` (#3384 gate)
- [x] `cargo build --all`
- [x] `cargo test --all` — 0 failures
- [x] **Parity tripwires (NO shift):** `ledger_close_meta_vectors` (2 ok), `tx_meta_hash_vectors` (1 ok/1 ignored), `validation_parity` (12 ok), `scp_parity_tests` (124 ok) — all byte-identical; the fix touches only the empty-input hot-archive merge path, which was producing the wrong (non-core) bucket, so no already-correct ledger-close hash shifts.

## Deviations from plan

- The plan placed the regression in `crates/ledger/tests/ledger_close_integration.rs` using `henyey_app::initialize_genesis`/`build_genesis_entries`. Those live in `henyey-app`, which depends on `henyey-ledger` — so they cannot be a dev-dep of `henyey-ledger` (circular). The full from-genesis L1→L16 replay was used to **localize and validate** the fix offline (reproducing core's `9f58962b…`/`46531748…`), but the committed regression is a **narrow `crate:bucket` unit test** that isolates the exact pinned mechanism (the empty-input hot-archive merge metaentry), per the plan's "narrow unit test isolating the pinned mechanism" clause. This is tighter, has no cross-crate fixture dependency, and fails on `3ab671c8` / passes after the fix.
- Localization category resolved to the **hot-archive** sub-list (the plan's candidate set spanned live-merge/(b) and a boundary field/(c)); the EvictionIterator value (a) was refuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)