### PR TITLE
Emit maxSorobanTxSetSize in /info ledger object

### DIFF
--- a/crates/app/src/compat_http/handlers/info.rs
+++ b/crates/app/src/compat_http/handlers/info.rs
@@ -131,6 +131,108 @@ struct CompatPeerInfo {
 mod tests {
     use super::*;
 
+    use axum::body::Body;
+    use http::Request;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use crate::app::App;
+    use crate::compat_http::{build_compat_router, CompatServerState};
+
+    /// Build a `CompatServerState` backed by a real (minimal) `App` with a
+    /// tempdir database and no default peers. Returns `(TempDir, state)`; the
+    /// `TempDir` guard is returned first so it outlives the state (which holds
+    /// open DB handles).
+    async fn mk_compat_state() -> (tempfile::TempDir, Arc<CompatServerState>) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("compat-info.db");
+        let mut config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        config.overlay.known_peers.clear();
+        config.is_compat_config = true;
+        let app = App::new(config).await.unwrap();
+        let state = Arc::new(CompatServerState {
+            app: Arc::new(app),
+            started_on: "2024-01-01T00:00:00Z".to_string(),
+            prometheus_handle: None,
+            #[cfg(feature = "loadgen")]
+            loadgen_state: None,
+        });
+        (dir, state)
+    }
+
+    /// Collect a JSON response body and parse it.
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// When a Soroban network config exists, the compat `/info` ledger object
+    /// carries `maxSorobanTxSetSize` equal to the ledger's max tx count
+    /// (stellar-core's OPERATIONS resource). This is what supercluster's
+    /// `GetSorobanMaxTxSetSize().Value` reads. Fails on main (field absent).
+    #[tokio::test]
+    async fn test_info_soroban_tx_set_size_present_when_soroban_config() {
+        let (_dir, state) = mk_compat_state().await;
+        state
+            .app
+            .ledger_manager()
+            .set_soroban_network_info_for_test(henyey_ledger::SorobanNetworkInfo {
+                ledger_max_tx_count: 500,
+                ..Default::default()
+            });
+        let router = build_compat_router(state);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/info")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let json = body_json(response).await;
+        assert_eq!(
+            json["info"]["ledger"]["maxSorobanTxSetSize"],
+            500,
+            "maxSorobanTxSetSize must equal ledger_max_tx_count, got: {:?}",
+            json["info"]["ledger"].get("maxSorobanTxSetSize")
+        );
+    }
+
+    /// Pre-Soroban (no network config): the key must be absent, mirroring
+    /// stellar-core's conditional emission gated on
+    /// `hasLastClosedSorobanNetworkConfig()`.
+    #[tokio::test]
+    async fn test_info_soroban_tx_set_size_absent_pre_soroban() {
+        let (_dir, state) = mk_compat_state().await;
+        let router = build_compat_router(state);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/info")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let json = body_json(response).await;
+        assert!(
+            json["info"]["ledger"].get("maxSorobanTxSetSize").is_none(),
+            "maxSorobanTxSetSize must be absent pre-soroban, got: {:?}",
+            json["info"]["ledger"].get("maxSorobanTxSetSize")
+        );
+    }
+
     /// Verify that the `/info` response JSON shape matches stellar-core.
     ///
     /// This test constructs a `CompatInfoWrapper` by hand and asserts that the

--- a/crates/app/src/compat_http/handlers/info.rs
+++ b/crates/app/src/compat_http/handlers/info.rs
@@ -47,6 +47,10 @@ pub(crate) async fn compat_info_handler(
             base_fee: ledger.base_fee,
             base_reserve: ledger.base_reserve,
             max_tx_set_size: ledger.max_tx_set_size,
+            // Present only when a Soroban network config exists (protocol ≥ 20),
+            // mirroring stellar-core's `hasLastClosedSorobanNetworkConfig()` gate;
+            // value is the ledger's max OPERATIONS resource == ledger_max_tx_count.
+            max_soroban_tx_set_size: app.soroban_network_info().map(|i| i.ledger_max_tx_count),
             flags: if ledger.flags != 0 {
                 Some(ledger.flags)
             } else {
@@ -115,6 +119,14 @@ struct CompatLedgerInfo {
     base_reserve: u32,
     #[serde(rename = "maxTxSetSize")]
     max_tx_set_size: u32,
+    /// Max Soroban tx-set size (ledger's max OPERATIONS resource). Present only
+    /// when the last-closed ledger has a Soroban network config (protocol ≥ 20),
+    /// matching stellar-core `ApplicationImpl::getJsonInfo()` (lines 478-484).
+    #[serde(
+        rename = "maxSorobanTxSetSize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    max_soroban_tx_set_size: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flags: Option<u32>,
     age: u64,
@@ -254,6 +266,7 @@ mod tests {
                     base_fee: 100,
                     base_reserve: 100000000,
                     max_tx_set_size: 1000,
+                    max_soroban_tx_set_size: None,
                     flags: None,
                     age: 5,
                 },
@@ -345,6 +358,7 @@ mod tests {
                     base_fee: 100,
                     base_reserve: 100000000,
                     max_tx_set_size: 1000,
+                    max_soroban_tx_set_size: None,
                     flags: Some(3),
                     age: 0,
                 },
@@ -381,6 +395,7 @@ mod tests {
                     base_fee: 100,
                     base_reserve: 100000000,
                     max_tx_set_size: 1000,
+                    max_soroban_tx_set_size: None,
                     flags: None,
                     age: 0,
                 },
@@ -421,6 +436,7 @@ mod tests {
                     base_fee: 100,
                     base_reserve: 100000000,
                     max_tx_set_size: 1000,
+                    max_soroban_tx_set_size: None,
                     flags: None,
                     age: 0,
                 },
@@ -501,6 +517,7 @@ mod tests {
                     base_fee: 100,
                     base_reserve: 100000000,
                     max_tx_set_size: 1000,
+                    max_soroban_tx_set_size: None,
                     flags: None,
                     age: 0,
                 },
@@ -561,6 +578,7 @@ mod tests {
                     base_fee: 100,
                     base_reserve: 100000000,
                     max_tx_set_size: 1000,
+                    max_soroban_tx_set_size: None,
                     flags: None,
                     age: 0,
                 },

--- a/crates/app/src/http/handlers/info.rs
+++ b/crates/app/src/http/handlers/info.rs
@@ -368,6 +368,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_info_handler_soroban_tx_set_size_present() {
+        let (_dir, state) = test_server_state("abc123def456").await;
+        state
+            .app
+            .ledger_manager()
+            .set_soroban_network_info_for_test(henyey_ledger::SorobanNetworkInfo {
+                ledger_max_tx_count: 500,
+                ..Default::default()
+            });
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/info")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let json = body_json(response).await;
+        assert_eq!(
+            json["ledger"]["maxSorobanTxSetSize"],
+            500,
+            "maxSorobanTxSetSize must equal ledger_max_tx_count when a soroban \
+             config exists, got: {:?}",
+            json["ledger"].get("maxSorobanTxSetSize")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_info_handler_soroban_tx_set_size_absent() {
+        // Fresh App, no soroban network config set: soroban_network_info() is
+        // None, so the key must be absent (mirrors stellar-core's conditional
+        // emission gated on hasLastClosedSorobanNetworkConfig()).
+        let (_dir, state) = test_server_state("abc123def456").await;
+        let app = build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/info")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let json = body_json(response).await;
+        assert!(
+            json["ledger"].get("maxSorobanTxSetSize").is_none(),
+            "maxSorobanTxSetSize must be absent with no soroban config, got: {:?}",
+            json["ledger"].get("maxSorobanTxSetSize")
+        );
+    }
+
+    #[tokio::test]
     async fn test_info_handler_commit_hash_absent() {
         let (_dir, state) = test_server_state("").await;
         let app = build_router(state);

--- a/crates/app/src/http/handlers/info.rs
+++ b/crates/app/src/http/handlers/info.rs
@@ -64,6 +64,13 @@ pub(crate) async fn info_handler(State(state): State<Arc<ServerState>>) -> Json<
     let ledger = state.app.ledger_summary();
     let (pending_count, authenticated_count) = state.app.peer_counts().await;
     let quorum = state.app.quorum_info_for_info();
+    // Present only when a Soroban network config exists (protocol ≥ 20),
+    // mirroring stellar-core's `hasLastClosedSorobanNetworkConfig()` gate. The
+    // value is the ledger's max OPERATIONS resource == `ledger_max_tx_count`.
+    let max_soroban_tx_set_size = state
+        .app
+        .soroban_network_info()
+        .map(|i| i.ledger_max_tx_count);
 
     Json(InfoResponse {
         build: henyey_common::version::build_version_string(&info.version),
@@ -84,6 +91,7 @@ pub(crate) async fn info_handler(State(state): State<Arc<ServerState>>) -> Json<
             base_fee: ledger.base_fee,
             base_reserve: ledger.base_reserve,
             max_tx_set_size: ledger.max_tx_set_size,
+            max_soroban_tx_set_size,
             flags: ledger.flags,
             age: ledger.age,
         },

--- a/crates/app/src/http/types/info.rs
+++ b/crates/app/src/http/types/info.rs
@@ -54,6 +54,14 @@ pub struct InfoLedgerSummary {
     pub base_fee: u32,
     pub base_reserve: u32,
     pub max_tx_set_size: u32,
+    /// Max Soroban tx-set size (ledger's max OPERATIONS resource). Present only
+    /// when the last-closed ledger has a Soroban network config (protocol ≥ 20),
+    /// mirroring stellar-core's conditional emission in `ApplicationImpl::getJsonInfo()`.
+    #[serde(
+        rename = "maxSorobanTxSetSize",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_soroban_tx_set_size: Option<u32>,
     pub flags: u32,
     /// Seconds since last ledger close.
     pub age: u64,
@@ -146,6 +154,7 @@ mod tests {
                 base_fee: 100,
                 base_reserve: 5000000,
                 max_tx_set_size: 1000,
+                max_soroban_tx_set_size: None,
                 flags: 0,
                 age: 5,
             },


### PR DESCRIPTION
Closes #3586

## Summary

henyey's `/info` ledger object omitted `maxSorobanTxSetSize`, so supercluster's `GetSorobanMaxTxSetSize().Value` NullRef'd at the SSC soroban-upgrade step. This adds `maxSorobanTxSetSize` (camelCase, `Option<u32>` with `skip_serializing_if = "Option::is_none"`) to the `/info` ledger object in the compat handler (the one supercluster reads), the native handler, and the shared `InfoLedgerSummary` type.

The value is `app.soroban_network_info().map(|i| i.ledger_max_tx_count)`, which equals stellar-core's `maxLedgerResources(isSoroban=true).getVal(OPERATIONS)` == `SorobanNetworkConfig::ledgerMaxTxCount()` (the same XDR field `ContractExecutionLanes.ledgerMaxTxCount`). The key is emitted only when a Soroban network config exists (`soroban_network_info().is_some()`, i.e. core's `hasLastClosedSorobanNetworkConfig()`, which returns `None` pre-protocol-20) and omitted otherwise — matching stellar-core `ApplicationImpl.cpp:478-484` exactly. This unblocks the SSC henyey-majority mission at the soroban-upgrade step (compat-chain refs #3578 / #3584).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3586#issuecomment-4780951748)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-app --all-targets (RUSTFLAGS=-Dwarnings)
- [x] cargo build --all
- [x] cargo test --all passes

## Regression test (kind: bug-fix)

- **Tests:** `compat_http::handlers::info::tests::test_info_soroban_tx_set_size_present_when_soroban_config` and `http::handlers::info::tests::test_info_handler_soroban_tx_set_size_present` (router-backed, App with `set_soroban_network_info_for_test(ledger_max_tx_count: 500)`).
- **Pre-fix:** committed as `86c849f0` — verified FAILED with: `maxSorobanTxSetSize` absent → JSON `null` (left `Null`, right `500`).
- **Post-fix:** verified PASSES after `f3b16e2f`.
- Two companion guard tests (`..._absent_pre_soroban` / `..._soroban_tx_set_size_absent`) pin the conditional: fresh App with no Soroban config ⇒ key absent.

## Parity considerations

Matches stellar-core `ApplicationImpl.cpp:478-484` (conditional + value), traced link-by-link to `NetworkConfig.cpp` and `TxResource.h`. `/info` is a non-consensus diagnostic endpoint — purely additive optional camelCase key, no consensus/hash path touched. No byte-identical `/info` golden tripwire exists; the existing reference fixture `compat_http/test_fixtures/info_synced.json` already shows `maxSorobanTxSetSize` and needs no change.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)