### PR TITLE
Reload loadgen account sequence number + handle Banned as skip

### DIFF
--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -754,13 +754,45 @@ impl TxGenerator {
     /// `load_account`). An account that cannot be loaded yet (None / Err) is
     /// treated as not-yet-synced so the caller keeps waiting.
     pub fn check_accounts_synced(&self) -> bool {
-        for account in self.accounts.values() {
-            match self.app.load_account_sequence(&account.account_id) {
-                Ok(Some(db_seq)) if db_seq == account.sequence_number => {}
+        Self::accounts_synced_with(self.accounts.values(), |id| {
+            self.app.load_account_sequence(id).ok().flatten()
+        })
+    }
+
+    /// Pure core of [`check_accounts_synced`]: `true` when every account's
+    /// in-memory (expected) sequence number equals its on-ledger sequence
+    /// number, as reported by `load_seq` (returns `None` when the account
+    /// can't be loaded yet — treated as not-yet-synced). Factored out so the
+    /// cross-run synced semantics can be unit-tested without a live `App`.
+    fn accounts_synced_with<'a, F>(
+        accounts: impl Iterator<Item = &'a TestAccount>,
+        load_seq: F,
+    ) -> bool
+    where
+        F: Fn(&AccountId) -> Option<i64>,
+    {
+        for account in accounts {
+            match load_seq(&account.account_id) {
+                Some(db_seq) if db_seq == account.sequence_number => {}
                 _ => return false,
             }
         }
         true
+    }
+
+    /// Clear the per-account sequence-number cache.
+    ///
+    /// Parity port of stellar-core `TxGenerator::reset()`
+    /// (`src/simulation/TxGenerator.cpp`), which `LoadGenerator::reset()` calls
+    /// before every run. The cache holds each account's *expected* (in-memory)
+    /// sequence number; carrying it across independent loadgen runs poisons
+    /// [`check_accounts_synced`] — a later run would keep inspecting a prior
+    /// run's accounts, whose expected seq may never match the ledger (e.g. a
+    /// tx that was submitted but dropped on queue overflow left the cached seq
+    /// permanently ahead of on-ledger), so `wait_till_complete` times out even
+    /// though the current run's own accounts are fully applied.
+    pub fn reset(&mut self) {
+        self.accounts.clear();
     }
 
     /// Build CreateAccount operations for a range of accounts.
@@ -1339,14 +1371,40 @@ impl LoadGenerator {
     /// assignment of deployed contract instances to accounts.
     ///
     /// Matches stellar-core `LoadGenerator::start()`.
+    /// Reset all per-run account state before starting a new load run.
+    ///
+    /// Parity port of stellar-core `LoadGenerator::reset()`
+    /// (`src/simulation/LoadGenerator.cpp`): clears the available/in-use account
+    /// pools, the invoke contract-instance map, and — via `TxGenerator::reset()`
+    /// — the per-account sequence-number cache.
+    ///
+    /// Clearing the seq cache between runs is required for parity. A single
+    /// `LoadGenerator` instance is reused across every `/generateload` run (it
+    /// holds the Soroban deploy state across upgrade-setup → create_upgrade), so
+    /// without this reset the cache accumulates every prior run's accounts.
+    /// [`check_accounts_synced`] then keeps inspecting them, and any account
+    /// left with an expected seq ahead of the ledger (a tx dropped on queue
+    /// overflow under heavy load) makes a later run — even create_upgrade with a
+    /// single tx — time out in `wait_till_complete` despite its own accounts
+    /// being fully applied.
+    ///
+    /// Soroban deploy state (`code_key` / `contract_instance_keys`) is
+    /// intentionally NOT cleared here so the create_upgrade run can consume the
+    /// contract deployed by the preceding upgrade-setup run; setup modes clear
+    /// it separately via [`reset_soroban_state`](Self::reset_soroban_state).
+    pub fn reset(&mut self) {
+        self.accounts_available.clear();
+        self.accounts_in_use.clear();
+        self.contract_instances.clear();
+        self.tx_generator.reset();
+    }
+
     fn start(&mut self, config: &mut GeneratedLoadConfig) {
         self.start_time = Some(Instant::now());
         self.total_submitted = 0;
         self.last_second = 0;
         self.failed = false;
-        self.accounts_available.clear();
-        self.accounts_in_use.clear();
-        self.contract_instances.clear();
+        self.reset();
 
         // Overlay-only gate (LoadGenerator.cpp:293): SOROBAN_INVOKE_APPLY_LOAD
         // may only run in overlay-only mode. stellar-core resets + throws; we
@@ -2875,6 +2933,58 @@ mod tests {
             &instances,
             |_| true
         ));
+    }
+
+    /// Regression for the cross-run account-cache poisoning that made every
+    /// henyey loadgen run after the first time out `wait_till_complete`.
+    ///
+    /// A single `LoadGenerator` is reused across runs, so `TxGenerator::accounts`
+    /// accumulated every prior run's accounts. If any carried an expected
+    /// sequence number ahead of the ledger (e.g. a tx dropped on queue overflow
+    /// under heavy load), `check_accounts_synced` stayed false forever — a later
+    /// run (e.g. create_upgrade with a single tx) timed out even though its own
+    /// account was fully applied. stellar-core avoids this by calling
+    /// `mTxGenerator.reset()` in `LoadGenerator::reset()` before each run.
+    #[test]
+    fn test_account_cache_reset_clears_cross_run_poisoning() {
+        // Prior run's account: cached/expected seq 42, but only seq 10 ever
+        // applied on-ledger (later txs dropped) → permanently unsynced.
+        let mut prior = TestAccount::from_name("TestAccount-prior", 0);
+        prior.sequence_number = 42;
+        // Current run's account: cached seq 7, fully applied on-ledger.
+        let current = TestAccount::from_name("TestAccount-current", 7);
+
+        let prior_id = prior.account_id.clone();
+        let current_id = current.account_id.clone();
+        let ledger_seq = move |id: &AccountId| -> Option<i64> {
+            if *id == prior_id {
+                Some(10)
+            } else if *id == current_id {
+                Some(7)
+            } else {
+                None
+            }
+        };
+
+        // With the prior run's account still cached, the current run is NEVER
+        // reported synced — the poisoning that timed out wait_till_complete.
+        let mut accounts: BTreeMap<u64, TestAccount> = BTreeMap::new();
+        accounts.insert(0, prior);
+        accounts.insert(1, current.clone());
+        assert!(
+            !TxGenerator::accounts_synced_with(accounts.values(), &ledger_seq),
+            "a stale prior-run account must poison the synced check (pre-reset state)"
+        );
+
+        // reset() (parity with TxGenerator::reset()) drops every cached account.
+        // After it, only the current run's (applied) account is re-cached → the
+        // run is reported synced and wait_till_complete completes promptly.
+        accounts.clear();
+        accounts.insert(1, current);
+        assert!(
+            TxGenerator::accounts_synced_with(accounts.values(), &ledger_seq),
+            "after reset, only the current run's applied account remains → synced"
+        );
     }
 
     #[test]

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -131,6 +131,16 @@ fn classify_submit_result(
         TxQueueResult::TryAgainLater | TxQueueResult::FeeTooLow if skip_low_fee_txs => {
             SubmitAction::SkipLowFee
         }
+        // A banned tx cannot be re-added for `ban_depth` ledgers. stellar-core's
+        // canAdd returns ADD_STATUS_TRY_AGAIN_LATER for this (TransactionQueue.cpp
+        // :327); the loadgen's correct response is to skip and roll back the
+        // seqnum (re-submitting the same — deterministic — tx would just hit the
+        // ban again until it expires). The account is re-selected on a later
+        // step and, once the ban lifts (or its prior tx applies), proceeds. This
+        // pairs with the #3611 seq refresh: after a tx ages out and is banned,
+        // the refresh regenerates the SAME tx, so banned must be a skip, not a
+        // hard failure.
+        TxQueueResult::Banned => SubmitAction::SkipLowFee,
         // Transient tx-queue backpressure (#3574): retry the same tx with a
         // back-off until the generous cap, then surface a genuinely wedged
         // queue as a run failure. `TryAgainLater` only reaches here when
@@ -741,6 +751,30 @@ impl TxGenerator {
             }
         }
         false
+    }
+
+    /// Refresh a cached account's sequence number from the ledger before
+    /// generating a transaction for it, unless running in overlay-only mode.
+    ///
+    /// Parity port of stellar-core `TxGenerator::maybeLoadAccountSequenceNumber`
+    /// (`src/simulation/TxGenerator.cpp`): in overlay-only mode the on-disk
+    /// seqnums stay frozen at genesis while the local counter is authoritative,
+    /// so the reload is skipped; otherwise the on-ledger seqnum is reloaded.
+    ///
+    /// Required for #3611. Under sustained load a tx can be discarded from the
+    /// tx queue without applying — it ages out at `pending_depth` (4) ledgers
+    /// and is auto-banned (`TransactionQueue::shift`, matching stellar-core).
+    /// The account is then no longer pending, so the loadgen re-selects it, but
+    /// its cached in-memory seq is still ahead of on-ledger. Without this
+    /// refresh the next tx is generated with a *gapped* seq (> on-ledger + 1),
+    /// which tx-set selection can never include (it only selects a contiguous
+    /// run from on-ledger + 1). Those gapped txns accumulate, the account never
+    /// syncs, and `wait_till_complete` burns its full timeout. Reloading the
+    /// on-ledger seq first regenerates the tx at the correct next seq.
+    pub fn maybe_load_account_sequence_number(&mut self, account_id: u64, overlay_only_mode: bool) {
+        if !overlay_only_mode {
+            self.load_account(account_id);
+        }
     }
 
     /// Return `true` when every cached account's on-ledger sequence number
@@ -1958,6 +1992,16 @@ impl LoadGenerator {
     ) -> bool {
         let mut num_tries = 0u32;
         let mut queue_full_tries = 0u32;
+
+        // Parity: stellar-core refreshes the source account's on-ledger
+        // sequence number before building each loadgen tx
+        // (TxGenerator::maybeLoadAccountSequenceNumber). This heals the seq gap
+        // that otherwise forms when a prior tx for this account was discarded
+        // from the queue (aged-out/banned at pending_depth ledgers under load)
+        // without applying — see the method docs and #3611. No-op for accounts
+        // not yet cached (the first tx loads its seq via find_account).
+        self.tx_generator
+            .maybe_load_account_sequence_number(source_account_id, config.overlay_only_mode);
 
         loop {
             // Generate the transaction based on mode
@@ -3200,6 +3244,30 @@ mod tests {
             ),
             SubmitAction::Accept,
         );
+    }
+
+    /// #3611: a `Banned` result must map to `SkipLowFee` (skip + seqnum
+    /// rollback), NOT `Fail`. After the #3611 seq refresh regenerates a tx whose
+    /// prior copy aged out and was banned, re-submitting the same deterministic
+    /// tx hits the ban; the run must skip it (the account proceeds once the ban
+    /// lifts) rather than abort. Independent of `skip_low_fee_txs` and the
+    /// retry caps. FAILS on origin/main (Banned routes to the `_ => Fail` arm).
+    #[test]
+    fn test_classify_submit_result_banned_skips_not_fails() {
+        for skip_low_fee in [true, false] {
+            assert_eq!(
+                classify_submit_result(
+                    TxQueueResult::Banned,
+                    /* queue_full_tries */ 0,
+                    /* bad_seq_tries */ 0,
+                    skip_low_fee,
+                    QUEUE_FULL_MAX_TRIES,
+                    LoadGenMode::Pay,
+                ),
+                SubmitAction::SkipLowFee,
+                "Banned must skip (rollback), not fail (skip_low_fee_txs={skip_low_fee})"
+            );
+        }
     }
 
     /// #3574: a genuinely wedged queue still surfaces — at the cap, `QueueFull`

--- a/crates/simulation/tests/app_simulation.rs
+++ b/crates/simulation/tests/app_simulation.rs
@@ -7,7 +7,7 @@ use henyey_crypto::SecretKey;
 use henyey_herder::scp_verify::PostVerifyReason;
 use henyey_simulation::{
     poll_until, CrashScope, GeneratedLoadConfig, LoadGenerator, LoadStep, PollOutcome, Simulation,
-    SimulationMode, Topologies,
+    SimulationMode, TestAccount, Topologies,
 };
 use serial_test::serial;
 
@@ -772,6 +772,76 @@ async fn test_load_account_sequence_finds_root_account() {
     assert!(
         seq_final.is_some(),
         "load_account_sequence must find root account after several ledger closes (bug #2357)"
+    );
+
+    sim.stop_all_nodes().await.expect("stop nodes");
+}
+
+/// Regression: `LoadGenerator::reset()` must clear the per-account sequence
+/// cache between runs, matching stellar-core's `mTxGenerator.reset()`.
+///
+/// A single `LoadGenerator` is reused across every `/generateload` run. Without
+/// the reset the cache carries every prior run's accounts forever; any left
+/// with an expected seq ahead of the ledger (a tx dropped on queue overflow
+/// under heavy load) keeps `check_accounts_synced` false for all later runs, so
+/// each subsequent run times out in `wait_till_complete` even though its own
+/// accounts are fully applied — the henyey-majority slowdown.
+///
+/// FAILS on main: `LoadGenerator::reset()` does not exist and `start()` never
+/// clears the seq cache.
+#[tokio::test]
+#[serial]
+async fn test_loadgen_reset_clears_account_seq_cache() {
+    let mut sim = Simulation::with_network(
+        SimulationMode::OverLoopback,
+        "Test SDF Network ; September 2015",
+    );
+
+    let seed = Hash256::hash(b"LOADGEN_RESET_NODE");
+    let secret = SecretKey::from_seed(&seed.0);
+    let quorum_set = QuorumSetConfig {
+        threshold_percent: 100,
+        validators: vec![secret.public_key().to_strkey()],
+        inner_sets: Vec::new(),
+    };
+    sim.add_app_node("node0", secret, quorum_set);
+    sim.start_all_nodes().await;
+    wait_for_app_state(&sim, "node0", AppState::Validating, Duration::from_secs(10)).await;
+    let app = sim.app("node0").expect("running app node");
+
+    let mut lg = LoadGenerator::new(app, "Test SDF Network ; September 2015".to_string());
+
+    // Residue from a prior run: an account whose cached expected seq (999) is
+    // far ahead of anything on-ledger (it isn't even funded), exactly the
+    // dropped-tx residue that poisons check_accounts_synced.
+    let sk = SecretKey::from_seed(&Hash256::hash(b"LOADGEN_RESET_POISON").0);
+    let pk = sk.public_key();
+    let account_id = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+        stellar_xdr::Uint256(*pk.as_bytes()),
+    ));
+    let poisoned = TestAccount {
+        secret_key: sk,
+        account_id,
+        sequence_number: 999,
+    };
+    lg.tx_generator_mut().accounts_mut().insert(123, poisoned);
+
+    assert_eq!(lg.tx_generator().accounts().len(), 1);
+    assert!(
+        !lg.tx_generator().check_accounts_synced(),
+        "a stale, never-applied prior-run account must read as not-synced"
+    );
+
+    // reset() (called by start() before every run) must drop the cached account.
+    lg.reset();
+
+    assert!(
+        lg.tx_generator().accounts().is_empty(),
+        "reset() must clear the per-account seq cache (parity with mTxGenerator.reset())"
+    );
+    assert!(
+        lg.tx_generator().check_accounts_synced(),
+        "an empty seq cache is trivially synced, so a fresh run completes promptly"
     );
 
     sim.stop_all_nodes().await.expect("stop nodes");

--- a/crates/simulation/tests/app_simulation.rs
+++ b/crates/simulation/tests/app_simulation.rs
@@ -847,6 +847,91 @@ async fn test_loadgen_reset_clears_account_seq_cache() {
     sim.stop_all_nodes().await.expect("stop nodes");
 }
 
+/// Regression for #3611: the loadgen must refresh an account's on-ledger
+/// sequence number before generating a tx (parity with stellar-core's
+/// `TxGenerator::maybeLoadAccountSequenceNumber`), so a seq gap left by a tx
+/// that was discarded from the queue without applying is healed instead of
+/// producing an unselectable gapped tx.
+///
+/// FAILS on main: `maybe_load_account_sequence_number` does not exist and the
+/// loadgen trusts its cached in-memory seq.
+#[tokio::test]
+#[serial]
+async fn test_loadgen_reloads_account_seq_before_tx() {
+    let mut sim = Simulation::with_network(
+        SimulationMode::OverLoopback,
+        "Test SDF Network ; September 2015",
+    );
+
+    let seed = Hash256::hash(b"LOADGEN_RELOAD_SEQ_NODE");
+    let secret = SecretKey::from_seed(&seed.0);
+    let quorum_set = QuorumSetConfig {
+        threshold_percent: 100,
+        validators: vec![secret.public_key().to_strkey()],
+        inner_sets: Vec::new(),
+    };
+    sim.add_app_node("node0", secret, quorum_set);
+    sim.start_all_nodes().await;
+    wait_for_app_state(&sim, "node0", AppState::Validating, Duration::from_secs(10)).await;
+    let app = sim.app("node0").expect("running app node");
+
+    // The genesis root account exists on-ledger at a known (low) seq.
+    let network_id = henyey_common::NetworkId::from_passphrase("Test SDF Network ; September 2015");
+    let root_sk = henyey_crypto::SecretKey::from_seed(network_id.as_bytes());
+    let root_pk = root_sk.public_key();
+    let root_aid = stellar_xdr::AccountId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+        stellar_xdr::Uint256(*root_pk.as_bytes()),
+    ));
+    let on_ledger = app
+        .load_account_sequence(&root_aid)
+        .expect("load root seq")
+        .expect("root account exists");
+
+    let mut lg = LoadGenerator::new(app, "Test SDF Network ; September 2015".to_string());
+
+    // Cache the root account under a numeric id with an in-memory seq far AHEAD
+    // of on-ledger — exactly the residue of a tx that was queued (seq advanced)
+    // then discarded without applying.
+    let ahead = on_ledger + 1000;
+    lg.tx_generator_mut().accounts_mut().insert(
+        7,
+        TestAccount {
+            secret_key: root_sk,
+            account_id: root_aid,
+            sequence_number: ahead,
+        },
+    );
+
+    // Overlay-only mode: seqnums are frozen, so the cached value is left ahead.
+    lg.tx_generator_mut()
+        .maybe_load_account_sequence_number(7, true);
+    assert_eq!(
+        lg.tx_generator()
+            .accounts()
+            .get(&7)
+            .unwrap()
+            .sequence_number,
+        ahead,
+        "overlay-only mode must NOT reload the sequence number"
+    );
+
+    // Normal mode: the on-ledger seq is reloaded, healing the gap so the next
+    // generated tx is at on-ledger + 1 rather than a gapped, unselectable seq.
+    lg.tx_generator_mut()
+        .maybe_load_account_sequence_number(7, false);
+    assert_eq!(
+        lg.tx_generator()
+            .accounts()
+            .get(&7)
+            .unwrap()
+            .sequence_number,
+        on_ledger,
+        "normal mode must reload the on-ledger sequence number (heals the gap)"
+    );
+
+    sim.stop_all_nodes().await.expect("stop nodes");
+}
+
 /// Regression test for #2357 with a pair topology: App::load_account_sequence
 /// must return the root account's sequence number, not Ok(None).
 #[tokio::test]


### PR DESCRIPTION
## What

Two loadgen parity/robustness fixes for the mixed-image heavy-load missions:

1. **Reload the source account's on-ledger sequence number before generating each loadgen tx**
   (parity port of stellar-core `TxGenerator::maybeLoadAccountSequenceNumber`), skipped only in
   overlay-only mode. Heals the seq gap that otherwise forms when a queued tx is discarded without
   applying (aged out / banned at `pending_depth` ledgers under load): without the refresh the
   cached in-memory seq stays ahead of on-ledger and the next tx is generated with a *gapped* seq
   that tx-set selection can never include.

2. **Handle a `Banned` submission result as a skip (rollback), not a hard run failure.** The seq
   refresh regenerates the same (deterministic) tx that just aged out and was banned, so
   re-submitting hits the ban until it expires; stellar-core's `canAdd` returns
   `ADD_STATUS_TRY_AGAIN_LATER` for banned txs (TransactionQueue.cpp:327), and the loadgen's matching
   response is to skip and let the account proceed on a later step. Previously `Banned` fell through
   to the `_ => Fail` arm and aborted the whole run.

## Why

Investigating #3611 (henyey-majority run-1 `wait_till_complete` timeout). A diagnostic build
confirmed (1) the seq refresh eliminates the gapped-account exclusion (0 gapped vs ~290/selection),
and (2) without the banned-skip, a single banned re-submission hard-fails the run.

## Scope / honesty

These fix two real bugs and are parity-correct, but they do **not** by themselves close #3611's
run-1 timeout. Root cause of that timeout is a tx-queue admission divergence (henyey's age-eviction
caps the queue below capacity so the surge fee-floor never engages, vs core rejecting low-fee txns at
admission) — filed as **#3612**. End-to-end the heavy 1c2h mission is unchanged (~10m49s); the value
here is correctness (no seq gaps, no Banned hard-fail).

## Tests

- unit: `test_classify_submit_result_banned_skips_not_fails` (Banned → SkipLowFee, not Fail).
- integration: `test_loadgen_reloads_account_seq_before_tx` (refresh heals an ahead-of-ledger cached
  seq in normal mode; no-op in overlay-only mode).
- `cargo test -p henyey-simulation` (98 lib + integration) and clippy clean.

Relates to #3611; follow-up #3612. Stacked on #3610 (loadgen account-cache reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
