### PR TITLE
Tune vendored supercluster for henyey heavy mixed-image runs

### DIFF
--- a/vendor/supercluster/VENDOR.md
+++ b/vendor/supercluster/VENDOR.md
@@ -37,7 +37,35 @@ and is reproducible without a separate fork.
      henyey-majority at 20k accts / 50k txs vs ~5 min light).
 
 Used to validate the henyey create_upgrade / loadgen fixes (#3601, #3602,
-#3604, #3606, #3607).
+#3604, #3606, #3607, #3609/#3610, #3613, #3614).
+
+## Running the heavy mixed-image A/B (runbook)
+
+To reproduce the core-majority vs henyey-majority comparison on Namespace (nsc):
+
+- **Resources:** the mission uses `SmallTestResources`, retuned in this fork to
+  512MB request / 2.5GB limit. Upstream's 256MB limit OOM-kills the henyey image
+  under heavy load; the low request keeps three core pods schedulable on one
+  ~8GB nsc node. (See `StellarKubeSpecs.SmallTestCoreResourceRequirements`.)
+- **Pre-fund accounts at genesis** with `--genesis-test-account-count <N>` (e.g.
+  `20000`, matching `--num-accounts`). Without it the loadgen's account-creation
+  step is unreliable against the BUILD_TESTS core image on these clusters
+  (core's loadgen aborts `"Account <id> must exist in the DB"`; henyey's fails
+  `TxNoAccount`). Genesis pre-funding skips creation and goes straight to the
+  payment/soroban runs.
+- **Tx-rate matters — pick a *sustainable* rate.** The network's per-ledger
+  apply ceiling is `max_tx_set_size / ledger_close_time` ≈ `1000 / 5.4s` ≈
+  **185 tx/s**. `--tx-rate 250` *over-drives* the network (queue backlog ages
+  out → loadgen accounts left unsynced → run-1 `wait_till_complete` timeouts on
+  BOTH images; see henyey #3611/#3612). Use `--tx-rate 150` for a representative
+  run: at a sustainable rate henyey-majority matches core-majority (~10.5 min,
+  0 run-1 timeouts). Only use 250 to deliberately exercise over-capacity
+  behavior.
+- **Example (per composition):**
+  `--num-accounts 20000 --num-txs 50000 --tx-rate 150 --genesis-test-account-count 20000`,
+  run `MixedImageLoadGenerationWithOldImageMajority` (2c1h, core-majority) and
+  `MixedImageLoadGenerationWithNewImageMajority` (1c2h, henyey-majority) with
+  `--core-http-via-pod-exec --image <henyey> --old-image <core BUILD_TESTS>`.
 
 ## Updating
 

--- a/vendor/supercluster/src/FSLibrary/MissionMixedImageLoadGeneration.fs
+++ b/vendor/supercluster/src/FSLibrary/MissionMixedImageLoadGeneration.fs
@@ -70,6 +70,10 @@ let mixedImageLoadGeneration (oldImageNodeCount: int) (context: MissionContext) 
 
     let context =
         { context.WithSmallLoadgenOptions with
+              // SmallTestResources is tuned in this vendored fork (512MB req /
+              // 2.5GB limit) so the henyey image is not OOM-killed under the
+              // heavy mixed-image profile on nsc 8GB nodes. See StellarKubeSpecs
+              // SmallTestCoreResourceRequirements and VENDOR.md.
               coreResources = SmallTestResources
               numAccounts = context.numAccounts
               numTxs = context.numTxs

--- a/vendor/supercluster/src/FSLibrary/StellarKubeSpecs.fs
+++ b/vendor/supercluster/src/FSLibrary/StellarKubeSpecs.fs
@@ -140,9 +140,14 @@ let UpgradeCoreResourceRequirements : V1ResourceRequirements =
     makeResourceRequirements 1000 256 4000 14000
 
 let SmallTestCoreResourceRequirements : V1ResourceRequirements =
-    // When running most missions, there are few core nodes, so each
-    // gets 0.1 vCPUs with bursting to 1vCPU and 256MB RAM guaranteed.
-    makeResourceRequirements 100 256 1000 256
+    // Vendored-fork tuning for henyey mixed-image runs on Namespace (nsc)
+    // single-node ~8GB clusters. Upstream's 256MB *limit* OOM-kills the henyey
+    // image under the heavy mixed-image profile (20k genesis accounts + sustained
+    // load). Keep the memory *request* low (512MB) so three core pods still
+    // schedule on one 8GB node, but raise the *limit* to 2.5GB so the henyey
+    // working set doesn't get OOM-killed (limits oversubscribe; only the
+    // loadgen-driver node spikes). CPU: 0.25 vCPU guaranteed, burst to 3.
+    makeResourceRequirements 250 512 3000 2560
 
 let MediumTestCoreResourceRequirements : V1ResourceRequirements =
     // About 2x more resources than for small tests, 0.2 vCPU/512 MB,


### PR DESCRIPTION
## What

Fold the heavy mixed-image A/B harness workarounds into the vendored supercluster
fork so the core-majority vs henyey-majority comparison reproduces without
rediscovering them each time. Docs/harness only — no henyey code change.

- **`SmallTestCoreResourceRequirements`**: 256MB limit → **512MB request / 2.5GB
  limit**. Upstream's 256MB limit OOM-kills the henyey image under the heavy
  profile (20k genesis accounts + sustained load). The low request keeps three
  core pods schedulable on a single ~8GB Namespace (nsc) node; the high limit
  (which oversubscribes — only the loadgen-driver node spikes) avoids the OOM.
- **`VENDOR.md` runbook** for the heavy A/B:
  - pre-fund accounts with `--genesis-test-account-count` (the loadgen
    account-creation step is unreliable against the BUILD_TESTS core image on
    these clusters);
  - tx-rate guidance: the per-ledger apply ceiling is ~185 tx/s
    (1000-op cap / ~5.4s ledger), so `--tx-rate 150` is representative
    (henyey-majority matches core-majority, 0 run-1 timeouts) while `--tx-rate
    250` deliberately over-drives **both** images (the #3611/#3612 run-1
    artifact);
  - an example invocation per composition.

## Why

While validating the loadgen fixes (#3610/#3613/#3614) these workarounds were
applied to a scratch copy and never folded back. Capturing them here is what lets
the next person run the heavy A/B out of the box. See #3611/#3612 for the
over-drive context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
