### PR TITLE
Track live maxTxSetSize in classic tx-queue capacity

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -1086,6 +1086,15 @@ impl App {
             self.herder.ledger_close_duration(),
         );
 
+        // Seed the classic queue ops capacity from the restored header's
+        // `maxTxSetSize` so admission tracks the live capacity from the very
+        // first ledger, before the first post-restore close runs (#3612).
+        self.herder.tx_queue().update_classic_queue_capacity(
+            header
+                .max_tx_set_size
+                .saturating_mul(POOL_LEDGER_MULTIPLIER),
+        );
+
         // Seed Soroban per-tx limits and dynamic resource limits from network config.
         if let Some(soroban_info) = self.soroban_network_info() {
             self.herder.tx_queue().set_soroban_limits(SorobanTxLimits {
@@ -2769,6 +2778,17 @@ impl App {
             if let Some(s) = selection_limit {
                 herder.tx_queue().update_soroban_selection_limits(s);
             }
+
+            // Re-derive the classic queue ops capacity from the live ledger
+            // header's `maxTxSetSize` so the limiter tracks `UpgradeMaxTxSetSize`.
+            // Parity: stellar-core `TxQueueLimiter::reset` rebuilds capacity from
+            // `maxScaledLedgerResources(false) = maxTxSetSize * mPoolLedgerMultiplier`
+            // every ledger close (#3612). Henyey froze this at app construction.
+            herder.tx_queue().update_classic_queue_capacity(
+                result_header
+                    .max_tx_set_size
+                    .saturating_mul(POOL_LEDGER_MULTIPLIER),
+            );
 
             let shift_result = herder.tx_queue().shift();
             crate::metrics::CLOSE_TX_QUEUE_SHIFT_UPDATE_SECONDS

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -1256,6 +1256,13 @@ impl EvictionThresholds {
     fn reset_soroban(&self) {
         self.soroban_lane_fees.write().clear();
     }
+
+    /// Reset only the global ops eviction threshold. Used when the classic ops
+    /// capacity changes (#3612) so a stale fee floor computed against the old
+    /// capacity does not reject admissions under the new one.
+    fn reset_global_ops(&self) {
+        *self.global_fees.write() = None;
+    }
 }
 
 /// ## Lock Ordering (MUST be followed by all methods)
@@ -1312,6 +1319,18 @@ pub struct TransactionQueue {
     /// Separate from queue-admission limits which apply
     /// `SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER` (2x).
     dynamic_selection_soroban_resources: RwLock<Option<Resource>>,
+    /// Dynamic classic queue ops capacity (already scaled by
+    /// POOL_LEDGER_MULTIPLIER), re-derived from the live ledger header's
+    /// `maxTxSetSize` on every ledger close. Takes precedence over the
+    /// construction-time `config.max_queue_ops` / `config.max_size`.
+    ///
+    /// Parity: stellar-core `TxQueueLimiter::reset(ledgerVersion)` rebuilds the
+    /// classic generic-lane capacity from `maxScaledLedgerResources(false)` =
+    /// `maxLedgerResources(false) * mPoolLedgerMultiplier`
+    /// (`TxQueueLimiter.cpp:61,244`), reading the live `maxTxSetSize` each close.
+    /// Henyey froze the capacity at app construction, so `UpgradeMaxTxSetSize`
+    /// was never tracked. See #3612.
+    dynamic_max_queue_ops: RwLock<Option<u32>>,
     /// Arbitrage flood damper. Acquired after `store` lock in `broadcast_with_visitor`
     /// and `shift()`. Cleared by `shift()`, preserved by `reset_and_rebuild()`.
     arb_damper: parking_lot::Mutex<arb_flood_damping::ArbitrageFloodDamper>,
@@ -1384,6 +1403,7 @@ impl TransactionQueue {
             skip_fee_balance_check: std::sync::atomic::AtomicBool::new(false),
             dynamic_queue_soroban_resources: RwLock::new(None),
             dynamic_selection_soroban_resources: RwLock::new(None),
+            dynamic_max_queue_ops: RwLock::new(None),
             arb_damper: parking_lot::Mutex::new(arb_damper),
             arb_tx_seen: std::sync::atomic::AtomicU64::new(0),
             arb_tx_dropped: std::sync::atomic::AtomicU64::new(0),
@@ -1475,6 +1495,52 @@ impl TransactionQueue {
             dynamic.clone()
         } else {
             self.config.max_queue_soroban_resources.clone()
+        }
+    }
+
+    /// Update the classic queue ops capacity from the live ledger header.
+    ///
+    /// `scaled_max_queue_ops` is the live `maxTxSetSize` already multiplied by
+    /// the pool ledger multiplier (the caller scales, mirroring how
+    /// [`update_soroban_resource_limits`](Self::update_soroban_resource_limits)
+    /// receives a pre-scaled `Resource`). Called on every ledger close so the
+    /// classic limiter tracks `UpgradeMaxTxSetSize`.
+    ///
+    /// Parity: stellar-core `TxQueueLimiter::reset(ledgerVersion)` rebuilds the
+    /// generic-lane capacity from `maxScaledLedgerResources(false)`
+    /// (`TxQueueLimiter.cpp:244`), which reads the live `maxTxSetSize` and scales
+    /// by `mPoolLedgerMultiplier`. The persistent global-ops eviction queue is
+    /// rebuilt lazily with the new limit, and the stale global-ops fee floor is
+    /// cleared so it cannot reject admissions against the old capacity. See #3612.
+    pub fn update_classic_queue_capacity(&self, scaled_max_queue_ops: u32) {
+        *self.dynamic_max_queue_ops.write() = Some(scaled_max_queue_ops);
+        // Drop the persistent global-ops queue so it rebuilds with the new
+        // limit on the next admission, and clear the stale global fee floor.
+        self.store.write().global_ops_queue = None;
+        self.eviction_thresholds.reset_global_ops();
+    }
+
+    /// Return the effective classic queue ops capacity.
+    ///
+    /// Prefers the dynamic value (re-derived from the live `maxTxSetSize` each
+    /// ledger close via [`update_classic_queue_capacity`](Self::update_classic_queue_capacity))
+    /// over the construction-time `config.max_queue_ops`. Returns `None` only
+    /// when neither is configured (classic ops gate disabled). See #3612.
+    pub fn effective_max_queue_ops(&self) -> Option<u32> {
+        let dynamic = *self.dynamic_max_queue_ops.read();
+        dynamic.or(self.config.max_queue_ops)
+    }
+
+    /// Return the effective classic queue tx-count cap.
+    ///
+    /// Tracks the live `maxTxSetSize` (scaled) when a dynamic capacity is set,
+    /// falling back to the construction-time `config.max_size`. Keeps the
+    /// tx-count guard consistent with the ops capacity after an
+    /// `UpgradeMaxTxSetSize`. See #3612.
+    pub fn effective_max_size(&self) -> usize {
+        match *self.dynamic_max_queue_ops.read() {
+            Some(ops) => ops as usize,
+            None => self.config.max_size,
         }
     }
 
@@ -1969,7 +2035,7 @@ impl TransactionQueue {
             lane_fees[GENERIC_LANE].as_ref(),
             &queued.fee_rate,
         ));
-        if self.config.max_queue_ops.is_some() {
+        if self.effective_max_queue_ops().is_some() {
             min_fee = min_fee.max(min_inclusion_fee_to_beat(
                 global_fee.as_ref(),
                 &queued.fee_rate,
@@ -2017,7 +2083,7 @@ impl TransactionQueue {
             }
         }
 
-        if self.config.max_queue_ops.is_some() {
+        if self.effective_max_queue_ops().is_some() {
             let global_fee = *self.eviction_thresholds.global_fees.read();
             if min_inclusion_fee_to_beat(global_fee.as_ref(), &candidate.queued.fee_rate) > 0 {
                 return Err(TxQueueResult::FeeTooLow);
@@ -2123,7 +2189,7 @@ impl TransactionQueue {
             }
         }
 
-        if let Some(limit) = self.config.max_queue_ops {
+        if let Some(limit) = self.effective_max_queue_ops() {
             store.ensure_global_ops_queue(limit as i64, candidate.ledger_version);
             let exclusion = build_eviction_exclusion(
                 store.global_ops_queue.as_ref().unwrap(),
@@ -2457,7 +2523,7 @@ impl TransactionQueue {
         ledger_version: u32,
     ) -> std::result::Result<(), TxQueueResult> {
         let effective_len = store.len().saturating_sub(pending_eviction_count);
-        if effective_len < self.config.max_size {
+        if effective_len < self.effective_max_size() {
             return Ok(());
         }
 

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -5627,6 +5627,43 @@ mod tests {
         assert_eq!(eff, dynamic_limit);
     }
 
+    /// Regression for #3612: the classic queue's effective ops/size capacity
+    /// must track the live `maxTxSetSize` (scaled by POOL_LEDGER_MULTIPLIER and
+    /// applied via `update_classic_queue_capacity`) on every ledger close,
+    /// mirroring stellar-core `TxQueueLimiter::reset` rebuilding capacity from
+    /// `maxScaledLedgerResources`. Before the fix the capacity is frozen at the
+    /// construction value and ignores `UpgradeMaxTxSetSize`.
+    #[test]
+    fn test_classic_queue_capacity_tracks_live_max_tx_set_size() {
+        // Construction-time capacity: maxTxSetSize=50, multiplier=2 → 100 ops.
+        const MULT: u32 = 2;
+        let initial_ops = 50 * MULT;
+        let config = TxQueueConfig {
+            max_size: initial_ops as usize,
+            max_queue_ops: Some(initial_ops),
+            ..Default::default()
+        };
+        let queue = TransactionQueue::new(config);
+
+        // Before any per-ledger update, the effective capacity is the
+        // construction-time value.
+        assert_eq!(queue.effective_max_queue_ops(), Some(initial_ops));
+        assert_eq!(queue.effective_max_size(), initial_ops as usize);
+
+        // UpgradeMaxTxSetSize raises maxTxSetSize 50 → 200; the per-ledger-close
+        // reset must grow the effective capacity to 200 * MULT = 400 ops.
+        let upgraded_ops = 200 * MULT;
+        queue.update_classic_queue_capacity(upgraded_ops);
+        assert_eq!(queue.effective_max_queue_ops(), Some(upgraded_ops));
+        assert_eq!(queue.effective_max_size(), upgraded_ops as usize);
+
+        // A downgrade 200 → 50 must shrink the capacity symmetrically.
+        let downgraded_ops = 50 * MULT;
+        queue.update_classic_queue_capacity(downgraded_ops);
+        assert_eq!(queue.effective_max_queue_ops(), Some(downgraded_ops));
+        assert_eq!(queue.effective_max_size(), downgraded_ops as usize);
+    }
+
     /// Without static config, effective returns None until dynamic update.
     #[test]
     fn test_effective_queue_soroban_resources_none_without_config() {


### PR DESCRIPTION
Refs #3612

## Summary

The classic transaction queue's ops capacity (`max_queue_ops`) and tx-count cap (`max_size`) were frozen at app construction (`1000 * POOL_LEDGER_MULTIPLIER`, `crates/app/src/app/mod.rs`) and never re-derived when `UpgradeMaxTxSetSize` changed the live ledger header. Stellar-core's `TxQueueLimiter::reset(ledgerVersion)` rebuilds the classic generic-lane capacity from `maxScaledLedgerResources(false) = maxTxSetSize * mPoolLedgerMultiplier` (`TxQueueLimiter.cpp:61,244`) on **every** ledger close, so core's classic queue capacity tracks `maxTxSetSize`; henyey's did not — a latent deterministic parity gap (issue option 3).

This PR re-derives the classic ops capacity from the live header's `max_tx_set_size` on each ledger close (and at bootstrap/restore), scaled by `POOL_LEDGER_MULTIPLIER`, preferring it over the construction-time config:

- `TransactionQueue::update_classic_queue_capacity(scaled_max_queue_ops)` stores the live capacity, drops the persistent global-ops eviction queue so it rebuilds with the new limit, and clears the stale global fee floor.
- `effective_max_queue_ops()` / `effective_max_size()` prefer the dynamic value over `config.max_queue_ops` / `config.max_size`; the admission gates (`check_and_collect_evictions`, `ensure_queue_capacity`, fee-floor checks) now read the effective values.
- Wired into the per-ledger-close path (`ledger_close.rs`, inside the `spawn_blocking` closure where `result_header.max_tx_set_size` is available) and the bootstrap seed (`seed_validation_context`), mirroring the existing dynamic-Soroban-limits pattern.

**Parity scope:** only the classic ops capacity tracks `maxTxSetSize`, matching core. The DEX lane (`mMaxDexOperations`) and byte allowances are independent fixed config in core and are **not** scaled by `maxTxSetSize`, so they are left unchanged (avoiding the divergence that scaling them would introduce).

This closes the **deterministic capacity-tracking** parity gap only. The emergent age-vs-capacity eviction-timing root cause behind #3611's loadgen run-1 divergence (issue options 1/2) requires the mixed-image runtime comparison and stays **operator-gated** per the converged plan — hence `Refs #3612`, not `Fixes`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3612#issuecomment-4800989945)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings` (the CI gate) passes
- [x] `cargo test -p henyey-herder --lib tx_queue` — 308 passed
- [x] `cargo build -p henyey-herder -p henyey-app --all-targets` clean

## Regression test

- **Test:** `crates/herder/src/tx_queue/mod.rs::test_classic_queue_capacity_tracks_live_max_tx_set_size`
- **Pre-fix:** committed as `019f2398` — verified FAILED (capacity frozen; `update_classic_queue_capacity` / `effective_max_queue_ops` / `effective_max_size` did not exist).
- **Post-fix:** verified PASSES after `ddf921d9` — effective capacity grows 50→200 (×2 → 400 ops) on upgrade and shrinks 200→50 on downgrade.

## Deviations from plan

The converged plan named `TxQueueLimiter::reset` (`crates/herder/src/tx_queue_limiter.rs:227`) as the fix site. During implementation I found `TxQueueLimiter` is **only constructed in its own unit tests** — it is not in the production admission path. The production classic-capacity gate is `TransactionQueue` / `QueueStore` in `crates/herder/src/tx_queue/mod.rs`, driven by `TxQueueConfig.max_queue_ops` / `max_size` (frozen at `mod.rs` construction, exactly as the issue's option 3 describes). Fixing only the dead `TxQueueLimiter::reset` would have been a no-op. The fix is therefore implemented in the real production component; the design (re-derive classic capacity from the live `maxTxSetSize` per ledger close) is unchanged from the plan's intent.

The plan/issue also mentioned scaling "DEX-lane / classic-byte-allowance × POOL_LEDGER_MULTIPLIER" with `maxTxSetSize`. Verified against core: only the generic-lane **ops** capacity comes from `maxScaledLedgerResources`; DEX/byte allowances are independent. Scaling them would diverge from core, so they are intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)