### PR TITLE
Pace loadgen on submit attempts, fail run on PayPregenerated reject

### DIFF
--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -3434,4 +3434,129 @@ mod tests {
             SubmitAction::Accept,
         );
     }
+
+    // ---------------------------------------------------------------------
+    // #3638: per-step pacing counter must track ATTEMPTS (mirroring core's
+    // `++count` / `mTotalSubmitted += count`, LoadGenerator.cpp:900,919), not
+    // just accepts. `n_txs` (work remaining) stays accept-gated. These tests
+    // drive the pure accounting helpers so the pacing logic is deterministic
+    // and decoupled from a live `App`.
+    // ---------------------------------------------------------------------
+
+    /// #3638 key regression: the pacing counter advances by the number of
+    /// ATTEMPTS in a step, not the number of accepts. A step that attempts 5
+    /// txns and accepts 2 must advance `total_submitted` by 5.
+    ///
+    /// FAILS on origin/main: there is no `step_pacing_update` helper and the
+    /// loop adds only accepts (`submitted_this_step += 1` inside `if ok`), so
+    /// the counter would advance by 2.
+    #[test]
+    fn test_pacing_counter_counts_attempts_not_just_accepts() {
+        // Five outcomes: 2 accepted, 3 attempted-but-not-accepted. All five are
+        // attempts; none is "not attempted".
+        let outcomes = [
+            SubmitOutcome::Accepted,
+            SubmitOutcome::NotAccepted,
+            SubmitOutcome::Accepted,
+            SubmitOutcome::NotAccepted,
+            SubmitOutcome::NotAccepted,
+        ];
+        let attempts: i64 = outcomes.iter().filter(|o| o.is_attempt()).count() as i64;
+        let accepts: i64 = outcomes.iter().filter(|o| o.is_accepted()).count() as i64;
+        assert_eq!(attempts, 5, "all five outcomes are attempts");
+        assert_eq!(accepts, 2, "two of the five were accepted");
+
+        // Pacing counter advances by attempts (5), NOT accepts (2).
+        let total_submitted = 100;
+        assert_eq!(
+            step_pacing_update(total_submitted, attempts),
+            105,
+            "pacing counter must advance by attempts (mirrors mTotalSubmitted += count)"
+        );
+    }
+
+    /// #3638: under a rejection-heavy step the next step's deficit must track
+    /// `rate*elapsed - attempts_so_far` (bounded ≈ one step's worth), NOT the
+    /// inflated `rate*elapsed - accepts_so_far`. Driven by feeding scalars into
+    /// the pure pacing helper + the `get_tx_per_step` deficit math (no `Instant`
+    /// flakiness).
+    ///
+    /// FAILS on origin/main: with accepts-only accounting the deficit balloons.
+    #[test]
+    fn test_deficit_tracks_rate_under_rejection() {
+        // tx_rate = 100 tx/s. After 1s the cumulative target is 100.
+        let tx_rate: i64 = 100;
+        let elapsed_ms_after_step_1: i64 = 1000;
+        let target_after_step_1 = elapsed_ms_after_step_1 * tx_rate / 1000; // 100
+
+        // Step 1 attempted all 100 targeted txns but only 10 were accepted
+        // (90 rejected under queue pressure).
+        let attempts_step_1: i64 = 100;
+        let accepts_step_1: i64 = 10;
+
+        // Attempts-based pacing (the fix): total_submitted == attempts.
+        let total_attempts = step_pacing_update(0, attempts_step_1);
+        let deficit_attempts = (target_after_step_1 - total_attempts).max(0);
+
+        // Accepts-only pacing (the bug on main): total_submitted == accepts.
+        let total_accepts = step_pacing_update(0, accepts_step_1);
+        let deficit_accepts = (target_after_step_1 - total_accepts).max(0);
+
+        // The fix keeps the deficit bounded (≈ 0 here — we already attempted the
+        // full step's target), while the bug leaves a 90-tx deficit that the
+        // next step would burst to "catch up".
+        assert_eq!(deficit_attempts, 0, "attempts-based pacing fully amortizes");
+        assert_eq!(
+            deficit_accepts, 90,
+            "accepts-only pacing leaves an inflated deficit (the bug)"
+        );
+        assert!(
+            deficit_attempts < deficit_accepts,
+            "attempts-based deficit must be bounded relative to accepts-only"
+        );
+    }
+
+    /// #3638 (Critic A): a step whose inner loop hits the
+    /// `get_next_available_account -> None` break makes ZERO `submit_tx` calls
+    /// (a non-attempt), so the pacing counter must NOT advance. Guards against
+    /// the fix over-counting the no-account case.
+    #[test]
+    fn test_not_attempted_does_not_advance_pacing() {
+        // Zero attempts this step (the loop broke before any submit_tx call).
+        let total_submitted = 42;
+        assert_eq!(
+            step_pacing_update(total_submitted, 0),
+            42,
+            "a step with no attempts must not advance the pacing counter"
+        );
+        // SubmitOutcome's attempt predicate is the seam the loop uses to decide
+        // whether an iteration counts; only attempted outcomes are attempts.
+        assert!(SubmitOutcome::Accepted.is_attempt());
+        assert!(SubmitOutcome::NotAccepted.is_attempt());
+    }
+
+    /// #3638 (amplifier, same bug): a non-`Added` submit result for
+    /// `PayPregenerated` must fail the run (set `self.failed`), mirroring core's
+    /// `submitTx` PAY_PREGENERATED fail-on-reject (LoadGenerator.cpp:958-963),
+    /// instead of silently draining the next tx from the file.
+    ///
+    /// Driven via the pure decision helper `pay_pregenerated_reject_fails` (the
+    /// plan permits a pure seam over the App harness, since `submit_tx` awaits a
+    /// real `App` and a deterministic reject is not cheaply reproducible).
+    ///
+    /// FAILS on origin/main: the helper does not exist and the PayPregenerated
+    /// arm returns `false` without setting `self.failed`.
+    #[test]
+    fn test_pay_pregenerated_reject_fails_run() {
+        // Any non-Added result fails the run.
+        assert!(pay_pregenerated_reject_fails(&TxQueueResult::QueueFull));
+        assert!(pay_pregenerated_reject_fails(&TxQueueResult::TryAgainLater));
+        assert!(pay_pregenerated_reject_fails(&TxQueueResult::Banned));
+        assert!(pay_pregenerated_reject_fails(&TxQueueResult::FeeTooLow));
+        assert!(pay_pregenerated_reject_fails(&TxQueueResult::Invalid(
+            Some(TxResultCode::TxBadSeq)
+        )));
+        // Added is the only accepted result — does NOT fail the run.
+        assert!(!pay_pregenerated_reject_fails(&TxQueueResult::Added));
+    }
 }

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -156,6 +156,69 @@ fn classify_submit_result(
     }
 }
 
+/// Outcome of an *attempted* transaction submission (one inner-loop iteration
+/// of `generate_load` that actually called [`LoadGenerator::submit_tx`]).
+///
+/// The third, implicit outcome — **not attempted** — is the inner loop breaking
+/// before `submit_tx` is ever called (e.g. `get_next_available_account`
+/// returned `None`). A not-attempted iteration produces no `SubmitOutcome` and
+/// never advances the pacing counter.
+///
+/// #3638: stellar-core's `generateLoad` bumps its pacing counter (`++count`,
+/// then `mTotalSubmitted += count`, LoadGenerator.cpp:900,919) once per
+/// *attempt* regardless of acceptance, while only decrementing the work-
+/// remaining count (`--cfg.nTxs`, line 874) on *acceptance*. Henyey must match:
+/// the pacing counter advances on every attempt (`Accepted` or `NotAccepted`),
+/// `config.n_txs` decrements only on `Accepted`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitOutcome {
+    /// The tx was added to the queue — counts as an attempt AND an accept.
+    Accepted,
+    /// The tx was attempted but the queue did not accept it (classic reject,
+    /// `SkipLowFee`, banned, or — for `PayPregenerated` — a fail-the-run
+    /// reject). Counts as an attempt but NOT an accept.
+    NotAccepted,
+}
+
+impl SubmitOutcome {
+    /// Whether this outcome counts as a pacing **attempt** (advances
+    /// `total_submitted`). Both variants are attempts; the non-attempt case
+    /// never produces a `SubmitOutcome` (the loop breaks before `submit_tx`).
+    fn is_attempt(self) -> bool {
+        matches!(self, SubmitOutcome::Accepted | SubmitOutcome::NotAccepted)
+    }
+
+    /// Whether the tx was accepted into the queue (decrements `n_txs`).
+    fn is_accepted(self) -> bool {
+        matches!(self, SubmitOutcome::Accepted)
+    }
+}
+
+/// Pure pacing-counter update: advance the cumulative `total_submitted`
+/// (pacing) counter by the number of submission *attempts* made in a step.
+///
+/// #3638 parity: mirrors stellar-core's `mTotalSubmitted += count`
+/// (LoadGenerator.cpp:919) where `count` is the per-step attempt tally
+/// (`++count` per submitted tx, line 900) — NOT the accept tally. Feeding this
+/// the attempt count keeps `get_tx_per_step`'s deficit (`target -
+/// total_submitted`) amortizing correctly under queue rejection instead of
+/// ballooning and bursting on the next step.
+fn step_pacing_update(total_submitted: i64, attempts_this_step: i64) -> i64 {
+    total_submitted + attempts_this_step
+}
+
+/// Pure decision: whether a `PayPregenerated` submission result must FAIL the
+/// run.
+///
+/// #3638 parity: stellar-core's `submitTx` sets `mFailed = true` and aborts on
+/// any non-PENDING result for `PAY_PREGENERATED` (LoadGenerator.cpp:958-963) —
+/// each pregenerated tx is read once from the file, so re-submitting would
+/// consume the *next* tx and silently over-drain the file. Only `Added`
+/// (accepted) keeps the run alive.
+fn pay_pregenerated_reject_fails(result: &TxQueueResult) -> bool {
+    !matches!(result, TxQueueResult::Added)
+}
+
 /// Sentinel account ID for the network root account.
 const ROOT_ACCOUNT_ID: u64 = u64::MAX;
 
@@ -1713,7 +1776,13 @@ impl LoadGenerator {
 
             // Submit transactions for this step
             let ledger_num = self.tx_generator.app.current_ledger_seq();
-            let mut submitted_this_step = 0i64;
+            // #3638: count ATTEMPTS, not accepts. The pacing counter
+            // (`total_submitted`) advances per attempt to mirror stellar-core's
+            // `++count` / `mTotalSubmitted += count` (LoadGenerator.cpp:900,
+            // 919), so `get_tx_per_step`'s deficit amortizes under rejection
+            // instead of bursting. `config.n_txs` (work remaining) still
+            // decrements only on accept (core's `--cfg.nTxs`, line 874).
+            let mut attempts_this_step = 0i64;
             for _ in 0..txs_this_step {
                 if config.n_txs == 0 {
                     break;
@@ -1728,21 +1797,33 @@ impl LoadGenerator {
                     match self.get_next_available_account(ledger_num) {
                         Some(id) => id,
                         None => {
+                            // Not-attempted: no `submit_tx` call, so the pacing
+                            // counter must NOT advance for this iteration
+                            // (core's `++count` is only after a submit).
                             debug!("No available accounts, waiting for cleanup");
                             break;
                         }
                     }
                 };
 
-                let ok = self.submit_tx(config, source_id, ledger_num).await;
-                if ok {
+                // Every reached `submit_tx` call is an attempt — both
+                // `Accepted` and `NotAccepted` advance pacing; only `Accepted`
+                // decrements the work-remaining count.
+                let outcome = self.submit_tx(config, source_id, ledger_num).await;
+                if outcome.is_attempt() {
+                    attempts_this_step += 1;
+                }
+                if outcome.is_accepted() {
                     config.n_txs = config.n_txs.saturating_sub(1);
-                    submitted_this_step += 1;
                 } else if self.failed {
+                    // Fold this attempt into the pacing counter before bailing
+                    // so the accounting stays consistent on the failure path.
+                    self.total_submitted =
+                        step_pacing_update(self.total_submitted, attempts_this_step);
                     return LoadResult::Failed;
                 }
             }
-            self.total_submitted += submitted_this_step;
+            self.total_submitted = step_pacing_update(self.total_submitted, attempts_this_step);
 
             tokio::time::sleep(step_duration).await;
         }
@@ -2038,7 +2119,7 @@ impl LoadGenerator {
         config: &mut GeneratedLoadConfig,
         source_account_id: u64,
         ledger_num: u32,
-    ) -> bool {
+    ) -> SubmitOutcome {
         let mut num_tries = 0u32;
         let mut queue_full_tries = 0u32;
 
@@ -2061,7 +2142,7 @@ impl LoadGenerator {
                 Err(e) => {
                     warn!("Failed to build tx (mode={:?}): {}", config.mode, e);
                     self.failed = true;
-                    return false;
+                    return SubmitOutcome::NotAccepted;
                 }
             };
 
@@ -2077,12 +2158,17 @@ impl LoadGenerator {
 
             // PayPregenerated does not re-submit on failure: each tx is read
             // once from the file, so a retry would consume the *next* tx
-            // (stellar-core LoadGenerator.cpp:874).
+            // (stellar-core LoadGenerator.cpp:874). A reject FAILS the run
+            // (mirroring core's `submitTx` mFailed+abort, LoadGenerator.cpp:
+            // 958-963) instead of silently draining the next tx from the file
+            // (#3638).
             if config.mode == LoadGenMode::PayPregenerated {
-                if !matches!(result, TxQueueResult::Added) {
+                if pay_pregenerated_reject_fails(&result) {
                     app_metrics::LOADGEN_TXN_REJECTED.increment(1.0);
+                    self.failed = true;
+                    return SubmitOutcome::NotAccepted;
                 }
-                return matches!(result, TxQueueResult::Added);
+                return SubmitOutcome::Accepted;
             }
 
             if !matches!(result, TxQueueResult::Added) {
@@ -2108,7 +2194,7 @@ impl LoadGenerator {
                 config.queue_full_max_tries,
                 config.mode,
             ) {
-                SubmitAction::Accept => return true,
+                SubmitAction::Accept => return SubmitOutcome::Accepted,
                 SubmitAction::RetryBadSeq => {
                     // Refresh sequence number from DB
                     self.tx_generator.load_account(source_account_id);
@@ -2123,7 +2209,7 @@ impl LoadGenerator {
                     if let Some(account) = self.tx_generator.accounts.get_mut(&source_account_id) {
                         account.sequence_number -= 1;
                     }
-                    return false;
+                    return SubmitOutcome::NotAccepted;
                 }
                 SubmitAction::RetryQueueFull => {
                     // Transient tx-queue backpressure: roll back the consumed
@@ -2158,7 +2244,7 @@ impl LoadGenerator {
                         result, num_tries, queue_full_tries
                     );
                     self.failed = true;
-                    return false;
+                    return SubmitOutcome::NotAccepted;
                 }
             }
         }


### PR DESCRIPTION
Closes #3638

## Summary

henyey's loadgen paces via a cumulative-target rate limiter (`get_tx_per_step`, matching core's `getTxPerStep`), but the pacing counter `total_submitted` advanced only on **accepted** txns, whereas stellar-core advances per **attempt** (`LoadGenerator.cpp:900,919` — `++count` regardless of accept, then `mTotalSubmitted += count`). Under queue rejection henyey's deficit never amortized, so each step burst harder to "catch up" — the observed 1.5–6.7x overshoot that grows with the rejection rate.

This change feeds the pacing counter per **attempt** instead. Work-remaining (`config.n_txs`) stays **accept**-gated, matching core's `--cfg.nTxs` (line 874). `submit_tx` now returns a three-way `SubmitOutcome` (`Accepted` / `NotAccepted`); the **not-attempted** case (`get_next_available_account → None` break) produces no outcome and never advances pacing. The per-step pacing update is extracted into a pure helper (`step_pacing_update`) for unit-testability, following the existing `classify_submit_result` precedent.

Same-bug amplifier also fixed: a `PayPregenerated` reject now sets `self.failed` and fails the run (`pay_pregenerated_reject_fails`), mirroring core's `submitTx` mFailed+abort (`LoadGenerator.cpp:958-963`), instead of silently draining the next tx from the file.

`get_tx_per_step` is left unchanged (already matches `getTxPerStep`).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3638#issuecomment-4806307627)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-simulation --all-targets -- -D warnings`
- [x] `cargo build -p henyey-simulation --all-targets`
- [x] `cargo test -p henyey-simulation --lib` (103 passed, incl. all loadgen + new pacing tests)

## Regression test (kind: bug-fix)

- **Tests:** in `crates/simulation/src/loadgen.rs` `#[cfg(test)]`:
  - `test_pacing_counter_counts_attempts_not_just_accepts` (5 attempts / 2 accepts → pacing +5, not +2)
  - `test_deficit_tracks_rate_under_rejection` (attempts-based deficit bounded; accepts-only balloons to 90)
  - `test_not_attempted_does_not_advance_pacing` (no-account break → pacing +0)
  - `test_pay_pregenerated_reject_fails_run` (any non-`Added` → fail run)
- **Pre-fix:** committed as `5bc4c023` — verified FAILED: tests do not compile on main (`SubmitOutcome`, `step_pacing_update`, `pay_pregenerated_reject_fails` do not exist — the missing parity surface).
- **Post-fix:** verified PASS after `883af261`.

## Deviations from plan

The plan offered two drivers for `test_pay_pregenerated_reject_fails_run`: the `app_simulation.rs` App harness, or a pure seam ("if a pure seam is feasible, assert via the classification logic instead. /do picks the drivable form"). I chose the **pure seam** (`pay_pregenerated_reject_fails`) — a deterministic queue reject is not cheaply reproducible through a live `App`, and the pure helper matches the `classify_submit_result` precedent the plan endorses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)