### PR TITLE
Restart on /info-unresponsive-but-alive near-tip stall (monitor 3e)

### DIFF
--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -839,22 +839,51 @@ PROC_RESPONSIVE=$([ -n "$INFO_BODY" ] && echo yes || echo no)
 NODE_STATE=$(printf '%s' "$INFO_BODY" | grep -oP '"state"\s*:\s*"\K[^"]+' | head -1)
 # CURRENT_LCL: local last-closed-ledger number (from /info `ledger.num`).
 CURRENT_LCL=$(printf '%s' "$INFO_BODY" | grep -oP '"num"\s*:\s*\K[0-9]+' | head -1)
+# HEARTBEAT_AGE_SEC (#3579): seconds since the most recent `heartbeat=true` log
+# line. Liveness fallback for the "/info-unresponsive-but-alive near-tip stall":
+# when /info is empty (PROC_RESPONSIVE=no) but the event loop is still ticking,
+# a recent heartbeat (<=120s) proves the node is alive so (3e) can still fire on
+# the frozen-lcl/unhealthy/age signature instead of falling through every gate.
+# Pulled from monitor.log via grep_heartbeat_lines (the shared detector). Left
+# empty when no heartbeat is found (→ "unknown", fallback inert).
+HEARTBEAT_LINE=$(grep_heartbeat_lines "$LOG" 1 2>/dev/null)
+HEARTBEAT_AGE_SEC=""
+if [ -n "$HEARTBEAT_LINE" ]; then
+  HB_TS=$(printf '%s' "$HEARTBEAT_LINE" | grep -oP '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}' | head -1)
+  if [ -n "$HB_TS" ]; then
+    HB_EPOCH=$(date -d "$HB_TS" +%s 2>/dev/null)
+    [ -n "$HB_EPOCH" ] && HEARTBEAT_AGE_SEC=$(( $(date +%s) - HB_EPOCH ))
+  fi
+fi
+# When /info is empty, fall back to the heartbeat line for NODE_STATE/CURRENT_LCL
+# (the issue's "pull lcl from the latest heartbeat `ledger=`" guidance). Heartbeat
+# implies the validator is up and validating, so default NODE_STATE to "Synced!"
+# (state-gate-passing) and pull lcl from `ledger=<n>`; RPC `latestLedger` is the
+# secondary source. Both stay empty if neither is available (gate fails closed).
+if [ "$PROC_RESPONSIVE" = "no" ] && [ -n "$HEARTBEAT_LINE" ]; then
+  [ -z "$NODE_STATE" ] && NODE_STATE="Synced!"
+  [ -z "$CURRENT_LCL" ] && CURRENT_LCL=$(printf '%s' "$HEARTBEAT_LINE" | grep -oP 'ledger[=:]\s*\K[0-9]+' | head -1)
+fi
 # AGE_SEC: RPC getHealth wall-clock `age` (the check-(2) staleness signal).
 # RPC_STATUS: "healthy" | "unhealthy" from validator-mode getHealth.
 # RSS_MB: the RSS measured in check (4) (reused; OOM gate owns RSS-over-floor).
 STUCK_STATE_FILE="/home/tomer/data/$MONITOR_SESSION_ID/metrics/stuck_restart_state"
 mkdir -p "$(dirname "$STUCK_STATE_FILE")"
 classify_stuck_alive_sync "$NODE_STATE" "$CURRENT_LCL" "$AGE_SEC" "$RPC_STATUS" \
-  "$RSS_MB" "$PROC_RESPONSIVE" "$STUCK_STATE_FILE"
+  "$RSS_MB" "$PROC_RESPONSIVE" "$STUCK_STATE_FILE" "$(date +%s)" "$HEARTBEAT_AGE_SEC"
 ```
 
 `classify_stuck_alive_sync` sets `STUCK_ALIVE_SYNC`. It is `yes` only when ALL
 six hold: state matches `valid|synced|track` (case-insensitive substring; never
-`Catching up`/`Booting`); `PROC_RESPONSIVE=yes`; `RPC_STATUS=unhealthy`;
-`AGE_SEC > 600`; frozen-lcl wall-clock dwell `>= 600s` (cadence-independent,
-mirroring check (2)'s `<ledger>|<ts>` STUCK idiom — fires at ~10 min of freeze
-regardless of tick spacing); and `RSS_MB < 16384`. Thresholds are named
-constants at the top of the function for operator retuning. Guards: a **900s
+`Catching up`/`Booting`); the node is **alive** — `PROC_RESPONSIVE=yes` OR (when
+/info is unresponsive) a `heartbeat=true` line within `HEARTBEAT_AGE_SEC <= 120s`
+(#3579 the "/info-unresponsive-but-alive near-tip stall"; a stale/absent
+heartbeat stays the (3b) wedge case, keeping the two mutually exclusive);
+`RPC_STATUS=unhealthy`; `AGE_SEC > 600`; frozen-lcl wall-clock dwell `>= 600s`
+(cadence-independent, mirroring check (2)'s `<ledger>|<ts>` STUCK idiom — fires
+at ~10 min of freeze regardless of tick spacing); and `RSS_MB < 16384`.
+Thresholds are named constants at the top of the function for operator retuning.
+Guards: a **900s
 cooldown** (`NOW - last_restart < 900` → `cooldown`, no restart this tick) and a
 **max-3-restarts / 2h** guard (`>= 3` restarts in a 7200s rolling window →
 `escalate`, no restart).

--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -1067,7 +1067,8 @@ diff_is_test_only() {
 
 # ─────────────────────────────────────────────────────────────────────────────
 # classify_stuck_alive_sync NODE_STATE CURRENT_LCL AGE_SEC RPC_STATUS RSS_MB \
-#                           PROC_RESPONSIVE STATE_FILE [NOW_EPOCH]
+#                           PROC_RESPONSIVE STATE_FILE [NOW_EPOCH] \
+#                           [HEARTBEAT_AGE_SEC]
 #
 # Pure decision function for the monitor-tick remediation rung (3e):
 # "stuck-but-alive SYNC FAILURE" auto-restart (issue #3219).
@@ -1077,9 +1078,14 @@ diff_is_test_only() {
 # `unhealthy`, and RSS UNDER the OOM floor. This is the residual failure mode
 # left over after (3c) soft-fail-wipe (owns the fatal-state-wipe case) and (3b)
 # wedge (owns the UNRESPONSIVE / frozen-event-loop case). (3e) is the MIRROR of
-# (3b): (3b) fires when the admin port is dead/timed-out; (3e) requires a live,
-# answering port (PROC_RESPONSIVE=yes). The two are mutually exclusive by
-# construction, so (3e) can never poach the wedge path.
+# (3b): (3b) fires when the admin port is dead/timed-out; (3e) requires a live
+# node. Liveness is proven by EITHER the admin port answering
+# (PROC_RESPONSIVE=yes) OR — when /info is unresponsive — a `heartbeat=true` log
+# line within HEARTBEAT_ALIVE_SEC (=120s), proving the event loop still ticks
+# (#3579: the "/info-unresponsive-but-alive near-tip stall"). The two remain
+# mutually exclusive: (3b) wedge requires a stale/absent heartbeat (truly
+# frozen loop); a fresh heartbeat routes the node to (3e) instead. (3e) can
+# never poach the genuinely-wedged path.
 #
 # Band-aid for root cause #3218 (overlay SCP broadcast backpressure). The
 # max-restarts→escalate guard ensures a restart loop surfaces as `urgent`
@@ -1132,6 +1138,10 @@ classify_stuck_alive_sync() {
   local proc_responsive="$6"
   local state_file="$7"
   local now_epoch="${8:-$(date +%s)}"
+  # Optional arg 9 (#3579): seconds since the most recent `heartbeat=true` log
+  # line. Empty / "-1" / non-numeric means "unknown / no recent heartbeat". Used
+  # ONLY as a liveness fallback when /info is unresponsive (proc_responsive=no).
+  local heartbeat_age_sec="${9:-}"
 
   # Named thresholds (operator-retunable).
   local STUCK_AGE_SEC=600
@@ -1140,6 +1150,11 @@ classify_stuck_alive_sync() {
   local STUCK_COOLDOWN_SEC=900
   local STUCK_WINDOW_SEC=7200
   local MAX_STUCK_RESTARTS=3
+  # Liveness-fallback window: a heartbeat this recent proves the event loop is
+  # ticking even when /info is down. Mirrors the (3b) wedge 120s freshness gate,
+  # so a node with a stale (>120s) heartbeat is "wedged" (3b owns it), while a
+  # fresh-heartbeat node is "alive" and routes to (3e). (#3579)
+  local HEARTBEAT_ALIVE_SEC=120
 
   STUCK_ALIVE_SYNC="no"
 
@@ -1194,8 +1209,21 @@ classify_stuck_alive_sync() {
     *valid*|*synced*|*track*) : ;;   # match — continue
     *) _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0 ;;
   esac
-  # 2. Process responsive (mirror of (3b) wedge).
-  [[ "$proc_responsive" == "yes" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
+  # 2. Process alive. Primary signal: /info answered (proc_responsive=yes,
+  #    mirror of (3b) wedge). Fallback (#3579): /info is unresponsive but a
+  #    `heartbeat=true` log line appeared within HEARTBEAT_ALIVE_SEC, proving the
+  #    event loop is still ticking — the "/info-unresponsive-but-alive" near-tip
+  #    stall. (3b) wedge keeps the truly-wedged case (no recent heartbeat); the
+  #    120s window matches (3b)'s freshness gate so the two stay mutually
+  #    exclusive (alive-via-heartbeat → here; stale/no heartbeat → wedge).
+  local proc_alive="no"
+  if [[ "$proc_responsive" == "yes" ]]; then
+    proc_alive="yes"
+  elif [[ "$heartbeat_age_sec" =~ ^[0-9]+$ ]] \
+       && [[ "$heartbeat_age_sec" -le "$HEARTBEAT_ALIVE_SEC" ]]; then
+    proc_alive="yes"
+  fi
+  [[ "$proc_alive" == "yes" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
   # 3. RPC unhealthy.
   [[ "$rpc_status" == "unhealthy" ]] || { _write_stuck_state; STUCK_ALIVE_SYNC="no"; return 0; }
   # 4. age over threshold.

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -2029,6 +2029,96 @@ PYEOF
       "(3e) rung not wired in monitor-tick/SKILL.md"
   fi
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # classify_stuck_alive_sync — /info-unresponsive-but-alive fallback (T63l–T63o)
+  # Source: scripts/lib/monitor-decisions.sh — (3e) liveness gate widening (#3579)
+  #
+  # Extra (optional) positional arg 9: HEARTBEAT_AGE_SEC — seconds since the last
+  # `heartbeat=true` log line (empty/-1 = unknown/none). When /info is down
+  # (PROC_RESPONSIVE=no) but a heartbeat appeared within ~120s, the node is alive
+  # (event loop ticking) and (3e) must STILL be able to fire on the near-tip-stall
+  # signature. (3b) wedge keeps the truly-wedged case (no recent heartbeat).
+  #
+  # Contract: classify_stuck_alive_sync NODE_STATE CURRENT_LCL AGE_SEC RPC_STATUS \
+  #             RSS_MB PROC_RESPONSIVE STATE_FILE [NOW_EPOCH] [HEARTBEAT_AGE_SEC]
+  # ════════════════════════════════════════════════════════════════════════════
+
+  # ── Test 63l: /info unresponsive + recent heartbeat (60s) → yes ────────────
+  # The exact #3579 signature: alive (heartbeat 60s ago) but /info empty, lcl
+  # frozen 700s, age 700, unhealthy, RSS under floor. (3e) MUST now fire.
+  # RED on origin/main (PROC_RESPONSIVE=no → condition 2 fails → "no").
+  local sa_l="$sa_dir/l.state"
+  _sa_seed "$sa_l" 55000000 700
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "no" "$sa_l" "$NOW_SA" 60
+  if [[ "$STUCK_ALIVE_SYNC" == "yes" ]]; then
+    tap_ok "stuck-alive: /info unresponsive + recent heartbeat (60s) near-tip stall → yes (#3579)"
+  else
+    tap_not_ok "stuck-alive: /info unresponsive + recent heartbeat near-tip stall → yes (#3579)" \
+      "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63m: /info unresponsive + NO recent heartbeat (180s) → no ─────────
+  # Truly wedged (event loop not ticking) — (3b) wedge owns this, NOT (3e).
+  # Guards against (3e) poaching the wedge path via the new fallback.
+  local sa_m="$sa_dir/m.state"
+  _sa_seed "$sa_m" 55000000 700
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "no" "$sa_m" "$NOW_SA" 180
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: /info unresponsive + stale heartbeat (180s>120s) → no (3b wedge owns it)"
+  else
+    tap_not_ok "stuck-alive: /info unresponsive + stale heartbeat → no (3b wedge owns it)" \
+      "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63n: /info unresponsive + recent heartbeat but RPC healthy → no ───
+  # False-positive guard: a healthy node whose /info is just flaky must NOT be
+  # restarted. RPC healthy + low age means it is making progress.
+  local sa_n="$sa_dir/n.state"
+  _sa_seed "$sa_n" 55000000 4
+  classify_stuck_alive_sync "Synced!" 55000000 4 "healthy" 10240 "no" "$sa_n" "$NOW_SA" 30
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: /info unresponsive + heartbeat-alive but RPC healthy → no (false-positive guard)"
+  else
+    tap_not_ok "stuck-alive: /info unresponsive + heartbeat-alive but RPC healthy → no" \
+      "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63o: /info unresponsive + no heartbeat info (omitted arg) → no ────
+  # Backward compatibility: when arg 9 is omitted (legacy callers) and /info is
+  # down, the fallback has no signal → (3e) must not fire (unchanged behavior).
+  local sa_o="$sa_dir/o.state"
+  _sa_seed "$sa_o" 55000000 700
+  classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "no" "$sa_o" "$NOW_SA"
+  if [[ "$STUCK_ALIVE_SYNC" == "no" ]]; then
+    tap_ok "stuck-alive: /info unresponsive + no heartbeat arg → no (backward-compat, unchanged)"
+  else
+    tap_not_ok "stuck-alive: /info unresponsive + no heartbeat arg → no (backward-compat)" \
+      "got STUCK_ALIVE_SYNC=$STUCK_ALIVE_SYNC"
+  fi
+
+  # ── Test 63p: heartbeat-fallback fires identically under zsh ───────────────
+  # The monitor runs under zsh; the new fallback must not rely on bash-only
+  # builtins or zsh-reserved vars (status/path/argv/options). Exercise the
+  # #3579 yes-case in a `zsh -c` subshell (mirror of T20c3-zsh).
+  if command -v zsh >/dev/null 2>&1; then
+    local sa_p="$sa_dir/p.state"
+    _sa_seed "$sa_p" 55000000 700
+    local zsh_sa_out
+    zsh_sa_out=$(zsh -c '
+      source "$1/scripts/lib/monitor-decisions.sh"
+      classify_stuck_alive_sync "Synced!" 55000000 700 "unhealthy" 10240 "no" "$2" 1700000000 60
+      printf "%s" "$STUCK_ALIVE_SYNC"
+    ' -- "$REPO_ROOT" "$sa_p" 2>&1)
+    if [[ "$zsh_sa_out" == "yes" ]]; then
+      tap_ok "stuck-alive: /info unresponsive + recent heartbeat near-tip stall → yes under zsh (#3579)"
+    else
+      tap_not_ok "stuck-alive: /info unresponsive + recent heartbeat near-tip stall → yes under zsh (#3579)" \
+        "got: '$zsh_sa_out'"
+    fi
+  else
+    tap_skip "stuck-alive: heartbeat-fallback under zsh (#3579)" "zsh not found"
+  fi
+
   # ── Test 64: Tick history capture uses quoted heredoc + datetime.now ────────
   # Structural assertion scoped to the fenced code block in "Tick history capture".
   local tick_hist_block


### PR DESCRIPTION
Closes #3579

⚠️ **Deploy-critical monitor change — requires operator review/merge; do NOT auto-merge (per pipeline policy, same as #3594).**

## Summary

The monitor-tick (3e) "stuck-but-alive" auto-restart rung gated liveness solely on `PROC_RESPONSIVE` (admin `/info` answered non-empty). During a sustained near-tip stall where `/info` is unresponsive but the event loop is still ticking (heartbeats flowing, `lcl` frozen, RPC `unhealthy`, no `watchdog_freeze`), `/info`-down forced `PROC_RESPONSIVE=no` so (3e) was skipped — yet (3b) wedge did not fire either (it requires `watchdog_freeze`), leaving an active SYNC FAILURE unrecovered (#3576 family).

This adds a **log-heartbeat-recency liveness fallback** to `classify_stuck_alive_sync`: condition (2) now passes when `/info` answers **OR** (when `/info` is unresponsive) a `heartbeat=true` log line appeared within `HEARTBEAT_ALIVE_SEC = 120s` — proving the event loop is alive. The 120s window matches (3b) wedge's freshness gate, so the two remain **mutually exclusive**: a stale/absent heartbeat stays the truly-wedged (3b) case; a fresh heartbeat routes to (3e).

### Detection gate (trigger conditions + false-positive guard)
All other gates are **unchanged**, keeping the conservative bias against a harmful false restart of a healthy validator:
- state matches `valid|synced|track`, RPC `unhealthy`, `age > 600s`, frozen-lcl dwell `>= 600s`, `RSS < 16384` MB, 900s cooldown, max-3-restarts/2h escalate.
- False-positive guard: an RPC-`healthy` node whose `/info` is merely flaky is NOT restarted (RPC-healthy → gate fails). A node with a stale heartbeat (>120s) is treated as wedged and left to (3b), not poached by (3e).

The new arg 9 (`HEARTBEAT_AGE_SEC`) is **optional and backward-compatible** (legacy callers unaffected). The `.claude/skills/monitor-tick/SKILL.md` (3e) caller now derives `HEARTBEAT_AGE_SEC` (and `NODE_STATE`/`CURRENT_LCL` fallbacks) from the heartbeat log when `/info` is empty, per the issue's fix sketch.

## Files changed
- `scripts/lib/monitor-decisions.sh` — `classify_stuck_alive_sync` liveness fallback (where the (3e) decision logic lives).
- `.claude/skills/monitor-tick/SKILL.md` — (3e) caller computes/passes the heartbeat age; prose updated.
- `scripts/test-monitor-skill-snippets.sh` — regression tests T63l–T63p.

## Test plan
- [x] `scripts/test-monitor-skill-snippets.sh` — 424 tests, 0 failures (bash).
- [x] zsh portability: new T63p exercises the yes-case via `zsh -c 'source …; classify_stuck_alive_sync …'`; lib also sources + fires correctly under direct `zsh -c`. No bash-only builtins / zsh-reserved vars introduced.
- [x] pre-commit `cargo fmt --check` + `cargo clippy --all -- -D warnings` pass (shell-only change; hook still green).

## Regression test
- **Test:** `scripts/test-monitor-skill-snippets.sh` — T63l `/info unresponsive + recent heartbeat (60s) near-tip stall → yes`; zsh mirror T63p.
- **Pre-fix:** committed as `42656cc8` — verified FAILED (`not ok` — current logic returns `no` because condition (2) requires `PROC_RESPONSIVE=yes`).
- **Post-fix:** verified PASSES after `7731338f`. Guard tests T63m (stale heartbeat → no, 3b owns it), T63n (RPC-healthy false-positive guard → no), T63o (backward-compat) all pass.

## Deviations from plan

Issue was triaged BLOCKED awaiting operator greenlight, then advanced to `ready-for-doing` by the operator. Implemented per the issue body's "Concrete fix sketch" (heartbeat-recency fallback). `.agents/skills/monitor-tick/SKILL.md` left untouched — it already diverges from `.claude/` on main and is not the test-referenced authoritative copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)