### PR TITLE
Add inbound idle-drop flow-control diagnostics (#3570)

### DIFF
--- a/crates/overlay/src/flow_control.rs
+++ b/crates/overlay/src/flow_control.rs
@@ -554,6 +554,12 @@ pub struct FlowControl {
     pub(crate) dropped_adverts: AtomicU64,
     /// Metrics - messages dropped from demand queue.
     pub(crate) dropped_demands: AtomicU64,
+    /// #3570 observability: monotonic count of SEND_MORE_EXTENDED grants
+    /// received from the peer. A value of 0 on an idle-dropped inbound peer is
+    /// the leading-hypothesis signal — the peer never granted us outbound
+    /// capacity, so we could not flood SCP to it and it idled out. Purely a
+    /// diagnostic counter; does not affect any flow-control decision.
+    pub(crate) send_more_received_count: AtomicU64,
 }
 
 impl FlowControl {
@@ -598,6 +604,7 @@ impl FlowControl {
             dropped_txs: AtomicU64::new(0),
             dropped_adverts: AtomicU64::new(0),
             dropped_demands: AtomicU64::new(0),
+            send_more_received_count: AtomicU64::new(0),
         }
     }
 
@@ -631,6 +638,7 @@ impl FlowControl {
             dropped_txs: AtomicU64::new(0),
             dropped_adverts: AtomicU64::new(0),
             dropped_demands: AtomicU64::new(0),
+            send_more_received_count: AtomicU64::new(0),
         }
     }
 
@@ -690,6 +698,12 @@ impl FlowControl {
     /// Release outbound capacity when receiving SEND_MORE_EXTENDED.
     pub fn maybe_release_capacity(&self, msg: &StellarMessage) {
         if let StellarMessage::SendMoreExtended(send_more) = msg {
+            // #3570 observability: count grants received from the peer. Bumped
+            // for every processed SEND_MORE_EXTENDED, independent of the
+            // capacity math below. Read only by the inbound-drop diagnostic.
+            self.send_more_received_count
+                .fetch_add(1, Ordering::Relaxed);
+
             let mut state = self.state.lock().unwrap();
 
             if let Some(start) = state.no_outbound_capacity.take() {
@@ -1094,6 +1108,15 @@ impl FlowControl {
         }
     }
 
+    /// Test-only: backdate the no-outbound-capacity timer so timeout checks see
+    /// it as stale. Used to exercise the send-mode-idle drop path without
+    /// waiting real seconds.
+    #[cfg(test)]
+    pub(crate) fn force_no_outbound_capacity_age(&self, secs: u64) {
+        let mut state = self.state.lock().unwrap();
+        state.no_outbound_capacity = Some(Instant::now() - std::time::Duration::from_secs(secs));
+    }
+
     /// Check if throttling should be applied.
     pub fn maybe_throttle_read(&self) -> bool {
         let mut state = self.state.lock().unwrap();
@@ -1144,6 +1167,7 @@ impl FlowControl {
             advert_queue_size: state.outbound_queues[MessagePriority::FloodAdvert as usize].len(),
             tx_queue_byte_count: state.tx_queue_byte_count,
             is_throttled: state.last_throttle.is_some(),
+            send_more_received_count: self.send_more_received_count.load(Ordering::Relaxed),
         }
     }
 }
@@ -1179,6 +1203,10 @@ pub struct FlowControlStats {
     pub tx_queue_byte_count: usize,
     /// Whether reading is throttled.
     pub is_throttled: bool,
+    /// #3570 observability: monotonic count of SEND_MORE_EXTENDED grants
+    /// received from the peer. 0 means the peer never granted us outbound
+    /// capacity (the leading-hypothesis signal for inbound idle-outs).
+    pub send_more_received_count: u64,
 }
 
 /// Check if a message requires flow control capacity tracking.

--- a/crates/overlay/src/flow_control.rs
+++ b/crates/overlay/src/flow_control.rs
@@ -1569,6 +1569,49 @@ mod tests {
     }
 
     #[test]
+    fn test_send_more_received_count_increments() {
+        // #3570 observability: a fresh FlowControl has never received a
+        // SEND_MORE_EXTENDED grant, so the count is 0. Each
+        // `maybe_release_capacity` that processes a SEND_MORE_EXTENDED bumps a
+        // monotonic counter surfaced via `get_stats()`. Non-SEND_MORE messages
+        // do not bump it. This is the leading-hypothesis signal: an inbound
+        // peer that never grants capacity (count stays 0) idles out.
+        let fc = FlowControl::default();
+        assert_eq!(
+            fc.get_stats().send_more_received_count,
+            0,
+            "fresh FlowControl reports zero SEND_MORE grants received"
+        );
+
+        let send_more = StellarMessage::SendMoreExtended(SendMoreExtended {
+            num_messages: 1,
+            num_bytes: 1,
+        });
+        fc.maybe_release_capacity(&send_more);
+        assert_eq!(
+            fc.get_stats().send_more_received_count,
+            1,
+            "one SEND_MORE_EXTENDED bumps the counter to 1"
+        );
+
+        fc.maybe_release_capacity(&send_more);
+        assert_eq!(
+            fc.get_stats().send_more_received_count,
+            2,
+            "counter is monotonic across grants"
+        );
+
+        // A non-SEND_MORE message must NOT bump the counter.
+        let tx = make_tx_message();
+        fc.maybe_release_capacity(&tx);
+        assert_eq!(
+            fc.get_stats().send_more_received_count,
+            2,
+            "non-SEND_MORE message does not bump the SEND_MORE counter"
+        );
+    }
+
+    #[test]
     fn test_no_outbound_capacity_timeout_clears_after_send_more_extended() {
         let fc = FlowControl::default();
 

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -498,6 +498,9 @@ struct PeerLoopCtx<'a> {
     peer_rate_limiter: &'a mut PeerRateLimiter,
     scp_messages: &'a mut u64,
     last_write: &'a mut Instant,
+    /// #3570 observability: loop-local count of SCP envelopes henyey has
+    /// written to this peer (accumulated from SEND_MORE-triggered drains).
+    scp_written: &'a mut u64,
 }
 
 /// Read-only timing and message counters for timeout checks.
@@ -506,6 +509,61 @@ struct PeerTimingInfo {
     last_write: Instant,
     total_messages: u64,
     scp_messages: u64,
+}
+
+/// #3570 observability: which timeout fired when a peer is dropped.
+///
+/// Carried out of [`OverlayManager::check_peer_timeouts`] (which previously
+/// returned a bare `bool`) so the inbound-drop diagnostic can record the
+/// specific reason. The drop *conditions* and metric increments are unchanged
+/// — this only labels which one tripped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IdleReason {
+    /// No read AND no write for >= PEER_TIMEOUT (30s). Matches Peer.cpp:450-451.
+    Idle,
+    /// No write for >= PEER_STRAGGLER_TIMEOUT (120s).
+    Straggler,
+    /// No outbound capacity (no SEND_MORE_EXTENDED) for >= 60s. OVERLAY_SPEC §5.6.
+    SendModeIdle,
+}
+
+impl IdleReason {
+    /// Short, low-cardinality label for the `overlay_inbound_diag` warn field.
+    fn as_str(self) -> &'static str {
+        match self {
+            IdleReason::Idle => "idle",
+            IdleReason::Straggler => "straggler",
+            IdleReason::SendModeIdle => "send_mode_idle",
+        }
+    }
+}
+
+/// #3570 observability: per-inbound-peer flow-control snapshot gathered at the
+/// idle-timeout drop, so the operator can pin WHY each inbound peer idles out.
+///
+/// All fields are reads of already-tracked state — building this struct has no
+/// effect on any drop condition, SEND_MORE grant, or flood behavior. The
+/// leading-hypothesis signature is: `idle_reason ∈ {idle, send_mode_idle}` +
+/// `send_more_received == 0` + `peer_message_capacity == 0` + `scp_written == 0`
+/// + `scp_queue_depth > 0` (we had SCP to flood but were blocked on capacity).
+#[derive(Debug, Clone)]
+pub(super) struct InboundDropDiag {
+    /// SEND_MORE_EXTENDED grants received from the peer (0 = never granted).
+    pub send_more_received: u64,
+    /// SCP envelopes henyey actually wrote to this peer over the connection.
+    pub scp_written: u64,
+    /// SCP messages still queued (had SCP to send but blocked on capacity).
+    pub scp_queue_depth: usize,
+    /// Peer's currently-granted outbound message capacity (0 = exhausted/none).
+    pub peer_message_capacity: u64,
+    /// Peer's currently-granted outbound byte capacity.
+    pub peer_bytes_capacity: u64,
+    /// Seconds since henyey last wrote to this peer.
+    pub last_write_age_secs: u64,
+    /// Seconds since henyey last read from this peer.
+    pub last_read_age_secs: u64,
+    /// Which timeout fired.
+    pub idle_reason: IdleReason,
 }
 
 /// Result from handling a received message — controls the peer loop's flow.
@@ -618,13 +676,17 @@ pub(super) fn should_skip_generic_routing(message: &StellarMessage) -> bool {
 impl OverlayManager {
     /// Check whether the peer has exceeded idle or straggler timeouts.
     ///
-    /// Returns `true` if the peer should be dropped.
+    /// Returns `Some(IdleReason)` identifying which timeout fired (and thus that
+    /// the peer should be dropped), or `None` if the peer is still live. The
+    /// drop conditions and metric increments are unchanged from the prior
+    /// `bool`-returning form; the reason is carried out solely so the #3570
+    /// inbound-drop diagnostic at the call site can label the cause.
     fn check_peer_timeouts(
         peer_id: &PeerId,
         timing: &PeerTimingInfo,
         flow_control: &FlowControl,
         metrics: &crate::metrics::OverlayMetrics,
-    ) -> bool {
+    ) -> Option<IdleReason> {
         const PEER_TIMEOUT: Duration = Duration::from_secs(30);
         const PEER_STRAGGLER_TIMEOUT: Duration = Duration::from_secs(120);
         // OVERLAY_SPEC §5.6 — drop peer if no SEND_MORE_EXTENDED for this long.
@@ -639,7 +701,7 @@ impl OverlayManager {
                 peer_id, timing.total_messages, timing.scp_messages
             );
             metrics.timeouts_idle.inc();
-            return true;
+            return Some(IdleReason::Idle);
         }
         if now.duration_since(timing.last_write) >= PEER_STRAGGLER_TIMEOUT {
             warn!(
@@ -647,7 +709,7 @@ impl OverlayManager {
                 peer_id, timing.total_messages, timing.scp_messages
             );
             metrics.timeouts_straggler.inc();
-            return true;
+            return Some(IdleReason::Straggler);
         }
         if flow_control.no_outbound_capacity_timeout(PEER_SEND_MODE_IDLE_TIMEOUT_SECS) {
             warn!(
@@ -655,9 +717,60 @@ impl OverlayManager {
                 peer_id, PEER_SEND_MODE_IDLE_TIMEOUT_SECS
             );
             metrics.timeouts_idle.inc();
-            return true;
+            return Some(IdleReason::SendModeIdle);
         }
-        false
+        None
+    }
+
+    /// #3570 observability: build the [`InboundDropDiag`] snapshot for a peer
+    /// being dropped on a timeout. Pure read of already-tracked state — this
+    /// has no effect on any drop condition, SEND_MORE grant, or flood behavior.
+    ///
+    /// `last_read`/`last_write` are the loop-local `Instant`s; `scp_written` is
+    /// the loop-local count of SCP envelopes henyey wrote to this peer.
+    fn build_inbound_drop_diag(
+        flow_control: &FlowControl,
+        last_read: Instant,
+        last_write: Instant,
+        scp_written: u64,
+        idle_reason: IdleReason,
+    ) -> InboundDropDiag {
+        let stats = flow_control.get_stats();
+        InboundDropDiag {
+            send_more_received: stats.send_more_received_count,
+            scp_written,
+            scp_queue_depth: stats.scp_queue_size,
+            peer_message_capacity: stats.peer_message_capacity,
+            peer_bytes_capacity: stats.peer_bytes_capacity,
+            last_write_age_secs: last_write.elapsed().as_secs(),
+            last_read_age_secs: last_read.elapsed().as_secs(),
+            idle_reason,
+        }
+    }
+
+    /// #3570 observability: emit the per-inbound-peer idle-drop diagnostic.
+    /// Inbound-gated, mirroring [`Self::log_inbound_drop_diag`]. Reads only
+    /// already-tracked state; does not alter control flow.
+    fn log_inbound_idle_drop_diag(peer: &Peer, peer_id: &PeerId, diag: &InboundDropDiag) {
+        if peer.direction() != ConnectionDirection::Inbound {
+            return;
+        }
+        warn!(
+            target: "overlay_inbound_diag",
+            peer_id = %peer_id,
+            addr = %peer.remote_addr(),
+            direction = "inbound",
+            authenticated = peer.is_ready(),
+            idle_reason = diag.idle_reason.as_str(),
+            send_more_received = diag.send_more_received,
+            scp_written = diag.scp_written,
+            scp_queue_depth = diag.scp_queue_depth,
+            peer_message_capacity = diag.peer_message_capacity,
+            peer_bytes_capacity = diag.peer_bytes_capacity,
+            last_write_age_secs = diag.last_write_age_secs,
+            last_read_age_secs = diag.last_read_age_secs,
+            "inbound peer dropped on idle timeout; per-peer flow-control signals recorded"
+        );
     }
 
     /// Send a ping (GetScpQuorumset with a random hash) if due and idle.
@@ -712,15 +825,15 @@ impl OverlayManager {
 
     /// Handle a received `SendMoreExtended` message: release outbound capacity
     /// and drain queued messages. Returns `Err` if the drain send fails (peer
-    /// should be dropped), `Ok(true)` if any messages were written, `Ok(false)`
-    /// otherwise.
+    /// should be dropped), or `Ok(BatchSendOutcome)` describing the drain
+    /// (whether anything was written and how many SCP envelopes).
     async fn handle_send_more_extended(
         peer: &mut Peer,
         peer_id: &PeerId,
         message: &StellarMessage,
         flow_control: &FlowControl,
         metrics: &crate::metrics::OverlayMetrics,
-    ) -> std::result::Result<bool, ()> {
+    ) -> std::result::Result<BatchSendOutcome, ()> {
         if let StellarMessage::SendMoreExtended(sme) = message {
             debug!(
                 "Peer {} sent SEND_MORE_EXTENDED: num_messages={}, num_bytes={}",
@@ -732,14 +845,17 @@ impl OverlayManager {
             }
             flow_control.maybe_release_capacity(message);
             match Self::send_flow_controlled_batch(peer, flow_control, metrics).await {
-                Ok(sent) => Ok(sent),
+                Ok(outcome) => Ok(outcome),
                 Err(e) => {
                     debug!("Failed to drain queue to {}: {}", peer_id, e);
                     Err(())
                 }
             }
         } else {
-            Ok(false)
+            Ok(BatchSendOutcome {
+                sent: false,
+                scp_written: 0,
+            })
         }
     }
 
@@ -1008,6 +1124,10 @@ impl OverlayManager {
         // Track message counts for periodic diagnostics
         let mut total_messages: u64 = 0;
         let mut scp_messages: u64 = 0;
+        // #3570 observability: SCP envelopes henyey has written to this peer
+        // (accumulated from flow-controlled batch sends). Read only by the
+        // inbound idle-drop diagnostic; affects no control flow.
+        let mut scp_written: u64 = 0;
         let mut last_stats_log = Instant::now();
 
         // Single periodic timer for ping, SendMore, and timeout checks.
@@ -1054,10 +1174,12 @@ impl OverlayManager {
                             flow_control.add_msg_and_maybe_trim_queue(m);
                             // Send whatever has capacity
                             match Self::send_flow_controlled_batch(&mut peer, &flow_control, &state.metrics).await {
-                                Ok(sent) => {
-                                    if sent {
+                                Ok(outcome) => {
+                                    if outcome.sent {
                                         last_write = Instant::now();
                                     }
+                                    // #3570 observability: accumulate SCP writes.
+                                    scp_written += outcome.scp_written;
                                 }
                                 Err(e) => {
                                     debug!("Failed to send batch to {}: {}", peer_id, e);
@@ -1128,6 +1250,7 @@ impl OverlayManager {
                                     peer_rate_limiter: &mut peer_rate_limiter,
                                     scp_messages: &mut scp_messages,
                                     last_write: &mut last_write,
+                                    scp_written: &mut scp_written,
                                 },
                                 &flow_control,
                                 &state,
@@ -1161,12 +1284,26 @@ impl OverlayManager {
 
                 // Periodic tasks: ping, timeout checks
                 _ = periodic_interval.tick() => {
-                    if Self::check_peer_timeouts(&peer_id, &PeerTimingInfo {
+                    if let Some(idle_reason) = Self::check_peer_timeouts(&peer_id, &PeerTimingInfo {
                         last_read,
                         last_write,
                         total_messages,
                         scp_messages,
                     }, &flow_control, &state.metrics) {
+                        // #3570 observability: emit the per-inbound-peer
+                        // flow-control snapshot so the operator can pin WHY this
+                        // peer idled out. Gathered BEFORE the break to avoid
+                        // borrow conflicts; reads only already-tracked state and
+                        // does not alter the drop (the `break` is unconditional
+                        // on a timeout, exactly as before).
+                        let diag = Self::build_inbound_drop_diag(
+                            &flow_control,
+                            last_read,
+                            last_write,
+                            scp_written,
+                            idle_reason,
+                        );
+                        Self::log_inbound_idle_drop_diag(&peer, &peer_id, &diag);
                         break;
                     }
 
@@ -1271,10 +1408,12 @@ impl OverlayManager {
                 )
                 .await
                 {
-                    Ok(sent) => {
-                        if sent {
+                    Ok(outcome) => {
+                        if outcome.sent {
                             *ctx.last_write = Instant::now();
                         }
+                        // #3570 observability: accumulate SCP envelopes written.
+                        *ctx.scp_written += outcome.scp_written;
                     }
                     Err(()) => return RecvAction::Break,
                 }
@@ -1318,18 +1457,22 @@ impl OverlayManager {
     /// Send queued outbound messages that have flow control capacity.
     ///
     /// Retrieves the next batch from FlowControl's priority queues,
-    /// sends each message, then cleans up sent entries. Returns true
-    /// if any messages were sent.
+    /// sends each message, then cleans up sent entries. Returns a
+    /// [`BatchSendOutcome`] reporting whether any message was sent and how many
+    /// SCP envelopes were written (the latter for the #3570 inbound-drop diag).
     pub(super) async fn send_flow_controlled_batch(
         peer: &mut Peer,
         flow_control: &FlowControl,
         metrics: &crate::metrics::OverlayMetrics,
-    ) -> crate::Result<bool> {
+    ) -> crate::Result<BatchSendOutcome> {
         use crate::flow_control::MessagePriority;
 
         let batch = flow_control.get_next_batch_to_send();
         if batch.is_empty() {
-            return Ok(false);
+            return Ok(BatchSendOutcome {
+                sent: false,
+                scp_written: 0,
+            });
         }
 
         // Group sent messages by priority for process_sent_messages
@@ -1350,9 +1493,25 @@ impl OverlayManager {
             }
         }
 
+        // #3570 observability: SCP envelopes actually written this batch. The
+        // ping path sends GetScpQuorumset (not an SCP envelope, and not routed
+        // through this batch), so it is correctly excluded.
+        let scp_written = sent_by_priority[MessagePriority::Scp as usize].len() as u64;
+
         flow_control.process_sent_messages(&sent_by_priority);
-        Ok(true)
+        Ok(BatchSendOutcome {
+            sent: true,
+            scp_written,
+        })
     }
+}
+
+/// #3570 observability: outcome of [`OverlayManager::send_flow_controlled_batch`].
+pub(super) struct BatchSendOutcome {
+    /// Whether any message was written this batch (preserves the prior `bool`).
+    pub sent: bool,
+    /// Number of SCP envelopes written this batch.
+    pub scp_written: u64,
 }
 
 #[cfg(test)]
@@ -1401,7 +1560,7 @@ mod tests {
         // #3570: check_peer_timeouts now returns Option<IdleReason> instead of
         // bool, so the idle-drop call site can carry WHICH timeout fired into
         // the diagnostic. The drop conditions themselves are unchanged.
-        use crate::flow_control::{FlowControl, FlowControlConfig};
+        use crate::flow_control::FlowControl;
         let metrics = crate::metrics::OverlayMetrics::new();
         let peer_id = PeerId::from_bytes([7u8; 32]);
         let stale = Instant::now() - Duration::from_secs(40);
@@ -1433,8 +1592,10 @@ mod tests {
         );
 
         // Fresh clocks, but no outbound capacity for >=60s → SendModeIdle.
-        // A default FlowControl has no_outbound_capacity set at construction.
+        // A default FlowControl has no_outbound_capacity set at construction;
+        // backdate it past the 60s send-mode-idle threshold.
         let fc_no_capacity = FlowControl::default();
+        fc_no_capacity.force_no_outbound_capacity_age(70);
         assert_eq!(
             OverlayManager::check_peer_timeouts(
                 &peer_id,

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -1397,6 +1397,157 @@ mod tests {
     }
 
     #[test]
+    fn test_check_peer_timeouts_returns_reason() {
+        // #3570: check_peer_timeouts now returns Option<IdleReason> instead of
+        // bool, so the idle-drop call site can carry WHICH timeout fired into
+        // the diagnostic. The drop conditions themselves are unchanged.
+        use crate::flow_control::{FlowControl, FlowControlConfig};
+        let metrics = crate::metrics::OverlayMetrics::new();
+        let peer_id = PeerId::from_bytes([7u8; 32]);
+        let stale = Instant::now() - Duration::from_secs(40);
+        let fresh = Instant::now();
+
+        // Both clocks stale (>30s) → Idle.
+        let fc_with_capacity = FlowControl::default();
+        // Grant capacity so the send-mode-idle path does NOT fire, isolating Idle.
+        fc_with_capacity.maybe_release_capacity(&StellarMessage::SendMoreExtended(
+            stellar_xdr::SendMoreExtended {
+                num_messages: 10,
+                num_bytes: 10_000,
+            },
+        ));
+        assert_eq!(
+            OverlayManager::check_peer_timeouts(
+                &peer_id,
+                &PeerTimingInfo {
+                    last_read: stale,
+                    last_write: stale,
+                    total_messages: 2,
+                    scp_messages: 0,
+                },
+                &fc_with_capacity,
+                &metrics,
+            ),
+            Some(IdleReason::Idle),
+            "both clocks stale with capacity → Idle"
+        );
+
+        // Fresh clocks, but no outbound capacity for >=60s → SendModeIdle.
+        // A default FlowControl has no_outbound_capacity set at construction.
+        let fc_no_capacity = FlowControl::default();
+        assert_eq!(
+            OverlayManager::check_peer_timeouts(
+                &peer_id,
+                &PeerTimingInfo {
+                    last_read: fresh,
+                    last_write: fresh,
+                    total_messages: 2,
+                    scp_messages: 0,
+                },
+                &fc_no_capacity,
+                &metrics,
+            ),
+            Some(IdleReason::SendModeIdle),
+            "fresh clocks but no capacity for >=60s → SendModeIdle"
+        );
+
+        // Everything fresh and capacity granted → None.
+        assert_eq!(
+            OverlayManager::check_peer_timeouts(
+                &peer_id,
+                &PeerTimingInfo {
+                    last_read: fresh,
+                    last_write: fresh,
+                    total_messages: 10,
+                    scp_messages: 5,
+                },
+                &fc_with_capacity,
+                &metrics,
+            ),
+            None,
+            "fresh and capacitated → no timeout"
+        );
+    }
+
+    #[test]
+    fn test_inbound_idle_drop_emits_diag_with_flow_signals() {
+        // #3570: at the idle-timeout drop, gather an InboundDropDiag from the
+        // already-tracked per-peer state so the operator can pin WHY each
+        // inbound peer idles out. The leading-hypothesis signature is:
+        // idle_reason ∈ {Idle, SendModeIdle}, send_more_received=0 (peer never
+        // granted us capacity), scp_written=0 (we wrote no SCP envelopes),
+        // scp_queue_depth>0 (we HAD SCP to send but were blocked on capacity).
+        //
+        // We assert on the RETURNED STRUCT, not on scraped log output.
+        use crate::flow_control::FlowControl;
+        use stellar_xdr::{ScpEnvelope, ScpStatement, ScpStatementPledges};
+
+        // Inbound peer that authenticated but never sent SEND_MORE_EXTENDED back:
+        // no_outbound_capacity is set, send_more_received_count stays 0.
+        let fc = FlowControl::default();
+        assert_eq!(fc.get_stats().send_more_received_count, 0);
+
+        // Enqueue an SCP flood message so the SCP queue is non-empty (we have
+        // SCP to broadcast to this peer, but no capacity to send it).
+        let scp_env = ScpEnvelope {
+            statement: ScpStatement {
+                node_id: stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+                    stellar_xdr::Uint256([0u8; 32]),
+                )),
+                slot_index: 1,
+                pledges: ScpStatementPledges::Externalize(stellar_xdr::ScpStatementExternalize {
+                    commit: stellar_xdr::ScpBallot {
+                        counter: 1,
+                        value: vec![1u8].try_into().unwrap(),
+                    },
+                    n_h: 1,
+                    commit_quorum_set_hash: stellar_xdr::Hash([0u8; 32]),
+                }),
+            },
+            signature: stellar_xdr::Signature(Vec::new().try_into().unwrap()),
+        };
+        fc.add_msg_and_maybe_trim_queue(StellarMessage::ScpMessage(scp_env));
+        assert!(
+            fc.get_stats().scp_queue_size > 0,
+            "SCP flood message should be queued"
+        );
+
+        // Idle clock advanced past PEER_TIMEOUT for both read and write.
+        let stale = Instant::now() - Duration::from_secs(40);
+
+        // No SCP envelopes were written on this connection (capacity-blocked).
+        let scp_written: u64 = 0;
+
+        let diag = OverlayManager::build_inbound_drop_diag(
+            &fc,
+            stale, // last_read
+            stale, // last_write
+            scp_written,
+            IdleReason::Idle,
+        );
+
+        assert_eq!(diag.send_more_received, 0, "peer never granted capacity");
+        assert_eq!(diag.scp_written, 0, "no SCP envelopes written");
+        assert!(diag.scp_queue_depth > 0, "had SCP queued but blocked");
+        assert_eq!(diag.peer_message_capacity, 0, "no capacity granted");
+        assert!(
+            diag.last_write_age_secs >= 40,
+            "last_write age reflects the stale clock"
+        );
+        assert!(
+            diag.last_read_age_secs >= 40,
+            "last_read age reflects the stale clock"
+        );
+        assert!(
+            matches!(
+                diag.idle_reason,
+                IdleReason::Idle | IdleReason::SendModeIdle
+            ),
+            "idle_reason in the leading-hypothesis set"
+        );
+    }
+
+    #[test]
     fn test_idle_timeout_constants_match_upstream() {
         // Verify our timeout constants match stellar-core defaults:
         // - PEER_TIMEOUT = 30 (Config.cpp:258)


### PR DESCRIPTION
Closes #3570

## Summary

Mainnet `stellar_overlay_inbound_authenticated` sits at sustained 0: inbound peers authenticate, exchange ~2 messages, send no SCP, then idle-timeout (`total_msgs=2, scp_msgs=0`). The flood-set hypothesis is offline-disproven (inbound peers ARE in the SCP broadcast set, byte-faithful to core), so this PR is **observability instrumentation only** — it extends the #3420 `overlay_inbound_diag` lens (lineage #3419 → #3420) to the idle-timeout drop path so the next operator deploy yields the live per-inbound-peer data needed to pin the residual idle-out root cause.

It captures, per dropped inbound peer: `send_more_received` (SEND_MORE_EXTENDED grants from the peer — 0 ⇒ peer never granted us capacity = leading hypothesis), `scp_written` (SCP envelopes henyey actually wrote), `scp_queue_depth` / `peer_message_capacity` / `peer_bytes_capacity` (reused from `FlowControl::get_stats()`), `last_write_age` / `last_read_age`, and `idle_reason` (Idle / Straggler / SendModeIdle). The leading-hypothesis signature is directly visible: `idle_reason ∈ {idle, send_mode_idle}` + `send_more_received=0` + `peer_message_capacity=0` + `scp_written=0` + `scp_queue_depth>0`.

**This does NOT change peer/flood/consensus behavior.** Drop conditions (idle 30s ↔ `Peer.cpp:450-451`, straggler 120s, send-mode-idle 60s §5.6), SEND_MORE grant semantics, and flood-to-all-authenticated-peers are byte-unchanged. The change only reads already-tracked state and emits a tracing `warn!`. `45a97265` is untouched. Tracing-only per Critic C — no new Prometheus counter.

## Changes

- `crates/overlay/src/flow_control.rs` — monotonic `send_more_received_count` bumped in `maybe_release_capacity`, surfaced via `FlowControlStats`.
- `crates/overlay/src/manager/peer_loop.rs` — `check_peer_timeouts` returns `Option<IdleReason>` (was `bool`); `send_flow_controlled_batch` reports SCP envelopes written via a `BatchSendOutcome`, threaded into a loop-local `scp_written`; at the idle `break`, gather an `InboundDropDiag` struct and emit `warn!(target: "overlay_inbound_diag", ...)` (inbound-gated, mirroring `log_inbound_drop_diag`).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3570#issuecomment-4777803209)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-overlay -p henyey-app --all-targets (RUSTFLAGS=-Dwarnings)
- [x] cargo build --all
- [x] cargo test -p henyey-overlay (458 lib tests pass; existing handshake/flow-control/idle-timeout tests preserved)
- [x] cargo test --all (green, exit 0)
- [x] parity tripwires byte-identical: scp_parity_tests (124 passed), validation/herder tests green — overlay-only change, no consensus/parity path touched

## Regression test (failing-test-first)

- **Tests:** `flow_control.rs::test_send_more_received_count_increments`, `peer_loop.rs::test_check_peer_timeouts_returns_reason`, `peer_loop.rs::test_inbound_idle_drop_emits_diag_with_flow_signals`
- **Pre-fix:** committed as `7f523425` — verified FAILED on origin/main (compile errors: `send_more_received_count` field absent, `IdleReason`/`InboundDropDiag` types absent, `check_peer_timeouts` returns `bool` not `Option<_>`, `build_inbound_drop_diag` fn absent)
- **Post-fix:** verified PASS after `e8b9d35a`. The idle-drop test asserts on the RETURNED `InboundDropDiag` struct (`send_more_received=0`, `scp_written=0`, `scp_queue_depth>0`, `idle_reason ∈ {Idle, SendModeIdle}`), not on log scraping.

## Deviations from plan

None. Optional Prometheus counter omitted per Critic C (kept tracing-only). The one net-new state field — `send_more_received_count` — is flagged for reviewer scrutiny; it is justified over inferring from `peer_message_capacity>0` because a peer can grant then have capacity consumed back to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)