### PR TITLE
Fix flaky create_upgrade in henyey-majority SSC missions (#3602)

### DIFF
--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -1485,7 +1485,10 @@ impl LoadGenerator {
                     // the create-upgrade loadgen completes; if we reported "done"
                     // on submit, the `ConfigUpgradeSet` entry would not yet be in
                     // a closed ledger and the arm would be rejected (#3596).
-                    self.wait_till_complete().await;
+                    self.wait_till_complete(config).await;
+                    if self.failed {
+                        return LoadResult::Failed;
+                    }
                     // For create_upgrade, account-sync is necessary but not
                     // sufficient: the TEMPORARY ConfigUpgradeSet ContractData
                     // write can lag the source-account seq update in the
@@ -1555,19 +1558,37 @@ impl LoadGenerator {
     }
 
     /// Wait until every submitted transaction has been applied (accounts
-    /// synced) before declaring the run complete.
+    /// synced) — and, for Soroban setup modes, until the deployed contract
+    /// code + instance entries actually exist on-ledger — before declaring the
+    /// run complete.
     ///
     /// Parity: stellar-core `LoadGenerator::waitTillComplete()`
-    /// (`src/simulation/LoadGenerator.cpp:1345`) polls `checkAccountSynced`
-    /// each ledger until there are no inconsistencies (all txns applied),
-    /// timing out after `TIMEOUT_NUM_LEDGERS` (20). We poll ~once per second
-    /// and bound the wait by ledger advancement so a dropped/never-applied tx
-    /// can't hang the run forever.
-    async fn wait_till_complete(&mut self) {
+    /// (`src/simulation/LoadGenerator.cpp:1345`) gates completion on BOTH
+    /// `checkAccountSynced().empty()` AND `checkSorobanStateSynced(cfg).empty()`
+    /// each ledger, timing out after `TIMEOUT_NUM_LEDGERS`. The Soroban-state
+    /// gate is load-bearing for the create_upgrade flow (#3602): under the
+    /// genesis `MinimumSorobanNetworkConfig` (`ledgerMaxTxCount = 1`,
+    /// `ledgerMaxInstructions = 2_500_000`) the upgrade-setup `create_contract`
+    /// deploy competes for the single per-ledger Soroban slot and can be
+    /// surge-excluded for several ledgers. Account-sync alone returns as soon
+    /// as the source seq advances (a *failed* apply still bumps the seq), so
+    /// without the state gate the run could report "complete" while the
+    /// contract instance was never created — the subsequent `create_upgrade`
+    /// then writes nothing resolvable and the SSC arm hangs. We poll ~once per
+    /// second and bound the wait by ledger advancement.
+    ///
+    /// On timeout with the Soroban state still unsynced (setup modes), the run
+    /// is marked failed — parity with stellar-core `emitFailure` — so the
+    /// mission fails fast and is retried, rather than silently proceeding to a
+    /// create_upgrade that can never resolve.
+    async fn wait_till_complete(&mut self, config: &GeneratedLoadConfig) {
         const TIMEOUT_NUM_LEDGERS: u32 = 30;
+        let check_soroban = config.mode.is_soroban_setup();
         let start_ledger = self.tx_generator.app.current_ledger_seq();
         loop {
-            if self.tx_generator.check_accounts_synced() {
+            let accounts_synced = self.tx_generator.check_accounts_synced();
+            let soroban_synced = !check_soroban || self.soroban_state_synced();
+            if accounts_synced && soroban_synced {
                 return;
             }
             let elapsed = self
@@ -1578,13 +1599,61 @@ impl LoadGenerator {
             if elapsed >= TIMEOUT_NUM_LEDGERS {
                 warn!(
                     timeout_ledgers = TIMEOUT_NUM_LEDGERS,
+                    accounts_synced,
+                    soroban_synced,
                     "loadgen wait-till-complete timed out; some submitted txns \
                      were not applied (likely dropped before inclusion)"
                 );
+                // Parity: emitFailure(!sorobanIsDone). A setup run whose
+                // contract code/instance never materialized must fail — a
+                // downstream create_upgrade built against the missing instance
+                // would never produce a resolvable ConfigUpgradeSet entry.
+                if check_soroban && !soroban_synced {
+                    self.failed = true;
+                }
                 return;
             }
             tokio::time::sleep(Duration::from_millis(1000)).await;
         }
+    }
+
+    /// Whether the Soroban setup's deployed code + contract-instance entries
+    /// exist on-ledger.
+    ///
+    /// Parity: stellar-core `LoadGenerator::checkSorobanStateSynced()`
+    /// (`src/simulation/LoadGenerator.cpp:1259`), which loads every
+    /// `mContractInstanceKeys` entry plus `mCodeKey` and reports those still
+    /// missing. Here we require the code key and every recorded contract
+    /// instance key to be present in the live ledger. (The `config.n_instances`
+    /// counter is decremented during deployment, so we check the accumulated
+    /// `contract_instance_keys` set directly rather than the counter.)
+    fn soroban_state_synced(&self) -> bool {
+        Self::soroban_state_synced_inner(
+            self.code_key.as_ref(),
+            &self.contract_instance_keys,
+            |key| matches!(self.tx_generator.app.has_ledger_entry(key), Ok(true)),
+        )
+    }
+
+    /// Pure decision for [`Self::soroban_state_synced`], split out so the
+    /// completion gate can be unit-tested without a live `App`. Returns `true`
+    /// iff the code key exists, at least one instance was deployed, and every
+    /// recorded instance key exists (per the `entry_present` probe).
+    pub(crate) fn soroban_state_synced_inner(
+        code_key: Option<&LedgerKey>,
+        instance_keys: &HashSet<LedgerKey>,
+        entry_present: impl Fn(&LedgerKey) -> bool,
+    ) -> bool {
+        let Some(code_key) = code_key else {
+            // No code uploaded yet — setup is not complete.
+            return false;
+        };
+        if !entry_present(code_key) {
+            return false;
+        }
+        // At least one instance must have been deployed, and all recorded
+        // instance keys must exist on-ledger.
+        !instance_keys.is_empty() && instance_keys.iter().all(entry_present)
     }
 
     /// Wait until the `create_upgrade` ConfigUpgradeSet entry is resolvable by
@@ -2640,6 +2709,59 @@ mod tests {
         assert!(
             LoadGenerator::config_upgrade_set_key_from(&two, &cfg, fixture_load_entry).is_err()
         );
+    }
+
+    /// #3602 regression: the Soroban-setup completion gate must require BOTH
+    /// the uploaded code key AND every deployed instance key to actually exist
+    /// on-ledger — not merely that the source account's sequence advanced. The
+    /// flake was the loadgen reporting setup "complete" (account-synced) while
+    /// the `create_contract` deploy never materialized the instance, then
+    /// running `create_upgrade` against the missing instance (which can never
+    /// produce a resolvable ConfigUpgradeSet entry).
+    #[test]
+    fn test_soroban_state_synced_inner_gating() {
+        let code_key = LedgerKey::ContractCode(stellar_xdr::LedgerKeyContractCode {
+            hash: stellar_xdr::Hash([5u8; 32]),
+        });
+        let instances = single_instance_key([9u8; 32]);
+        let inst_key = instances.iter().next().unwrap().clone();
+
+        // No code uploaded yet → not synced.
+        assert!(!LoadGenerator::soroban_state_synced_inner(
+            None,
+            &instances,
+            |_| true
+        ));
+
+        // Code present but no instance deployed → not synced.
+        let empty = std::collections::HashSet::new();
+        assert!(!LoadGenerator::soroban_state_synced_inner(
+            Some(&code_key),
+            &empty,
+            |_| true
+        ));
+
+        // Code key not yet on-ledger (upload didn't materialize) → not synced.
+        assert!(!LoadGenerator::soroban_state_synced_inner(
+            Some(&code_key),
+            &instances,
+            |k| k != &code_key
+        ));
+
+        // Instance not on-ledger (the #3602 failure: deploy never created it)
+        // → not synced, even though code exists.
+        assert!(!LoadGenerator::soroban_state_synced_inner(
+            Some(&code_key),
+            &instances,
+            |k| k != &inst_key
+        ));
+
+        // Code + instance both present on-ledger → synced.
+        assert!(LoadGenerator::soroban_state_synced_inner(
+            Some(&code_key),
+            &instances,
+            |_| true
+        ));
     }
 
     #[test]

--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -726,23 +726,29 @@ define_wasm_compilation_context!(
 /// Whether to withhold the persistent module cache from this host function's
 /// `invoke_host_function` call.
 ///
-/// Passing the module cache makes the host compile (to native) any module it
-/// encounters that isn't already cached, and charges that compile cost against
-/// the transaction's instruction budget. For `UploadContractWasm` this adds the
-/// full Wasm native-compile cost (~1.5M instructions for a tiny contract) on top
-/// of parsing, which under the genesis `MinimumSorobanNetworkConfig`
-/// (`txMaxInstructions = 2_500_000`) pushes the upload over budget and fails it
-/// with `ResourceLimitExceeded` — non-deterministically, depending on whether
-/// the module happened to already be cached (#3602).
-///
-/// An upload does not execute contract code, so it has no need of the cache; the
-/// module is compiled (un-metered) by the ledger-close module-cache warming
+/// Invariant preserved: an `UploadContractWasm` must be metered purely on
+/// parsing, never on module compilation — matching how stellar-core meters
+/// uploads. An upload does not execute contract code; the module is compiled
+/// (un-metered) by the ledger-close module-cache warming
 /// (`addAnyContractsToModuleCache` parity) for the *next* ledger's deploy/invoke.
-/// stellar-core's uploads are not charged this compile cost. Withholding the
-/// cache here makes upload metering deterministic and parity-correct.
 ///
-/// Execution paths (`InvokeContract`, and `CreateContract`/`CreateContractV2`
-/// which read or run the referenced code) keep the cache.
+/// Note: in the pinned soroban-env the upload path (`upload_contract_wasm`)
+/// parses with a throwaway engine and never consults `module_cache`, so
+/// withholding it here is currently a **metering no-op** — verified equivalent
+/// to passing `Some(cache)` (same instructions, output, footprint, refund,
+/// events). It is withheld anyway as a defensive parity guard: it documents that
+/// uploads have no need of the cache and ensures upload metering can never become
+/// dependent on cache state (e.g. a future/compile-on-miss env would otherwise
+/// charge the native-compile cost — ~1.5M instructions for a tiny contract —
+/// against the genesis `MinimumSorobanNetworkConfig` `txMaxInstructions =
+/// 2_500_000` budget). The load-bearing fix for the #3602 flake is the loadgen
+/// completion gate (`LoadGenerator::wait_till_complete`); this guard is the
+/// accompanying parity hardening.
+///
+/// Only `UploadContractWasm` is withheld. Execution paths — `InvokeContract`,
+/// and `CreateContract`/`CreateContractV2` which read or run the referenced
+/// code — keep the cache; withholding it from those would itself diverge from
+/// stellar-core, which passes the populated cache to every host function.
 pub(crate) fn upload_skips_module_cache(host_function: &stellar_xdr::HostFunction) -> bool {
     matches!(
         host_function,
@@ -1241,18 +1247,10 @@ fn execute_host_function_p24(
         "P24",
     )?;
 
-    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
-    // the host compile the *uploaded* module into the cache on a miss, charging
-    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
-    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
-    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
-    // failing it with ResourceLimitExceeded — non-deterministically, depending on
-    // whether the module was already cached from a prior attempt (#3602). Uploads
-    // do not execute the contract, so the cache must not factor into upload
-    // metering (stellar-core meters them without this charge). Skip the cache for
-    // the non-executing host functions (UploadContractWasm, CreateContract) so
-    // metering is deterministic and within budget. InvokeContract and
-    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    // Module cache: withheld from UploadContractWasm only, so an upload is
+    // metered parse-only and never on compilation (see
+    // `upload_skips_module_cache` for the parity rationale; verified inert in the
+    // pinned env, kept as a defensive guard). All executing paths keep the cache.
     let module_cache = if upload_skips_module_cache(host_function) {
         None
     } else {
@@ -1506,18 +1504,10 @@ fn execute_host_function_p25(
         "P25",
     )?;
 
-    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
-    // the host compile the *uploaded* module into the cache on a miss, charging
-    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
-    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
-    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
-    // failing it with ResourceLimitExceeded — non-deterministically, depending on
-    // whether the module was already cached from a prior attempt (#3602). Uploads
-    // do not execute the contract, so the cache must not factor into upload
-    // metering (stellar-core meters them without this charge). Skip the cache for
-    // the non-executing host functions (UploadContractWasm, CreateContract) so
-    // metering is deterministic and within budget. InvokeContract and
-    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    // Module cache: withheld from UploadContractWasm only, so an upload is
+    // metered parse-only and never on compilation (see
+    // `upload_skips_module_cache` for the parity rationale; verified inert in the
+    // pinned env, kept as a defensive guard). All executing paths keep the cache.
     let module_cache = if upload_skips_module_cache(host_function) {
         None
     } else {
@@ -1916,18 +1906,10 @@ fn execute_host_function_p26(
         "P26",
     )?;
 
-    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
-    // the host compile the *uploaded* module into the cache on a miss, charging
-    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
-    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
-    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
-    // failing it with ResourceLimitExceeded — non-deterministically, depending on
-    // whether the module was already cached from a prior attempt (#3602). Uploads
-    // do not execute the contract, so the cache must not factor into upload
-    // metering (stellar-core meters them without this charge). Skip the cache for
-    // the non-executing host functions (UploadContractWasm, CreateContract) so
-    // metering is deterministic and within budget. InvokeContract and
-    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    // Module cache: withheld from UploadContractWasm only, so an upload is
+    // metered parse-only and never on compilation (see
+    // `upload_skips_module_cache` for the parity rationale; verified inert in the
+    // pinned env, kept as a defensive guard). All executing paths keep the cache.
     let module_cache = if upload_skips_module_cache(host_function) {
         None
     } else {
@@ -2184,18 +2166,10 @@ fn execute_host_function_p27(
         "P27",
     )?;
 
-    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
-    // the host compile the *uploaded* module into the cache on a miss, charging
-    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
-    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
-    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
-    // failing it with ResourceLimitExceeded — non-deterministically, depending on
-    // whether the module was already cached from a prior attempt (#3602). Uploads
-    // do not execute the contract, so the cache must not factor into upload
-    // metering (stellar-core meters them without this charge). Skip the cache for
-    // the non-executing host functions (UploadContractWasm, CreateContract) so
-    // metering is deterministic and within budget. InvokeContract and
-    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    // Module cache: withheld from UploadContractWasm only, so an upload is
+    // metered parse-only and never on compilation (see
+    // `upload_skips_module_cache` for the parity rationale; verified inert in the
+    // pinned env, kept as a defensive guard). All executing paths keep the cache.
     let module_cache = if upload_skips_module_cache(host_function) {
         None
     } else {

--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -723,6 +723,33 @@ define_wasm_compilation_context!(
     HostErrorP27
 );
 
+/// Whether to withhold the persistent module cache from this host function's
+/// `invoke_host_function` call.
+///
+/// Passing the module cache makes the host compile (to native) any module it
+/// encounters that isn't already cached, and charges that compile cost against
+/// the transaction's instruction budget. For `UploadContractWasm` this adds the
+/// full Wasm native-compile cost (~1.5M instructions for a tiny contract) on top
+/// of parsing, which under the genesis `MinimumSorobanNetworkConfig`
+/// (`txMaxInstructions = 2_500_000`) pushes the upload over budget and fails it
+/// with `ResourceLimitExceeded` — non-deterministically, depending on whether
+/// the module happened to already be cached (#3602).
+///
+/// An upload does not execute contract code, so it has no need of the cache; the
+/// module is compiled (un-metered) by the ledger-close module-cache warming
+/// (`addAnyContractsToModuleCache` parity) for the *next* ledger's deploy/invoke.
+/// stellar-core's uploads are not charged this compile cost. Withholding the
+/// cache here makes upload metering deterministic and parity-correct.
+///
+/// Execution paths (`InvokeContract`, and `CreateContract`/`CreateContractV2`
+/// which read or run the referenced code) keep the cache.
+pub(crate) fn upload_skips_module_cache(host_function: &stellar_xdr::HostFunction) -> bool {
+    matches!(
+        host_function,
+        stellar_xdr::HostFunction::UploadContractWasm(_)
+    )
+}
+
 /// Execute a Soroban host function with an optional pre-populated module cache.
 ///
 /// This is the same as `execute_host_function` but accepts an optional persistent
@@ -1214,16 +1241,32 @@ fn execute_host_function_p24(
         "P24",
     )?;
 
-    // Use existing module cache — it must always be provided.
-    let module_cache = existing_cache
-        .unwrap_or_else(|| {
-            panic!(
-                "P24: Module cache is not available — this is a bug. \
-                The persistent module cache should always be initialized before TX execution."
-            )
-        })
-        .clone();
-    let module_cache = Some(module_cache);
+    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
+    // the host compile the *uploaded* module into the cache on a miss, charging
+    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
+    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
+    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
+    // failing it with ResourceLimitExceeded — non-deterministically, depending on
+    // whether the module was already cached from a prior attempt (#3602). Uploads
+    // do not execute the contract, so the cache must not factor into upload
+    // metering (stellar-core meters them without this charge). Skip the cache for
+    // the non-executing host functions (UploadContractWasm, CreateContract) so
+    // metering is deterministic and within budget. InvokeContract and
+    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    let module_cache = if upload_skips_module_cache(host_function) {
+        None
+    } else {
+        Some(
+            existing_cache
+                .unwrap_or_else(|| {
+                    panic!(
+                        "P24: Module cache is not available — this is a bug. \
+                        The persistent module cache should always be initialized before TX execution."
+                    )
+                })
+                .clone(),
+        )
+    };
 
     // ── Encode inputs and call non-typed invoke_host_function() ──
     let inputs = encode_invocation_inputs(host_function, soroban_data, source, auth_entries)?;
@@ -1463,16 +1506,32 @@ fn execute_host_function_p25(
         "P25",
     )?;
 
-    // Use existing module cache — it must always be provided.
-    let module_cache = existing_cache
-        .unwrap_or_else(|| {
-            panic!(
-                "P25: Module cache is not available — this is a bug. \
-                The persistent module cache should always be initialized before TX execution."
-            )
-        })
-        .clone();
-    let module_cache = Some(module_cache);
+    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
+    // the host compile the *uploaded* module into the cache on a miss, charging
+    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
+    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
+    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
+    // failing it with ResourceLimitExceeded — non-deterministically, depending on
+    // whether the module was already cached from a prior attempt (#3602). Uploads
+    // do not execute the contract, so the cache must not factor into upload
+    // metering (stellar-core meters them without this charge). Skip the cache for
+    // the non-executing host functions (UploadContractWasm, CreateContract) so
+    // metering is deterministic and within budget. InvokeContract and
+    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    let module_cache = if upload_skips_module_cache(host_function) {
+        None
+    } else {
+        Some(
+            existing_cache
+                .unwrap_or_else(|| {
+                    panic!(
+                        "P25: Module cache is not available — this is a bug. \
+                        The persistent module cache should always be initialized before TX execution."
+                    )
+                })
+                .clone(),
+        )
+    };
 
     // ── Encode inputs and call non-typed invoke_host_function() ──
     // All budget metering (ValDeser for inputs, ValSer for outputs) is handled
@@ -1857,16 +1916,32 @@ fn execute_host_function_p26(
         "P26",
     )?;
 
-    // Use existing module cache — it must always be provided.
-    let module_cache = existing_cache
-        .unwrap_or_else(|| {
-            panic!(
-                "P26: Module cache is not available — this is a bug. \
-                The persistent module cache should always be initialized before TX execution."
-            )
-        })
-        .clone();
-    let module_cache = Some(module_cache);
+    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
+    // the host compile the *uploaded* module into the cache on a miss, charging
+    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
+    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
+    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
+    // failing it with ResourceLimitExceeded — non-deterministically, depending on
+    // whether the module was already cached from a prior attempt (#3602). Uploads
+    // do not execute the contract, so the cache must not factor into upload
+    // metering (stellar-core meters them without this charge). Skip the cache for
+    // the non-executing host functions (UploadContractWasm, CreateContract) so
+    // metering is deterministic and within budget. InvokeContract and
+    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    let module_cache = if upload_skips_module_cache(host_function) {
+        None
+    } else {
+        Some(
+            existing_cache
+                .unwrap_or_else(|| {
+                    panic!(
+                        "P26: Module cache is not available — this is a bug. \
+                        The persistent module cache should always be initialized before TX execution."
+                    )
+                })
+                .clone(),
+        )
+    };
 
     // ── Encode inputs and call non-typed invoke_host_function() ──
     let inputs = encode_invocation_inputs(host_function, soroban_data, source, auth_entries)?;
@@ -2109,16 +2184,32 @@ fn execute_host_function_p27(
         "P27",
     )?;
 
-    // Use existing module cache — it must always be provided.
-    let module_cache = existing_cache
-        .unwrap_or_else(|| {
-            panic!(
-                "P27: Module cache is not available — this is a bug. \
-                The persistent module cache should always be initialized before TX execution."
-            )
-        })
-        .clone();
-    let module_cache = Some(module_cache);
+    // Reusable module cache (CAP-0062): passing it to invoke_host_function makes
+    // the host compile the *uploaded* module into the cache on a miss, charging
+    // the ~1.5M-instruction native-compile cost against upload_wasm metering.
+    // Under the genesis MinimumSorobanNetworkConfig (txMaxInstructions =
+    // 2_500_000) that pushes the write_bytes upload over budget (~3.2M > 2.5M),
+    // failing it with ResourceLimitExceeded — non-deterministically, depending on
+    // whether the module was already cached from a prior attempt (#3602). Uploads
+    // do not execute the contract, so the cache must not factor into upload
+    // metering (stellar-core meters them without this charge). Skip the cache for
+    // the non-executing host functions (UploadContractWasm, CreateContract) so
+    // metering is deterministic and within budget. InvokeContract and
+    // CreateContractV2 (constructor) still execute code, so they keep the cache.
+    let module_cache = if upload_skips_module_cache(host_function) {
+        None
+    } else {
+        Some(
+            existing_cache
+                .unwrap_or_else(|| {
+                    panic!(
+                        "P27: Module cache is not available — this is a bug. \
+                        The persistent module cache should always be initialized before TX execution."
+                    )
+                })
+                .clone(),
+        )
+    };
 
     // ── Encode inputs and call non-typed invoke_host_function() ──
     let inputs = encode_invocation_inputs(host_function, soroban_data, source, auth_entries)?;
@@ -2274,6 +2365,49 @@ mod tests {
         });
         let hash = compute_key_hash(&key);
         assert_ne!(hash.0, [0u8; 32]);
+    }
+
+    /// #3602: the persistent module cache is withheld only from
+    /// `UploadContractWasm` (so the upload is metered parse-only, not
+    /// parse+native-compile, fitting the genesis txMaxInstructions budget).
+    /// Execution paths keep the cache.
+    #[test]
+    fn test_upload_skips_module_cache() {
+        use stellar_xdr::{
+            ContractIdPreimage, ContractIdPreimageFromAddress, CreateContractArgs,
+            CreateContractArgsV2, Hash, HostFunction, InvokeContractArgs, ScAddress, ScSymbol,
+            ScVal, Uint256,
+        };
+
+        // Upload: cache withheld.
+        assert!(upload_skips_module_cache(
+            &HostFunction::UploadContractWasm(vec![0u8; 8].try_into().unwrap())
+        ));
+
+        // Invoke: cache kept (executes the contract).
+        let invoke = HostFunction::InvokeContract(InvokeContractArgs {
+            contract_address: ScAddress::Contract(stellar_xdr::ContractId(Hash([1u8; 32]))),
+            function_name: ScSymbol("f".try_into().unwrap()),
+            args: Vec::new().try_into().unwrap(),
+        });
+        assert!(!upload_skips_module_cache(&invoke));
+
+        // CreateContract / V2: cache kept (reads/runs the referenced code).
+        let preimage = ContractIdPreimage::Address(ContractIdPreimageFromAddress {
+            address: ScAddress::Contract(stellar_xdr::ContractId(Hash([2u8; 32]))),
+            salt: Uint256([0u8; 32]),
+        });
+        let create = HostFunction::CreateContract(CreateContractArgs {
+            contract_id_preimage: preimage.clone(),
+            executable: stellar_xdr::ContractExecutable::Wasm(Hash([3u8; 32])),
+        });
+        assert!(!upload_skips_module_cache(&create));
+        let create_v2 = HostFunction::CreateContractV2(CreateContractArgsV2 {
+            contract_id_preimage: preimage,
+            executable: stellar_xdr::ContractExecutable::Wasm(Hash([3u8; 32])),
+            constructor_args: vec![ScVal::Void].try_into().unwrap(),
+        });
+        assert!(!upload_skips_module_cache(&create_v2));
     }
 
     /// V27 protocol routes to a P27 module cache; V26 still routes to P26.


### PR DESCRIPTION
## Summary

Fixes #3602 — the intermittent (~50% in all-henyey runs) hang of the
`MixedImageLoadGeneration` config-upgrade step when henyey drives the load
generator.

Two changes, **reframed after review** (the host.rs change is *not* the
root-cause cure it was originally described as — see below):

1. **Gate Soroban-setup loadgen completion on contract-state sync** — the
   load-bearing fix.
2. **Withhold the module cache from `UploadContractWasm`** — a verified-inert
   defensive parity guard (not the cure), with accurate comments.

## Root cause (revised)

Under the genesis `MinimumSorobanNetworkConfig` (`ledgerMaxTxCount = 1`), the
upgrade-setup deploy competes for the single per-ledger Soroban slot and can be
surge-excluded for several ledgers. `wait_till_complete` previously gated only
on **account-sync**, which returns as soon as the source account's sequence
advances — and a *failed/never-applied* setup tx still leaves the seq where the
poll is satisfied. So the loadgen reported setup "complete" while the contract
code/instance was never materialized; the downstream `create_upgrade` then had
nothing to resolve and the SSC `/upgrades?configupgradesetkey` arm hung.

## Fix

**(1) Load-bearing — loadgen completion gate.** `wait_till_complete` now also
gates on `soroban_state_synced()` (uploaded code key + every deployed instance
key present on-ledger) for Soroban-setup modes, and marks the run **failed**
(`LoadResult::Failed`) on timeout-with-unsynced. This mirrors stellar-core
`LoadGenerator::checkSorobanStateSynced` (`LoadGenerator.cpp:1259`) +
`emitFailure`, so a setup whose instance never materialized fails fast and is
retried rather than silently proceeding to an unresolvable `create_upgrade`.
The pure decision is factored into `soroban_state_synced_inner` with a unit test.

**(2) Defensive parity guard — withhold the module cache from uploads.**
`upload_skips_module_cache()` returns true only for `UploadContractWasm`, and the
`execute_host_function_p24..p27` paths pass `None` for those.

> **Review note (corrects the original framing):** tracing the pinned
> soroban-env shows the upload path (`upload_contract_wasm`) parses with a
> throwaway engine and **never consults the module cache** — so for an upload,
> `Some(cache)` vs `None` is **byte-identical metering** (same instructions,
> output, footprint, refund, events) on every protocol (P27 routes through the
> p26 env `b351f88`). The originally-stated mechanism ("passing the cache charges
> ~1.5M native-compile against the 2.5M upload budget") does **not** occur in
> this host version; this change is therefore a **no-op on the consensus path**,
> not the cure. It is kept as a defensive guard that documents uploads have no
> need of the cache and pins upload metering parse-only (matching stellar-core,
> which also never charges uploads for cache interaction). Only
> `UploadContractWasm` is withheld — the executing paths (`InvokeContract`,
> `CreateContract`/`CreateContractV2`) keep the cache, since withholding it from
> those would itself diverge from core.

## Validation

Supercluster `MixedImageLoadGeneration`, protocol 27, fresh clusters:

| Composition | Before | After |
|---|---|---|
| All-henyey (0c3h) | ~50% pass | **8/8 pass** |
| Core-majority mixed (2c1h) | pass | **3/3 pass** (no consensus divergence) |

The 2c1h result confirms no state-hash divergence in a mixed cluster (consistent
with the host.rs change being inert). Note the 8/8 was observed with **both**
changes present; the loadgen gate is the parity-correct fix, and (per the review
note) confirming the gate alone reproduces 8/8 — vs the host.rs guard
contributing — would need a host.rs-free SSC run.

Tests: `henyey-tx` lib + `henyey-simulation` lib green; `test_upload_skips_module_cache`
and `test_soroban_state_synced_inner_gating`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)