### PR TITLE
Honor LOADGEN_WASM_BYTES_FOR_TESTING for SorobanUpload size (#3605)

### DIFF
--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -83,6 +83,8 @@ const SUPPORTED_KEYS: &[&str] = &[
     "TESTING_UPGRADE_RESERVE",
     "TESTING_UPGRADE_MAX_TX_SET_SIZE",
     "RUN_STANDALONE",
+    "LOADGEN_WASM_BYTES_FOR_TESTING",
+    "LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING",
     // Sub-tables (handled structurally)
     "HISTORY",
     "VALIDATORS",
@@ -661,6 +663,15 @@ pub fn translate_stellar_core_config(raw: &toml::Value) -> anyhow::Result<AppCon
     }
     if let Some(v) = get_bool(table, "RUN_STANDALONE") {
         config.testing.run_standalone = v;
+    }
+    // SorobanUpload WASM sizing (parity: stellar-core samples the upload size
+    // from LOADGEN_WASM_BYTES_FOR_TESTING weighted by
+    // LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING; absent → built-in default).
+    if let Some(v) = get_u32_array(table, "LOADGEN_WASM_BYTES_FOR_TESTING") {
+        config.testing.loadgen_wasm_bytes = v;
+    }
+    if let Some(v) = get_u32_array(table, "LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING") {
+        config.testing.loadgen_wasm_bytes_distribution = v;
     }
 
     // --- Ignored keys (accepted silently for compatibility) ---
@@ -1278,6 +1289,25 @@ fn get_u32(table: &toml::map::Map<String, toml::Value>, key: &str) -> Option<u32
             None
         }
     }
+}
+
+/// Read a TOML array of non-negative integers as `Vec<u32>`. Returns `None`
+/// if the key is absent or not an array; elements that aren't u32-representable
+/// integers are skipped with a warning.
+fn get_u32_array(table: &toml::map::Map<String, toml::Value>, key: &str) -> Option<Vec<u32>> {
+    let arr = table.get(key)?.as_array()?;
+    let mut out = Vec::with_capacity(arr.len());
+    for elem in arr {
+        match elem.as_integer().and_then(|i| u32::try_from(i).ok()) {
+            Some(v) => out.push(v),
+            None => tracing::warn!(
+                key,
+                element = %elem,
+                "Compat config array element is not a u32; skipping"
+            ),
+        }
+    }
+    Some(out)
 }
 
 fn get_usize(table: &toml::map::Map<String, toml::Value>, key: &str) -> Option<usize> {

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -721,6 +721,20 @@ pub struct TestingConfig {
     /// Maps to stellar-core's `RUN_STANDALONE`.
     #[serde(default)]
     pub run_standalone: bool,
+
+    /// WASM byte-size values sampled for `SorobanUpload` load (the random WASMs
+    /// uploaded by `soroban_random_wasm_transaction`). Maps to stellar-core's
+    /// `LOADGEN_WASM_BYTES_FOR_TESTING`; paired weights are
+    /// [`Self::loadgen_wasm_bytes_distribution`]. When empty, the loadgen falls
+    /// back to its built-in default size (parity with core's `DEFAULT_WASM_BYTES`).
+    #[serde(default)]
+    pub loadgen_wasm_bytes: Vec<u32>,
+
+    /// Sampling weights paired with [`Self::loadgen_wasm_bytes`]. Maps to
+    /// stellar-core's `LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING`. When empty
+    /// or mismatched in length, the values are sampled uniformly.
+    #[serde(default)]
+    pub loadgen_wasm_bytes_distribution: Vec<u32>,
 }
 
 impl TestingConfig {
@@ -750,6 +764,8 @@ impl Default for TestingConfig {
             testing_upgrade_reserve: default_testing_upgrade_reserve(),
             testing_upgrade_max_tx_set_size: default_testing_upgrade_max_tx_set_size(),
             run_standalone: false,
+            loadgen_wasm_bytes: Vec::new(),
+            loadgen_wasm_bytes_distribution: Vec::new(),
         }
     }
 }

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -155,6 +155,38 @@ const DEFAULT_WASM_SIZE: usize = 35_000;
 /// Default inclusion fee for Soroban transactions.
 const DEFAULT_SOROBAN_INCLUSION_FEE: u32 = 100;
 
+/// Sample a `SorobanUpload` WASM size from `values`, weighted by `weights`.
+///
+/// Parity with stellar-core's `sampleDiscrete(LOADGEN_WASM_BYTES_FOR_TESTING,
+/// LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING, DEFAULT_WASM_BYTES)`
+/// (TxGenerator.cpp:1647): empty `values` → `default`; a single value is used
+/// directly; otherwise pick weighted by `weights`, falling back to uniform when
+/// `weights` doesn't line up with `values`. `seed` makes the choice
+/// deterministic per (account, ledger).
+fn sample_wasm_size(values: &[u32], weights: &[u32], default: usize, seed: u64) -> usize {
+    match values {
+        [] => default,
+        [single] => *single as usize,
+        _ => {
+            let weighted = weights.len() == values.len() && weights.iter().any(|&w| w > 0);
+            if weighted {
+                let total: u64 = weights.iter().map(|&w| u64::from(w)).sum();
+                let mut pick = seed % total;
+                for (v, &w) in values.iter().zip(weights.iter()) {
+                    let w = u64::from(w);
+                    if pick < w {
+                        return *v as usize;
+                    }
+                    pick -= w;
+                }
+                values[values.len() - 1] as usize
+            } else {
+                values[(seed % values.len() as u64) as usize] as usize
+            }
+        }
+    }
+}
+
 /// Base CPU instruction budget for contract invocations.
 const INVOKE_BASE_INSTRUCTIONS: u32 = 2_000_000;
 
@@ -897,9 +929,23 @@ impl TxGenerator {
         account_id: u64,
         inclusion_fee: u32,
     ) -> anyhow::Result<(u64, TransactionEnvelope)> {
-        let wasm_size = DEFAULT_WASM_SIZE;
-        let wasm =
-            SorobanTxBuilder::random_wasm(wasm_size, deterministic_rand(account_id, ledger_num));
+        // Parity: stellar-core sizes each random upload by sampling
+        // LOADGEN_WASM_BYTES_FOR_TESTING (weighted by
+        // LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING), falling back to
+        // DEFAULT_WASM_BYTES when unset (TxGenerator.cpp:1647). Honoring the
+        // config lets missions that don't raise the per-tx limits
+        // (`WithSmallLoadgenOptions` → 1 KB) keep uploads within the genesis
+        // `maxContractSizeBytes`; previously we hardcoded ~35 KB, which forced
+        // those missions to additionally raise the Soroban per-tx limits.
+        let seed = deterministic_rand(account_id, ledger_num);
+        let testing = &self.app.config().testing;
+        let wasm_size = sample_wasm_size(
+            &testing.loadgen_wasm_bytes,
+            &testing.loadgen_wasm_bytes_distribution,
+            DEFAULT_WASM_SIZE,
+            seed,
+        );
+        let wasm = SorobanTxBuilder::random_wasm(wasm_size, seed);
         let (sk, seq) = self.next_source_sequence(account_id, ledger_num);
         let builder = self.soroban_builder();
         let envelope = builder.upload_wasm_tx(&sk, seq, &wasm, inclusion_fee)?;
@@ -2640,6 +2686,25 @@ mod tests {
         assert!(
             LoadGenerator::config_upgrade_set_key_from(&two, &cfg, fixture_load_entry).is_err()
         );
+    }
+
+    /// Parity: upload size sampling honors LOADGEN_WASM_BYTES_FOR_TESTING.
+    #[test]
+    fn test_sample_wasm_size() {
+        // Empty values → default (core's DEFAULT_WASM_BYTES fallback).
+        assert_eq!(sample_wasm_size(&[], &[], 35_000, 123), 35_000);
+        // Single value is used directly regardless of seed.
+        assert_eq!(sample_wasm_size(&[1024], &[1], 35_000, 0), 1024);
+        assert_eq!(sample_wasm_size(&[1024], &[], 35_000, 999), 1024);
+        // Weighted: weight 0 on the first means it's never picked.
+        for seed in 0..10u64 {
+            assert_eq!(sample_wasm_size(&[100, 200], &[0, 1], 35_000, seed), 200);
+        }
+        // Mismatched weights → uniform over values (both reachable).
+        let picks: std::collections::HashSet<usize> = (0..8u64)
+            .map(|s| sample_wasm_size(&[10, 20], &[], 35_000, s))
+            .collect();
+        assert!(picks.contains(&10) && picks.contains(&20));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3605.

## Problem

henyey's loadgen hardcoded the `SorobanUpload` random-WASM size at `DEFAULT_WASM_SIZE = 35_000`, ignoring `LOADGEN_WASM_BYTES_FOR_TESTING` — the config stellar-core honors (`sampleDiscrete`, `TxGenerator.cpp:1647`). So supercluster missions that deliberately upload small WASMs (`WithSmallLoadgenOptions` → `[(1024,1)]`, "intended to fit within the default limits") still uploaded 35 KB on henyey, exceeding the genesis `maxContractSizeBytes` (2000) and forcing an otherwise-unnecessary per-tx-limit upgrade in the mission.

## Fix

- Parse `LOADGEN_WASM_BYTES_FOR_TESTING` and `LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING` into `TestingConfig` (`compat_config.rs`).
- Sample the per-upload size from them in `soroban_random_wasm_transaction` via `sample_wasm_size` (parity with core's `sampleDiscrete`), defaulting to `DEFAULT_WASM_SIZE` when unset.
- Unit tests: `test_sample_wasm_size`.

## Validation

SSC `MixedImageLoadGenerationAllNewImage` (all-henyey) with the mission's `UpgradeSorobanTxLimits` step **removed**: the soroban_upload phase completed `submitted=200` with **no `maxContractSize` rejections** (henyey now uploads 1 KB, matching core). Pairs with #3604 for full mixed-image SSC validation.

Note: an unrelated residual flake in the create_upgrade *setup* phase (tracked under #3602/#3604) is being investigated separately; it is upstream of and orthogonal to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)