### PR TITLE
Pass pregenerate-loadgen-txs flags as separate argv tokens (#3627)

### DIFF
--- a/vendor/supercluster/src/FSLibrary/StellarKubeSpecs.fs
+++ b/vendor/supercluster/src/FSLibrary/StellarKubeSpecs.fs
@@ -597,9 +597,9 @@ type NetworkCfg with
                 runCoreIf
                     true
                     [| "pregenerate-loadgen-txs"
-                       "--count " + txs.ToString()
-                       "--accounts " + accounts.ToString()
-                       "--offset " + offset.ToString() |]
+                       "--count"; txs.ToString()
+                       "--accounts"; accounts.ToString()
+                       "--offset"; offset.ToString() |]
 
         let initialCatchup = runCoreIf init.initialCatchup [| "catchup"; "current/0" |]
 


### PR DESCRIPTION
Closes #3627.

The vendored Supercluster harness (`StellarKubeSpecs.fs`) built each pregenerate flag as a single joined token, e.g. `"--count " + txs.ToString()` → the argv element `--count 610000`. stellar-core's parser tolerates that; henyey's clap rejects it (`unexpected argument '--count 610000'`), so henyey nodes crash-looped at the pregenerate init step. Pass flag and value as separate array elements — accepted by both images.

(Harness-side fix; the henyey CLI could also be made to tolerate the joined form, but the separate-token form is the more correct invocation.) Found while running MaxTPSClassic core-vs-henyey on Namespace.