### PR TITLE
Serialize native SorobanInfoResponse for compat /sorobaninfo

### DIFF
--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -15,6 +15,8 @@ use axum::Json;
 use serde::Deserialize;
 
 use crate::app::AppState;
+use henyey_ledger::SorobanNetworkInfo;
+
 use crate::compat_http::CompatServerState;
 use crate::http::types::{
     CompatSorobanInfoResponse, ConnectParams, DropPeerParams, SorobanInfoResponse, UnbanParams,
@@ -435,12 +437,20 @@ pub(crate) async fn compat_sorobaninfo_handler(
     match state.app.soroban_network_info() {
         Some(info) => {
             let protocol_version = state.app.ledger_info().protocol_version;
-            let native = SorobanInfoResponse::from_network_info(&info, protocol_version);
-            let compat = CompatSorobanInfoResponse::from(&native);
-            Json(serde_json::json!({ "info": compat }))
+            Json(compat_sorobaninfo_body(&info, protocol_version))
         }
         None => Json(serde_json::json!({"info": "Soroban not available"})),
     }
+}
+
+/// Build the `/sorobaninfo` compat JSON body from a live `SorobanNetworkInfo`.
+///
+/// Pure (no `App`/state) so it is directly unit-testable. The body is the
+/// exact bytes the handler returns for the `Some` branch.
+fn compat_sorobaninfo_body(info: &SorobanNetworkInfo, protocol_version: u32) -> serde_json::Value {
+    let native = SorobanInfoResponse::from_network_info(info, protocol_version);
+    let compat = CompatSorobanInfoResponse::from(&native);
+    serde_json::json!({ "info": compat })
 }
 
 // ── Survey endpoints (stellar-core URL paths) ───────────────────────────
@@ -1275,97 +1285,245 @@ mod tests {
 
     // ── /sorobaninfo compat response shape tests ────────────────────────
     //
-    // These tests exercise the **production** projection chain
-    // `SorobanNetworkInfo` → `SorobanInfoResponse::from_network_info` →
-    // `CompatSorobanInfoResponse::from` → `Json({"info": ...})`. They no
-    // longer replicate JSON literals; the upstream type tests in
-    // `crates/app/src/http/types/soroban.rs` cover the value-correctness
-    // and structural-projection invariants. Here we only confirm the
-    // wire-shape envelope (`{"info": {...}}`) and the protocol-23 gate
-    // visible through serde.
+    // These tests exercise the **production** handler body builder
+    // `compat_sorobaninfo_body` — the exact bytes the `/sorobaninfo` compat
+    // handler returns. stellar-core's `CommandHandler::sorobanInfo`
+    // (CommandHandler.cpp:898-1041) returns a TOP-LEVEL object (no wrapper)
+    // with nested `ledger`/`tx`/`state_archival`/`scp` sub-objects and flat
+    // `fee_*`/`max_contract_*`/`max_dependent_tx_clusters` scalars.
+    // supercluster's `GetSorobanInfo()` reads `.Ledger.MaxInstructions`,
+    // `.Tx.*`, `.Scp.*` at the ROOT, so any `{"info": ...}` wrapper makes
+    // its JsonProvider raise `Property 'ledger' not found at ''` (#3578).
 
-    use crate::http::types::{CompatSorobanInfoResponse, SorobanInfoResponse, SorobanScpSettings};
-
-    /// Build a minimal CompatSorobanInfoResponse with explicit values
-    /// (avoids reaching into henyey_ledger from this test module).
-    fn make_compat(
-        max_dependent_tx_clusters: Option<u32>,
-        max_footprint_size: Option<u32>,
-        scp: Option<SorobanScpSettings>,
-    ) -> CompatSorobanInfoResponse {
-        CompatSorobanInfoResponse {
-            ledger_max_instructions: 100,
-            tx_max_instructions: 50,
-            tx_memory_limit: 1024,
-            ledger_max_read_ledger_entries: 10,
-            ledger_max_read_bytes: 2048,
-            ledger_max_write_ledger_entries: 5,
-            ledger_max_write_bytes: 1024,
-            ledger_max_tx_count: 100,
-            tx_max_size_bytes: 512,
-            average_bucket_list_size: 100_000_000,
-            bucket_list_size_snapshot_period: 30,
-            max_dependent_tx_clusters,
-            max_footprint_size,
-            scp,
+    /// Build a `SorobanNetworkInfo` with distinct non-zero values so a
+    /// field-swap regression is easy to spot. Mirrors the sentinel used by
+    /// the `http::types::soroban` tests.
+    fn sentinel_network_info() -> SorobanNetworkInfo {
+        SorobanNetworkInfo {
+            max_contract_size: 2,
+            max_contract_data_key_size: 3,
+            max_contract_data_entry_size: 5,
+            tx_max_instructions: 7,
+            ledger_max_instructions: 11,
+            fee_rate_per_instructions_increment: 13,
+            tx_memory_limit: 17,
+            ledger_max_read_ledger_entries: 19,
+            ledger_max_read_bytes: 23,
+            ledger_max_write_ledger_entries: 29,
+            ledger_max_write_bytes: 31,
+            tx_max_read_ledger_entries: 37,
+            tx_max_read_bytes: 41,
+            tx_max_write_ledger_entries: 43,
+            tx_max_write_bytes: 47,
+            fee_read_ledger_entry: 53,
+            fee_write_ledger_entry: 59,
+            fee_read_1kb: 61,
+            fee_write_1kb: 67,
+            fee_historical_1kb: 71,
+            tx_max_contract_events_size_bytes: 73,
+            fee_contract_events_size_1kb: 79,
+            ledger_max_tx_size_bytes: 83,
+            tx_max_size_bytes: 89,
+            fee_transaction_size_1kb: 97,
+            ledger_max_tx_count: 101,
+            max_entry_ttl: 103,
+            min_temporary_ttl: 107,
+            min_persistent_ttl: 109,
+            persistent_rent_rate_denominator: 113,
+            temp_rent_rate_denominator: 127,
+            max_entries_to_archive: 131,
+            bucketlist_size_window_sample_size: 137,
+            eviction_scan_size: 139,
+            starting_eviction_scan_level: 149,
+            average_bucket_list_size: 151,
+            state_target_size_bytes: 157,
+            rent_fee_1kb_state_size_low: 163,
+            rent_fee_1kb_state_size_high: 167,
+            state_size_rent_fee_growth_factor: 173,
+            nomination_timeout_initial_ms: 179,
+            nomination_timeout_increment_ms: 181,
+            ballot_timeout_initial_ms: 191,
+            ballot_timeout_increment_ms: 193,
+            ledger_target_close_time_ms: 197,
+            ledger_max_dependent_tx_clusters: 199,
+            tx_max_footprint_entries: 211,
         }
     }
 
-    /// Pre-P23: the `{"info": ...}` envelope contains the always-present
-    /// keys but omits the three protocol-23 fields. Asserts the wire
-    /// shape produced by the production handler path.
+    /// The compat `/sorobaninfo` body MUST match stellar-core's shape: a
+    /// top-level object (NO `info` wrapper) with nested `ledger`/`tx`
+    /// sub-objects and top-level `fee_*`/`state_archival`/`max_contract_*`/
+    /// `max_dependent_tx_clusters`/`scp`.
+    ///
+    /// FAILS on `origin/main` (handler emits `{"info": {flattened…}}` — the
+    /// root has an `info` key and no top-level `ledger`).
     #[test]
-    fn test_compat_sorobaninfo_pre_protocol_23_omits_scp_fields() {
-        let compat = make_compat(None, None, None);
-        let envelope = serde_json::json!({ "info": compat });
-        let info = envelope["info"].as_object().unwrap();
+    fn test_compat_sorobaninfo_matches_stellar_core_shape() {
+        let info = sentinel_network_info();
+        let body = compat_sorobaninfo_body(&info, 23);
+        let root = body.as_object().expect("body must be a JSON object");
 
+        // No stellar-rpc `info` wrapper — the soroban info IS the root.
         assert!(
-            !info.contains_key("scp"),
-            "scp should be absent for pre-protocol 23"
+            !root.contains_key("info"),
+            "compat body must not wrap the soroban info under an `info` key \
+             (stellar-core returns the object at the root)"
         );
+
+        // Nested `ledger` with `max_instructions`.
+        let ledger = root
+            .get("ledger")
+            .and_then(|v| v.as_object())
+            .expect("top-level `ledger` object must be present");
+        assert_eq!(ledger["max_instructions"], 11);
+
+        // Nested `tx` with the keys supercluster reads.
+        let tx = root
+            .get("tx")
+            .and_then(|v| v.as_object())
+            .expect("top-level `tx` object must be present");
+        assert_eq!(tx["max_instructions"], 7);
+        assert_eq!(tx["max_size_bytes"], 89);
+        assert_eq!(tx["memory_limit"], 17);
+
+        // Top-level flat scalars + nested objects.
+        assert_eq!(root["fee_read_1kb"], 61);
         assert!(
-            !info.contains_key("max_dependent_tx_clusters"),
-            "max_dependent_tx_clusters should be absent for pre-protocol 23"
+            root.get("state_archival")
+                .and_then(|v| v.as_object())
+                .is_some(),
+            "top-level `state_archival` object must be present"
         );
+        assert_eq!(root["max_contract_size"], 2);
+        assert_eq!(root["max_dependent_tx_clusters"], 199);
         assert!(
-            !info.contains_key("max_footprint_size"),
-            "max_footprint_size should be absent for pre-protocol 23"
-        );
-        // Always-present keys.
-        assert!(
-            info.contains_key("average_bucket_list_size"),
-            "average_bucket_list_size should always be present"
-        );
-        assert!(
-            info.contains_key("bucket_list_size_snapshot_period"),
-            "bucket_list_size_snapshot_period should always be present"
+            root.get("scp").and_then(|v| v.as_object()).is_some(),
+            "top-level `scp` object must be present at P23"
         );
     }
 
-    /// P23+: the `{"info": ...}` envelope includes the three protocol-23
-    /// fields, including the nested `scp` block with all five expected
-    /// keys.
+    /// Every accessor path supercluster's `GetSorobanInfo()` reads must
+    /// exist at the JSON root at protocol 23.
+    ///
+    /// FAILS on `origin/main` (flat keys live under the `info` wrapper, so
+    /// `ledger`/`tx`/`scp` are absent at the root).
+    #[test]
+    fn test_compat_sorobaninfo_parses_against_supercluster_sample_keys() {
+        let info = sentinel_network_info();
+        let body = compat_sorobaninfo_body(&info, 23);
+        let root = body.as_object().expect("body must be a JSON object");
+
+        let ledger = root
+            .get("ledger")
+            .and_then(|v| v.as_object())
+            .expect("`ledger` object must be present");
+        for key in [
+            "max_instructions",
+            "max_read_bytes",
+            "max_read_ledger_entries",
+            "max_write_bytes",
+            "max_write_ledger_entries",
+            "max_tx_count",
+            "max_tx_size_bytes",
+        ] {
+            assert!(ledger.contains_key(key), "ledger missing key: {key}");
+        }
+
+        let tx = root
+            .get("tx")
+            .and_then(|v| v.as_object())
+            .expect("`tx` object must be present");
+        for key in [
+            "max_instructions",
+            "max_read_bytes",
+            "max_read_ledger_entries",
+            "max_write_bytes",
+            "max_write_ledger_entries",
+            "memory_limit",
+            "max_size_bytes",
+            "max_contract_events_size_bytes",
+            "max_footprint_size",
+        ] {
+            assert!(tx.contains_key(key), "tx missing key: {key}");
+        }
+
+        for key in [
+            "max_contract_size",
+            "max_contract_data_key_size",
+            "max_contract_data_entry_size",
+            "max_dependent_tx_clusters",
+        ] {
+            assert!(root.contains_key(key), "root missing key: {key}");
+        }
+
+        let scp = root
+            .get("scp")
+            .and_then(|v| v.as_object())
+            .expect("`scp` object must be present at P23");
+        for key in [
+            "ledger_close_time_ms",
+            "nomination_timeout_ms",
+            "nomination_timeout_inc_ms",
+            "ballot_timeout_ms",
+            "ballot_timeout_inc_ms",
+        ] {
+            assert!(scp.contains_key(key), "scp missing key: {key}");
+        }
+
+        for key in [
+            "fee_rate_per_instructions_increment",
+            "fee_read_ledger_entry",
+            "fee_write_ledger_entry",
+            "fee_read_1kb",
+            "fee_write_1kb",
+            "fee_historical_1kb",
+            "fee_contract_events_size_1kb",
+            "fee_transaction_size_1kb",
+        ] {
+            assert!(root.contains_key(key), "root missing fee key: {key}");
+        }
+    }
+
+    /// Pre-P23: the P23-gated fields are omitted from the (now top-level)
+    /// shape — `tx.max_footprint_size`, top-level `scp`, and top-level
+    /// `max_dependent_tx_clusters` all absent.
+    #[test]
+    fn test_compat_sorobaninfo_pre_protocol_23_omits_scp_fields() {
+        let info = sentinel_network_info();
+        let body = compat_sorobaninfo_body(&info, 22);
+        let root = body.as_object().expect("body must be a JSON object");
+
+        assert!(
+            !root.contains_key("info"),
+            "compat body must not wrap the soroban info under an `info` key"
+        );
+        assert!(
+            !root.contains_key("scp"),
+            "scp should be absent for pre-protocol 23"
+        );
+        assert!(
+            !root.contains_key("max_dependent_tx_clusters"),
+            "max_dependent_tx_clusters should be absent for pre-protocol 23"
+        );
+        assert!(
+            root["tx"].get("max_footprint_size").is_none(),
+            "tx.max_footprint_size should be absent for pre-protocol 23"
+        );
+    }
+
+    /// P23+: the P23-gated fields are present in the top-level shape — the
+    /// nested `scp` block with all five keys, `tx.max_footprint_size`, and
+    /// top-level `max_dependent_tx_clusters`.
     #[test]
     fn test_compat_sorobaninfo_protocol_23_includes_scp_fields() {
-        let compat = make_compat(
-            Some(8),
-            Some(40),
-            Some(SorobanScpSettings {
-                ledger_close_time_ms: 5000,
-                nomination_timeout_ms: 1000,
-                nomination_timeout_inc_ms: 500,
-                ballot_timeout_ms: 1000,
-                ballot_timeout_inc_ms: 1000,
-            }),
-        );
-        let envelope = serde_json::json!({ "info": compat });
-        let info = envelope["info"].as_object().unwrap();
+        let info = sentinel_network_info();
+        let body = compat_sorobaninfo_body(&info, 23);
+        let root = body.as_object().expect("body must be a JSON object");
 
-        assert_eq!(info["max_dependent_tx_clusters"], 8);
-        assert_eq!(info["max_footprint_size"], 40);
+        assert_eq!(root["max_dependent_tx_clusters"], 199);
+        assert_eq!(root["tx"]["max_footprint_size"], 211);
 
-        let scp = info["scp"].as_object().unwrap();
+        let scp = root["scp"].as_object().unwrap();
         for key in [
             "ledger_close_time_ms",
             "nomination_timeout_ms",
@@ -1378,89 +1536,25 @@ mod tests {
         assert_eq!(scp.len(), 5, "unexpected extra SCP fields in compat");
     }
 
-    /// End-to-end: a `SorobanInfoResponse` built for P23 round-trips
-    /// through `CompatSorobanInfoResponse::from` and `serde_json::json!`
-    /// into the expected envelope, with values pulled from the right
-    /// nested paths. This is the regression test that would have caught
-    /// the kind of drift addressed by #2020 had it existed in the
-    /// original PR.
+    /// The compat handler body pulls values from the right nested paths of
+    /// the native projection (no flattening, no `info` wrapper).
     #[test]
-    fn test_compat_envelope_pulls_values_through_native_response() {
-        // Hand-build a SorobanInfoResponse so the test does not depend on
-        // henyey_ledger here (the upstream test in http::types::soroban
-        // already covers SorobanNetworkInfo → SorobanInfoResponse).
-        let scp = SorobanScpSettings {
-            ledger_close_time_ms: 5000,
-            nomination_timeout_ms: 1000,
-            nomination_timeout_inc_ms: 500,
-            ballot_timeout_ms: 1500,
-            ballot_timeout_inc_ms: 200,
-        };
-        let native = SorobanInfoResponse {
-            max_contract_size: 64_000,
-            max_contract_data_key_size: 250,
-            max_contract_data_entry_size: 65_000,
-            tx: crate::http::types::SorobanTxLimits {
-                max_instructions: 100_000_000,
-                memory_limit: 41_943_040,
-                max_read_ledger_entries: 40,
-                max_read_bytes: 200_704,
-                max_write_ledger_entries: 25,
-                max_write_bytes: 132_096,
-                max_contract_events_size_bytes: 8_198,
-                max_size_bytes: 129_024,
-                max_footprint_size: Some(60),
-            },
-            ledger: crate::http::types::SorobanLedgerLimits {
-                max_instructions: 500_000_000,
-                max_read_ledger_entries: 200,
-                max_read_bytes: 500_000,
-                max_write_ledger_entries: 125,
-                max_write_bytes: 500_000,
-                max_tx_size_bytes: 130_048,
-                max_tx_count: 100,
-            },
-            fee_rate_per_instructions_increment: 100,
-            fee_read_ledger_entry: 6250,
-            fee_write_ledger_entry: 10_000,
-            fee_read_1kb: 1786,
-            fee_write_1kb: 11_800,
-            fee_historical_1kb: 16_235,
-            fee_contract_events_size_1kb: 10_000,
-            fee_transaction_size_1kb: 1624,
-            state_archival: crate::http::types::SorobanStateArchival {
-                max_entry_ttl: 6_312_000,
-                min_temporary_ttl: 17_280,
-                min_persistent_ttl: 4096,
-                persistent_rent_rate_denominator: 5_362_408,
-                temp_rent_rate_denominator: 5_362_408,
-                max_entries_to_archive: 1000,
-                bucketlist_size_window_sample_size: 30,
-                eviction_scan_size: 100_000,
-                starting_eviction_scan_level: 7,
-                bucket_list_size_snapshot_period: 30,
-                average_bucket_list_size: 100_000_000,
-            },
-            max_dependent_tx_clusters: Some(2),
-            scp: Some(scp),
-        };
+    fn test_compat_sorobaninfo_pulls_values_through_native_response() {
+        let info = sentinel_network_info();
+        let body = compat_sorobaninfo_body(&info, 23);
+        let root = body.as_object().expect("body must be a JSON object");
 
-        let compat = CompatSorobanInfoResponse::from(&native);
-        let envelope = serde_json::json!({ "info": compat });
-
-        // Wire shape: `{"info": {...}}`
-        assert!(envelope.is_object());
-        let info = envelope["info"].as_object().expect("info must be object");
-
-        // Every flat compat key sources from the right native path.
-        assert_eq!(info["ledger_max_instructions"], 500_000_000);
-        assert_eq!(info["tx_max_instructions"], 100_000_000);
-        assert_eq!(info["tx_max_size_bytes"], 129_024);
-        assert_eq!(info["max_footprint_size"], 60);
-        assert_eq!(info["max_dependent_tx_clusters"], 2);
-        assert_eq!(info["bucket_list_size_snapshot_period"], 30);
-        assert_eq!(info["scp"]["ballot_timeout_ms"], 1500);
-        assert_eq!(info["scp"]["nomination_timeout_inc_ms"], 500);
+        assert_eq!(root["ledger"]["max_instructions"], 11);
+        assert_eq!(root["tx"]["max_instructions"], 7);
+        assert_eq!(root["tx"]["max_size_bytes"], 89);
+        assert_eq!(root["tx"]["max_footprint_size"], 211);
+        assert_eq!(root["max_dependent_tx_clusters"], 199);
+        assert_eq!(
+            root["state_archival"]["bucket_list_size_snapshot_period"],
+            137
+        );
+        assert_eq!(root["scp"]["ballot_timeout_ms"], 191);
+        assert_eq!(root["scp"]["nomination_timeout_inc_ms"], 181);
     }
 
     // ── ISO 8601 parser tests ───────────────────────────────────────────

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -18,9 +18,7 @@ use crate::app::AppState;
 use henyey_ledger::SorobanNetworkInfo;
 
 use crate::compat_http::CompatServerState;
-use crate::http::types::{
-    CompatSorobanInfoResponse, ConnectParams, DropPeerParams, SorobanInfoResponse, UnbanParams,
-};
+use crate::http::types::{ConnectParams, DropPeerParams, SorobanInfoResponse, UnbanParams};
 
 // ── Admin endpoints (plain text) ─────────────────────────────────────────
 
@@ -423,14 +421,17 @@ pub(crate) async fn compat_dumpproposedsettings_handler(
 
 /// GET /sorobaninfo
 ///
-/// Returns the stellar-rpc compat shape: a flattened **subset** of the
-/// native `/sorobaninfo` basic format wrapped under `{"info": ...}`.
+/// Matches stellar-core's `CommandHandler::sorobanInfo` exactly: a TOP-LEVEL
+/// object (no `info` wrapper) with nested `ledger`/`tx`/`state_archival`/`scp`
+/// sub-objects and flat `fee_*`/`max_contract_*`/`max_dependent_tx_clusters`
+/// scalars. supercluster's `GetSorobanInfo()` reads `.Ledger.MaxInstructions`,
+/// `.Tx.*`, `.Scp.*` at the JSON root, so any wrapper makes its JsonProvider
+/// raise `Property 'ledger' not found at ''` (#3578).
 ///
-/// All field projection — including the protocol-23 gating — flows through
-/// [`SorobanInfoResponse::from_network_info`]. The compat handler reshapes
-/// that result via [`CompatSorobanInfoResponse::from`], which is a pure
-/// data shuffle with no protocol logic. This guarantees the two handlers
-/// cannot drift on shared fields or the protocol-23 gate.
+/// The body reuses the parity-verified native projection
+/// [`SorobanInfoResponse::from_network_info`] verbatim — the same shape the
+/// native `/sorobaninfo` handler ships — so the two handlers cannot drift and
+/// the protocol-23 gate lives in exactly one place.
 pub(crate) async fn compat_sorobaninfo_handler(
     State(state): State<Arc<CompatServerState>>,
 ) -> impl IntoResponse {
@@ -446,11 +447,12 @@ pub(crate) async fn compat_sorobaninfo_handler(
 /// Build the `/sorobaninfo` compat JSON body from a live `SorobanNetworkInfo`.
 ///
 /// Pure (no `App`/state) so it is directly unit-testable. The body is the
-/// exact bytes the handler returns for the `Some` branch.
+/// exact bytes the handler returns for the `Some` branch: the native
+/// `SorobanInfoResponse` serialized directly (stellar-core's top-level
+/// nested shape, no `info` wrapper).
 fn compat_sorobaninfo_body(info: &SorobanNetworkInfo, protocol_version: u32) -> serde_json::Value {
     let native = SorobanInfoResponse::from_network_info(info, protocol_version);
-    let compat = CompatSorobanInfoResponse::from(&native);
-    serde_json::json!({ "info": compat })
+    serde_json::to_value(native).expect("SorobanInfoResponse always serializes")
 }
 
 // ── Survey endpoints (stellar-core URL paths) ───────────────────────────

--- a/crates/app/src/http/types/soroban.rs
+++ b/crates/app/src/http/types/soroban.rs
@@ -1,9 +1,10 @@
 //! Types for Soroban-related endpoints.
 //!
 //! `SorobanInfoResponse` is the single source of truth for projecting
-//! [`henyey_ledger::SorobanNetworkInfo`] into JSON. The native handler
-//! ([`crate::http::handlers::soroban::sorobaninfo_handler`]) serializes it
-//! directly; the compat handler reshapes it via [`CompatSorobanInfoResponse`].
+//! [`henyey_ledger::SorobanNetworkInfo`] into JSON. Both the native handler
+//! ([`crate::http::handlers::soroban::sorobaninfo_handler`]) and the compat
+//! `/sorobaninfo` handler serialize it directly — the same stellar-core
+//! top-level nested shape, no wrapper.
 //!
 //! Protocol-23 gating lives in exactly one place —
 //! [`SorobanInfoResponse::from_network_info`] — and
@@ -112,11 +113,10 @@ impl SorobanInfoResponse {
     /// response.
     ///
     /// This is the **single read of `SorobanNetworkInfo`**. Both the native
-    /// handler and the compat handler must funnel through this constructor;
-    /// the compat handler then reshapes the result via
-    /// [`CompatSorobanInfoResponse::from`]. Centralizing the projection here
-    /// — and encoding the protocol-23 gating as `Some`/`None` on the
-    /// optional fields — makes cross-handler drift on shared fields and the
+    /// handler and the compat handler funnel through this constructor and
+    /// serialize the result directly. Centralizing the projection here — and
+    /// encoding the protocol-23 gating as `Some`/`None` on the optional
+    /// fields — makes cross-handler drift on shared fields and the
     /// protocol-23 gate structurally impossible.
     pub(crate) fn from_network_info(info: &SorobanNetworkInfo, protocol_version: u32) -> Self {
         let p23_or_later = protocol_version >= 23;
@@ -177,74 +177,6 @@ impl SorobanInfoResponse {
                 ballot_timeout_ms: info.ballot_timeout_initial_ms,
                 ballot_timeout_inc_ms: info.ballot_timeout_increment_ms,
             }),
-        }
-    }
-}
-
-/// Compat (stellar-rpc) `/sorobaninfo` response body.
-///
-/// This is a deliberate flattened **subset** of [`SorobanInfoResponse`] —
-/// the shape stellar-rpc consumes. It's wrapped under `{"info": ...}` by
-/// the compat handler.
-///
-/// `serde(skip_serializing_if = "Option::is_none")` on the protocol-23
-/// fields means omission is a property of the type, not a runtime
-/// conditional in the handler. The conversion
-/// `From<&SorobanInfoResponse>` is a pure data shuffle — no protocol-23
-/// logic — so the gate exists in exactly one place
-/// ([`SorobanInfoResponse::from_network_info`]) and cannot drift.
-///
-/// New fields added to `SorobanNetworkInfo` flow into the native response
-/// automatically, but appearing in compat is an explicit choice: it
-/// requires adding a field here and a line in the `From` impl. This is by
-/// design — compat is a deliberate subset of native, not an automatic
-/// mirror.
-#[derive(Serialize)]
-pub(crate) struct CompatSorobanInfoResponse {
-    pub ledger_max_instructions: i64,
-    pub tx_max_instructions: i64,
-    pub tx_memory_limit: u32,
-    pub ledger_max_read_ledger_entries: u32,
-    pub ledger_max_read_bytes: u32,
-    pub ledger_max_write_ledger_entries: u32,
-    pub ledger_max_write_bytes: u32,
-    pub ledger_max_tx_count: u32,
-    pub tx_max_size_bytes: u32,
-    pub average_bucket_list_size: u64,
-    pub bucket_list_size_snapshot_period: u32,
-    /// Protocol 23+: maximum dependent TX clusters per parallel stage.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_dependent_tx_clusters: Option<u32>,
-    /// Protocol 23+: maximum footprint entries per transaction.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_footprint_size: Option<u32>,
-    /// Protocol 23+: SCP timing settings.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scp: Option<SorobanScpSettings>,
-}
-
-impl From<&SorobanInfoResponse> for CompatSorobanInfoResponse {
-    /// Pure data-shuffling conversion — no protocol-23 logic.
-    ///
-    /// Protocol-23 omission has already been encoded as `None` in
-    /// `SorobanInfoResponse` by [`SorobanInfoResponse::from_network_info`],
-    /// so this conversion just propagates the optionality.
-    fn from(r: &SorobanInfoResponse) -> Self {
-        Self {
-            ledger_max_instructions: r.ledger.max_instructions,
-            tx_max_instructions: r.tx.max_instructions,
-            tx_memory_limit: r.tx.memory_limit,
-            ledger_max_read_ledger_entries: r.ledger.max_read_ledger_entries,
-            ledger_max_read_bytes: r.ledger.max_read_bytes,
-            ledger_max_write_ledger_entries: r.ledger.max_write_ledger_entries,
-            ledger_max_write_bytes: r.ledger.max_write_bytes,
-            ledger_max_tx_count: r.ledger.max_tx_count,
-            tx_max_size_bytes: r.tx.max_size_bytes,
-            average_bucket_list_size: r.state_archival.average_bucket_list_size,
-            bucket_list_size_snapshot_period: r.state_archival.bucket_list_size_snapshot_period,
-            max_dependent_tx_clusters: r.max_dependent_tx_clusters,
-            max_footprint_size: r.tx.max_footprint_size,
-            scp: r.scp.clone(),
         }
     }
 }
@@ -430,7 +362,7 @@ mod tests {
         );
     }
 
-    // ── from_network_info / CompatSorobanInfoResponse tests ─────────────────
+    // ── from_network_info tests ─────────────────────────────────────────────
 
     /// Build a `SorobanNetworkInfo` with sentinel values that make
     /// field-swap regressions easy to spot. Each field gets a distinct
@@ -581,173 +513,5 @@ mod tests {
         assert_eq!(scp.nomination_timeout_inc_ms, 181);
         assert_eq!(scp.ballot_timeout_ms, 191);
         assert_eq!(scp.ballot_timeout_inc_ms, 193);
-    }
-
-    /// Verify the conversion from `SorobanInfoResponse` to the compat
-    /// shape pulls every field from the right nested path.
-    #[test]
-    fn test_compat_from_response_basic_shape() {
-        let info = sentinel_network_info();
-        let native = SorobanInfoResponse::from_network_info(&info, 23);
-        let compat = CompatSorobanInfoResponse::from(&native);
-
-        assert_eq!(
-            compat.ledger_max_instructions,
-            native.ledger.max_instructions
-        );
-        assert_eq!(compat.tx_max_instructions, native.tx.max_instructions);
-        assert_eq!(compat.tx_memory_limit, native.tx.memory_limit);
-        assert_eq!(
-            compat.ledger_max_read_ledger_entries,
-            native.ledger.max_read_ledger_entries
-        );
-        assert_eq!(compat.ledger_max_read_bytes, native.ledger.max_read_bytes);
-        assert_eq!(
-            compat.ledger_max_write_ledger_entries,
-            native.ledger.max_write_ledger_entries
-        );
-        assert_eq!(compat.ledger_max_write_bytes, native.ledger.max_write_bytes);
-        assert_eq!(compat.ledger_max_tx_count, native.ledger.max_tx_count);
-        assert_eq!(compat.tx_max_size_bytes, native.tx.max_size_bytes);
-        assert_eq!(
-            compat.average_bucket_list_size,
-            native.state_archival.average_bucket_list_size
-        );
-        assert_eq!(
-            compat.bucket_list_size_snapshot_period,
-            native.state_archival.bucket_list_size_snapshot_period
-        );
-        assert_eq!(
-            compat.max_dependent_tx_clusters,
-            native.max_dependent_tx_clusters
-        );
-        assert_eq!(compat.max_footprint_size, native.tx.max_footprint_size);
-        assert_eq!(
-            compat.scp.as_ref().map(|s| s.ledger_close_time_ms),
-            native.scp.as_ref().map(|s| s.ledger_close_time_ms)
-        );
-    }
-
-    /// `serde(skip_serializing_if)` must omit P23 fields when None and
-    /// emit them when Some.
-    #[test]
-    fn test_compat_serializes_with_p23_omission() {
-        // Pre-P23: all three optionals absent.
-        let info = sentinel_network_info();
-        let native = SorobanInfoResponse::from_network_info(&info, 22);
-        let compat = CompatSorobanInfoResponse::from(&native);
-        let json = serde_json::to_value(&compat).unwrap();
-
-        let obj = json.as_object().expect("compat must serialize as object");
-        assert!(!obj.contains_key("scp"), "scp must be absent pre-P23");
-        assert!(
-            !obj.contains_key("max_dependent_tx_clusters"),
-            "max_dependent_tx_clusters must be absent pre-P23"
-        );
-        assert!(
-            !obj.contains_key("max_footprint_size"),
-            "max_footprint_size must be absent pre-P23"
-        );
-
-        // P23+: all three present with correct values.
-        let native = SorobanInfoResponse::from_network_info(&info, 23);
-        let compat = CompatSorobanInfoResponse::from(&native);
-        let json = serde_json::to_value(&compat).unwrap();
-        assert_eq!(json["max_dependent_tx_clusters"], 199);
-        assert_eq!(json["max_footprint_size"], 211);
-        let scp = json["scp"]
-            .as_object()
-            .expect("scp must be present at P23+");
-        for key in [
-            "ledger_close_time_ms",
-            "nomination_timeout_ms",
-            "nomination_timeout_inc_ms",
-            "ballot_timeout_ms",
-            "ballot_timeout_inc_ms",
-        ] {
-            assert!(scp.contains_key(key), "compat scp missing key: {key}");
-        }
-        assert_eq!(scp.len(), 5, "unexpected extra SCP fields in compat");
-    }
-
-    /// Structural assertion: every key in the compat JSON corresponds to
-    /// the right nested path in the native JSON. This is the regression
-    /// test that #2020 needed — it locks in "compat is a strict (flattened)
-    /// subset of native" and any future drift fails the test.
-    #[test]
-    fn test_compat_is_strict_projection_of_native() {
-        let info = sentinel_network_info();
-        for protocol_version in [22u32, 23] {
-            let native_struct = SorobanInfoResponse::from_network_info(&info, protocol_version);
-            let compat_struct = CompatSorobanInfoResponse::from(&native_struct);
-            let native = serde_json::to_value(&native_struct).unwrap();
-            let compat = serde_json::to_value(&compat_struct).unwrap();
-
-            // Map: compat key -> native JSON path. This is the contract.
-            // If a key appears in compat, its value MUST equal the value at
-            // the listed native path.
-            let mappings: &[(&str, &[&str])] = &[
-                ("ledger_max_instructions", &["ledger", "max_instructions"]),
-                ("tx_max_instructions", &["tx", "max_instructions"]),
-                ("tx_memory_limit", &["tx", "memory_limit"]),
-                (
-                    "ledger_max_read_ledger_entries",
-                    &["ledger", "max_read_ledger_entries"],
-                ),
-                ("ledger_max_read_bytes", &["ledger", "max_read_bytes"]),
-                (
-                    "ledger_max_write_ledger_entries",
-                    &["ledger", "max_write_ledger_entries"],
-                ),
-                ("ledger_max_write_bytes", &["ledger", "max_write_bytes"]),
-                ("ledger_max_tx_count", &["ledger", "max_tx_count"]),
-                ("tx_max_size_bytes", &["tx", "max_size_bytes"]),
-                (
-                    "average_bucket_list_size",
-                    &["state_archival", "average_bucket_list_size"],
-                ),
-                (
-                    "bucket_list_size_snapshot_period",
-                    &["state_archival", "bucket_list_size_snapshot_period"],
-                ),
-                ("max_dependent_tx_clusters", &["max_dependent_tx_clusters"]),
-                ("max_footprint_size", &["tx", "max_footprint_size"]),
-                ("scp", &["scp"]),
-            ];
-
-            // Sanity: compat must not contain any unmapped keys. If this
-            // fails, someone added a field to CompatSorobanInfoResponse
-            // without updating this contract — and that's exactly the kind
-            // of drift this test guards against.
-            let compat_obj = compat.as_object().expect("compat must be object");
-            for key in compat_obj.keys() {
-                assert!(
-                    mappings.iter().any(|(k, _)| k == key),
-                    "compat key {key:?} missing from compat→native mapping \
-                     (P{protocol_version}). Add it to `mappings` if intentional."
-                );
-            }
-
-            // For every present compat key, value must match native path.
-            for (compat_key, native_path) in mappings {
-                let Some(compat_val) = compat_obj.get(*compat_key) else {
-                    // P22 omits the three protocol-23 fields; that's fine.
-                    continue;
-                };
-                let mut native_val = &native;
-                for seg in *native_path {
-                    native_val = native_val.get(*seg).unwrap_or_else(|| {
-                        panic!(
-                            "native path {native_path:?} missing at P{protocol_version} \
-                             — required by compat key {compat_key:?}"
-                        )
-                    });
-                }
-                assert_eq!(
-                    compat_val, native_val,
-                    "compat[{compat_key:?}] != native{native_path:?} at P{protocol_version}"
-                );
-            }
-        }
     }
 }


### PR DESCRIPTION
Closes #3578

## Summary

henyey's compat `/sorobaninfo` wrapped a flattened stellar-rpc-flavored subset under `{"info": …}`, leaving the JSON root with a single `info` key. stellar-core (`CommandHandler::sorobanInfo`) returns a **top-level** object with nested `ledger`/`tx`/`state_archival`/`scp` sub-objects and flat `fee_*`/`max_contract_*`/`max_dependent_tx_clusters` scalars. Supercluster's `GetSorobanInfo()` reads `.Ledger.MaxInstructions`/`.Tx.*`/`.Scp.*` at the **root**, so the `info` wrapper made its JsonProvider raise `Property 'ledger' not found at ''` and failed SSC soroban-loadgen missions.

The fix routes the compat handler through the parity-verified native projection `SorobanInfoResponse::from_network_info` and serializes it directly — the same shape the native `/sorobaninfo` handler already ships. The now-dead `CompatSorobanInfoResponse` struct, its `From<&SorobanInfoResponse>` impl, and its flattened-shape tests are deleted (required under `-Dwarnings`; a dead divergent shape is a parity hazard). Protocol-23 gating is unchanged — it lives solely in `from_network_info`.

This is the next blocker after the SSC-compat lineage #3550 (`/info`) / #3572 (`/metrics`) / #3574 (QueueFull retry); it unblocks SSC soroban-loadgen `GetSorobanInfo` / `UpgradeSorobanLedgerLimitsWithMultiplier`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3578#issuecomment-4779658464)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-app --all-targets (RUSTFLAGS=-Dwarnings) — zero warnings after dead-struct deletion
- [x] cargo build --all
- [x] cargo test --all passes

## Regression test (kind: bug-fix)

- **Tests:** `crates/app/src/compat_http/handlers/plaintext.rs::test_compat_sorobaninfo_matches_stellar_core_shape` + `::test_compat_sorobaninfo_parses_against_supercluster_sample_keys`
- **Pre-fix:** committed as `b1b8c320` — verified FAILED with `compat body must not wrap the soroban info under an `info` key` / `` `ledger` object must be present `` (all 5 compat tests failed on the `{"info":{flat…}}` body).
- **Post-fix:** verified PASS after `49b96aea`. Native `from_network_info` tests preserved unchanged.

## Deviations from plan

None. The plan's `compat_sorobaninfo_handler` body was factored into a pure `compat_sorobaninfo_body(info, protocol_version) -> serde_json::Value` helper so the exact handler bytes are directly unit-testable (and so the regression tests fail behaviorally on main rather than only failing to compile). The `None` branch keeps `{"info": "Soroban not available"}` per the plan's minor note (off the failing path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)