### PR TITLE
Reset loadgen account-sequence cache between runs

### DIFF
--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -1364,13 +1364,6 @@ impl LoadGenerator {
         }
     }
 
-    /// Initialize the account pool for a load generation run.
-    ///
-    /// Populates `accounts_available` with account IDs `[offset, offset + n_accounts)`.
-    /// For Soroban invoke modes, builds the `contract_instances` map via round-robin
-    /// assignment of deployed contract instances to accounts.
-    ///
-    /// Matches stellar-core `LoadGenerator::start()`.
     /// Reset all per-run account state before starting a new load run.
     ///
     /// Parity port of stellar-core `LoadGenerator::reset()`
@@ -1399,6 +1392,13 @@ impl LoadGenerator {
         self.tx_generator.reset();
     }
 
+    /// Initialize the account pool for a load generation run.
+    ///
+    /// Populates `accounts_available` with account IDs `[offset, offset + n_accounts)`.
+    /// For Soroban invoke modes, builds the `contract_instances` map via round-robin
+    /// assignment of deployed contract instances to accounts.
+    ///
+    /// Matches stellar-core `LoadGenerator::start()`.
     fn start(&mut self, config: &mut GeneratedLoadConfig) {
         self.start_time = Some(Instant::now());
         self.total_submitted = 0;

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -754,13 +754,45 @@ impl TxGenerator {
     /// `load_account`). An account that cannot be loaded yet (None / Err) is
     /// treated as not-yet-synced so the caller keeps waiting.
     pub fn check_accounts_synced(&self) -> bool {
-        for account in self.accounts.values() {
-            match self.app.load_account_sequence(&account.account_id) {
-                Ok(Some(db_seq)) if db_seq == account.sequence_number => {}
+        Self::accounts_synced_with(self.accounts.values(), |id| {
+            self.app.load_account_sequence(id).ok().flatten()
+        })
+    }
+
+    /// Pure core of [`check_accounts_synced`]: `true` when every account's
+    /// in-memory (expected) sequence number equals its on-ledger sequence
+    /// number, as reported by `load_seq` (returns `None` when the account
+    /// can't be loaded yet — treated as not-yet-synced). Factored out so the
+    /// cross-run synced semantics can be unit-tested without a live `App`.
+    fn accounts_synced_with<'a, F>(
+        accounts: impl Iterator<Item = &'a TestAccount>,
+        load_seq: F,
+    ) -> bool
+    where
+        F: Fn(&AccountId) -> Option<i64>,
+    {
+        for account in accounts {
+            match load_seq(&account.account_id) {
+                Some(db_seq) if db_seq == account.sequence_number => {}
                 _ => return false,
             }
         }
         true
+    }
+
+    /// Clear the per-account sequence-number cache.
+    ///
+    /// Parity port of stellar-core `TxGenerator::reset()`
+    /// (`src/simulation/TxGenerator.cpp`), which `LoadGenerator::reset()` calls
+    /// before every run. The cache holds each account's *expected* (in-memory)
+    /// sequence number; carrying it across independent loadgen runs poisons
+    /// [`check_accounts_synced`] — a later run would keep inspecting a prior
+    /// run's accounts, whose expected seq may never match the ledger (e.g. a
+    /// tx that was submitted but dropped on queue overflow left the cached seq
+    /// permanently ahead of on-ledger), so `wait_till_complete` times out even
+    /// though the current run's own accounts are fully applied.
+    pub fn reset(&mut self) {
+        self.accounts.clear();
     }
 
     /// Build CreateAccount operations for a range of accounts.
@@ -1339,14 +1371,40 @@ impl LoadGenerator {
     /// assignment of deployed contract instances to accounts.
     ///
     /// Matches stellar-core `LoadGenerator::start()`.
+    /// Reset all per-run account state before starting a new load run.
+    ///
+    /// Parity port of stellar-core `LoadGenerator::reset()`
+    /// (`src/simulation/LoadGenerator.cpp`): clears the available/in-use account
+    /// pools, the invoke contract-instance map, and — via `TxGenerator::reset()`
+    /// — the per-account sequence-number cache.
+    ///
+    /// Clearing the seq cache between runs is required for parity. A single
+    /// `LoadGenerator` instance is reused across every `/generateload` run (it
+    /// holds the Soroban deploy state across upgrade-setup → create_upgrade), so
+    /// without this reset the cache accumulates every prior run's accounts.
+    /// [`check_accounts_synced`] then keeps inspecting them, and any account
+    /// left with an expected seq ahead of the ledger (a tx dropped on queue
+    /// overflow under heavy load) makes a later run — even create_upgrade with a
+    /// single tx — time out in `wait_till_complete` despite its own accounts
+    /// being fully applied.
+    ///
+    /// Soroban deploy state (`code_key` / `contract_instance_keys`) is
+    /// intentionally NOT cleared here so the create_upgrade run can consume the
+    /// contract deployed by the preceding upgrade-setup run; setup modes clear
+    /// it separately via [`reset_soroban_state`](Self::reset_soroban_state).
+    pub fn reset(&mut self) {
+        self.accounts_available.clear();
+        self.accounts_in_use.clear();
+        self.contract_instances.clear();
+        self.tx_generator.reset();
+    }
+
     fn start(&mut self, config: &mut GeneratedLoadConfig) {
         self.start_time = Some(Instant::now());
         self.total_submitted = 0;
         self.last_second = 0;
         self.failed = false;
-        self.accounts_available.clear();
-        self.accounts_in_use.clear();
-        self.contract_instances.clear();
+        self.reset();
 
         // Overlay-only gate (LoadGenerator.cpp:293): SOROBAN_INVOKE_APPLY_LOAD
         // may only run in overlay-only mode. stellar-core resets + throws; we
@@ -2875,6 +2933,58 @@ mod tests {
             &instances,
             |_| true
         ));
+    }
+
+    /// Regression for the cross-run account-cache poisoning that made every
+    /// henyey loadgen run after the first time out `wait_till_complete`.
+    ///
+    /// A single `LoadGenerator` is reused across runs, so `TxGenerator::accounts`
+    /// accumulated every prior run's accounts. If any carried an expected
+    /// sequence number ahead of the ledger (e.g. a tx dropped on queue overflow
+    /// under heavy load), `check_accounts_synced` stayed false forever — a later
+    /// run (e.g. create_upgrade with a single tx) timed out even though its own
+    /// account was fully applied. stellar-core avoids this by calling
+    /// `mTxGenerator.reset()` in `LoadGenerator::reset()` before each run.
+    #[test]
+    fn test_account_cache_reset_clears_cross_run_poisoning() {
+        // Prior run's account: cached/expected seq 42, but only seq 10 ever
+        // applied on-ledger (later txs dropped) → permanently unsynced.
+        let mut prior = TestAccount::from_name("TestAccount-prior", 0);
+        prior.sequence_number = 42;
+        // Current run's account: cached seq 7, fully applied on-ledger.
+        let current = TestAccount::from_name("TestAccount-current", 7);
+
+        let prior_id = prior.account_id.clone();
+        let current_id = current.account_id.clone();
+        let ledger_seq = move |id: &AccountId| -> Option<i64> {
+            if *id == prior_id {
+                Some(10)
+            } else if *id == current_id {
+                Some(7)
+            } else {
+                None
+            }
+        };
+
+        // With the prior run's account still cached, the current run is NEVER
+        // reported synced — the poisoning that timed out wait_till_complete.
+        let mut accounts: BTreeMap<u64, TestAccount> = BTreeMap::new();
+        accounts.insert(0, prior);
+        accounts.insert(1, current.clone());
+        assert!(
+            !TxGenerator::accounts_synced_with(accounts.values(), &ledger_seq),
+            "a stale prior-run account must poison the synced check (pre-reset state)"
+        );
+
+        // reset() (parity with TxGenerator::reset()) drops every cached account.
+        // After it, only the current run's (applied) account is re-cached → the
+        // run is reported synced and wait_till_complete completes promptly.
+        accounts.clear();
+        accounts.insert(1, current);
+        assert!(
+            TxGenerator::accounts_synced_with(accounts.values(), &ledger_seq),
+            "after reset, only the current run's applied account remains → synced"
+        );
     }
 
     #[test]

--- a/crates/simulation/tests/app_simulation.rs
+++ b/crates/simulation/tests/app_simulation.rs
@@ -7,7 +7,7 @@ use henyey_crypto::SecretKey;
 use henyey_herder::scp_verify::PostVerifyReason;
 use henyey_simulation::{
     poll_until, CrashScope, GeneratedLoadConfig, LoadGenerator, LoadStep, PollOutcome, Simulation,
-    SimulationMode, Topologies,
+    SimulationMode, TestAccount, Topologies,
 };
 use serial_test::serial;
 
@@ -772,6 +772,76 @@ async fn test_load_account_sequence_finds_root_account() {
     assert!(
         seq_final.is_some(),
         "load_account_sequence must find root account after several ledger closes (bug #2357)"
+    );
+
+    sim.stop_all_nodes().await.expect("stop nodes");
+}
+
+/// Regression: `LoadGenerator::reset()` must clear the per-account sequence
+/// cache between runs, matching stellar-core's `mTxGenerator.reset()`.
+///
+/// A single `LoadGenerator` is reused across every `/generateload` run. Without
+/// the reset the cache carries every prior run's accounts forever; any left
+/// with an expected seq ahead of the ledger (a tx dropped on queue overflow
+/// under heavy load) keeps `check_accounts_synced` false for all later runs, so
+/// each subsequent run times out in `wait_till_complete` even though its own
+/// accounts are fully applied — the henyey-majority slowdown.
+///
+/// FAILS on main: `LoadGenerator::reset()` does not exist and `start()` never
+/// clears the seq cache.
+#[tokio::test]
+#[serial]
+async fn test_loadgen_reset_clears_account_seq_cache() {
+    let mut sim = Simulation::with_network(
+        SimulationMode::OverLoopback,
+        "Test SDF Network ; September 2015",
+    );
+
+    let seed = Hash256::hash(b"LOADGEN_RESET_NODE");
+    let secret = SecretKey::from_seed(&seed.0);
+    let quorum_set = QuorumSetConfig {
+        threshold_percent: 100,
+        validators: vec![secret.public_key().to_strkey()],
+        inner_sets: Vec::new(),
+    };
+    sim.add_app_node("node0", secret, quorum_set);
+    sim.start_all_nodes().await;
+    wait_for_app_state(&sim, "node0", AppState::Validating, Duration::from_secs(10)).await;
+    let app = sim.app("node0").expect("running app node");
+
+    let mut lg = LoadGenerator::new(app, "Test SDF Network ; September 2015".to_string());
+
+    // Residue from a prior run: an account whose cached expected seq (999) is
+    // far ahead of anything on-ledger (it isn't even funded), exactly the
+    // dropped-tx residue that poisons check_accounts_synced.
+    let sk = SecretKey::from_seed(&Hash256::hash(b"LOADGEN_RESET_POISON").0);
+    let pk = sk.public_key();
+    let account_id = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+        stellar_xdr::Uint256(*pk.as_bytes()),
+    ));
+    let poisoned = TestAccount {
+        secret_key: sk,
+        account_id,
+        sequence_number: 999,
+    };
+    lg.tx_generator_mut().accounts_mut().insert(123, poisoned);
+
+    assert_eq!(lg.tx_generator().accounts().len(), 1);
+    assert!(
+        !lg.tx_generator().check_accounts_synced(),
+        "a stale, never-applied prior-run account must read as not-synced"
+    );
+
+    // reset() (called by start() before every run) must drop the cached account.
+    lg.reset();
+
+    assert!(
+        lg.tx_generator().accounts().is_empty(),
+        "reset() must clear the per-account seq cache (parity with mTxGenerator.reset())"
+    );
+    assert!(
+        lg.tx_generator().check_accounts_synced(),
+        "an empty seq cache is trivially synced, so a fresh run completes promptly"
     );
 
     sim.stop_all_nodes().await.expect("stop nodes");


### PR DESCRIPTION
## What

Reset the loadgen `TxGenerator` account-sequence cache between runs, matching
stellar-core's `LoadGenerator::reset()` → `mTxGenerator.reset()`.

Fixes #3609.

## Why

A single `LoadGenerator` is reused across every `/generateload` run (it holds
the Soroban deploy state across upgrade-setup → create_upgrade). Its
`TxGenerator` account cache — each account's expected in-memory sequence number
— was never cleared between runs. `check_accounts_synced()` (the gate
`wait_till_complete` waits on) iterates the whole accumulated cache, so every run
after the first inspects all prior runs' accounts. Any account left seq-ahead of
the ledger (a tx dropped/rejected before inclusion under load) keeps the cache
unsynced forever, so each subsequent run burns its full 30-ledger
`wait_till_complete` timeout (~150s) despite its own accounts being applied.

In the henyey-majority mixed-image mission this made every run after the first
time out, doubling the mission time vs core-majority.

## Fix

`LoadGenerator::reset()` (parity port of stellar-core's `reset()`) clears the
available/in-use account pools, the invoke contract-instance map, and — via a
new `TxGenerator::reset()` — the per-account seq cache; `start()` calls it.
Soroban deploy state (`code_key` / `contract_instance_keys`) is intentionally
left intact so create_upgrade can still consume the preceding setup's contract.

## Tests

- Unit: `test_account_cache_reset_clears_cross_run_poisoning` — a stale prior-run
  account poisons the synced check; reset clears it.
- Integration: `test_loadgen_reset_clears_account_seq_cache` — `reset()` empties
  the live `TxGenerator` cache and the run reads as synced again.
- `cargo test -p henyey-simulation` (97 lib + the new integration test) and
  `cargo clippy -p henyey-simulation` clean.

## Validation (supercluster, identical config, only the henyey image differs)

| composition | image | duration | wait-timeouts |
|---|---|---|---|
| 2c1h core-majority | — | 8m51s | runs 2–4 fast |
| 1c2h henyey-majority | unfixed | 18m20s | 4 (runs 1–4) |
| 1c2h henyey-majority | fixed | 11m2s | 1 (run 1 only) |

All passed (exit 0, consistency OK, create_upgrade applied). Removes 3 of the 4
per-run timeouts (~7m18s).

## Follow-up

A residual ~2m11s gap vs core-majority remains: run 1 alone still times out once
(a few accounts left seq-ahead within a single run — not cross-run poisoning).
Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
