### PR TITLE
Fix zsh-reserved `status`/`path` locals in monitor deploy-gate helpers (#3581)

### DIFF
--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -688,16 +688,19 @@ grep_heartbeat_lines() {
 # Prints the verdict to stdout. Returns 0 always.
 # ─────────────────────────────────────────────────────────────────────────────
 classify_path_binary_relevance() {
-  local path="$1"
+  # NOTE: must NOT be named `path` — under zsh `path` is a special array tied to
+  # $PATH, so `local path=…` would clobber the command search path for the whole
+  # function (#3581 zsh-safety sweep). Use a non-reserved name.
+  local rel_path="$1"
 
   # Empty path → fail-safe.
-  if [[ -z "$path" ]]; then
+  if [[ -z "$rel_path" ]]; then
     echo "rebuild"
     return 0
   fi
 
   # --- Allowlist: paths that never compile into the release binary. ---
-  case "$path" in
+  case "$rel_path" in
     .github/*|.claude/*|scripts/*|docs/*|metrics/*)
       echo "no-impact"; return 0 ;;
     .gitignore|.gitattributes|.gitmodules)
@@ -735,19 +738,19 @@ classify_path_binary_relevance() {
       echo "no-impact"; return 0 ;;
   esac
   # Root-level *.md (e.g. README.md, CLAUDE.md) — no slash, .md suffix.
-  if [[ "$path" != */* && "$path" == *.md ]]; then
+  if [[ "$rel_path" != */* && "$rel_path" == *.md ]]; then
     echo "no-impact"; return 0
   fi
 
   # --- crates/<crate>/tests/** : integration tests, never in --release lib/bin.
   # Matches a `tests/` directory directly under a single crate dir.
-  if [[ "$path" == crates/*/tests/* ]]; then
+  if [[ "$rel_path" == crates/*/tests/* ]]; then
     echo "test-only"; return 0
   fi
 
   # --- crates/**/src/**.rs : source that MAY be hunk-level test-only.
   # Must be a .rs file living under a `src/` directory inside crates/.
-  if [[ "$path" == crates/*/src/*.rs && "$path" == *.rs ]]; then
+  if [[ "$rel_path" == crates/*/src/*.rs && "$rel_path" == *.rs ]]; then
     echo "needs-hunk-check"; return 0
   fi
 
@@ -819,15 +822,20 @@ fi
 
 select_latest_green_deploy_target() {
   local deployed_sha="$1" origin_sha="$2"
-  local line sha status conclusion
+  # NOTE: must NOT be named `status` — under zsh `status` is a read-only special
+  # parameter (alias for $?), so `local … status …` aborts the function at the
+  # declaration before the read loop runs, yielding empty stdout. Empty stdout
+  # makes the deploy gate fail-closed to `defer-no-green`, silently deferring
+  # every deploy (#3581). Use a non-reserved name.
+  local line sha run_status conclusion
   local saw_green=0           # any completed/success record at all
   local saw_on_main=0         # any green record that is on main (ancestor of HEAD)
 
-  while IFS='|' read -r sha status conclusion; do
+  while IFS='|' read -r sha run_status conclusion; do
     # Skip blank lines.
     [[ -z "$sha" ]] && continue
     # Only completed/success records are deploy candidates.
-    [[ "$status" == "completed" && "$conclusion" == "success" ]] || continue
+    [[ "$run_status" == "completed" && "$conclusion" == "success" ]] || continue
     saw_green=1
 
     # Guardrail 1 — on main: the green sha must be an ancestor-or-equal of the

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -10011,6 +10011,53 @@ BOARDEOF
     tap_not_ok "select_latest_green: green > MAX_DEPLOY_WALK ahead → empty + walk-exceeded (#3351)" "out='$_out6' err='$_err6'"
   fi
 
+  # ── #3581: select_latest_green_deploy_target runs under zsh ────────────────
+  # The monitor-tick deploy gate invokes this selector INLINE in the tick shell,
+  # which is zsh. Under zsh, `status` is a read-only special parameter (alias for
+  # $?), so the function's `local line sha status conclusion` aborted the function
+  # at the declaration line BEFORE the read loop, yielding empty stdout — which
+  # the gate fail-closes to `defer-no-green`, silently deferring EVERY deploy.
+  # The six bash cases above cannot catch this (the bug is zsh-specific), so this
+  # test invokes the function inside a `zsh -c` subprocess with its own hermetic
+  # ancestry oracle (green sha G on-main, 1 commit ahead of DEP) and asserts the
+  # selector returns G — i.e. it neither aborts nor mis-reports. Gated on zsh
+  # availability (matching the 20c3-zsh / 78c-zsh convention).
+  if command -v zsh >/dev/null 2>&1; then
+    local zsh_sel
+    zsh_sel=$(zsh -c '
+      emulate -L zsh
+      source "$1/scripts/lib/monitor-decisions.sh"
+      # Hermetic linear-main oracle: DEP -> G -> HEAD; G is on main, 1 ahead of DEP.
+      _order_of() {
+        case "$1" in
+          DEP)  print 0 ;;
+          G)    print 1 ;;
+          HEAD) print 2 ;;
+          *)    print "" ;;
+        esac
+      }
+      is_ancestor() {
+        local ra rb
+        ra="$(_order_of "$1")"; rb="$(_order_of "$2")"
+        [[ -n "$ra" && -n "$rb" && "$ra" -le "$rb" ]]
+      }
+      commits_ahead() {
+        local rd rs
+        rd="$(_order_of "$1")"; rs="$(_order_of "$2")"
+        if [[ -z "$rd" || -z "$rs" || "$rs" -le "$rd" ]]; then print 0; return 0; fi
+        print $(( rs - rd ))
+      }
+      printf "%s\n" "G|completed|success" | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null
+    ' -- "$REPO_ROOT")
+    if [[ "$zsh_sel" == "G" ]]; then
+      tap_ok "select_latest_green: runs under zsh without read-only-status abort (#3581)"
+    else
+      tap_not_ok "select_latest_green: runs under zsh without read-only-status abort (#3581)" "got '$zsh_sel' (expected 'G')"
+    fi
+  else
+    tap_skip "select_latest_green: runs under zsh without read-only-status abort (#3581)" "zsh not found"
+  fi
+
   # Restore real git oracles so no later test sees the stubs.
   unset -f is_ancestor commits_ahead _order_of
 


### PR DESCRIPTION
Closes #3581

## ⚠️ DEPLOY-CRITICAL monitor-pipeline — DO NOT AUTO-MERGE, operator merge required

This touches the live deploy gate selector. Per the converged plan it is **operator-merge only** — do not auto-merge.

## Summary

Fixes the zsh-`status` regression introduced by the just-merged #3558: `select_latest_green_deploy_target` (the latest-green Verify-Execution deploy selector) declared `local line sha status conclusion`. Under **zsh** — the monitor's actual shell — `status` is a read-only special parameter (alias for `$?`), so the `local` aborted the function at the declaration line *before* the `read` loop ran, yielding empty stdout. The monitor-tick deploy gate fail-closes empty stdout to `defer-no-green`, so in production this **silently deferred every auto-deploy** (the running validator was unaffected — the gate fails safe — so there was no validator-blocking symptom, just no auto-ships).

The fix renames `status` → `run_status` at all three sites (declaration, the `IFS='|' read -r` loop, and the `completed`/`success` guard). In the same zsh-safety sweep, `classify_path_binary_relevance` used `local path` — under zsh `path` is a special array tied to `$PATH` (clobbers the command search path for the function) — so `path` → `rel_path` at all six sites. A whole-file sweep for other zsh-reserved/special collisions (`status`/`path`/`argv`/`options`/`cdpath`/`fignore`/`fpath`/…) in `local`/`read` positions found no others.

This is a **pure variable rename**: the selection algorithm, all fail-closed guardrails (on-main / not-backwards / walk-bound), the reason tokens (`no-green-run`, `green-equals-deployed`, `green-behind-deployed`, `green-not-on-main`, `walk-exceeded`), and the empty-stdout contract are **byte-for-byte unchanged** — the diff shows only the renames plus two explanatory comments. Verified against the six preserved #3351 selection cases.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3581#issuecomment-4779699018)

## Test plan

- [x] `bash -n` + `zsh -n` on `scripts/lib/monitor-decisions.sh`
- [x] `bash -n` on `scripts/test-monitor-skill-snippets.sh`
- [x] `shellcheck` on both files — zero new findings vs `origin/main` (13/13 mds, 182/182 harness)
- [x] `scripts/test-monitor-skill-snippets.sh` (plain): 418 tests, 0 failures; all six #3351 selection cases + nine classify_path cases pass
- [x] cargo fmt + clippy (pre-commit hook) pass
- Note: `--strict` mode FATAL ("Structural drift: monitor-loop/SKILL.md calls recover_session_from_stdout without fail-fast") is **pre-existing** — identical FATAL on a pristine `origin/main` checkout, unrelated to this change.

## Regression test (kind: bug-fix)

- **Test:** `scripts/test-monitor-skill-snippets.sh` — `select_latest_green: runs under zsh without read-only-status abort (#3581)`, inside the existing #3351 block, gated on `command -v zsh`, invokes the selector in a `zsh -c` subprocess with a hermetic ancestry oracle (green sha `G` on-main, 1 ahead of `DEP`) and asserts stdout == `G`. A bash-only test cannot catch this — the bug is zsh-specific, so the test explicitly invokes `zsh -c` (matching the harness's 20c3-zsh / 78c-zsh convention).
- **Pre-fix:** committed as `4803a8ad` — verified FAILED on `origin/main`: `select_latest_green_deploy_target:6: read-only variable: status` → empty stdout ≠ `G` → `not ok 405`.
- **Post-fix:** verified PASSES after `2081b453` → `ok 405`.

## Deploy-safety

Pure rename + zsh-compat. The selection logic is byte-for-byte unchanged and the fail-closed guardrails are intact: empty stdout ⇒ caller MUST NOT deploy; never deploy a behind/off-main/over-walk sha; `green-equals-deployed` stays a no-op. Verified against the six preserved #3351 guardrail cases (head-cancelled→G, no-green-run, green-equals-deployed, green-behind-deployed, green-not-on-main, walk-exceeded).

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)