### PR TITLE
Clear OOM quarantine on VE-green, not merge (#3632)

### DIFF
--- a/scripts/lib/deploy-quarantine.sh
+++ b/scripts/lib/deploy-quarantine.sh
@@ -14,9 +14,11 @@
 #   - Remaining fields: optional free-text reason (single line)
 #   - An optional `resolved:<40-hex>` token MAY appear anywhere in the reason
 #     (token-boundary-anchored). It records the fix commit that resolves the
-#     quarantine: once that fix SHA is an ancestor of origin/main, the entry
-#     auto-clears (see check_quarantine_active). Additive — absent on legacy
-#     entries, which keep the per-hunk content-check as their backstop.
+#     quarantine: once that fix SHA is an ancestor of origin/main (MERGED) AND
+#     is VE-green (a fix-containing sha has passed `Verify Execution (Mainnet)`,
+#     so it is an actual deploy target — #3632), the entry auto-clears (see
+#     check_quarantine_active). Additive — absent on legacy entries, which keep
+#     the per-hunk content-check as their backstop.
 #   - Lines starting with # (after optional whitespace) are comments
 #   - Blank/whitespace-only lines are skipped
 #   - CRLF is stripped during parsing
@@ -268,6 +270,80 @@ _quarantine_any_hunk_present() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# quarantine_resolved_is_ve_green SHA   (issue #3632)
+#
+# VE-green oracle for the resolved-token auto-clear in check_quarantine_active.
+# Returns 0 iff SHA (or one of its descendants that is on main) is itself a
+# VALID DEPLOY TARGET — i.e. has a `success` `Verify Execution (Mainnet)` run.
+# Returns non-zero (1) when no such run exists or on any gh/parse error.
+#
+# WHY THIS EXISTS: a resolved-token records the fix PR's MERGE commit. On a busy
+# `main` that merge lands long before the daily `Verify Execution (Mainnet)`
+# cron validates it. The old auto-clear (`merge-base --is-ancestor <fix> main`)
+# cleared the quarantine the instant the fix MERGED — but the deploy gate
+# (`select_latest_green_deploy_target`) ships the LATEST VE-green sha, which in
+# that window is still a PRE-FIX commit. Clearing on merge therefore green-lit
+# shipping a binary that does NOT contain the fix (#3632). Gating the clear on
+# the fix being VE-green mirrors the selector's own notion of "deployable" so
+# the quarantine only lifts once a fix-containing sha is actually a deploy
+# target.
+#
+# The "(or a descendant on main)" allowance: VE runs on whatever sha was HEAD at
+# the cron, which is usually a DESCENDANT of the fix merge, not the merge commit
+# itself. A green VE on any on-main descendant of <fix> proves a fix-containing
+# binary passed VE, so it satisfies the clear. We therefore accept a `success`
+# VE run whose headSha is <fix> OR has <fix> as an ancestor (and is itself on
+# main). Cross-shell ancestry uses the same `is_ancestor` oracle convention as
+# monitor-decisions.sh.
+#
+# OVERRIDABLE FOR TESTS: like monitor-decisions.sh's `is_ancestor`, this is a
+# hermetic injection point. Tests define `quarantine_resolved_is_ve_green`
+# before sourcing (or shadow it) to drive the predicate without touching gh.
+# The `command -v` guard (NOT bash-only `declare -F`) keeps the default-define
+# correct under zsh, where `declare` aliases `typeset` (#3592).
+#
+# FAIL-SAFE: any uncertainty (no green VE run, gh/network/parse error, no
+# locally-resolvable ancestry) returns non-zero → the caller does NOT clear and
+# falls through to the per-hunk content-check (BLOCK backstop). A false
+# "not-VE-green" only delays a deploy (recoverable); a false "VE-green" would
+# clear a quarantine for a not-yet-verified fix (the #3632 hazard).
+# ─────────────────────────────────────────────────────────────────────────────
+if ! command -v quarantine_resolved_is_ve_green >/dev/null 2>&1; then
+  quarantine_resolved_is_ve_green() {
+    local fix_sha="$1"
+    [[ "$fix_sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+    local repo="${QUARANTINE_GH_REPO:-stellar-experimental/henyey}"
+
+    # Pull recent successful `Verify Execution (Mainnet)` head SHAs (newest
+    # first). The workflow `name:` is literally "Verify Execution (Mainnet)".
+    # `--jq` keeps only completed/success records and emits their headSha, one
+    # per line. Any gh/network error → empty → fail-safe non-zero below.
+    local ve_heads
+    ve_heads="$(gh run list --repo "$repo" \
+                  --workflow "Verify Execution (Mainnet)" --branch main --limit 30 \
+                  --json headSha,status,conclusion \
+                  --jq '.[] | select(.status=="completed" and .conclusion=="success") | .headSha' \
+                2>/dev/null)" || return 1
+    [[ -z "$ve_heads" ]] && return 1
+
+    # A green VE on <fix> itself, or on any on-main DESCENDANT of <fix>, proves
+    # a fix-containing binary passed VE. `is_ancestor <fix> <ve_head>` is 0 when
+    # ve_head == fix or ve_head is a descendant. We require ve_head be on main
+    # too (ancestor of origin/main HEAD) so a stale/off-main green never counts.
+    local ve_head
+    while IFS= read -r ve_head; do
+      [[ "$ve_head" =~ ^[0-9a-f]{40}$ ]] || continue
+      if git merge-base --is-ancestor "$fix_sha" "$ve_head" 2>/dev/null \
+         && git merge-base --is-ancestor "$ve_head" origin/main 2>/dev/null; then
+        return 0
+      fi
+    done <<< "$ve_heads"
+
+    return 1
+  }
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
 # check_quarantine_active QUARANTINE_FILE
 #
 # Read-only + git subprocess. Determines if any quarantined SHA's *content*
@@ -283,21 +359,31 @@ _quarantine_any_hunk_present() {
 #
 # Algorithm per entry:
 #   1. If SHA is NOT an ancestor of origin/main → not deployed, skip.
-#   2. resolved-SHA auto-clear (#3256): if the entry carries a valid
-#      `resolved:<fix-sha>` token, the fix SHA is NOT the entry's own SHA
-#      (self-resolution guard), and that fix SHA is an ancestor of origin/main
-#      (`git merge-base --is-ancestor` → 0), the fix has genuinely landed →
-#      CLEAR this entry (skip the content-check). This is the ONLY way an
-#      annotated bundled-commit quarantine auto-clears while benign hunks of
-#      the same commit are intentionally retained (the tick-199 false-block:
+#   2. resolved-SHA auto-clear (#3256, VE-green-gated for #3632): if the entry
+#      carries a valid `resolved:<fix-sha>` token, the fix SHA is NOT the
+#      entry's own SHA (self-resolution guard), that fix SHA is an ancestor of
+#      origin/main (`git merge-base --is-ancestor` → 0, i.e. the fix MERGED),
+#      AND the fix is VE-green (`quarantine_resolved_is_ve_green` → 0: a
+#      fix-containing sha has a `success` `Verify Execution (Mainnet)` run, so
+#      it is an actual deploy target), the fix has genuinely landed AND is
+#      deployable → CLEAR this entry (skip the content-check). This is the ONLY
+#      way an annotated bundled-commit quarantine auto-clears while benign hunks
+#      of the same commit are intentionally retained (the tick-199 false-block:
 #      #3238 bundled a harmful `retain:false` hunk removed by #3251 with benign
 #      hunks kept on main; the per-hunk check below stays BLOCKED forever
 #      because the benign hunks legitimately reverse-apply). An operator/
-#      automation stamps `resolved:` once; the gate auto-clears on merge.
+#      automation stamps `resolved:` once; the gate auto-clears once the fix is
+#      both merged and VE-green.
+#      WHY VE-GREEN (#3632): the deploy gate ships the LATEST VE-green sha, not
+#      origin HEAD. On a busy main a fix MERGES long before the daily VE cron
+#      validates it; in that window the latest VE-green sha is still a PRE-FIX
+#      commit, so clearing on merge alone let the gate ship the pre-fix binary —
+#      the exact deploy the hold existed to prevent.
 #      FAIL-SAFE: a missing token, self-resolution, a not-yet-merged fix
-#      (`--is-ancestor` → 1), OR a git error on the resolved-ancestry check
-#      (rc>=128) all FALL THROUGH to the per-hunk content-check below — the
-#      resolved path can only CLEAR, never relax the existing backstop.
+#      (`--is-ancestor` → 1), a git error on the resolved-ancestry check
+#      (rc>=128), OR a merged-but-not-yet-VE-green fix all FALL THROUGH to the
+#      per-hunk content-check below — the resolved path can only CLEAR, never
+#      relax the existing backstop.
 #   3. If the entry was not auto-cleared by step 2 → split its diff
 #      (`git diff sha^..sha`) into per-hunk patches and reverse-apply-check
 #      EACH hunk independently (`_quarantine_any_hunk_present`). The entry is
@@ -380,21 +466,35 @@ check_quarantine_active() {
       continue
     fi
 
-    # Step 2: resolved-SHA auto-clear (#3256). If this entry carries a valid
-    # `resolved:<fix-sha>` that is NOT its own SHA (self-resolution guard) and
-    # the fix SHA is an ancestor of origin/main, the fix has genuinely landed
-    # → CLEAR this entry. Every uncertain case (no token, self-resolution,
-    # not-yet-merged, git error) FALLS THROUGH to the per-hunk content-check
-    # below — the resolved path can only clear, never weaken the backstop.
+    # Step 2: resolved-SHA auto-clear (#3256, tightened for #3632). If this
+    # entry carries a valid `resolved:<fix-sha>` that is NOT its own SHA
+    # (self-resolution guard), the fix SHA is an ancestor of origin/main (the
+    # fix has MERGED), AND the fix is VE-green (a fix-containing sha has passed
+    # `Verify Execution (Mainnet)` → is an actual deploy target) → CLEAR this
+    # entry. Every uncertain case (no token, self-resolution, not-yet-merged,
+    # git error, OR merged-but-not-yet-VE-green) FALLS THROUGH to the per-hunk
+    # content-check below — the resolved path can only clear, never weaken the
+    # backstop.
+    #
+    # WHY VE-GREEN AND NOT MERGE (#3632): the deploy gate ships the LATEST
+    # VE-green sha (`select_latest_green_deploy_target`), not origin HEAD. On a
+    # busy main the fix MERGES long before the daily VE cron validates it; in
+    # that window the latest VE-green sha is still a PRE-FIX commit. Clearing on
+    # merge alone let the gate ship that pre-fix binary — the exact deploy the
+    # hold existed to prevent. Requiring VE-green mirrors the selector's own
+    # notion of "deployable", so the quarantine lifts only once a fix-containing
+    # sha is actually a deploy target.
     if [[ "$resolved" =~ ^[0-9a-f]{40}$ && "$resolved" != "$sha" ]]; then
       resolved_rc=0
       git merge-base --is-ancestor "$resolved" origin/main 2>/dev/null || resolved_rc=$?
-      if [[ "$resolved_rc" -eq 0 ]]; then
-        # Fix commit is on main → the quarantine is resolved → CLEAR.
+      if [[ "$resolved_rc" -eq 0 ]] && quarantine_resolved_is_ve_green "$resolved"; then
+        # Fix commit is on main AND VE-green → the quarantine is resolved →
+        # CLEAR. (Merged-but-not-yet-VE-green falls through to BLOCK below.)
         continue
       fi
-      # resolved_rc == 1 (fix not yet merged) OR rc>=128 (git error): do NOT
-      # clear — fall through to the per-hunk content-check (fail-closed).
+      # resolved_rc == 1 (fix not yet merged), rc>=128 (git error), OR merged
+      # but not yet VE-green (#3632): do NOT clear — fall through to the
+      # per-hunk content-check (fail-closed).
     fi
 
     # Step 3: per-hunk content check. The SHA is an ancestor; ask whether ANY

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -2688,21 +2688,57 @@ CANNED
     esac
   }
 
-  # ── Test 78f — bundled commit + surviving benign hunk + resolved-on-main → CLEAR
-  # FAILS on origin/main today (no `resolved` parsing → blocked_active, the
-  # tick-199 bug); PASSES after the resolved short-circuit lands.
+  # VE-green oracle stub (#3632). The resolved-token auto-clear in
+  # check_quarantine_active now ALSO requires the fix sha be VE-green, not just
+  # merged. We shadow the overridable `quarantine_resolved_is_ve_green` oracle so
+  # the predicate is driven by `$_Q_VE_GREEN_RC` (0 = a fix-containing sha passed
+  # `Verify Execution (Mainnet)`; 1 = merged-but-not-yet-VE-green). The merge
+  # (ancestry) side stays driven by `$_Q_RESOLVED_RC` via `_q_resolved_git`. The
+  # two are orthogonal, exactly mirroring the merge-vs-VE-green split the gate now
+  # enforces. Default 0 so the pre-#3632 "merged ⇒ clear" tests stay green when
+  # they intend a fully-resolved (merged + VE-green) fix.
+  _q_resolved_ve_green() { return "${_Q_VE_GREEN_RC:-0}"; }
+
+  # ── Test 78f — bundled commit + surviving benign hunk + resolved-on-main +
+  #   VE-green → CLEAR. FAILS on origin/main pre-#3256 (no `resolved` parsing →
+  #   blocked_active, the tick-199 bug); PASSES once the resolved short-circuit
+  #   lands. Post-#3632 the fix must ALSO be VE-green (_Q_VE_GREEN_RC=0).
   printf '%s regression #3238 resolved:%s\n' "$sha1" "$sha2" > "$qdir/resolved_clear.txt"
   _Q_RESOLVED_RC=0
+  _Q_VE_GREEN_RC=0
   git() { _q_resolved_git "$@"; }
+  quarantine_resolved_is_ve_green() { _q_resolved_ve_green "$@"; }
   local rc78f=0
   check_quarantine_active "$qdir/resolved_clear.txt" || rc78f=$?
-  unset -f git
-  unset _Q_RESOLVED_RC
+  unset -f git quarantine_resolved_is_ve_green
+  unset _Q_RESOLVED_RC _Q_VE_GREEN_RC
   if [[ $rc78f -eq 1 && "$QUARANTINE_STATUS" == "clear" && -z "$QUARANTINED_MATCH" ]]; then
-    tap_ok "quarantine-active: bundled commit + resolved-on-main auto-clears (#3256)"
+    tap_ok "quarantine-active: bundled commit + resolved-on-main + VE-green auto-clears (#3256, #3632)"
   else
-    tap_not_ok "quarantine-active: bundled commit + resolved-on-main auto-clears (#3256)" \
+    tap_not_ok "quarantine-active: bundled commit + resolved-on-main + VE-green auto-clears (#3256, #3632)" \
       "rc=$rc78f status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
+  fi
+
+  # ── Test 78f2 — REGRESSION FOR #3632: resolved fix is MERGED (on main) but NOT
+  #   yet VE-green → must stay BLOCKED. This is the exact #3632 hazard: clearing
+  #   on merge alone let the deploy gate ship the latest VE-green sha, which is
+  #   still a PRE-FIX commit. FAILS on origin/main today (merge-only clear →
+  #   QUARANTINE_STATUS=clear); PASSES after the VE-green gate lands (the
+  #   merged-but-not-VE-green fix falls through to the per-hunk BLOCK).
+  printf '%s regression #3238 resolved:%s\n' "$sha1" "$sha2" > "$qdir/resolved_merged_not_vegreen.txt"
+  _Q_RESOLVED_RC=0    # fix IS merged (ancestor of origin/main)
+  _Q_VE_GREEN_RC=1    # fix is NOT yet VE-green
+  git() { _q_resolved_git "$@"; }
+  quarantine_resolved_is_ve_green() { _q_resolved_ve_green "$@"; }
+  local rc78f2=0
+  check_quarantine_active "$qdir/resolved_merged_not_vegreen.txt" || rc78f2=$?
+  unset -f git quarantine_resolved_is_ve_green
+  unset _Q_RESOLVED_RC _Q_VE_GREEN_RC
+  if [[ $rc78f2 -eq 0 && "$QUARANTINE_STATUS" == "blocked_active" && "$QUARANTINED_MATCH" == "$sha1" ]]; then
+    tap_ok "quarantine-active: resolved merged but NOT VE-green stays blocked (#3632)"
+  else
+    tap_not_ok "quarantine-active: resolved merged but NOT VE-green stays blocked (#3632)" \
+      "rc=$rc78f2 status=$QUARANTINE_STATUS match=$QUARANTINED_MATCH"
   fi
 
   # ── Test 78g — resolved-SHA NOT yet on main → stays blocked (fail-safe) ─────
@@ -2910,13 +2946,16 @@ CANNED
   parse_quarantine_file "$qdir/autostamp_e2e.txt"
   local stamped78s="$QUARANTINE_RESOLVED"
   # Now the gate: sha1 ancestor + benign hunk present (partial), but resolved
-  # sha2 is on main → CLEAR. Reuse the resolved-aware git mock (sha2 merged).
+  # sha2 is on main AND VE-green → CLEAR. Reuse the resolved-aware git mock
+  # (sha2 merged) + the VE-green oracle stub (#3632, sha2 VE-green).
   _Q_RESOLVED_RC=0
+  _Q_VE_GREEN_RC=0
   git() { _q_resolved_git "$@"; }
+  quarantine_resolved_is_ve_green() { _q_resolved_ve_green "$@"; }
   local rc78s=0
   check_quarantine_active "$qdir/autostamp_e2e.txt" || rc78s=$?
-  unset -f git
-  unset _Q_RESOLVED_RC
+  unset -f git quarantine_resolved_is_ve_green
+  unset _Q_RESOLVED_RC _Q_VE_GREEN_RC
   unset _GH_PR_FOR_ISSUE _GH_PR_STATE _GH_PR_MERGESHA
   if [[ "$stamped78s" == "$sha2" && $rc78s -eq 1 && "$QUARANTINE_STATUS" == "clear" && -z "$QUARANTINED_MATCH" ]]; then
     tap_ok "quarantine-autostamp: reason #N + merged PR → stamps resolved:<sha>, gate auto-clears (#3258→#3260)"

--- a/scripts/test-shell-lib-cross-shell.sh
+++ b/scripts/test-shell-lib-cross-shell.sh
@@ -70,7 +70,7 @@ expected_funcs_for() {
     dedup-filing.sh)
       echo "dedup_load dedup_prune dedup_check dedup_record dedup_remove dedup_update_field dedup_write" ;;
     deploy-quarantine.sh)
-      echo "parse_quarantine_file check_quarantine_active check_quarantine_ancestry quarantine_append quarantine_remove quarantine_resolve quarantine_autostamp" ;;
+      echo "parse_quarantine_file check_quarantine_active check_quarantine_ancestry quarantine_append quarantine_remove quarantine_resolve quarantine_autostamp quarantine_resolved_is_ve_green" ;;
     monitor-decisions.sh)
       echo "check_session_wiped check_long_stale_session detect_crash_state cleanup_guard" ;;
     review-pr-merge.sh)


### PR DESCRIPTION
## ⚠️ SELF-MODIFYING (scripts/lib deploy-gate) + URGENT — requires operator approval before merge

This PR modifies the deploy-gate quarantine logic that the monitor runs against itself. **Do NOT merge without operator approval.** The operator has **already mitigated this manually** (re-quarantined `b0231cc4` with a non-parseable reason so autostamp cannot re-stamp it), so this is **not actively dangerous** — but the permanent code fix should still land.

## Problem (#3632)

`check_quarantine_active`'s `resolved:<fix-sha>` auto-clear cleared a quarantine the instant the fix PR **MERGED** (the fix sha became an ancestor of `origin/main`). But the deploy gate ships the **latest VE-green sha** via `select_latest_green_deploy_target`, not `origin` HEAD.

On a busy `main` the fix merges long before the daily `Verify Execution (Mainnet)` cron validates it. In that window the latest VE-green sha is still a **pre-fix** commit, so clearing on merge alone green-lit shipping a binary that lacks the fix — the exact deploy the hold existed to prevent. Observed this tick: the gate would have shipped pre-fix `b0231cc4` for the #3623 OOM hold (a ~42 GB buffering-peak restart of an OOM-fragile binary on the no-swap host).

## Fix (operator's option 3 — VE-green-gated clearance)

Gate the resolved-token clearance on the fix being **VE-green**, mirroring the selector's own notion of "deployable":

- New overridable oracle `quarantine_resolved_is_ve_green <sha>` in `scripts/lib/deploy-quarantine.sh` (default queries `gh run list` for a `success` `Verify Execution (Mainnet)` run whose `headSha` is the fix sha **or an on-main descendant** — a green VE on any fix-containing descendant proves a fix-containing binary passed VE). Injection-overridable like `monitor-decisions.sh`'s `is_ancestor`, `command -v`-guarded for zsh.
- `check_quarantine_active` step 2 now requires `merge-base --is-ancestor <fix> main` **AND** `quarantine_resolved_is_ve_green <fix>` to clear. A **merged-but-not-yet-VE-green** fix falls through to the per-hunk content-check (BLOCK, fail-safe).
- Fail-safe preserved: any uncertainty (no green VE run, gh/parse error, no resolvable ancestry) → does **not** clear. The resolved path can only clear, never weaken the backstop.

## Tests

- **Regression `78f2`** (new): resolved fix MERGED but NOT VE-green → must stay `blocked_active`. **Fails on current `main`** (merge-only clear → `clear`), **passes** after the VE-green gate.
- Updated `78f` / `78s` to stub the VE-green oracle (merged + VE-green ⇒ clear).
- Added the oracle to the cross-shell function surface (`test-shell-lib-cross-shell.sh`).

Evidence:
```
# fail-before (stock lib, new test kept):
not ok 130 - quarantine-active: resolved merged but NOT VE-green stays blocked (#3632)
# pass-after (full suite):
test-monitor-skill-snippets.sh : 426 ok, 0 not ok, rc=0
test-shell-lib-cross-shell.sh  : 27/27 ok, rc=0
```

Closes #3632

🤖 Generated with [Claude Code](https://claude.com/claude-code)