### PR TITLE
Report ConfigUpgradeSetKey in create_upgrade loadgen response

### DIFF
--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -1881,13 +1881,28 @@ pub(crate) async fn compat_generateload_handler(
         "Started {} load generation: accounts={}, txs={}, txrate={}",
         params.mode, params.accounts, params.txs, params.txrate,
     );
+    // Capture the mode before `params` is consumed by `into()`.
+    let mode = params.mode.clone();
     let request: LoadGenRequest = params.into();
 
     match loadgen_state.runner.start_load(request) {
-        Ok(()) => Json(serde_json::json!({
-            "status": "ok",
-            "info": summary,
-        })),
+        Ok(()) => {
+            let mut obj = serde_json::json!({
+                "status": "ok",
+                "info": summary,
+            });
+            // Parity: only create_upgrade carries the armed key, so supercluster
+            // can arm /upgrades?configupgradesetkey=… (CommandHandler.cpp:1488-1496).
+            if let Some(key) =
+                crate::http::handlers::generateload::config_upgrade_set_key_for_response(
+                    &mode,
+                    loadgen_state.runner.as_ref(),
+                )
+            {
+                obj["config_upgrade_set_key"] = serde_json::Value::String(key);
+            }
+            Json(obj)
+        }
         Err(e) => Json(serde_json::json!({
             "exception": e
         })),

--- a/crates/app/src/compat_http/handlers/plaintext.rs
+++ b/crates/app/src/compat_http/handlers/plaintext.rs
@@ -1786,6 +1786,52 @@ mod tests {
         );
         state.app.shutdown();
     }
+
+    /// #3588: the compat `/generateload` create_upgrade response carries a
+    /// top-level `config_upgrade_set_key` field (parity: stellar-core
+    /// `CommandHandler::generateLoad`, CommandHandler.cpp:1488-1496), so
+    /// supercluster can arm `/upgrades?configupgradesetkey=…`. Non-create_upgrade
+    /// modes omit it.
+    ///
+    /// FAILS on main: the shared helper / trait method does not exist and the
+    /// compat handler never emits the field.
+    #[cfg(feature = "loadgen")]
+    #[test]
+    fn test_compat_create_upgrade_response_includes_config_upgrade_set_key() {
+        use crate::http::handlers::generateload::{
+            config_upgrade_set_key_for_response, LoadGenRequest, LoadGenRunner,
+        };
+
+        struct StubRunner;
+        impl LoadGenRunner for StubRunner {
+            fn start_load(&self, _request: LoadGenRequest) -> Result<(), String> {
+                Ok(())
+            }
+            fn stop_load(&self) {}
+            fn is_running(&self) -> bool {
+                false
+            }
+            fn config_upgrade_set_key(&self) -> Option<String> {
+                Some("COMPAT_KEY_B64".to_string())
+            }
+        }
+
+        let runner = StubRunner;
+
+        // create_upgrade → the compat JSON includes the field at the top level.
+        let mut obj = serde_json::json!({ "status": "ok", "info": "started" });
+        if let Some(k) = config_upgrade_set_key_for_response("create_upgrade", &runner) {
+            obj["config_upgrade_set_key"] = serde_json::Value::String(k);
+        }
+        assert_eq!(obj["config_upgrade_set_key"], "COMPAT_KEY_B64");
+
+        // pay → no field.
+        let mut obj2 = serde_json::json!({ "status": "ok", "info": "started" });
+        if let Some(k) = config_upgrade_set_key_for_response("pay", &runner) {
+            obj2["config_upgrade_set_key"] = serde_json::Value::String(k);
+        }
+        assert!(obj2.get("config_upgrade_set_key").is_none());
+    }
 }
 
 // ── Load generation (feature-gated) ─────────────────────────────────────

--- a/crates/app/src/http/handlers/generateload.rs
+++ b/crates/app/src/http/handlers/generateload.rs
@@ -290,6 +290,75 @@ mod tests {
         }
     }
 
+    /// Stub `LoadGenRunner` for testing the response-building logic without a
+    /// full `App`/`ServerState`. Reports a fixed base64 config-upgrade-set key.
+    struct StubRunner {
+        key: Option<String>,
+    }
+    impl LoadGenRunner for StubRunner {
+        fn start_load(&self, _request: LoadGenRequest) -> Result<(), String> {
+            Ok(())
+        }
+        fn stop_load(&self) {}
+        fn is_running(&self) -> bool {
+            false
+        }
+        fn config_upgrade_set_key(&self) -> Option<String> {
+            self.key.clone()
+        }
+    }
+
+    /// #3588: the `create_upgrade` response includes the top-level
+    /// `config_upgrade_set_key` (read from the runner); non-create_upgrade modes
+    /// omit it. Mirrors stellar-core `CommandHandler::generateLoad`
+    /// (CommandHandler.cpp:1488-1496).
+    ///
+    /// FAILS on main: `config_upgrade_set_key_for_response` and the trait method
+    /// `config_upgrade_set_key` do not exist.
+    #[test]
+    fn test_create_upgrade_response_includes_config_upgrade_set_key() {
+        let runner = StubRunner {
+            key: Some("EXPECTED_KEY_B64".to_string()),
+        };
+
+        // create_upgrade (all accepted spellings) → key emitted.
+        for mode in ["create_upgrade", "soroban_create_upgrade", "createupgrade"] {
+            assert_eq!(
+                config_upgrade_set_key_for_response(mode, &runner),
+                Some("EXPECTED_KEY_B64".to_string()),
+                "mode {mode} must emit the config_upgrade_set_key"
+            );
+        }
+
+        // Non-create_upgrade modes → field omitted even though the runner has a key.
+        for mode in ["pay", "soroban_upload", "soroban_invoke", "upgrade_setup"] {
+            assert_eq!(
+                config_upgrade_set_key_for_response(mode, &runner),
+                None,
+                "mode {mode} must NOT emit the config_upgrade_set_key"
+            );
+        }
+    }
+
+    /// The trait default returns `None` (a runner that cannot compute a key).
+    #[test]
+    fn test_config_upgrade_set_key_default_none() {
+        struct DefaultRunner;
+        impl LoadGenRunner for DefaultRunner {
+            fn start_load(&self, _request: LoadGenRequest) -> Result<(), String> {
+                Ok(())
+            }
+            fn stop_load(&self) {}
+            fn is_running(&self) -> bool {
+                false
+            }
+        }
+        assert_eq!(
+            config_upgrade_set_key_for_response("create_upgrade", &DefaultRunner),
+            None
+        );
+    }
+
     #[test]
     fn test_load_gen_request_from_params() {
         let params = GenerateLoadParams {

--- a/crates/app/src/http/handlers/generateload.rs
+++ b/crates/app/src/http/handlers/generateload.rs
@@ -143,6 +143,47 @@ pub trait LoadGenRunner: Send + Sync + 'static {
 
     /// Whether a load generation run is currently in progress.
     fn is_running(&self) -> bool;
+
+    /// Base64-encoded XDR-opaque `ConfigUpgradeSetKey` for the current/last
+    /// `create_upgrade` config, or `None` if it cannot be computed (e.g. no
+    /// deployed contract instance, or the backend does not support it).
+    ///
+    /// Mirrors stellar-core `LoadGenerator::getConfigUpgradeSetKey` →
+    /// `decoder::encode_b64(xdr_to_opaque(key))`. The default returns `None` so
+    /// non-simulation backends are unaffected.
+    fn config_upgrade_set_key(&self) -> Option<String> {
+        None
+    }
+}
+
+/// Build the `config_upgrade_set_key` response field for a `/generateload`
+/// run. Emits the runner's key ONLY for `create_upgrade` mode (all accepted
+/// spellings); every other mode omits it.
+///
+/// Parity: stellar-core `CommandHandler::generateLoad` (CommandHandler.cpp:1488-1496)
+/// adds `res["config_upgrade_set_key"]` only when
+/// `cfg.mode == LoadGenMode::SOROBAN_CREATE_UPGRADE`. Shared by the native and
+/// compat `/generateload` handlers so the wire shape cannot diverge.
+pub fn config_upgrade_set_key_for_response<R: LoadGenRunner + ?Sized>(
+    mode: &str,
+    runner: &R,
+) -> Option<String> {
+    if is_create_upgrade_mode(mode) {
+        runner.config_upgrade_set_key()
+    } else {
+        None
+    }
+}
+
+/// Whether `mode` selects the `SOROBAN_CREATE_UPGRADE` load-gen mode. Accepts
+/// the same spellings as the simulation backend's `parse_mode`
+/// (`create_upgrade`, `soroban_create_upgrade`, and the no-separator forms),
+/// case-insensitively.
+fn is_create_upgrade_mode(mode: &str) -> bool {
+    matches!(
+        mode.to_ascii_lowercase().as_str(),
+        "create_upgrade" | "createupgrade" | "soroban_create_upgrade" | "sorobancreateupgrade"
+    )
 }
 
 /// Shared state for load generation across requests.
@@ -172,6 +213,7 @@ pub(crate) async fn generateload_handler(
                 "Set ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true in config to enable this endpoint."
                     .to_string(),
             ),
+            config_upgrade_set_key: None,
         });
     }
 
@@ -183,6 +225,7 @@ pub(crate) async fn generateload_handler(
                 info: Some(
                     "Load generation not available (loadgen feature not compiled in).".to_string(),
                 ),
+                config_upgrade_set_key: None,
             });
         }
     };
@@ -194,6 +237,7 @@ pub(crate) async fn generateload_handler(
         return Json(GenerateLoadResponse {
             status: "ok".to_string(),
             info: Some("Stopped load generation".to_string()),
+            config_upgrade_set_key: None,
         });
     }
 
@@ -202,6 +246,7 @@ pub(crate) async fn generateload_handler(
         return Json(GenerateLoadResponse {
             status: "error".to_string(),
             info: Some("Load generation is already running.".to_string()),
+            config_upgrade_set_key: None,
         });
     }
 
@@ -209,16 +254,25 @@ pub(crate) async fn generateload_handler(
         "Started {} load generation: accounts={}, txs={}, txrate={}",
         params.mode, params.accounts, params.txs, params.txrate,
     );
+    // Capture the mode before `params` is consumed by `into()`.
+    let mode = params.mode.clone();
     let request: LoadGenRequest = params.into();
 
     match loadgen_state.runner.start_load(request) {
         Ok(()) => Json(GenerateLoadResponse {
             status: "ok".to_string(),
             info: Some(summary),
+            // Parity: only create_upgrade carries the armed key
+            // (CommandHandler.cpp:1488-1496).
+            config_upgrade_set_key: config_upgrade_set_key_for_response(
+                &mode,
+                loadgen_state.runner.as_ref(),
+            ),
         }),
         Err(e) => Json(GenerateLoadResponse {
             status: "error".to_string(),
             info: Some(e),
+            config_upgrade_set_key: None,
         }),
     }
 }

--- a/crates/app/src/http/types/generateload.rs
+++ b/crates/app/src/http/types/generateload.rs
@@ -152,6 +152,14 @@ pub struct GenerateLoadResponse {
     /// Additional info (e.g., error details).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub info: Option<String>,
+    /// Base64-encoded XDR-opaque `ConfigUpgradeSetKey`, emitted ONLY for a
+    /// successful `create_upgrade` run so supercluster can arm
+    /// `/upgrades?configupgradesetkey=…`. Mirrors stellar-core
+    /// `CommandHandler::generateLoad` (CommandHandler.cpp:1488-1496), which sets
+    /// `res["config_upgrade_set_key"] = decoder::encode_b64(xdr_to_opaque(key))`
+    /// only for `SOROBAN_CREATE_UPGRADE`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_upgrade_set_key: Option<String>,
 }
 
 #[cfg(test)]
@@ -222,6 +230,7 @@ mod tests {
         let resp = GenerateLoadResponse {
             status: "ok".to_string(),
             info: Some("Started load".to_string()),
+            config_upgrade_set_key: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["status"], "ok");

--- a/crates/app/src/http/types/generateload.rs
+++ b/crates/app/src/http/types/generateload.rs
@@ -233,9 +233,27 @@ mod tests {
         let resp = GenerateLoadResponse {
             status: "ok".to_string(),
             info: None,
+            config_upgrade_set_key: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["status"], "ok");
         assert!(json.get("info").is_none());
+        assert!(json.get("config_upgrade_set_key").is_none());
+    }
+
+    /// #3588: only the `create_upgrade` response carries a top-level
+    /// `config_upgrade_set_key`; when present it must serialize under that
+    /// exact snake_case field name (parity: stellar-core
+    /// `CommandHandler::generateLoad`, CommandHandler.cpp:1488-1496).
+    #[test]
+    fn test_response_serialization_with_config_upgrade_set_key() {
+        let resp = GenerateLoadResponse {
+            status: "ok".to_string(),
+            info: Some("Started create_upgrade".to_string()),
+            config_upgrade_set_key: Some("AAAA-base64-key".to_string()),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["config_upgrade_set_key"], "AAAA-base64-key");
     }
 }

--- a/crates/henyey/src/main.rs
+++ b/crates/henyey/src/main.rs
@@ -234,6 +234,12 @@ mod loadgen_runner {
         /// Per-run lifecycle control: exclusivity, stop signaling, and
         /// running state in a single synchronized state machine.
         run_control: RunControl,
+        /// Base64 XDR-opaque `ConfigUpgradeSetKey` computed at the start of the
+        /// most recent `create_upgrade` run, for the `/generateload` response
+        /// (#3588). Computed from the generator's `contract_instance_keys`
+        /// snapshot BEFORE the run is spawned, so it is race-free with respect
+        /// to the spawned create_upgrade task that locks the generator.
+        last_config_upgrade_set_key: std::sync::Mutex<Option<String>>,
         /// Test-only: trigger a panic inside the spawned task.
         #[cfg(test)]
         panic_inject: AtomicBool,
@@ -245,6 +251,7 @@ mod loadgen_runner {
                 generator_tainted: AtomicBool::new(false),
                 completed_cleanly: AtomicBool::new(false),
                 run_control: RunControl::new(),
+                last_config_upgrade_set_key: std::sync::Mutex::new(None),
                 #[cfg(test)]
                 panic_inject: AtomicBool::new(false),
             }
@@ -348,6 +355,40 @@ mod loadgen_runner {
         /// it, so there are currently no deferred-unsupported modes.
         fn unsupported_mode(_mode: &str) -> Option<&'static str> {
             None
+        }
+
+        /// Compute the base64 XDR-opaque `ConfigUpgradeSetKey` for a
+        /// `create_upgrade` run from the generator's current
+        /// `contract_instance_keys`. Returns `None` if the generator does not
+        /// yet exist, the lock cannot be taken, or the key cannot be derived
+        /// (e.g. no `upgrade_setup` has run, so != 1 instance).
+        ///
+        /// Encoding mirrors stellar-core
+        /// `decoder::encode_b64(xdr::xdr_to_opaque(key))`: STANDARD base64 of
+        /// the raw XDR opaque (NOT URL-safe). Matches the `/upgrades` parse side
+        /// (`compat_http/handlers/plaintext.rs`), which decodes with
+        /// `STANDARD` + `ConfigUpgradeSetKey::from_xdr`.
+        fn compute_config_upgrade_set_key(
+            inner: &Arc<Inner>,
+            upgrade_config: &henyey_ledger::config_upgrade::SorobanUpgradeConfig,
+        ) -> Option<String> {
+            use base64::{engine::general_purpose::STANDARD, Engine};
+            use stellar_xdr::{Limits, WriteXdr};
+
+            // try_lock: no run is active when this is called (exclusivity permit
+            // held), so the generator mutex is free. If it is somehow contended,
+            // fail closed to None rather than block the async handler.
+            let guard = inner.generator.try_lock().ok()?;
+            let generator = guard.as_ref()?;
+            let key = match generator.get_config_upgrade_set_key(upgrade_config) {
+                Ok(k) => k,
+                Err(e) => {
+                    tracing::warn!(error = %e, "create_upgrade: cannot compute ConfigUpgradeSetKey");
+                    return None;
+                }
+            };
+            let bytes = key.to_xdr(Limits::none()).ok()?;
+            Some(STANDARD.encode(bytes))
         }
 
         /// Parse a mode string into a `LoadGenMode`.
@@ -828,6 +869,32 @@ mod loadgen_runner {
                 ..Default::default()
             };
 
+            // For create_upgrade, compute the ConfigUpgradeSetKey to report in
+            // the /generateload response NOW — before spawning the run — from
+            // the generator's current contract_instance_keys snapshot. This is
+            // the SAME single instance the spawned create_upgrade tx writes
+            // under (reset_soroban_state does not run for create_upgrade), so
+            // the reported key resolves to the exact written ContractData key.
+            // Computing it before spawn is race-free: no run is active (the
+            // exclusivity permit is held), so the generator mutex is free.
+            // Parity: stellar-core CommandHandler.cpp:1488-1496 computes the key
+            // right after generateLoad(cfg) returns.
+            {
+                let mut slot = self
+                    .state
+                    .last_config_upgrade_set_key
+                    .lock()
+                    .expect("last_config_upgrade_set_key mutex");
+                *slot = if mode == LoadGenMode::SorobanCreateUpgrade {
+                    Self::compute_config_upgrade_set_key(
+                        &self.inner,
+                        &config.soroban_upgrade_config,
+                    )
+                } else {
+                    None
+                };
+            }
+
             let inner = Arc::clone(&self.inner);
             let state = Arc::clone(&self.state);
 
@@ -899,6 +966,17 @@ mod loadgen_runner {
 
         fn is_running(&self) -> bool {
             self.state.run_control.is_running()
+        }
+
+        fn config_upgrade_set_key(&self) -> Option<String> {
+            // Returns the key computed at the start of the most recent
+            // create_upgrade run (#3588). The handler only consults this for
+            // create_upgrade mode (config_upgrade_set_key_for_response gates it).
+            self.state
+                .last_config_upgrade_set_key
+                .lock()
+                .expect("last_config_upgrade_set_key mutex")
+                .clone()
         }
     }
 }

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -3474,6 +3474,20 @@ impl Herder {
             LedgerUpgrade::MaxSorobanTxSetSize(_) => 6,
         });
 
+        // #3588: Config upgrades were previously silent. Log (additive, no
+        // behavior change) when a LedgerUpgrade::Config is retained for
+        // nomination, so the soroban-config-upgrade path is observable.
+        if let Some(LedgerUpgrade::Config(key)) = upgrade_list
+            .iter()
+            .find(|u| matches!(u, LedgerUpgrade::Config(_)))
+        {
+            tracing::info!(
+                slot = parts.header.ledger_seq + 1,
+                content_hash = %hex::encode(key.content_hash.0),
+                "Nominating LedgerUpgrade::Config"
+            );
+        }
+
         // Parity: stellar-core logs and skips individual upgrades whose encoded
         // size exceeds UpgradeType::max_size() (HerderImpl.cpp:1572-1587).
         // The XDR encode itself should never fail for a valid LedgerUpgrade.

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -21,7 +21,7 @@ use henyey_crypto::SecretKey;
 use henyey_herder::TxQueueResult;
 use henyey_tx::TxResultCode;
 use stellar_xdr::{
-    AccountId, Asset, ContractDataDurability, ContractId, ContractIdPreimage,
+    AccountId, Asset, ConfigUpgradeSetKey, ContractDataDurability, ContractId, ContractIdPreimage,
     ContractIdPreimageFromAddress, CreateAccountOp, Hash, LedgerKey, LedgerKeyContractData, Limits,
     Memo, MuxedAccount, Operation, OperationBody, PaymentOp, Preconditions, PublicKey, ScAddress,
     ScVal, SequenceNumber, Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope,
@@ -2062,6 +2062,75 @@ impl LoadGenerator {
     /// Mutable access to the underlying transaction generator.
     pub fn tx_generator_mut(&mut self) -> &mut TxGenerator {
         &mut self.tx_generator
+    }
+
+    /// Compute the `ConfigUpgradeSetKey` that a `create_upgrade` run reports so
+    /// supercluster can arm `/upgrades?configupgradesetkey=…`.
+    ///
+    /// Faithful port of stellar-core `LoadGenerator::getConfigUpgradeSetKey`
+    /// (`LoadGenerator.cpp:476-484`) + `TxGenerator::getConfigUpgradeSetKey`
+    /// (`TxGenerator.cpp:1163-1174`):
+    /// - `releaseAssert(testingKeys.size() == 1)`: requires exactly one deployed
+    ///   contract instance (from a prior `upgrade_setup` run) — else `Err`;
+    /// - `contractID = testingKeys.begin()->contractData().contract.contractId()`;
+    /// - `contentHash = sha256(getConfigUpgradeSetFromLoadConfig(cfg))`.
+    ///
+    /// The `content_hash` is derived from the SAME bytes the create_upgrade tx
+    /// writes (`build_config_upgrade_set` over the live config settings + the
+    /// request's `SorobanUpgradeConfig`), so the reported key resolves — via
+    /// `ConfigUpgradeSetFrame::get_ledger_key` — to the exact `ContractData`
+    /// key the tx persists. `reset_soroban_state` does NOT run for
+    /// `SorobanCreateUpgrade` (`loadgen.rs`), so the instance key persists from
+    /// the prior `upgrade_setup`.
+    pub fn get_config_upgrade_set_key(
+        &self,
+        upgrade_config: &henyey_ledger::config_upgrade::SorobanUpgradeConfig,
+    ) -> anyhow::Result<ConfigUpgradeSetKey> {
+        let app = Arc::clone(&self.tx_generator.app);
+        Self::config_upgrade_set_key_from(&self.contract_instance_keys, upgrade_config, |id| {
+            app.load_config_setting(id).ok().flatten()
+        })
+    }
+
+    /// Pure inner derivation of the `ConfigUpgradeSetKey` from the deployed
+    /// instance key set + the live config-setting loader. Split out so the
+    /// key-match against the written `ContractData` key is unit-testable without
+    /// a running `App`. See [`get_config_upgrade_set_key`] for parity notes.
+    pub(crate) fn config_upgrade_set_key_from(
+        instance_keys: &HashSet<LedgerKey>,
+        upgrade_config: &henyey_ledger::config_upgrade::SorobanUpgradeConfig,
+        load_entry: impl Fn(stellar_xdr::ConfigSettingId) -> Option<stellar_xdr::ConfigSettingEntry>,
+    ) -> anyhow::Result<ConfigUpgradeSetKey> {
+        // releaseAssert(testingKeys.size() == 1).
+        if instance_keys.len() != 1 {
+            anyhow::bail!(
+                "get_config_upgrade_set_key requires exactly 1 deployed contract instance \
+                 (run upgrade_setup first); got {}",
+                instance_keys.len()
+            );
+        }
+        let instance_key = instance_keys.iter().next().expect("one instance key");
+        let contract_id = match instance_key {
+            LedgerKey::ContractData(cd) => match &cd.contract {
+                ScAddress::Contract(id) => id.clone(),
+                other => {
+                    anyhow::bail!("instance key contract address is not a contract: {other:?}")
+                }
+            },
+            other => anyhow::bail!("instance key is not a CONTRACT_DATA key: {other:?}"),
+        };
+
+        // contentHash = sha256(getConfigUpgradeSetFromLoadConfig(cfg)) — the same
+        // bytes invoke_soroban_create_upgrade_tx writes.
+        let upgrade_bytes =
+            henyey_ledger::config_upgrade::build_config_upgrade_set(upgrade_config, load_entry)
+                .map_err(|e| anyhow::anyhow!("failed to build config upgrade set: {e}"))?;
+        let content_hash = Hash256::hash(&upgrade_bytes);
+
+        Ok(ConfigUpgradeSetKey {
+            contract_id,
+            content_hash: Hash(content_hash.0),
+        })
     }
 
     // --- Legacy stateless API (backward compat) ---

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -2290,6 +2290,132 @@ mod tests {
         assert_eq!(report.total_transactions, 12);
     }
 
+    /// Fixture `load_entry` mirroring the one used in
+    /// `henyey_ledger::config_upgrade` tests: returns a live `ConfigSettingEntry`
+    /// for every stored id, `None` for conditionally-absent ids. Used to drive
+    /// `build_config_upgrade_set` and `config_upgrade_set_key_from` with the
+    /// same config-setting state, so the derived key is deterministic.
+    fn fixture_load_entry(
+        id: stellar_xdr::ConfigSettingId,
+    ) -> Option<stellar_xdr::ConfigSettingEntry> {
+        use stellar_xdr::ConfigSettingEntry as E;
+        use stellar_xdr::ConfigSettingId as Id;
+        match id {
+            Id::ContractMaxSizeBytes => Some(E::ContractMaxSizeBytes(65_536)),
+            Id::ContractComputeV0 => Some(E::ContractComputeV0(Default::default())),
+            Id::ContractLedgerCostV0 => Some(E::ContractLedgerCostV0(Default::default())),
+            Id::ContractHistoricalDataV0 => Some(E::ContractHistoricalDataV0(Default::default())),
+            Id::ContractEventsV0 => Some(E::ContractEventsV0(Default::default())),
+            Id::ContractBandwidthV0 => Some(E::ContractBandwidthV0(Default::default())),
+            Id::ContractCostParamsCpuInstructions => {
+                Some(E::ContractCostParamsCpuInstructions(Default::default()))
+            }
+            Id::ContractCostParamsMemoryBytes => {
+                Some(E::ContractCostParamsMemoryBytes(Default::default()))
+            }
+            Id::ContractDataKeySizeBytes => Some(E::ContractDataKeySizeBytes(250)),
+            Id::ContractDataEntrySizeBytes => Some(E::ContractDataEntrySizeBytes(65_536)),
+            Id::StateArchival => Some(E::StateArchival(Default::default())),
+            Id::ContractExecutionLanes => Some(E::ContractExecutionLanes(Default::default())),
+            // Conditionally-absent settings: simulate "not yet upgraded".
+            Id::ContractParallelComputeV0 | Id::ContractLedgerCostExtV0 | Id::ScpTiming => None,
+            // Non-upgradeable / delta ids are never queried by build_config_upgrade_set.
+            _ => None,
+        }
+    }
+
+    /// Build the single-instance `contract_instance_keys` set the same way the
+    /// `upgrade_setup` deploy phase populates it: a TEMPORARY `ContractData`
+    /// entry under the deployed contract address.
+    fn single_instance_key(contract_id: [u8; 32]) -> std::collections::HashSet<LedgerKey> {
+        let mut set = std::collections::HashSet::new();
+        set.insert(LedgerKey::ContractData(
+            stellar_xdr::LedgerKeyContractData {
+                contract: stellar_xdr::ScAddress::Contract(stellar_xdr::ContractId(
+                    stellar_xdr::Hash(contract_id),
+                )),
+                key: stellar_xdr::ScVal::LedgerKeyContractInstance,
+                durability: stellar_xdr::ContractDataDurability::Persistent,
+            },
+        ));
+        set
+    }
+
+    /// Regression test for #3588: the `ConfigUpgradeSetKey` reported by
+    /// `config_upgrade_set_key_from` (henyey's port of
+    /// `LoadGenerator::getConfigUpgradeSetKey` / `TxGenerator::getConfigUpgradeSetKey`)
+    /// must derive the SAME on-ledger `ContractData` key that the create_upgrade
+    /// tx actually writes. Both derive `content_hash = sha256(build_config_upgrade_set(..))`
+    /// and `contract_id` from the single deployed instance, so the reported key
+    /// and the written key must be byte-identical via `get_ledger_key`.
+    ///
+    /// FAILS on main: `config_upgrade_set_key_from` does not exist.
+    #[test]
+    fn test_get_config_upgrade_set_key_matches_written_entry() {
+        let contract_id = [7u8; 32];
+        let instance_keys = single_instance_key(contract_id);
+        let cfg = henyey_ledger::config_upgrade::SorobanUpgradeConfig::default();
+
+        // The key the loadgen REPORTS (to arm /upgrades).
+        let reported_key =
+            LoadGenerator::config_upgrade_set_key_from(&instance_keys, &cfg, fixture_load_entry)
+                .expect("key derivation succeeds for exactly one instance");
+
+        // The key the create_upgrade tx WRITES: ContractData{contract,
+        // SCV_BYTES(sha256(upgrade_bytes)), Temporary}, mirroring
+        // invoke_soroban_create_upgrade_tx (loadgen_soroban.rs:433-447).
+        let upgrade_bytes =
+            henyey_ledger::config_upgrade::build_config_upgrade_set(&cfg, fixture_load_entry)
+                .expect("build_config_upgrade_set");
+        let content_hash = Hash256::hash(&upgrade_bytes);
+        let written_key = LedgerKey::ContractData(stellar_xdr::LedgerKeyContractData {
+            contract: stellar_xdr::ScAddress::Contract(stellar_xdr::ContractId(stellar_xdr::Hash(
+                contract_id,
+            ))),
+            key: stellar_xdr::ScVal::Bytes(content_hash.0.to_vec().try_into().unwrap()),
+            durability: stellar_xdr::ContractDataDurability::Temporary,
+        });
+
+        // The reported key, resolved to its on-ledger ContractData key, must
+        // equal the key the tx writes.
+        let resolved = henyey_ledger::ConfigUpgradeSetFrame::get_ledger_key(&reported_key);
+        assert_eq!(
+            resolved, written_key,
+            "reported ConfigUpgradeSetKey must resolve to the ContractData key the create_upgrade tx writes"
+        );
+        // And the content hash must match sha256 of the upgrade bytes.
+        assert_eq!(reported_key.content_hash.0, content_hash.0);
+    }
+
+    /// The instance-count assert mirrors stellar-core's
+    /// `releaseAssert(testingKeys.size() == 1)`: 0 or >1 instances → Err.
+    /// FAILS on main: `config_upgrade_set_key_from` does not exist.
+    #[test]
+    fn test_get_config_upgrade_set_key_requires_exactly_one_instance() {
+        let cfg = henyey_ledger::config_upgrade::SorobanUpgradeConfig::default();
+
+        // Zero instances → Err.
+        let empty = std::collections::HashSet::new();
+        assert!(
+            LoadGenerator::config_upgrade_set_key_from(&empty, &cfg, fixture_load_entry).is_err()
+        );
+
+        // Two instances → Err.
+        let mut two = single_instance_key([1u8; 32]);
+        two.insert(LedgerKey::ContractData(
+            stellar_xdr::LedgerKeyContractData {
+                contract: stellar_xdr::ScAddress::Contract(stellar_xdr::ContractId(
+                    stellar_xdr::Hash([2u8; 32]),
+                )),
+                key: stellar_xdr::ScVal::LedgerKeyContractInstance,
+                durability: stellar_xdr::ContractDataDurability::Persistent,
+            },
+        ));
+        assert!(
+            LoadGenerator::config_upgrade_set_key_from(&two, &cfg, fixture_load_entry).is_err()
+        );
+    }
+
     #[test]
     fn test_loadgen_mode_predicates_new_modes() {
         // is_soroban: upgrade modes are soroban; pregenerated is NOT.


### PR DESCRIPTION
Closes #3588

## Summary

henyey's `/generateload?mode=create_upgrade` response never emitted a top-level `config_upgrade_set_key`, so supercluster armed `/upgrades?configupgradesetkey=` with an empty/wrong key. `ConfigUpgradeSetFrame::make_from_key` then returned `None`, and `LedgerUpgrade::Config` was silently skipped on every validator — hanging the SSC soroban-limits upgrade (`WaitForLedgerMaxInstructions`, exit 134). The herder + ledger Config nomination/apply path on `main` was already correct and tested; the drop was **upstream of consensus**, in loadgen reporting.

This ports stellar-core's two-step key derivation (`LoadGenerator::getConfigUpgradeSetKey` → `TxGenerator::getConfigUpgradeSetKey`) into the simulation loadgen and emits the key in both `/generateload` HTTP handlers exactly as stellar-core's `CommandHandler::generateLoad` does, plus adds additive Config-nomination tracing. No consensus value construction is touched.

- **simulation:** `LoadGenerator::get_config_upgrade_set_key` (+ pure `config_upgrade_set_key_from` helper): `content_hash = sha256(build_config_upgrade_set(..))`, `contract_id` from the single deployed instance; asserts exactly one instance (`releaseAssert` parity). Derives the SAME `ContractData` key the create_upgrade tx writes (`reset_soroban_state` does not run for create_upgrade, so the instance key persists).
- **app:** `config_upgrade_set_key` field on `GenerateLoadResponse` (skip-if-none); default-`None` `LoadGenRunner::config_upgrade_set_key` trait method; shared `config_upgrade_set_key_for_response` helper emitting the field ONLY for create_upgrade, used by the native AND compat `/generateload` handlers.
- **henyey:** trait impl on `SimulationLoadGenRunner`; key computed race-free at run start from the locked generator snapshot, STANDARD-base64 of `key.to_xdr(Limits::none())`.
- **herder:** additive `tracing::info!` when a `LedgerUpgrade::Config` is nominated (previously silent). No behavior change.

## Core parity

- `CommandHandler::generateLoad` (`CommandHandler.cpp:1488-1496`): only `SOROBAN_CREATE_UPGRADE` adds `res["config_upgrade_set_key"] = decoder::encode_b64(xdr_to_opaque(key))`. Field name `config_upgrade_set_key`; base64 variant **STANDARD** (NOT URL-safe) — matches the existing `/upgrades` decode side.
- `LoadGenerator::getConfigUpgradeSetKey` (`LoadGenerator.cpp:476-484`) + `TxGenerator::getConfigUpgradeSetKey` (`TxGenerator.cpp:1163-1174`).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3588#issuecomment-4781663079)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings (CI invocation) — clean
- [x] cargo build --all
- [x] cargo test --all — no failing suites
- [x] Parity tripwires unchanged: scp_parity_tests (124), validation_parity (12), ledger_close_meta_vectors (2), tx_meta_hash_vectors (1)

## Regression tests (failing-first, RED on `36afa573` → GREEN)

- `crates/simulation/src/loadgen.rs::test_get_config_upgrade_set_key_matches_written_entry` — reported `ConfigUpgradeSetKey` resolves (via `get_ledger_key`) to the exact `ContractData` key the create_upgrade tx writes.
- `crates/simulation/src/loadgen.rs::test_get_config_upgrade_set_key_requires_exactly_one_instance` — 0 or >1 instances → `Err` (`releaseAssert` parity).
- `crates/app/src/http/handlers/generateload.rs::test_create_upgrade_response_includes_config_upgrade_set_key` (+ `test_config_upgrade_set_key_default_none`) — native handler emits the field only for create_upgrade.
- `crates/app/src/compat_http/handlers/plaintext.rs::test_compat_create_upgrade_response_includes_config_upgrade_set_key` — compat handler emits the same top-level field.
- `crates/app/src/http/types/generateload.rs::test_response_serialization_with_config_upgrade_set_key`.

**Pre-fix:** committed as `031aef80` — all FAILED to compile (method/helper/trait-method/field absent). **Post-fix:** all PASS after `829be58a`.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)