### PR TITLE
Refresh vendored-supercluster docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ cargo test -p henyey-scp
 
 See [docs/testing.md](docs/testing.md) for the full testing guide including CI pipeline details, debugging failures, and the test matrix.
 
+### Mixed-image interop (henyey ↔ stellar-core)
+
+End-to-end interop is exercised with the Stellar Supercluster harness, vendored
+in-tree at [`vendor/supercluster/`](vendor/supercluster/). See
+[`docs/supercluster-henyey-mixed-mission.md`](docs/supercluster-henyey-mixed-mission.md)
+for running a mixed-image mission (and the BUILD_TESTS core-image prerequisite),
+[`docs/supercluster-nsc-workflow.md`](docs/supercluster-nsc-workflow.md) for the
+`nsc` build/publish/provision workflow, and
+[`vendor/supercluster/VENDOR.md`](vendor/supercluster/VENDOR.md) for the harness
+provenance and heavy-load runbook.
+
 ## Run
 
 ### Full Node Mode (Testnet)

--- a/docs/supercluster-henyey-mixed-mission.md
+++ b/docs/supercluster-henyey-mixed-mission.md
@@ -1,111 +1,138 @@
 # Henyey Supercluster Mixed-Image Mission
 
-**Companion docs:** [`supercluster-nsc-workflow.md`](./supercluster-nsc-workflow.md), [`supercluster-feasibility.md`](./supercluster-feasibility.md).
+**Companion docs:** [`supercluster-nsc-workflow.md`](./supercluster-nsc-workflow.md)
+(building/publishing the henyey image and provisioning clusters via `nsc`),
+[`supercluster-feasibility.md`](./supercluster-feasibility.md), and
+[`../vendor/supercluster/VENDOR.md`](../vendor/supercluster/VENDOR.md)
+(the vendored harness: provenance, fork changes, and the heavy-load runbook).
 
-This runbook documents the current Henyey integration point with Stellar Supercluster (SSC): injecting a Henyey image as the **new image** in an existing mixed-image SSC mission.
+This runbook documents how to run a Henyey ↔ stellar-core **mixed-image**
+Supercluster (SSC) mission: henyey is injected as one image and stellar-core as
+the other, and the two interoperate in a single network.
 
-## Current Verified State
+## The harness is vendored in-tree
 
-The current verified mission is Supercluster's built-in:
+The SSC harness is vendored at [`vendor/supercluster/`](../vendor/supercluster/)
+(a snapshot of our fork; see `VENDOR.md` for provenance and the changes on top of
+upstream). Run the dotnet harness from there — no separate checkout or fork is
+needed, and the `--core-http-via-pod-exec` routing is already bundled.
 
-```text
-MixedImageLoadGenerationWithOldImageMajority
+## Prerequisite: a BUILD_TESTS stellar-core image
+
+Loadgen missions **require a `BUILD_TESTS` stellar-core image** as the
+`--old-image`. The `generateload` HTTP command and `GENESIS_TEST_ACCOUNT_COUNT`
+account creation are both `#ifdef BUILD_TESTS` in stellar-core, so **no public
+`stellar/stellar-core` tag works** — `stellar/stellar-core:latest` has neither
+and the mission cannot drive load against it.
+
+Build one from stellar-core's canonical `docker/Dockerfile.testing`, **minus**
+the `--enable-next-protocol-version-unsafe-for-production` flag (so the max
+protocol stays at the released version, matching henyey) and **minus** the
+privileged sysctl / `--enable-tracy` lines (tests stay on by default):
+
+```bash
+nsc docker login
+nsc build -f Dockerfile.testing --platform linux/amd64 --push \
+  -n nscr.io/<workspace>/stellar-core-testing:v27.0.0 .
 ```
 
-Henyey is not hardcoded in Supercluster. It is injected at runtime with the `--image` option. The stellar-core image is supplied as `--old-image`.
+Pin the **digest** (not the tag) when running missions. The currently published
+image is `nscr.io/k4jkul01t5rr0/stellar-core-testing@sha256:bc1de6bc77e729b6d34a67a325114d0d08b9ff30cecaa022087f8fec1754aece`
+(stellar-core v27.0.0 == the henyey submodule pin; has `test` / `gen-fuzz` /
+`pregenerate-loadgen-txs`). Match the protocol version to henyey's.
 
-Verified command shape:
+## Missions
+
+The vendored fork (`src/FSLibrary/MissionMixedImageLoadGeneration.fs`) provides
+four compositions over a 3-node network. The loadgen runs on the **majority**
+image (`coreSets[0]`):
+
+| mission | core / henyey | loadgen driver |
+|---|---|---|
+| `MixedImageLoadGenerationWithOldImageMajority` | 2 core / 1 henyey | stellar-core |
+| `MixedImageLoadGenerationWithNewImageMajority` | 1 core / 2 henyey | henyey |
+| `MixedImageLoadGenerationAllOldImage` | 3 core / 0 henyey | stellar-core (pure-core baseline) |
+| `MixedImageLoadGenerationAllNewImage` | 0 core / 3 henyey | henyey (pure-henyey) |
+
+Henyey is injected with `--image`; stellar-core with `--old-image`. Each mission
+boots both images from genesis, upgrades protocol + `maxTxSetSize`, runs a
+classic payment loadgen, then a Soroban config-upgrade + upload loadgen.
+
+## Running a mission
+
+From `vendor/supercluster/`:
 
 ```bash
 dotnet run --project src/App/App.fsproj --configuration Release -- mission \
-  MixedImageLoadGenerationWithOldImageMajority \
+  MixedImageLoadGenerationWithNewImageMajority \
   --kubeconfig /path/to/kubeconfig \
   --namespace default \
   --destination /path/to/artifacts \
-  --keep-data \
   --core-http-via-pod-exec \
-  --image nscr.io/<workspace>/henyey-ssc:<tag-or-digest> \
-  --old-image stellar/stellar-core:latest \
+  --image nscr.io/<workspace>/henyey:<tag-or-digest> \
+  --old-image nscr.io/<workspace>/stellar-core-testing@sha256:<digest> \
   --probe-timeout 240 \
-  --tx-rate 5 \
-  --num-txs 100 \
-  --num-accounts 100 \
-  --genesis-test-account-count 100
+  --num-accounts 20000 \
+  --num-txs 50000 \
+  --tx-rate 150 \
+  --genesis-test-account-count 20000
 ```
 
-`--core-http-via-pod-exec` requires the Supercluster branch/PR that routes core HTTP requests through pod exec. This is required for Namespace/k3s runners because `.local` ingress names and `svc.cluster.local` names are not resolvable from the local dotnet runner.
+- **`--core-http-via-pod-exec`** is required on Namespace/k3s runners: `.local`
+  ingress names and `svc.cluster.local` names aren't resolvable from the local
+  dotnet runner, so core HTTP is routed through `kubectl exec … curl`.
+- **`--genesis-test-account-count`** (match `--num-accounts`) pre-funds the
+  loadgen accounts at genesis. Without it the loadgen's account-creation step is
+  unreliable against the BUILD_TESTS core image on these clusters.
+- **`--tx-rate`**: pick a *sustainable* rate. The per-ledger apply ceiling is
+  `maxTxSetSize / ledger_close_time` ≈ `1000 / ~5.4s` ≈ **185 tx/s**. `150` is
+  representative; `250` deliberately over-drives the network (both images), which
+  surfaces a loadgen run-1 timeout artifact — see
+  [`VENDOR.md` → Running the heavy mixed-image A/B](../vendor/supercluster/VENDOR.md)
+  and henyey issues #3611 / #3612.
 
-## How Henyey Is Injected
+See [`supercluster-nsc-workflow.md`](./supercluster-nsc-workflow.md) for building
+and publishing the henyey image and provisioning the cluster + kubeconfig.
 
-In Supercluster, `MixedImageLoadGenerationWithOldImageMajority` is defined in:
+## How henyey is injected
 
-```text
-src/FSLibrary/MissionMixedImageLoadGeneration.fs
-```
-
-The relevant logic is:
+`mixedImageLoadGeneration n` builds `n` old-image (core) nodes and `3 - n`
+new-image (henyey) nodes; `WithOldImageMajority = 2`, `WithNewImageMajority = 1`,
+`AllOldImage = 3`, `AllNewImage = 0`:
 
 ```fsharp
-let newImage = context.image
-let oldImage = GetOrDefault context.oldImage newImage
+let newImage = context.image                           // --image     → henyey
+let oldImage = GetOrDefault context.oldImage newImage  // --old-image  → stellar-core
 ```
 
-For `MixedImageLoadGenerationWithOldImageMajority`:
+## What has been verified
 
-```fsharp
-let mixedImageLoadGenerationWithOldImageMajority (context: MissionContext) =
-    mixedImageLoadGeneration 2 context
-```
+- Henyey launches under the `stellar-core` entrypoint; SSC-generated
+  `stellar-core.cfg` is accepted without manual patching.
+- Henyey parses SSC explicit quorum sets (`"$PUBKEY $NAME"`) and translates SSC
+  invariant regex patterns Rust regex can't parse.
+- Henyey honors stellar-core-compatible `FORCE_SCP` defaulting; overlay framing
+  uses the XDR final-fragment bit; auth certs derive from the configured network
+  passphrase; henyey authenticates with stellar-core peers and participates in
+  quorum (`missing=0`).
+- Compat `/metrics` exposes the error-metric keys SSC's `CheckNoErrorMetrics`
+  expects; SSC HTTP access works via pod-exec.
+- End-to-end loadgen + create_upgrade + soroban-upload missions pass for both
+  core-majority and henyey-majority (after the loadgen fixes #3601/#3602/#3604/
+  #3606/#3607 and #3609/#3610/#3613/#3614).
 
-That means:
+## Genesis parity note
 
-- `--old-image stellar/stellar-core:latest` supplies the 2-node old-image majority.
-- `--image nscr.io/<workspace>/henyey-ssc:<tag-or-digest>` supplies the 1-node new-image minority, which is Henyey.
+stellar-core's genesis ledger-1 is root-only at protocol 0 in **non-BUILD_TESTS**
+images and is invariant to `GENESIS_TEST_ACCOUNT_COUNT`; henyey injects the N
+test accounts into genesis. With a **BUILD_TESTS** core image (as required above)
+both create the N genesis accounts, so `--genesis-test-account-count N` keeps the
+two genesis ledgers consistent. With a non-BUILD_TESTS core image they only match
+at `count=0`.
 
-## What Has Been Verified
+## Artifact checklist
 
-The integration run has verified:
-
-- Henyey image launches under the `stellar-core` entrypoint.
-- SSC-generated `stellar-core.cfg` is accepted without manual patching.
-- Henyey parses SSC explicit quorum sets with `"$PUBKEY $NAME"` validators.
-- Henyey translates SSC invariant regex patterns that Rust regex cannot parse.
-- Henyey honors stellar-core-compatible `FORCE_SCP` defaulting for validator configs.
-- Henyey overlay framing uses the XDR final-fragment bit correctly.
-- Henyey derives overlay auth certificates from the actual configured network passphrase.
-- Henyey authenticates with stellar-core peers.
-- Stellar-core quorum logs show Henyey participating in quorum (`missing=0`) after the overlay/network-ID fixes.
-- SSC HTTP access works with the pod-exec Supercluster branch.
-- Henyey compat `/metrics` exposes the error metric keys that SSC's `CheckNoErrorMetrics` expects.
-
-## Current Caveat
-
-`MixedImageLoadGenerationWithOldImageMajority` starts both images independently from genesis. Because Henyey and stellar-core construct different genesis ledgers, Supercluster's pairwise consistency check can fail at ledger 1:
-
-```text
-Inconsistent peers: ledger 1 = <core> on core-old-0 and <henyey> on core-new-0
-```
-
-This is a mission-shape limitation rather than evidence that Henyey cannot interoperate. A stronger final compatibility mission should start one side from the other's state, for example by using `VersionMixConsensus` or a custom mixed-image mission with `fetchDBFromPeer` / catchup from a common genesis.
-
-## Recommended Next Mission
-
-Use a mixed-image mission with a shared genesis state:
-
-- Build and push Henyey as an SSC-compatible image.
-- Use Henyey as `--image` and stellar-core as `--old-image`.
-- Start an initial stellar-core majority network.
-- Start Henyey from that network's state via database fetch or archive catchup.
-- Require authenticated overlay, advancing ledgers, and common ledger hash agreement after catchup.
-
-## Artifact Checklist
-
-Capture:
-
-- Henyey image tag and digest.
-- Namespace instance metadata and kubeconfig path.
-- Exact Supercluster command.
-- SSC-generated `stellar-core.cfg` for the Henyey pod.
-- Henyey and stellar-core pod logs.
-- Metrics JSON files emitted by Supercluster.
-- Final pass/fail reason and any follow-up issue links.
+Capture: henyey image tag + digest; the BUILD_TESTS core image digest; the
+kubeconfig path and Namespace instance metadata; the exact mission command;
+SSC-generated `stellar-core.cfg`; henyey + stellar-core pod logs; the per-node
+`*.metrics.json` SSC emits; and the final pass/fail reason + follow-up links.

--- a/docs/supercluster-nsc-workflow.md
+++ b/docs/supercluster-nsc-workflow.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-06-16
 **Verified against**: `nsc` `v0.0.522` (commit `30461801`, internal api 160), workspace `StellarDevelopmentFoundation`, registry `nscr.io/k4jkul01t5rr0`.
-**Companion doc**: [`docs/supercluster-feasibility.md`](./supercluster-feasibility.md) (the Phase 0–4 feasibility/execution plan this runbook operationalizes).
+**Companion docs**: [`docs/supercluster-feasibility.md`](./supercluster-feasibility.md) (the Phase 0–4 feasibility/execution plan this runbook operationalizes), [`docs/supercluster-henyey-mixed-mission.md`](./supercluster-henyey-mixed-mission.md) (running a mixed-image mission + the BUILD_TESTS core-image prerequisite), and [`../vendor/supercluster/VENDOR.md`](../vendor/supercluster/VENDOR.md) (the harness is vendored in-tree at `vendor/supercluster/`; provenance + heavy-load runbook).
 
 This is an operator runbook for the [Namespace](https://namespace.so) CLI (`nsc`) covering the build/publish/launch surface that Stellar Supercluster (SSC) missions consume. Every command block below was executed live during authoring and the captured output is real (not fabricated). Where a step belongs to the long-lived mission run rather than the nsc plumbing, it is explicitly marked.
 


### PR DESCRIPTION
## What

Refresh the vendored-supercluster docs, which predated the in-tree vendoring
(#3608) and had drifted. Docs only.

- **`docs/supercluster-henyey-mixed-mission.md`**:
  - point at `vendor/supercluster/` — the harness is in-tree, no external
    checkout/fork needed, pod-exec routing bundled;
  - **fix `--old-image`**: require a BUILD_TESTS stellar-core image (public
    `stellar/stellar-core:latest` has no `generateload` / `GENESIS_TEST_ACCOUNT_COUNT`)
    and document how to build it + the published digest;
  - list all four mission compositions (old/new-majority + all-old/all-new);
  - replace the light `--tx-rate 5` example with the genesis-prefund +
    sustainable-rate (~150 tx/s) example, and add the ~185 tx/s ceiling /
    over-drive caveat (links `VENDOR.md`, #3611/#3612);
  - refresh the genesis-parity note for the BUILD_TESTS image.
- **`README.md`**: add a "Mixed-image interop" subsection under Test linking the
  vendored harness + both runbooks.
- **`docs/supercluster-nsc-workflow.md`**: cross-link the mixed-mission doc and
  `VENDOR.md`.

## Why

A reader couldn't run a mixed-image mission correctly from the docs: nothing
pointed at the vendored copy, and `--old-image stellar/stellar-core:latest` can't
drive loadgen. See the issue for the full gap list.

Closes #3618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
