### PR TITLE
Use portable command -v for deploy-gate ancestry-oracle guards (#3592)

### DIFF
--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -811,12 +811,20 @@ classify_path_binary_relevance() {
 
 # Ancestry oracle (overridable for hermetic tests). Default: real git.
 # is_ancestor A B → 0 iff A is an ancestor-or-equal of B (A reachable from B).
-if ! declare -F is_ancestor >/dev/null 2>&1; then
+# NOTE: the existence guard MUST use the POSIX-portable `command -v`, NOT the
+# bash-only `declare -F`. Under zsh `declare` aliases `typeset`, so
+# `typeset -F is_ancestor` declares a FLOAT VARIABLE named is_ancestor and
+# returns 0 — the `! declare -F …` guard is then false, the fallback function
+# is NEVER defined, and the read loop hits `command not found: is_ancestor`,
+# mis-resolving every green-on-main run to `green-not-on-main` (#3592). Same
+# zsh-vs-bash class as the `status` reserved-var bug fixed in #3581.
+if ! command -v is_ancestor >/dev/null 2>&1; then
   is_ancestor() { git merge-base --is-ancestor "$1" "$2" 2>/dev/null; }
 fi
 # commits_ahead DEP SHA → number of commits in DEP..SHA (reachable from SHA,
 # not from DEP). Prints 0 on any error so the caller's numeric compare is safe.
-if ! declare -F commits_ahead >/dev/null 2>&1; then
+# Guarded with `command -v` (portable) — see the is_ancestor note above (#3592).
+if ! command -v commits_ahead >/dev/null 2>&1; then
   commits_ahead() { git rev-list --count "$1".."$2" 2>/dev/null || echo 0; }
 fi
 

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -10058,6 +10058,49 @@ BOARDEOF
     tap_skip "select_latest_green: runs under zsh without read-only-status abort (#3581)" "zsh not found"
   fi
 
+  # ── #3592: select_latest_green ancestry-oracle fallback defined under zsh ───
+  # The selector defines fallback `is_ancestor` / `commits_ahead` git oracles
+  # guarded by an existence check. That guard used the bash-only `declare -F`,
+  # which under zsh aliases `typeset -F NAME` — declaring a FLOAT VARIABLE named
+  # NAME and returning 0. So `! declare -F is_ancestor` was false, the fallback
+  # function was NEVER defined, and the read-loop's first `is_ancestor` call hit
+  # `command not found: is_ancestor` → the candidate was dropped → every
+  # green-on-main run mis-resolved to `green-not-on-main` (a missed deploy).
+  #
+  # The #3581 case above CANNOT catch this: it pre-defines its own oracle
+  # stubs after sourcing, so the script's fallback is never exercised. This
+  # case deliberately does NOT pre-define the oracle — it relies on the
+  # script's OWN fallback (the buggy guard path), backed by a hermetic single-
+  # commit git repo so the default `git merge-base --is-ancestor` resolves. The
+  # green record's sha equals the deployed sha and is its own ancestor, so a
+  # correct gate returns `green-equals-deployed`; the buggy guard returns
+  # `green-not-on-main`. Gated on zsh + git availability.
+  if command -v zsh >/dev/null 2>&1 && command -v git >/dev/null 2>&1; then
+    local zsh_repo zsh_sha zsh_reason
+    zsh_repo="$(mktemp -d)"
+    git -C "$zsh_repo" init -q 2>/dev/null
+    git -C "$zsh_repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m init 2>/dev/null
+    zsh_sha="$(git -C "$zsh_repo" rev-parse HEAD 2>/dev/null)"
+    # Capture the reason token (stderr) from the gate, sourcing the REAL script
+    # and relying on its fallback ancestry oracle (no pre-defined stubs).
+    zsh_reason=$(zsh -c '
+      emulate -L zsh
+      cd "$2" || exit 3
+      source "$1/scripts/lib/monitor-decisions.sh"
+      printf "%s\n" "$3|completed|success" \
+        | select_latest_green_deploy_target "$3" "$3" 2>&1 >/dev/null
+    ' -- "$REPO_ROOT" "$zsh_repo" "$zsh_sha")
+    if [[ "$zsh_reason" == *"green-equals-deployed"* \
+          && "$zsh_reason" != *"command not found"* ]]; then
+      tap_ok "select_latest_green: fallback is_ancestor defined under zsh — green-on-main resolves (#3592)"
+    else
+      tap_not_ok "select_latest_green: fallback is_ancestor defined under zsh — green-on-main resolves (#3592)" "got '$zsh_reason' (expected 'green-equals-deployed')"
+    fi
+    rm -rf "$zsh_repo"
+  else
+    tap_skip "select_latest_green: fallback is_ancestor defined under zsh — green-on-main resolves (#3592)" "zsh or git not found"
+  fi
+
   # Restore real git oracles so no later test sees the stubs.
   unset -f is_ancestor commits_ahead _order_of
 


### PR DESCRIPTION
Closes #3592

## ⚠️ Deploy-critical + self-modifying (scripts/lib/) — requires operator review/merge; do NOT auto-merge (per pipeline policy, same as #3585).

`scripts/lib/monitor-decisions.sh` is the deploy gate and lives on the pipeline self-modifying surface. This PR must NOT be auto-merged; it requires explicit operator approval, identical handling to #3585.

## Summary

Inside `select_latest_green_deploy_target`, the fallback `is_ancestor` and `commits_ahead` git ancestry oracles were defined behind a bash-only `declare -F NAME` existence guard. Under zsh (the operator's interactive shell, and the shell the monitor-tick runs in), `declare` aliases `typeset`, so `typeset -F is_ancestor` declares a **float variable** named `is_ancestor` and returns 0. The `! declare -F …` guard is therefore false, the fallback function is never defined, and the gate's read loop hits `command not found: is_ancestor` → it drops the candidate → every green Verify-Execution run on `main` is mis-resolved to `green-not-on-main`, silently refusing a legitimate deploy.

The fix replaces **both** guards with the POSIX-portable `command -v NAME` (true only for a defined function/command, never a variable). Behavior under bash is unchanged. Same zsh-vs-bash portability class as #3581 (the `status` reserved-var fix in this same function).

Two `declare -F` occurrences found and fixed (`is_ancestor`, `commits_ahead`).

## Test plan

- [x] cargo fmt --check (pre-commit hook)
- [x] cargo clippy --all -- -D warnings (pre-commit hook)
- [x] `scripts/test-monitor-skill-snippets.sh` — full harness green (420 tests, 0 failures)

## Regression test (kind: bug-fix)

- **Test:** `scripts/test-monitor-skill-snippets.sh` :: `select_latest_green: fallback is_ancestor defined under zsh — green-on-main resolves (#3592)` (TAP test 406)
- **Pre-fix:** committed as `a44baf5c` — verified FAILED (`not ok 406`): under zsh the script's fallback `is_ancestor` is never defined, the gate emits `command not found: is_ancestor` and returns `green-not-on-main` instead of `green-equals-deployed`.
- **Post-fix:** verified PASSES after `968e89be` (`ok 406`); reason token is now `green-equals-deployed`.

The new case deliberately does NOT pre-define the oracle (unlike the #3581 case, which would mask this bug) — it relies on the script's OWN fallback path, backed by a hermetic single-commit git repo. Gated on zsh + git availability.

## Deviations from plan

None. The triage Implementation Notes anticipated multiple `declare -F` sites; both (`is_ancestor` and `commits_ahead`) were located and fixed identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)