### PR TITLE
Emit stellar-core loadgen.* Prometheus meters from henyey's loadgen path

### DIFF
--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -788,6 +788,48 @@ metric_catalog! {
             => "History Archive State downloads that succeeded (and passed verify_has where applicable)";
         HISTORY_DOWNLOAD_HAS_FAILURE_TOTAL = "stellar_history_download_history_archive_state_failure_total"
             => "History Archive State downloads or verifications that failed";
+
+        // ── Loadgen meters (#3569) ─────────────────────────────────────
+        //
+        // Parity with stellar-core's medida loadgen meters
+        // (src/simulation/LoadGenerator.cpp + main/ApplicationImpl.cpp:1156).
+        // Supercluster's `IsLoadGenComplete` polls `loadgen_run_start ==
+        // loadgen_run_complete` to detect henyey-driven loadgen completion, so
+        // these must render with the EXACT bare-`loadgen_` names core's medida
+        // exporter emits (no `stellar_`/`henyey_` prefix, no dot→underscore
+        // munging — the literal string IS the exposition name). Pre-registered
+        // at zero so supercluster reads NotStarted (start==0) before a run
+        // rather than a missing series.
+        LOADGEN_RUN_START = "loadgen_run_start"
+            => "Loadgen runs started (parity: ApplicationImpl::generateLoad)";
+        LOADGEN_RUN_COMPLETE = "loadgen_run_complete"
+            => "Loadgen runs completed successfully (parity: LoadGenerator mLoadgenComplete)";
+        LOADGEN_RUN_FAILED = "loadgen_run_failed"
+            => "Loadgen runs that failed or were stopped (parity: LoadGenerator mLoadgenFail)";
+        LOADGEN_ACCOUNT_CREATED = "loadgen_account_created"
+            => "Loadgen accounts created (parity: registered-at-zero; core v27 marks this test-only)";
+        LOADGEN_TXN_ATTEMPTED = "loadgen_txn_attempted"
+            => "Loadgen transactions attempted (parity: LoadGenerator mTxnAttempted)";
+        LOADGEN_TXN_REJECTED = "loadgen_txn_rejected"
+            => "Loadgen transactions rejected by the tx queue (parity: LoadGenerator mTxnRejected)";
+        LOADGEN_TXN_BYTES = "loadgen_txn_bytes"
+            => "Loadgen transaction bytes submitted (parity: LoadGenerator mTxnBytes)";
+        LOADGEN_PAYMENT_SUBMITTED = "loadgen_payment_submitted"
+            => "Loadgen native payment operations submitted (parity: LoadGenerator mNativePayment, by op count)";
+        LOADGEN_PAYMENT_BYTES = "loadgen_payment_bytes"
+            => "Loadgen native payment transaction bytes (parity: LoadGenerator mNativePaymentBytes)";
+        LOADGEN_SOROBAN_UPLOAD = "loadgen_soroban_upload"
+            => "Loadgen Soroban upload transactions (parity: LoadGenerator mSorobanUploadTxs)";
+        LOADGEN_SOROBAN_INVOKE = "loadgen_soroban_invoke"
+            => "Loadgen Soroban invoke transactions (parity: LoadGenerator mSorobanInvokeTxs)";
+        LOADGEN_SOROBAN_SETUP_INVOKE = "loadgen_soroban_setup_invoke"
+            => "Loadgen Soroban setup-invoke transactions (parity: LoadGenerator mSorobanSetupInvokeTxs)";
+        LOADGEN_SOROBAN_SETUP_UPGRADE = "loadgen_soroban_setup_upgrade"
+            => "Loadgen Soroban setup-upgrade transactions (parity: LoadGenerator mSorobanSetupUpgradeTxs)";
+        LOADGEN_SOROBAN_CREATE_UPGRADE = "loadgen_soroban_create_upgrade"
+            => "Loadgen Soroban create-upgrade transactions (parity: LoadGenerator mSorobanCreateUpgradeTxs)";
+        LOADGEN_STEP_COUNT = "loadgen_step_count"
+            => "Loadgen generate_load loop iterations (parity: LoadGenerator mStepMeter)";
     }
 
     counters_no_prereg {
@@ -1757,6 +1799,121 @@ mod tests {
                 after.contains(&format!("{} 2", NAME)),
                 "{} should render 2 after two increments, got:\n{}",
                 NAME,
+                after
+            );
+        });
+    }
+
+    /// #3569: every loadgen meter is in the catalog and pre-registered at zero,
+    /// with the exact bare-`loadgen_` Prometheus name (no prefix, no munging) so
+    /// supercluster's `IsLoadGenComplete` reads match core's medida exporter.
+    #[test]
+    fn test_loadgen_meters_in_catalog() {
+        // (typed constant, expected literal Prometheus name) pairs.
+        let expected: &[(CounterMetric, &str)] = &[
+            (LOADGEN_RUN_START, "loadgen_run_start"),
+            (LOADGEN_RUN_COMPLETE, "loadgen_run_complete"),
+            (LOADGEN_RUN_FAILED, "loadgen_run_failed"),
+            (LOADGEN_ACCOUNT_CREATED, "loadgen_account_created"),
+            (LOADGEN_TXN_ATTEMPTED, "loadgen_txn_attempted"),
+            (LOADGEN_TXN_REJECTED, "loadgen_txn_rejected"),
+            (LOADGEN_TXN_BYTES, "loadgen_txn_bytes"),
+            (LOADGEN_PAYMENT_SUBMITTED, "loadgen_payment_submitted"),
+            (LOADGEN_PAYMENT_BYTES, "loadgen_payment_bytes"),
+            (LOADGEN_SOROBAN_UPLOAD, "loadgen_soroban_upload"),
+            (LOADGEN_SOROBAN_INVOKE, "loadgen_soroban_invoke"),
+            (LOADGEN_SOROBAN_SETUP_INVOKE, "loadgen_soroban_setup_invoke"),
+            (
+                LOADGEN_SOROBAN_SETUP_UPGRADE,
+                "loadgen_soroban_setup_upgrade",
+            ),
+            (
+                LOADGEN_SOROBAN_CREATE_UPGRADE,
+                "loadgen_soroban_create_upgrade",
+            ),
+            (LOADGEN_STEP_COUNT, "loadgen_step_count"),
+        ];
+
+        for (metric, name) in expected {
+            // The literal name must carry NO domain prefix (parity: core's
+            // medida keys are bare `loadgen.*`).
+            assert!(
+                !name.starts_with("stellar_") && !name.starts_with("henyey_"),
+                "loadgen meter {} must be a bare name (no domain prefix)",
+                name
+            );
+            // Typed constant equals the expected literal.
+            assert_eq!(*metric, *name, "constant {:?} != {}", metric, name);
+            // Present in the full catalog AND pre-registered at zero so the
+            // series exists on the first scrape.
+            assert!(
+                ALL_COUNTER_NAMES.contains(name),
+                "{} missing from ALL_COUNTER_NAMES",
+                name
+            );
+            assert!(
+                ALL_PREREGISTERED_COUNTER_NAMES.contains(name),
+                "{} should be pre-registered (present-at-zero)",
+                name
+            );
+        }
+    }
+
+    /// #3569: the loadgen run lifecycle renders the supercluster Success
+    /// condition. After a run, `loadgen_run_start == loadgen_run_complete` and
+    /// `loadgen_txn_attempted` reflects the attempt count, exactly as
+    /// supercluster's `IsLoadGenComplete` / `LogLoadGenProgressTowards` read.
+    #[test]
+    fn test_loadgen_run_lifecycle_renders() {
+        const N: u64 = 7;
+        let (recorder, handle) = fresh_local_recorder();
+        metrics::with_local_recorder(&recorder, || {
+            describe_metrics();
+            register_label_series();
+
+            // First scrape: run.start is pre-registered at 0 → supercluster
+            // reads NotStarted, not a missing series.
+            let before = handle.render();
+            assert!(
+                before.contains("loadgen_run_start 0"),
+                "loadgen_run_start should be pre-registered at 0, got:\n{}",
+                before
+            );
+            assert!(
+                before.contains("# TYPE loadgen_run_start counter"),
+                "loadgen_run_start should have TYPE counter"
+            );
+
+            // Drive a run lifecycle: start, N attempts, then complete, plus one
+            // mark of each soroban.* meter and step.count.
+            LOADGEN_RUN_START.increment(1);
+            for _ in 0..N {
+                LOADGEN_TXN_ATTEMPTED.increment(1);
+            }
+            LOADGEN_SOROBAN_UPLOAD.increment(1);
+            LOADGEN_SOROBAN_INVOKE.increment(1);
+            LOADGEN_SOROBAN_SETUP_INVOKE.increment(1);
+            LOADGEN_SOROBAN_SETUP_UPGRADE.increment(1);
+            LOADGEN_SOROBAN_CREATE_UPGRADE.increment(1);
+            LOADGEN_STEP_COUNT.increment(1);
+            LOADGEN_RUN_COMPLETE.increment(1);
+
+            let after = handle.render();
+            // Supercluster Success: run.start == run.complete (both 1).
+            assert!(
+                after.contains("loadgen_run_start 1"),
+                "loadgen_run_start should be 1, got:\n{}",
+                after
+            );
+            assert!(
+                after.contains("loadgen_run_complete 1"),
+                "loadgen_run_complete should be 1 (start==complete = Success), got:\n{}",
+                after
+            );
+            assert!(
+                after.contains(&format!("loadgen_txn_attempted {}", N)),
+                "loadgen_txn_attempted should be {}, got:\n{}",
+                N,
                 after
             );
         });

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -784,6 +784,13 @@ mod loadgen_runner {
             let (permit, stop_token) = LoadGenPermit::try_acquire(&self.state)
                 .ok_or_else(|| "Load generation is already running.".to_string())?;
 
+            // Mark the run-start meter once a run is actually committed (parity:
+            // stellar-core ApplicationImpl::generateLoad, ApplicationImpl.cpp:1156,
+            // which marks {"loadgen","run","start"} before driving the generator).
+            // Supercluster's IsLoadGenComplete reads loadgen_run_start ==
+            // loadgen_run_complete to detect completion (#3569).
+            henyey_app::metrics::LOADGEN_RUN_START.increment(1);
+
             let mut config = GeneratedLoadConfig {
                 mode,
                 n_accounts: request.accounts,
@@ -855,12 +862,23 @@ mod loadgen_runner {
 
                 match result {
                     henyey_simulation::LoadResult::Done { submitted } => {
+                        // Parity: LoadGenerator mLoadgenComplete.Mark()
+                        // (LoadGenerator.cpp:1384/1460). start==complete is
+                        // supercluster's Success condition (#3569).
+                        henyey_app::metrics::LOADGEN_RUN_COMPLETE.increment(1);
                         tracing::info!(submitted, "Load generation complete");
                     }
                     henyey_simulation::LoadResult::Stopped => {
+                        // Parity: LoadGenerator::stop() marks mLoadgenFail
+                        // (LoadGenerator.cpp:310). A stopped run is a failed run
+                        // from supercluster's perspective (#3569).
+                        henyey_app::metrics::LOADGEN_RUN_FAILED.increment(1);
                         tracing::info!("Load generation stopped");
                     }
                     henyey_simulation::LoadResult::Failed => {
+                        // Parity: LoadGenerator mLoadgenFail.Mark()
+                        // (LoadGenerator.cpp:565/749/1433).
+                        henyey_app::metrics::LOADGEN_RUN_FAILED.increment(1);
                         tracing::error!("Load generation failed");
                     }
                 }

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -33,3 +33,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 serial_test = "3"
+metrics-exporter-prometheus.workspace = true

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use henyey_app::metrics as app_metrics;
 use henyey_app::App;
 use henyey_common::{Hash256, NetworkId};
 use henyey_crypto::SecretKey;
@@ -21,10 +22,10 @@ use henyey_herder::TxQueueResult;
 use henyey_tx::TxResultCode;
 use stellar_xdr::{
     AccountId, Asset, ContractDataDurability, ContractId, ContractIdPreimage,
-    ContractIdPreimageFromAddress, CreateAccountOp, Hash, LedgerKey, LedgerKeyContractData, Memo,
-    MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions, PublicKey, ScAddress, ScVal,
-    SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope,
-    Uint256, VecM,
+    ContractIdPreimageFromAddress, CreateAccountOp, Hash, LedgerKey, LedgerKeyContractData, Limits,
+    Memo, MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions, PublicKey, ScAddress,
+    ScVal, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope,
+    Uint256, VecM, WriteXdr,
 };
 use tracing::{debug, info, warn};
 
@@ -1324,6 +1325,10 @@ impl LoadGenerator {
                 return LoadResult::Failed;
             }
 
+            // One step per loop iteration (parity: stellar-core
+            // LoadGenerator::getTxPerStep() mStepMeter.Mark(), LoadGenerator.cpp:211).
+            app_metrics::LOADGEN_STEP_COUNT.increment(1);
+
             // Check if all transactions for the current phase are submitted
             if !config.are_txs_remaining() {
                 // For setup modes, transition from phase 1 (upload) to phase 2 (deploy)
@@ -1510,13 +1515,28 @@ impl LoadGenerator {
                 }
             };
 
+            // Mirror stellar-core LoadGenerator::execute() metric ordering:
+            // mark the per-mode + per-tx attempt meters BEFORE submission, then
+            // mark `txn.rejected` if the tx queue does not accept the tx. One
+            // mark per execute()-equivalent (this inner-loop iteration), which
+            // includes txBAD_SEQ retries — matching core, where submitTx()
+            // re-enters execute() on each retry (#3569).
+            mark_tx_meters(config.mode, &envelope);
+
             let result = self.tx_generator.app.submit_transaction(envelope).await;
 
             // PayPregenerated does not re-submit on failure: each tx is read
             // once from the file, so a retry would consume the *next* tx
             // (stellar-core LoadGenerator.cpp:874).
             if config.mode == LoadGenMode::PayPregenerated {
+                if !matches!(result, TxQueueResult::Added) {
+                    app_metrics::LOADGEN_TXN_REJECTED.increment(1);
+                }
                 return matches!(result, TxQueueResult::Added);
+            }
+
+            if !matches!(result, TxQueueResult::Added) {
+                app_metrics::LOADGEN_TXN_REJECTED.increment(1);
             }
 
             match result {
@@ -1999,6 +2019,98 @@ fn deterministic_rand(a: u64, b: u32) -> u64 {
 /// Used by `PayPregenerated` to mirror stellar-core's
 /// `acc->setSequenceNumber(txFrame->getSeqNum())`. Fee-bump envelopes carry the
 /// inner v1 tx's seq; v0 envelopes carry their own.
+/// Number of operations in a transaction envelope.
+fn envelope_num_operations(env: &TransactionEnvelope) -> u64 {
+    match env {
+        TransactionEnvelope::TxV0(e) => e.tx.operations.len() as u64,
+        TransactionEnvelope::Tx(e) => e.tx.operations.len() as u64,
+        TransactionEnvelope::TxFeeBump(e) => match &e.tx.inner_tx {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.operations.len() as u64,
+        },
+    }
+}
+
+/// Whether the envelope carries any Soroban (`InvokeHostFunction`,
+/// `ExtendFootprintTtl`, `RestoreFootprint`) operation. Mirrors stellar-core
+/// `TransactionFrame::isSoroban()` for loadgen-meter classification purposes.
+fn envelope_is_soroban(env: &TransactionEnvelope) -> bool {
+    let ops: &[Operation] = match env {
+        TransactionEnvelope::TxV0(e) => e.tx.operations.as_slice(),
+        TransactionEnvelope::Tx(e) => e.tx.operations.as_slice(),
+        TransactionEnvelope::TxFeeBump(e) => match &e.tx.inner_tx {
+            stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) => inner.tx.operations.as_slice(),
+        },
+    };
+    ops.iter().any(|op| {
+        matches!(
+            op.body,
+            OperationBody::InvokeHostFunction(_)
+                | OperationBody::ExtendFootprintTtl(_)
+                | OperationBody::RestoreFootprint(_)
+        )
+    })
+}
+
+/// XDR byte size of an envelope. Best-effort parity with stellar-core's
+/// `xdr::xdr_argpack_size(*txf->toStellarMessage())`; we measure the envelope
+/// itself (core wraps it in a `StellarMessage`, adding a small fixed
+/// discriminant — immaterial for the `*_bytes` meters, which supercluster does
+/// not poll for completion).
+fn envelope_xdr_size(env: &TransactionEnvelope) -> u64 {
+    env.to_xdr(Limits::none())
+        .map(|b| b.len() as u64)
+        .unwrap_or(0)
+}
+
+/// Mark the loadgen per-tx meters for one generated transaction, mirroring the
+/// metric block of stellar-core `LoadGenerator::execute()` (LoadGenerator.cpp
+/// 1500-1611): per-mode meter first, then `txn.attempted` + `txn.bytes`. The
+/// caller marks `txn.rejected` afterward if the tx queue rejects the tx.
+///
+/// For `MixedClassicSoroban` (and other modes whose concrete sub-mode is only
+/// known from the built tx), classification is by inspecting the envelope —
+/// matching core's `MIXED_PREGEN_*` `isSoroban()` branch.
+fn mark_tx_meters(mode: LoadGenMode, env: &TransactionEnvelope) {
+    let xdr_size = envelope_xdr_size(env);
+    match mode {
+        LoadGenMode::Pay | LoadGenMode::PayPregenerated => {
+            app_metrics::LOADGEN_PAYMENT_SUBMITTED.increment(envelope_num_operations(env));
+            app_metrics::LOADGEN_PAYMENT_BYTES.increment(xdr_size);
+        }
+        LoadGenMode::SorobanUpload => {
+            app_metrics::LOADGEN_SOROBAN_UPLOAD.increment(1);
+        }
+        LoadGenMode::SorobanInvokeSetup => {
+            app_metrics::LOADGEN_SOROBAN_SETUP_INVOKE.increment(1);
+        }
+        LoadGenMode::SorobanUpgradeSetup => {
+            app_metrics::LOADGEN_SOROBAN_SETUP_UPGRADE.increment(1);
+        }
+        LoadGenMode::SorobanInvoke | LoadGenMode::SorobanInvokeApplyLoad => {
+            app_metrics::LOADGEN_SOROBAN_INVOKE.increment(1);
+        }
+        LoadGenMode::SorobanCreateUpgrade => {
+            app_metrics::LOADGEN_SOROBAN_CREATE_UPGRADE.increment(1);
+        }
+        LoadGenMode::MixedClassicSoroban => {
+            // Sub-mode is decided per-tx; classify by inspecting the built tx
+            // (parity: core's execute() switch on mLastMixedMode, equivalently
+            // the MIXED_PREGEN_* isSoroban() branch).
+            if envelope_is_soroban(env) {
+                app_metrics::LOADGEN_SOROBAN_INVOKE.increment(1);
+            } else {
+                app_metrics::LOADGEN_PAYMENT_SUBMITTED.increment(envelope_num_operations(env));
+                app_metrics::LOADGEN_PAYMENT_BYTES.increment(xdr_size);
+            }
+        }
+    }
+
+    // Per-tx attempt + bytes (parity: txm.mTxnAttempted.Mark() +
+    // txm.mTxnBytes.Mark(...) at the end of execute()).
+    app_metrics::LOADGEN_TXN_ATTEMPTED.increment(1);
+    app_metrics::LOADGEN_TXN_BYTES.increment(xdr_size);
+}
+
 fn envelope_seq_num(env: &TransactionEnvelope) -> i64 {
     match env {
         TransactionEnvelope::TxV0(e) => e.tx.seq_num.0,

--- a/crates/simulation/tests/loadgen_metrics.rs
+++ b/crates/simulation/tests/loadgen_metrics.rs
@@ -1,0 +1,275 @@
+//! Integration test for #3569: henyey's loadgen path must emit the
+//! stellar-core `loadgen.*` Prometheus meters so supercluster's
+//! `IsLoadGenComplete` can observe henyey-driven loadgen completion.
+//!
+//! This drives the real `LoadGenerator::generate_load` async loop against a
+//! live app-backed standalone validator and asserts that the per-tx meters
+//! (`loadgen_txn_attempted`, `loadgen_payment_submitted`, ...) move during the
+//! run. It fails on origin/main, where the meters are never emitted (the
+//! rendered `/metrics` text contains no `loadgen_*` series at all).
+//!
+//! The metrics recorder is a process-global singleton, so the test installs it
+//! exactly once (via an `OnceLock` guard wrapping the public
+//! `henyey_app::metrics::install_recorder()`), runs `#[serial]`, and uses
+//! delta-based (`>=`) assertions to stay robust against other simulation tests
+//! sharing the same recorder.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use henyey_app::App;
+use henyey_common::{deterministic_seed, Hash256, NetworkId};
+use henyey_crypto::{sign_hash, SecretKey};
+use henyey_simulation::{
+    GeneratedLoadConfig, LoadGenMode, LoadGenerator, LoadResult, Simulation, SimulationMode,
+};
+use henyey_tx::TransactionFrame;
+use metrics_exporter_prometheus::PrometheusHandle;
+use serial_test::serial;
+use stellar_xdr::{
+    AccountId, CreateAccountOp, DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody,
+    Preconditions, PublicKey, SequenceNumber, Signature, SignatureHint, Transaction,
+    TransactionEnvelope, TransactionExt, TransactionV1Envelope, Uint256, VecM,
+};
+
+const NETWORK_PASSPHRASE: &str = "Test SDF Network ; September 2015";
+
+/// Install the process-global metrics recorder exactly once and return its
+/// render handle. `install_recorder` panics if called twice, so the `OnceLock`
+/// guard makes repeated calls (across tests sharing the process) safe.
+fn global_recorder() -> &'static PrometheusHandle {
+    static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+    HANDLE.get_or_init(henyey_app::metrics::install_recorder)
+}
+
+/// Parse a single counter value out of a Prometheus exposition text body.
+/// Returns 0.0 if the series is absent (which is exactly the on-main failure
+/// mode this test guards against).
+fn scrape_counter(render: &str, name: &str) -> f64 {
+    for line in render.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        // Unlabeled counter line: "<name> <value>".
+        if let Some(rest) = line.strip_prefix(name) {
+            if let Some(value) = rest.trim().split_whitespace().next() {
+                if rest.starts_with(' ') {
+                    return value.parse().unwrap_or(0.0);
+                }
+            }
+        }
+    }
+    0.0
+}
+
+/// Derive the deterministic keypair the loadgen uses for numbered account `id`
+/// (`TestAccount-{id}`), matching `TestAccount::from_name`.
+fn loadgen_account_secret(id: u64) -> SecretKey {
+    SecretKey::from_seed(&deterministic_seed(&format!("TestAccount-{}", id)))
+}
+
+fn root_secret() -> SecretKey {
+    let network_id = NetworkId::from_passphrase(NETWORK_PASSPHRASE);
+    SecretKey::from_seed(network_id.as_bytes())
+}
+
+fn sign(mut envelope: TransactionEnvelope, secret: &SecretKey) -> TransactionEnvelope {
+    let network_id = NetworkId::from_passphrase(NETWORK_PASSPHRASE);
+    let hash = TransactionFrame::hash_envelope(&envelope, &network_id).expect("hash envelope");
+    let signature = sign_hash(secret, &hash);
+    let pk = secret.public_key();
+    let pk_bytes = pk.as_bytes();
+    let hint = SignatureHint([pk_bytes[28], pk_bytes[29], pk_bytes[30], pk_bytes[31]]);
+    let decorated = DecoratedSignature {
+        hint,
+        signature: Signature(signature.0.to_vec().try_into().unwrap_or_default()),
+    };
+    if let TransactionEnvelope::Tx(ref mut env) = envelope {
+        env.signatures = vec![decorated].try_into().unwrap_or_default();
+    }
+    envelope
+}
+
+/// Fund loadgen accounts `[0, n)` from the root account in a single tx, then
+/// close a ledger so they exist in the bucket list.
+async fn fund_loadgen_accounts(sim: &Simulation, app: &Arc<App>, n: u64, balance: i64) {
+    let root = root_secret();
+    let root_aid = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(
+        *root.public_key().as_bytes(),
+    )));
+    let root_seq = app
+        .load_account_sequence(&root_aid)
+        .expect("load root seq")
+        .expect("root account exists");
+
+    let mut ops = Vec::new();
+    for id in 0..n {
+        let dest = loadgen_account_secret(id).public_key();
+        ops.push(Operation {
+            source_account: None,
+            body: OperationBody::CreateAccount(CreateAccountOp {
+                destination: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(*dest.as_bytes()))),
+                starting_balance: balance,
+            }),
+        });
+    }
+
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256(*root.public_key().as_bytes())),
+        fee: 100 * n as u32,
+        seq_num: SequenceNumber(root_seq + 1),
+        cond: Preconditions::None,
+        memo: Memo::None,
+        operations: ops.try_into().expect("ops vec"),
+        ext: TransactionExt::V0,
+    };
+    let envelope = sign(
+        TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: VecM::default(),
+        }),
+        &root,
+    );
+
+    let result = app.submit_transaction(envelope).await;
+    assert!(
+        matches!(result, henyey_herder::TxQueueResult::Added),
+        "create-accounts tx must be accepted, got {:?}",
+        result
+    );
+
+    let target = app.current_ledger_seq() + 1;
+    manual_close_until(sim, target, 1, Duration::from_secs(40)).await;
+}
+
+/// Minimal manual-close loop for a standalone node (mirrors the helper in
+/// `app_simulation.rs`, duplicated here to keep this test self-contained).
+async fn manual_close_until(sim: &Simulation, target: u32, _quiet: u32, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let seq = sim.app("node0").expect("node0 app").current_ledger_seq();
+        if seq >= target {
+            return;
+        }
+        let _ = sim.manual_close_app_node("node0").await;
+        if std::time::Instant::now() > deadline {
+            panic!(
+                "manual_close_until: did not reach ledger {} (at {})",
+                target, seq
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_generate_load_increments_loadgen_meters() {
+    let handle = global_recorder();
+
+    // Standalone single-node validator (threshold 100%, self-quorum) — closes
+    // ledgers without peers.
+    let mut sim = Simulation::with_network(SimulationMode::OverTcp, NETWORK_PASSPHRASE);
+    let seed = Hash256::hash(b"LOADGEN_METRICS_3569");
+    let secret = SecretKey::from_seed(&seed.0);
+    let quorum_set = henyey_app::config::QuorumSetConfig {
+        threshold_percent: 100,
+        validators: vec![secret.public_key().to_strkey()],
+        inner_sets: Vec::new(),
+    };
+    sim.add_app_node("node0", secret, quorum_set);
+    sim.start_all_nodes().await;
+
+    // Wait until the standalone validator is validating (can close ledgers).
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(app) = sim.app("node0") {
+            if app.state().await == henyey_app::AppState::Validating {
+                break;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "node0 did not reach Validating in time"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let app = sim.app("node0").expect("node0 app exists");
+
+    // Fund a small pool of loadgen accounts on-ledger so Pay-mode submissions
+    // are accepted (so the run reaches LoadResult::Done).
+    const N_ACCOUNTS: u64 = 4;
+    fund_loadgen_accounts(&sim, &app, N_ACCOUNTS, 100_000_000).await;
+
+    // Snapshot meters before the run (delta-based assertions).
+    let before = handle.render();
+    let attempted_before = scrape_counter(&before, "loadgen_txn_attempted");
+    let payment_before = scrape_counter(&before, "loadgen_payment_submitted");
+    let step_before = scrape_counter(&before, "loadgen_step_count");
+
+    // Drive a short Pay-mode run. tx_rate is per-second; a handful of accounts
+    // and a low target keeps the run brief. We close ledgers concurrently so
+    // pending txs clear and accounts become available again.
+    let mut generator = LoadGenerator::new(Arc::clone(&app), NETWORK_PASSPHRASE.to_string());
+    let mut config = GeneratedLoadConfig {
+        mode: LoadGenMode::Pay,
+        n_accounts: N_ACCOUNTS as u32,
+        offset: 0,
+        n_txs: N_ACCOUNTS as u32,
+        tx_rate: 100,
+        ..Default::default()
+    };
+
+    let stop = AtomicBool::new(false);
+    let sim_for_close = &sim;
+    let closer = async {
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let _ = sim_for_close.manual_close_app_node("node0").await;
+        }
+    };
+    let run = generator.generate_load(&mut config, &stop);
+
+    let (result, _) = tokio::join!(run, closer);
+
+    // The run should complete (all N txs submitted). Even if it failed, the
+    // attempt meters must have moved — the key #3569 assertion.
+    let after = handle.render();
+    let attempted_after = scrape_counter(&after, "loadgen_txn_attempted");
+    let payment_after = scrape_counter(&after, "loadgen_payment_submitted");
+    let step_after = scrape_counter(&after, "loadgen_step_count");
+
+    assert!(
+        attempted_after >= attempted_before + N_ACCOUNTS as f64,
+        "loadgen_txn_attempted should increase by >= {} (was {}, now {})",
+        N_ACCOUNTS,
+        attempted_before,
+        attempted_after
+    );
+    assert!(
+        payment_after > payment_before,
+        "loadgen_payment_submitted should increase (was {}, now {})",
+        payment_before,
+        payment_after
+    );
+    assert!(
+        step_after > step_before,
+        "loadgen_step_count should increase (was {}, now {})",
+        step_before,
+        step_after
+    );
+
+    // The run reached a terminal state; if Done, supercluster's Success path
+    // (run_start == run_complete) is exercised by the binary's runner — here we
+    // assert the per-tx side-channel, which is the part that lives in
+    // henyey-simulation.
+    assert!(
+        matches!(result, LoadResult::Done { .. } | LoadResult::Failed),
+        "run reached a terminal state, got {:?}",
+        result
+    );
+
+    sim.stop_all_nodes().await.expect("stop standalone node");
+}


### PR DESCRIPTION
Closes #3569

## Summary

Henyey ran load generation but exposed none of the `loadgen.*` metrics that stellar-core's medida exporter emits. Supercluster's `IsLoadGenComplete` polls `loadgen_run_start == loadgen_run_complete` to detect completion, so **SSC henyey-majority loadgen missions (1c2h, 0c3h) hung** at the loadgen wait and failed even though henyey's loadgen worked. This registers the full loadgen meter set and increments them along henyey's loadgen path, matching stellar-core v27.0.0 names exactly, **unblocking SSC henyey-majority loadgen missions**.

- **Catalog** (`crates/app/src/metrics.rs`): the loadgen meters are added to the pre-registered `counters {}` block with the exact bare-`loadgen_` Prometheus names (no `stellar_`/`henyey_` prefix, no dot→underscore munging — the literal string IS the exposition name, matching core's exporter output and supercluster's reads), so each series renders at zero on the first scrape.
- **Per-tx meters** (`crates/simulation/src/loadgen.rs` `submit_tx`): `txn.attempted`/`txn.rejected`/`txn.bytes`, `payment.submitted` (by op count) / `payment.bytes`, and the `soroban.*` meters by mode, mirroring the metric block of `LoadGenerator::execute()` (per-mode meter first, then attempted+bytes, then rejected on a non-accepted submission). `step.count` once per `generate_load` loop iteration.
- **Run-lifecycle meters** (`crates/henyey/src/main.rs` `loadgen_runner`): `run.start` after permit acquisition (parity `ApplicationImpl.cpp:1156`), `run.complete` on `Done`, `run.failed` on both `Failed` and `Stopped` (parity: `LoadGenerator::stop()` marks `mLoadgenFail`).
- `loadgen_account_created` is registered-at-zero but not incremented, matching core v27 (test-only there); supercluster tolerates 0 for progress.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3569#issuecomment-4775450549)

## Test plan

- [x] `cargo fmt --check` (pre-commit hook)
- [x] `cargo clippy --all -- -D warnings` (pre-commit hook + `RUSTFLAGS=-Dwarnings` build of `-p henyey-app -p henyey-simulation -p henyey --all-targets`)
- [x] `cargo build --all`
- [x] `cargo test --all`
- [x] Parity tripwires byte-identical: `ledger_close_meta_vectors`, `tx_meta_hash_vectors` pass; `scp_parity_tests` unaffected (change touches none of ledger/scp/herder — counters are pure side channels).

## Regression test (kind: bug-fix)

- **Test:** `crates/simulation/tests/loadgen_metrics.rs::test_generate_load_increments_loadgen_meters` (plus `crates/app/src/metrics.rs::test_loadgen_meters_in_catalog` and `::test_loadgen_run_lifecycle_renders`)
- **Pre-fix:** committed as `2cc41de5` — verified FAILED with: `loadgen_txn_attempted should increase by >= 4 (was 0, now 0)` (meters never emitted on main).
- **Post-fix:** verified PASSES after `8e0846d4`.

## Deviations from plan

- `loadgen_*_bytes` meters measure the **envelope** XDR size; stellar-core measures `xdr_argpack_size(*toStellarMessage())` (envelope wrapped in a `StellarMessage`, adding a small fixed discriminant). Immaterial — supercluster does not poll the `*_bytes` meters for completion. Noted inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)