### PR TITLE
Match stellar-core purgeSlotsOutsideRange: add max-slot upper bound to SCP::purge_slots

### DIFF
--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1787,8 +1787,14 @@ impl Herder {
             // (HerderSCPDriver.cpp:1300-1337). Without this, the checkpoint
             // slot's SCP state can be evicted and the delayed
             // send_scp_state callback (#2670) silently sends nothing (#2706).
-            self.scp
-                .purge_slots(purge_slot.saturating_sub(1), Some(last_checkpoint));
+            // No upper bound on recovery: parity with core's
+            // eraseOutsideRange(purgeSlot, std::nullopt) (HerderImpl.cpp:573) —
+            // not tracking, so future slots are retained.
+            self.scp.purge_slots(
+                Some(purge_slot.saturating_sub(1)),
+                None,
+                Some(last_checkpoint),
+            );
 
             // Purge externalized values and pending tx set requests
             self.scp_driver.purge_slots_below(purge_slot);
@@ -3183,13 +3189,29 @@ impl Herder {
         // envelopes survive the retention window.
         let keep_slot = self.get_most_recent_checkpoint_seq();
 
+        // Tracking-gated upper bound, shared by every cleanup below. Parity:
+        // stellar-core threads a single maxSlotIndex
+        // (nextConsensusLedgerIndex()+LEDGER_VALIDITY_BRACKET, only when
+        // isTracking()) through HerderSCPDriver::purgeSlotsOutsideRange,
+        // SCP::purgeSlotsOutsideRange, and PendingEnvelopes::eraseOutsideRange
+        // (HerderImpl.cpp:260-290/1362, HerderSCPDriver.cpp:1653).
+        let max_slot = if self.is_tracking() {
+            Some(self.next_consensus_ledger_index().get() + LEDGER_VALIDITY_BRACKET)
+        } else {
+            None
+        };
+
         // Clean up old SCP state, preserving the most-recent-checkpoint
         // slot so the delayed send_scp_state callback (#2670) can still
         // find it after a long apply or upon validator startup (#2706).
+        // Threads the same tracking-gated max_slot upper bound as the
+        // fetching-envelope and tx-set-cache purges below, closing the gap
+        // where the SCP slots map retained far-future slots that core's
+        // SCP::purgeSlotsOutsideRange (SCP.cpp:73-105) would evict.
         // Parity: HerderSCPDriver::purgeSlotsOutsideRange
-        // (HerderSCPDriver.cpp:1300-1337).
+        // (HerderSCPDriver.cpp:1653).
         self.scp
-            .purge_slots(slot.saturating_sub(10), Some(keep_slot));
+            .purge_slots(Some(slot.saturating_sub(10)), max_slot, Some(keep_slot));
         // Purge deferred slot tracking alongside SCP slot cleanup
         self.scp_driver
             .purge_deferred_slots(slot.saturating_sub(10));
@@ -3201,11 +3223,6 @@ impl Herder {
         let min_ledger_seq = self.get_min_ledger_seq_to_remember();
         let min_slot = if min_ledger_seq > GENESIS_LEDGER_SEQ {
             Some(min_ledger_seq)
-        } else {
-            None
-        };
-        let max_slot = if self.is_tracking() {
-            Some(self.next_consensus_ledger_index().get() + LEDGER_VALIDITY_BRACKET)
         } else {
             None
         };

--- a/crates/scp/src/scp.rs
+++ b/crates/scp/src/scp.rs
@@ -330,18 +330,21 @@ impl<D: SCPDriver> SCP<D> {
         slot.force_externalize(value);
     }
 
-    /// Purge old slots to free memory.
+    /// Purge slots outside the `[min_slot, max_slot]` range to free memory.
     ///
-    /// Removes slots older than `max_slot_index`, but keeps `slot_to_keep`
-    /// even if it's below the threshold.
-    ///
-    /// Simplified variant of stellar-core's `SCP::purgeSlotsOutsideRange`
-    /// — only purges slots with index `< max_slot_index` (no min-bound
-    /// parameter). The full range-purge is not needed by current call sites.
-    pub fn purge_slots(&self, max_slot_index: u64, slot_to_keep: Option<u64>) {
-        self.slots.write().retain(|&slot_index, _| {
-            slot_index >= max_slot_index || slot_to_keep == Some(slot_index)
-        });
+    /// TEMPORARY (failing-test scaffold): lower-bound only — does NOT yet
+    /// honor `max_slot`. Replaced by the parity fix below.
+    pub fn purge_slots(
+        &self,
+        min_slot: Option<u64>,
+        _max_slot: Option<u64>,
+        slot_to_keep: Option<u64>,
+    ) {
+        if let Some(min) = min_slot {
+            self.slots
+                .write()
+                .retain(|&slot_index, _| slot_index >= min || slot_to_keep == Some(slot_index));
+        }
     }
 
     /// Get the number of active slots.
@@ -1436,12 +1439,90 @@ mod tests {
 
         assert_eq!(scp.slot_count(), 10);
 
-        // Purge old slots
-        scp.purge_slots(6, None);
+        // Purge old slots (lower bound only, no upper bound, no keep slot).
+        // Regression guard: the `min`-only case must remain byte-identical to
+        // the old single-bound `purge_slots` behavior.
+        scp.purge_slots(Some(6), None, None);
 
         assert_eq!(scp.slot_count(), 5);
         assert!(scp.get_externalized_value(5).is_none());
         assert!(scp.get_externalized_value(6).is_some());
+    }
+
+    /// Parity with stellar-core `SCP::purgeSlotsOutsideRange`: the `max` upper
+    /// bound must evict slots `> max` (which henyey's old lower-bound-only
+    /// `purge_slots` retained). RED on origin/main (no upper bound), GREEN
+    /// after the two-bounded fix.
+    #[test]
+    fn test_purge_slots_outside_range_evicts_above_max() {
+        let driver = Arc::new(MockDriver::bare());
+        let scp = SCP::new(make_node_id(1), true, make_empty_quorum_set(), driver);
+
+        for i in 1..=10 {
+            let value: Value = vec![i as u8].try_into().unwrap();
+            scp.force_externalize(i, value);
+        }
+        assert_eq!(scp.slot_count(), 10);
+
+        // Retain [min, max] = [3, 6]; evict {1,2} below and {7,8,9,10} above.
+        scp.purge_slots(Some(3), Some(6), None);
+
+        assert_eq!(scp.slot_count(), 4);
+        for keep in [3u64, 4, 5, 6] {
+            assert!(scp.has_slot(keep), "slot {keep} should be retained");
+        }
+        for evict in [1u64, 2, 7, 8, 9, 10] {
+            assert!(!scp.has_slot(evict), "slot {evict} should be evicted");
+        }
+    }
+
+    /// Parity with core's `maybeEraseSlot`: `slot_to_keep` survives BOTH
+    /// sweeps — including the `> max` upper sweep.
+    #[test]
+    fn test_purge_slots_outside_range_keeps_slot_to_keep_above_max() {
+        let driver = Arc::new(MockDriver::bare());
+        let scp = SCP::new(make_node_id(1), true, make_empty_quorum_set(), driver);
+
+        for i in 1..=10 {
+            let value: Value = vec![i as u8].try_into().unwrap();
+            scp.force_externalize(i, value);
+        }
+        assert_eq!(scp.slot_count(), 10);
+
+        // Retain [3, 5] plus slot_to_keep=9 even though 9 > max.
+        scp.purge_slots(Some(3), Some(5), Some(9));
+
+        for keep in [3u64, 4, 5, 9] {
+            assert!(scp.has_slot(keep), "slot {keep} should be retained");
+        }
+        for evict in [1u64, 2, 6, 7, 8, 10] {
+            assert!(!scp.has_slot(evict), "slot {evict} should be evicted");
+        }
+    }
+
+    /// Lower-bound regression: with `max = None`, NO future slot is evicted.
+    /// Preserves the recovery / not-tracking call-site semantics
+    /// (core's `eraseOutsideRange(purgeSlot, std::nullopt)`).
+    #[test]
+    fn test_purge_slots_no_max_retains_future_slots() {
+        let driver = Arc::new(MockDriver::bare());
+        let scp = SCP::new(make_node_id(1), true, make_empty_quorum_set(), driver);
+
+        for i in 1..=10 {
+            let value: Value = vec![i as u8].try_into().unwrap();
+            scp.force_externalize(i, value);
+        }
+
+        scp.purge_slots(Some(4), None, None);
+
+        // Only {1,2,3} below min are evicted; all of {4..=10} survive.
+        assert_eq!(scp.slot_count(), 7);
+        for keep in 4u64..=10 {
+            assert!(scp.has_slot(keep), "slot {keep} should be retained");
+        }
+        for evict in [1u64, 2, 3] {
+            assert!(!scp.has_slot(evict), "slot {evict} should be evicted");
+        }
     }
 
     // ==================== Tests for new parity features ====================

--- a/crates/scp/src/scp.rs
+++ b/crates/scp/src/scp.rs
@@ -332,19 +332,39 @@ impl<D: SCPDriver> SCP<D> {
 
     /// Purge slots outside the `[min_slot, max_slot]` range to free memory.
     ///
-    /// TEMPORARY (failing-test scaffold): lower-bound only — does NOT yet
-    /// honor `max_slot`. Replaced by the parity fix below.
+    /// Mirrors stellar-core's `SCP::purgeSlotsOutsideRange(minSlotIndex,
+    /// maxSlotIndex, slotToKeep)` (`SCP.cpp:73-105`): when `min_slot` is
+    /// `Some`, evict every slot `< min_slot`; when `max_slot` is `Some`,
+    /// evict every slot `> max_slot`. In BOTH sweeps `slot_to_keep` (when
+    /// `Some`) is retained even if it falls outside the range — matching
+    /// core's `maybeEraseSlot`, which advances past `slotToKeep` instead of
+    /// erasing it. A `None` bound disables that side of the sweep (core's
+    /// `std::nullopt`); a `None` `slot_to_keep` means no slot is exempt.
     pub fn purge_slots(
         &self,
         min_slot: Option<u64>,
-        _max_slot: Option<u64>,
+        max_slot: Option<u64>,
         slot_to_keep: Option<u64>,
     ) {
-        if let Some(min) = min_slot {
-            self.slots
-                .write()
-                .retain(|&slot_index, _| slot_index >= min || slot_to_keep == Some(slot_index));
+        if min_slot.is_none() && max_slot.is_none() {
+            return;
         }
+        self.slots.write().retain(|&slot_index, _| {
+            if slot_to_keep == Some(slot_index) {
+                return true;
+            }
+            if let Some(min) = min_slot {
+                if slot_index < min {
+                    return false;
+                }
+            }
+            if let Some(max) = max_slot {
+                if slot_index > max {
+                    return false;
+                }
+            }
+            true
+        });
     }
 
     /// Get the number of active slots.

--- a/crates/scp/src/slot.rs
+++ b/crates/scp/src/slot.rs
@@ -1699,7 +1699,7 @@ mod tests {
         assert_eq!(scp.slot_count(), 10);
 
         // Purge slots older than 8, but keep slot 3
-        scp.purge_slots(8, Some(3));
+        scp.purge_slots(Some(8), None, Some(3));
 
         let active = scp.active_slots();
         // Should keep slots 8, 9, 10 (>= 8) and slot 3 (slot_to_keep)
@@ -1734,7 +1734,7 @@ mod tests {
         assert_eq!(scp.slot_count(), 10);
 
         // Purge slots older than 8, no slot_to_keep
-        scp.purge_slots(8, None);
+        scp.purge_slots(Some(8), None, None);
 
         let active = scp.active_slots();
         assert_eq!(active.len(), 3, "should have slots 8, 9, 10 remaining");

--- a/crates/scp/tests/multi_node_simulation.rs
+++ b/crates/scp/tests/multi_node_simulation.rs
@@ -520,7 +520,7 @@ fn test_purge_old_slots() {
     assert_eq!(sim.get_node(&node1).slot_count(), 10);
 
     // Purge slots older than 6
-    sim.get_node(&node1).purge_slots(6, None);
+    sim.get_node(&node1).purge_slots(Some(6), None, None);
 
     assert_eq!(sim.get_node(&node1).slot_count(), 5);
     assert!(sim.get_node(&node1).get_externalized_value(5).is_none());
@@ -1593,7 +1593,7 @@ fn test_stress_slot_churn() {
 
         // Purge old slots, keeping only last 10
         if batch > 0 {
-            scp.purge_slots(end - 10, None);
+            scp.purge_slots(Some(end - 10), None, None);
         }
     }
 


### PR DESCRIPTION
Closes #3555

## Summary

henyey `SCP::purge_slots` was lower-bound only — it evicted slots below `min` but retained every far-future slot, diverging from stellar-core `SCP::purgeSlotsOutsideRange` (`SCP.cpp:73-105`), which also evicts slots above `maxSlotIndex`. The herder already computed the tracking-gated `max_slot` for the fetching-envelope (`erase_outside_range`) and tx-set-cache (`evict_cached_above`) purges but never threaded it into the SCP *slots* map. This PR closes exactly that one gap.

`purge_slots` becomes two-bounded with the additive signature `purge_slots(min_slot: Option<u64>, max_slot: Option<u64>, slot_to_keep: Option<u64>)`, mirroring core's `maybeEraseSlot`: evict `slot < min` (when `min` is `Some`) AND `slot > max` (when `max` is `Some`), retaining `slot_to_keep` in BOTH sweeps. Call-site threading:

- `ledger_closed` cleanup: `min = Some(slot.saturating_sub(10))`, `max = max_slot` (tracking-gated `next_consensus_ledger_index()+LEDGER_VALIDITY_BRACKET`, else `None`), `slot_to_keep = Some(keep_slot)`. The `max_slot` computation was hoisted above the SCP purge so all three cleanups share the same bound.
- out-of-sync recovery (not tracking): `min = Some(purge_slot.saturating_sub(1))`, `max = None`, `slot_to_keep = Some(last_checkpoint)` — parity with core `eraseOutsideRange(purgeSlot, std::nullopt)`.

No ballot/nomination/consensus-value semantics change — purely additive upper-bound eviction. `RESTORE_LIVE_ENVELOPE_REPLAY` stays disabled; the restart-rejoin stall is tracked separately in #3595.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3555#issuecomment-4783142464)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo build -p henyey-scp -p henyey-herder --all-targets (RUSTFLAGS=-Dwarnings) clean
- [x] cargo build --all
- [x] cargo test -p henyey-scp -p henyey-herder passes (scp lib 386, herder lib 1192, scp_parity_tests 124 — no shift)
- [x] cargo test --all passes (0 failures)

## Regression test (kind: parity-fix)

- **Tests:** `crates/scp/src/scp.rs::test_purge_slots_outside_range_evicts_above_max`, `::test_purge_slots_outside_range_keeps_slot_to_keep_above_max` (plus `::test_purge_slots_no_max_retains_future_slots` lower-bound regression guard and adapted `::test_purge_slots`)
- **Pre-fix:** committed as `7983636233214df30170252d49e87c47d4a5b5cc` — verified FAILED with: upper-bound slots `{7,8,9,10}` retained (`slot_count` 8 != 4); `slot 6 should be evicted`
- **Post-fix:** verified PASSES after `ef376635fe6b10c36a67eb5b4b08082530504c06`

## Parity

Byte/behavior-faithful to `SCP::purgeSlotsOutsideRange` (`SCP.cpp:73-105`); call-site threading matches `HerderImpl.cpp:260-290/573/1362` and `HerderSCPDriver.cpp:1653`. Parity tripwire: `scp_parity_tests` did NOT shift (124 passed); `validation_parity` / `ledger_close_meta_vectors` / `tx_meta_hash_vectors` untouched and green.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)