### PR TITLE
Verify uploaded wasm on-ledger before deploying instances (completes #3602)

### DIFF
--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -1615,30 +1615,6 @@ impl LoadGenerator {
         }
     }
 
-    /// Wait until every submitted transaction has been applied (accounts
-    /// synced) — and, for Soroban setup modes, until the deployed contract
-    /// code + instance entries actually exist on-ledger — before declaring the
-    /// run complete.
-    ///
-    /// Parity: stellar-core `LoadGenerator::waitTillComplete()`
-    /// (`src/simulation/LoadGenerator.cpp:1345`) gates completion on BOTH
-    /// `checkAccountSynced().empty()` AND `checkSorobanStateSynced(cfg).empty()`
-    /// each ledger, timing out after `TIMEOUT_NUM_LEDGERS`. The Soroban-state
-    /// gate is load-bearing for the create_upgrade flow (#3602): under the
-    /// genesis `MinimumSorobanNetworkConfig` (`ledgerMaxTxCount = 1`,
-    /// `ledgerMaxInstructions = 2_500_000`) the upgrade-setup `create_contract`
-    /// deploy competes for the single per-ledger Soroban slot and can be
-    /// surge-excluded for several ledgers. Account-sync alone returns as soon
-    /// as the source seq advances (a *failed* apply still bumps the seq), so
-    /// without the state gate the run could report "complete" while the
-    /// contract instance was never created — the subsequent `create_upgrade`
-    /// then writes nothing resolvable and the SSC arm hangs. We poll ~once per
-    /// second and bound the wait by ledger advancement.
-    ///
-    /// On timeout with the Soroban state still unsynced (setup modes), the run
-    /// is marked failed — parity with stellar-core `emitFailure` — so the
-    /// mission fails fast and is retried, rather than silently proceeding to a
-    /// create_upgrade that can never resolve.
     /// Wait until the uploaded setup wasm (`code_key`) exists on-ledger before
     /// deploying contract instances that reference it by hash.
     ///
@@ -1675,6 +1651,30 @@ impl LoadGenerator {
         }
     }
 
+    /// Wait until every submitted transaction has been applied (accounts
+    /// synced) — and, for Soroban setup modes, until the deployed contract
+    /// code + instance entries actually exist on-ledger — before declaring the
+    /// run complete.
+    ///
+    /// Parity: stellar-core `LoadGenerator::waitTillComplete()`
+    /// (`src/simulation/LoadGenerator.cpp:1345`) gates completion on BOTH
+    /// `checkAccountSynced().empty()` AND `checkSorobanStateSynced(cfg).empty()`
+    /// each ledger, timing out after `TIMEOUT_NUM_LEDGERS`. The Soroban-state
+    /// gate is load-bearing for the create_upgrade flow (#3602): under the
+    /// genesis `MinimumSorobanNetworkConfig` (`ledgerMaxTxCount = 1`,
+    /// `ledgerMaxInstructions = 2_500_000`) the upgrade-setup `create_contract`
+    /// deploy competes for the single per-ledger Soroban slot and can be
+    /// surge-excluded for several ledgers. Account-sync alone returns as soon
+    /// as the source seq advances (a *failed* apply still bumps the seq), so
+    /// without the state gate the run could report "complete" while the
+    /// contract instance was never created — the subsequent `create_upgrade`
+    /// then writes nothing resolvable and the SSC arm hangs. We poll ~once per
+    /// second and bound the wait by ledger advancement.
+    ///
+    /// On timeout with the Soroban state still unsynced (setup modes), the run
+    /// is marked failed — parity with stellar-core `emitFailure` — so the
+    /// mission fails fast and is retried, rather than silently proceeding to a
+    /// create_upgrade that can never resolve.
     async fn wait_till_complete(&mut self, config: &GeneratedLoadConfig) {
         const TIMEOUT_NUM_LEDGERS: u32 = 30;
         let check_soroban = config.mode.is_soroban_setup();

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -1515,10 +1515,22 @@ impl LoadGenerator {
                         config.n_wasms == 0,
                         "Expected all wasms to be uploaded before transitioning to phase 2"
                     );
+                    // Parity: stellar-core does not deploy instances until the
+                    // uploaded wasms are VERIFIED on-ledger — "waitTillFinished
+                    // will set nTxs for instances once wasms have been verified"
+                    // (LoadGenerator.cpp:360-362). The deploy (create_contract)
+                    // references the uploaded wasm by hash; under the genesis
+                    // 1-soroban-tx-per-ledger limit the deploy can otherwise win
+                    // its ledger slot before the upload applies and fail with
+                    // Storage(MissingValue) (code not found), leaving the
+                    // instance uncreated (soroban_synced=false) and the
+                    // create_upgrade unable to resolve (#3602 residual flake).
+                    self.wait_setup_code_applied().await;
                     config.n_txs = config.n_instances;
                     info!(
                         n_instances = config.n_instances,
-                        "Setup phase 1 complete, transitioning to instance deployment"
+                        "Setup phase 1 complete (wasm verified on-ledger), \
+                         transitioning to instance deployment"
                     );
                 } else {
                     // Parity: stellar-core does not emit `loadgen.run.complete`
@@ -1627,6 +1639,42 @@ impl LoadGenerator {
     /// is marked failed — parity with stellar-core `emitFailure` — so the
     /// mission fails fast and is retried, rather than silently proceeding to a
     /// create_upgrade that can never resolve.
+    /// Wait until the uploaded setup wasm (`code_key`) exists on-ledger before
+    /// deploying contract instances that reference it by hash.
+    ///
+    /// Parity: stellar-core's loadgen verifies uploaded wasms before setting
+    /// `nTxs` for the instance-deploy phase (`LoadGenerator.cpp:360-362`).
+    /// Without this gate, the `create_contract` deploy can be included before
+    /// the upload applies (under the genesis 1-soroban-tx-per-ledger limit) and
+    /// fail with `Storage(MissingValue)`. Bounded by ledger advancement so a
+    /// never-applied upload can't hang the run.
+    async fn wait_setup_code_applied(&mut self) {
+        const TIMEOUT_NUM_LEDGERS: u32 = 30;
+        let Some(code_key) = self.code_key.clone() else {
+            return;
+        };
+        let start_ledger = self.tx_generator.app.current_ledger_seq();
+        loop {
+            if matches!(self.tx_generator.app.has_ledger_entry(&code_key), Ok(true)) {
+                return;
+            }
+            let elapsed = self
+                .tx_generator
+                .app
+                .current_ledger_seq()
+                .saturating_sub(start_ledger);
+            if elapsed >= TIMEOUT_NUM_LEDGERS {
+                warn!(
+                    timeout_ledgers = TIMEOUT_NUM_LEDGERS,
+                    "setup: uploaded wasm not on-ledger before deploy timeout; \
+                     deploy may fail with MissingValue"
+                );
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
     async fn wait_till_complete(&mut self, config: &GeneratedLoadConfig) {
         const TIMEOUT_NUM_LEDGERS: u32 = 30;
         let check_soroban = config.mode.is_soroban_setup();


### PR DESCRIPTION
Completes the fix for #3602. PR #3604 fixed the upload-metering half but a residual ~50% setup flake remained on some clusters; this is the root cause of that residual.

## Root cause (captured via instrumented SSC run)

The upgrade-setup `create_contract` **deploy could be included before the `upload_wasm` it depends on applied**:

```
Setup phase 1 complete (upload submitted) -> phase 2 (deploy)
create_contract FAILED  Error(Storage, MissingValue)   <- deploy applied
upload_wasm OK cpu=1666573                              <- upload applied (5s later)
```

The deploy references the uploaded WASM by hash. Under the genesis `MinimumSorobanNetworkConfig` (`ledgerMaxTxCount = 1`), the deploy could win the single per-ledger Soroban slot before the upload applied, so the `ContractCode` wasn't in storage yet → `Storage(MissingValue)` → the contract instance is never created → `soroban_state_synced` stays false → `create_upgrade` never resolves and the mission hangs at the arm.

henyey transitioned setup phase 1→2 on **submission**; stellar-core gates it on **verification**: *"waitTillFinished will set nTxs for instances once wasms have been verified"* (`LoadGenerator.cpp:360-362`). The flake was timing/cluster-sensitive, which is why #3604's validation (on a favorable cluster) missed it.

## Fix

`wait_setup_code_applied()`: before transitioning Soroban setup from phase 1 (upload) to phase 2 (deploy), wait until the uploaded code key exists on-ledger (`has_ledger_entry`), bounded by ledger advancement. The deploy is then submitted only after the upload has applied (and the ledger-close module-cache warming has compiled it), so it reliably finds the code and instantiates within budget.

## Validation

SSC `MixedImageLoadGenerationAllNewImage` (all-henyey): **10/10 pass** on the exact cluster that was **~50% flaky** (2/4 with the prior image) before this change. `henyey-simulation` lib tests green.

Builds on #3604 (upload metering) and #3606 (upload-size config) — together these make henyey-majority mixed-image missions reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)