### PR TITLE
Monitor-tick: debounce benign inbound-auth-low banner + mtime-sorted retention (#3653, #3616)

### DIFF
--- a/.agents/skills/monitor-tick/SKILL.md
+++ b/.agents/skills/monitor-tick/SKILL.md
@@ -917,19 +917,23 @@ eval_memory_guardrail "$RSS_MB" "$AVAIL_MB" "${MONITOR_HOST_RAM_GB:-61}" \
 When the verdict is `restart`: Stop-PID, Rotate-log suffix `crashed`, Relaunch.
 
 **(5) Disk** — `df -h /home/tomer/data | tail -1`. If usage > 85%, flag LOW DISK.
-Then keep the 3 most recent rotated archives per category (the ISO 8601
-timestamp suffix sorts lexicographically, so `sort -r` gives newest-first;
-use `find -printf` not shell glob to survive zsh `NO_NOMATCH`):
+Then keep the 3 most recent rotated archives **per category, by mtime**, via the
+shared `prune_rotated_logs` helper (`scripts/lib/monitor-decisions.sh`, sourced
+at skill init). The helper discovers every `monitor.log.<category>-*` category
+present on disk — including legacy/other suffixes (`predeploy`, `coldcatchup`,
+`stopped`, `prerestart`, `freshstart`, …), not just a hardcoded
+`preredeploy/crashed/stuck/frozen` list — and orders retention by **mtime**, not
+by lexical filename. mtime ordering is correct even when an infixed variant such
+as `monitor.log.crashed-knit2lcl-20260615T192932Z` would otherwise sort its `k`
+ahead of a bare `crashed-20260623T…` under `sort -r` and wrongly retain the OLD
+log (#3616). It uses `find -printf` (not a shell glob) so it survives zsh
+`NO_NOMATCH`:
 
 ```bash
 logs_dir=/home/tomer/data/$MONITOR_SESSION_ID/logs
-[ -d "$logs_dir" ] && for pat in preredeploy crashed stuck frozen; do
-  find "$logs_dir" -maxdepth 1 -type f -name "monitor.log.$pat-*" \
-    -printf '%f\n' 2>/dev/null | sort -r | tail -n +4 \
-    | while read -r f; do rm -f "$logs_dir/$f"; done
-done
+prune_rotated_logs "$logs_dir" 3   # keeps newest 3 per category by mtime; sets PRUNED_LOG_COUNT
 ```
-Report how many files were removed if any.
+Report how many files were removed (`PRUNED_LOG_COUNT`) if any.
 
 **(6) Session disk** — `du -sh /home/tomer/data/$MONITOR_SESSION_ID/`
 and `du -sh /home/tomer/data/mainnet/`. If combined > 200 GB, flag SESSION DISK HIGH.
@@ -1336,6 +1340,13 @@ eval_result=$(python3 scripts/lib/eval-alarms.py \
    - Apply the cooldown + filing workflow below (§Firing alerts).
    - For alarms with `notes`, apply the investigation guidance before filing
      (e.g., "Sample /metrics 5x at 2s intervals to verify before filing").
+   - **Banner contribution by severity (#3653):** a firing **WARN/SYNC** alarm
+     flips the MONITOR banner to WARNING (or escalates per the Output rules); a
+     firing **NONC** alarm does **NOT** flip the banner — it is still reported on
+     the `metrics:` line and filed/commented as `Non-critical:`, but the banner
+     stays OK on its account. This keeps a known-benign chronic NONC condition
+     (e.g. `inbound-auth-low`) from pinning the banner to WARNING every tick
+     while a genuine WARN escalation (e.g. `inbound-auth-critical`) still surfaces.
 4. Check stderr (evaluator telemetry) for `series_matched=0` lines — these
    indicate dead alarms that need investigation.
 
@@ -2169,9 +2180,17 @@ The `wipe:` line is present when `SESSION_WIPED=yes` or `MAINNET_WIPED=yes`
 (or both). Format per the wipe-state composition table above. When neither
 fires, omit the line entirely.
 
-Use WARNING for threshold breaches. Use ACTION when a corrective action was
-taken (restart, deploy, filed a new issue, commented on an existing issue,
-session-wipe recovery). Use OFFLINE when the node cannot be recovered in
+Use WARNING for threshold breaches **of WARN/SYNC tier**. A firing **NONC-tier**
+alarm (e.g. `inbound-auth-low`, see #3653) does **NOT** flip the banner to
+WARNING: it is reported on the `metrics:` line and filed/commented as
+`Non-critical:` per the Bug Filing Workflow, but the banner stays at the level
+set by the WARN/SYNC/ACTION/OFFLINE signals only. This prevents a known-benign,
+chronically-firing, consensus-non-impacting condition from pinning the banner to
+WARNING on ~90% of ticks (alarm fatigue) while still surfacing it. A genuine
+escalation (e.g. zero authenticated inbound → `inbound-auth-critical`, WARN) is
+its own WARN-tier alarm and DOES flip the banner. Use ACTION when a corrective
+action was taken (restart, deploy, filed a new issue, commented on an existing
+issue, session-wipe recovery). Use OFFLINE when the node cannot be recovered in
 this tick (e.g., rebuild failed after session wipe).
 Use SYNC FAILURE (not WARNING) when the node has exceeded the active sync
 deadline (15m populated / 20m fresh-start / 60m crash-recovery) but is not closing ledgers in

--- a/.agents/skills/shared/metric-alarms.toml
+++ b/.agents/skills/shared/metric-alarms.toml
@@ -225,6 +225,8 @@ notes = ""
 
 [[alarm]]
 name = "inbound-auth-low"
+baseline_version = 2  # bumped in #3653: severity WARN→NONC. The < 3 chronic floor is structurally expected on firewall-limited hosts (non-standard peer_port, AWS SG only exposes 8009 — #1935) and is consensus-non-impacting (the host reaches all quorum orgs via outbound preferred_peers). Demoting to NONC keeps it reported/filed as Non-critical without pinning the banner to WARNING on ~90% of ticks (#3653); genuine isolation still escalates via inbound-auth-critical below.
+semantic_change_date = "2026-06-26T00:00:00Z"  # severity demotion WARN→NONC per #3653
 metric = "stellar_overlay_inbound_authenticated"
 kind = "gauge"
 extraction = "form1"
@@ -232,7 +234,7 @@ labels = []
 op = "<"
 threshold = 3
 for_ticks = 1
-severity = "WARN"
+severity = "NONC"
 gates = ["synced-only", "warmup-2-ticks"]
 cooldown_key = "stellar_overlay_inbound_authenticated"
 cooldown_seconds = 3600
@@ -240,7 +242,32 @@ filing_title = "metrics: stellar_overlay_inbound_authenticated — {value} < {th
 filing_search = "metrics: stellar_overlay_inbound_authenticated"
 summary = "Inbound authenticated peers below threshold"
 details = "inbound_auth={value} threshold={threshold}"
-notes = "Healthy fleet has 50+ inbound. Aggregate peer_count can be >=8 from outbound while inbound starves consensus."
+notes = "Healthy fleet has 50+ inbound. Aggregate peer_count can be >=8 from outbound while inbound starves consensus. NONC (not WARN) since #3653: on this firewall-limited host (#1935) a < 3 floor is structurally expected and consensus-non-impacting (outbound reaches all quorum orgs); it is reported/filed as Non-critical but does not flip the banner. A WORSE breach — zero authenticated inbound (genuine isolation) — still escalates to WARNING via the inbound-auth-critical alarm below."
+
+# Escalation tier for inbound-auth-low (#3653): zero authenticated inbound is a
+# genuine isolation signal (not the benign < 3 chronic floor), so it keeps WARN
+# and flips the banner. Shares the stellar_overlay_inbound_authenticated metric
+# with inbound-auth-low; allow_duplicate_cooldown is set because the two tiers
+# intentionally key off the same metric with distinct cooldown keys.
+[[alarm]]
+name = "inbound-auth-critical"
+metric = "stellar_overlay_inbound_authenticated"
+kind = "gauge"
+extraction = "form1"
+labels = []
+op = "<"
+threshold = 1
+for_ticks = 1
+severity = "WARN"
+gates = ["synced-only", "warmup-2-ticks"]
+cooldown_key = "stellar_overlay_inbound_authenticated_critical"
+allow_duplicate_cooldown = true
+cooldown_seconds = 3600
+filing_title = "metrics: stellar_overlay_inbound_authenticated — {value} < {threshold} (zero inbound)"
+filing_search = "metrics: stellar_overlay_inbound_authenticated"
+summary = "Zero authenticated inbound peers (genuine isolation)"
+details = "inbound_auth={value} threshold={threshold}"
+notes = "Escalation tier for inbound-auth-low (#3653). Fires only at zero authenticated inbound — a genuine isolation signal distinct from the benign < 3 chronic floor — and stays WARN so it flips the banner. The benign < 3 floor is handled (NONC, banner-neutral) by inbound-auth-low above."
 
 [[alarm]]
 name = "ledger-age-high"

--- a/.claude/skills/monitor-tick/SKILL.md
+++ b/.claude/skills/monitor-tick/SKILL.md
@@ -945,19 +945,23 @@ eval_memory_guardrail "$RSS_MB" "$AVAIL_MB" "${MONITOR_HOST_RAM_GB:-61}" \
 When the verdict is `restart`: Stop-PID, Rotate-log suffix `crashed`, Relaunch.
 
 **(5) Disk** — `df -h /home/tomer/data | tail -1`. If usage > 85%, flag LOW DISK.
-Then keep the 3 most recent rotated archives per category (the ISO 8601
-timestamp suffix sorts lexicographically, so `sort -r` gives newest-first;
-use `find -printf` not shell glob to survive zsh `NO_NOMATCH`):
+Then keep the 3 most recent rotated archives **per category, by mtime**, via the
+shared `prune_rotated_logs` helper (`scripts/lib/monitor-decisions.sh`, sourced
+at skill init). The helper discovers every `monitor.log.<category>-*` category
+present on disk — including legacy/other suffixes (`predeploy`, `coldcatchup`,
+`stopped`, `prerestart`, `freshstart`, …), not just a hardcoded
+`preredeploy/crashed/stuck/frozen` list — and orders retention by **mtime**, not
+by lexical filename. mtime ordering is correct even when an infixed variant such
+as `monitor.log.crashed-knit2lcl-20260615T192932Z` would otherwise sort its `k`
+ahead of a bare `crashed-20260623T…` under `sort -r` and wrongly retain the OLD
+log (#3616). It uses `find -printf` (not a shell glob) so it survives zsh
+`NO_NOMATCH`:
 
 ```bash
 logs_dir=/home/tomer/data/$MONITOR_SESSION_ID/logs
-[ -d "$logs_dir" ] && for pat in preredeploy crashed stuck frozen; do
-  find "$logs_dir" -maxdepth 1 -type f -name "monitor.log.$pat-*" \
-    -printf '%f\n' 2>/dev/null | sort -r | tail -n +4 \
-    | while read -r f; do rm -f "$logs_dir/$f"; done
-done
+prune_rotated_logs "$logs_dir" 3   # keeps newest 3 per category by mtime; sets PRUNED_LOG_COUNT
 ```
-Report how many files were removed if any.
+Report how many files were removed (`PRUNED_LOG_COUNT`) if any.
 
 **(6) Session disk** — `du -sh /home/tomer/data/$MONITOR_SESSION_ID/`
 and `du -sh /home/tomer/data/mainnet/`. If combined > 200 GB, flag SESSION DISK HIGH.
@@ -1364,6 +1368,13 @@ eval_result=$(python3 scripts/lib/eval-alarms.py \
    - Apply the cooldown + filing workflow below (§Firing alerts).
    - For alarms with `notes`, apply the investigation guidance before filing
      (e.g., "Sample /metrics 5x at 2s intervals to verify before filing").
+   - **Banner contribution by severity (#3653):** a firing **WARN/SYNC** alarm
+     flips the MONITOR banner to WARNING (or escalates per the Output rules); a
+     firing **NONC** alarm does **NOT** flip the banner — it is still reported on
+     the `metrics:` line and filed/commented as `Non-critical:`, but the banner
+     stays OK on its account. This keeps a known-benign chronic NONC condition
+     (e.g. `inbound-auth-low`) from pinning the banner to WARNING every tick
+     while a genuine WARN escalation (e.g. `inbound-auth-critical`) still surfaces.
 4. Check stderr (evaluator telemetry) for `series_matched=0` lines — these
    indicate dead alarms that need investigation.
 
@@ -2265,9 +2276,17 @@ The `wipe:` line is present when `SESSION_WIPED=yes` or `MAINNET_WIPED=yes`
 (or both). Format per the wipe-state composition table above. When neither
 fires, omit the line entirely.
 
-Use WARNING for threshold breaches. Use ACTION when a corrective action was
-taken (restart, deploy, filed a new issue, commented on an existing issue,
-session-wipe recovery). Use OFFLINE when the node cannot be recovered in
+Use WARNING for threshold breaches **of WARN/SYNC tier**. A firing **NONC-tier**
+alarm (e.g. `inbound-auth-low`, see #3653) does **NOT** flip the banner to
+WARNING: it is reported on the `metrics:` line and filed/commented as
+`Non-critical:` per the Bug Filing Workflow, but the banner stays at the level
+set by the WARN/SYNC/ACTION/OFFLINE signals only. This prevents a known-benign,
+chronically-firing, consensus-non-impacting condition from pinning the banner to
+WARNING on ~90% of ticks (alarm fatigue) while still surfacing it. A genuine
+escalation (e.g. zero authenticated inbound → `inbound-auth-critical`, WARN) is
+its own WARN-tier alarm and DOES flip the banner. Use ACTION when a corrective
+action was taken (restart, deploy, filed a new issue, commented on an existing
+issue, session-wipe recovery). Use OFFLINE when the node cannot be recovered in
 this tick (e.g., rebuild failed after session wipe).
 Use SYNC FAILURE (not WARNING) when the node has exceeded the active sync
 deadline (15m populated / 20m fresh-start / 60m crash-recovery) but is not closing ledgers in

--- a/.claude/skills/shared/metric-alarms.toml
+++ b/.claude/skills/shared/metric-alarms.toml
@@ -225,6 +225,8 @@ notes = ""
 
 [[alarm]]
 name = "inbound-auth-low"
+baseline_version = 2  # bumped in #3653: severity WARN→NONC. The < 3 chronic floor is structurally expected on firewall-limited hosts (non-standard peer_port, AWS SG only exposes 8009 — #1935) and is consensus-non-impacting (the host reaches all quorum orgs via outbound preferred_peers). Demoting to NONC keeps it reported/filed as Non-critical without pinning the banner to WARNING on ~90% of ticks (#3653); genuine isolation still escalates via inbound-auth-critical below.
+semantic_change_date = "2026-06-26T00:00:00Z"  # severity demotion WARN→NONC per #3653
 metric = "stellar_overlay_inbound_authenticated"
 kind = "gauge"
 extraction = "form1"
@@ -232,7 +234,7 @@ labels = []
 op = "<"
 threshold = 3
 for_ticks = 1
-severity = "WARN"
+severity = "NONC"
 gates = ["synced-only", "warmup-2-ticks"]
 cooldown_key = "stellar_overlay_inbound_authenticated"
 cooldown_seconds = 3600
@@ -240,7 +242,32 @@ filing_title = "metrics: stellar_overlay_inbound_authenticated — {value} < {th
 filing_search = "metrics: stellar_overlay_inbound_authenticated"
 summary = "Inbound authenticated peers below threshold"
 details = "inbound_auth={value} threshold={threshold}"
-notes = "Healthy fleet has 50+ inbound. Aggregate peer_count can be >=8 from outbound while inbound starves consensus."
+notes = "Healthy fleet has 50+ inbound. Aggregate peer_count can be >=8 from outbound while inbound starves consensus. NONC (not WARN) since #3653: on this firewall-limited host (#1935) a < 3 floor is structurally expected and consensus-non-impacting (outbound reaches all quorum orgs); it is reported/filed as Non-critical but does not flip the banner. A WORSE breach — zero authenticated inbound (genuine isolation) — still escalates to WARNING via the inbound-auth-critical alarm below."
+
+# Escalation tier for inbound-auth-low (#3653): zero authenticated inbound is a
+# genuine isolation signal (not the benign < 3 chronic floor), so it keeps WARN
+# and flips the banner. Shares the stellar_overlay_inbound_authenticated metric
+# with inbound-auth-low; allow_duplicate_cooldown is set because the two tiers
+# intentionally key off the same metric with distinct cooldown keys.
+[[alarm]]
+name = "inbound-auth-critical"
+metric = "stellar_overlay_inbound_authenticated"
+kind = "gauge"
+extraction = "form1"
+labels = []
+op = "<"
+threshold = 1
+for_ticks = 1
+severity = "WARN"
+gates = ["synced-only", "warmup-2-ticks"]
+cooldown_key = "stellar_overlay_inbound_authenticated_critical"
+allow_duplicate_cooldown = true
+cooldown_seconds = 3600
+filing_title = "metrics: stellar_overlay_inbound_authenticated — {value} < {threshold} (zero inbound)"
+filing_search = "metrics: stellar_overlay_inbound_authenticated"
+summary = "Zero authenticated inbound peers (genuine isolation)"
+details = "inbound_auth={value} threshold={threshold}"
+notes = "Escalation tier for inbound-auth-low (#3653). Fires only at zero authenticated inbound — a genuine isolation signal distinct from the benign < 3 chronic floor — and stays WARN so it flips the banner. The benign < 3 floor is handled (NONC, banner-neutral) by inbound-auth-low above."
 
 [[alarm]]
 name = "ledger-age-high"

--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -1267,3 +1267,76 @@ classify_stuck_alive_sync() {
   STUCK_ALIVE_SYNC="yes"
   return 0
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# prune_rotated_logs LOGS_DIR [KEEP_PER_CATEGORY]
+#
+# Rotated-log retention for monitor-tick check (5). Keeps the newest
+# KEEP_PER_CATEGORY (default 3) `monitor.log.<category>-*` archives per
+# category and deletes the rest, where the *category* is the suffix word
+# between `monitor.log.` and the first `-` (e.g. `crashed`, `preredeploy`,
+# `predeploy`, `coldcatchup`, `stopped`, `prerestart`, `freshstart`).
+#
+# Two fixes over the previous hardcoded `for pat in preredeploy crashed stuck
+# frozen` + `sort -r` (filename) loop (#3616):
+#   1. ALL categories are covered — legacy/other suffixes (`predeploy`,
+#      `coldcatchup`, `stopped`, `prerestart`, `freshstart`, …) are discovered
+#      from the files on disk, not from a hardcoded list, so they no longer
+#      accumulate unbounded.
+#   2. Retention is by **mtime**, not by lexical filename. An infixed variant
+#      such as `monitor.log.crashed-knit2lcl-20260615T192932Z` sorts its 'k'
+#      ahead of a bare `crashed-20260623T…` under `sort -r`, which retained the
+#      OLD logs and deleted the recent ones. mtime ordering keeps the newest.
+#
+# Arguments:
+#   LOGS_DIR           - directory containing monitor.log.<category>-* archives
+#   KEEP_PER_CATEGORY  - newest-N to keep per category (default 3)
+#
+# Sets globals:
+#   PRUNED_LOG_COUNT - number of files removed (0 if none / dir missing)
+#
+# Returns: 0 always (no-op on a missing dir or empty category set).
+# Portability: GNU find -printf, GNU sort, GNU sed -E, Bash 4+.
+# ─────────────────────────────────────────────────────────────────────────────
+prune_rotated_logs() {
+  local logs_dir="$1"
+  local keep="${2:-3}"
+
+  PRUNED_LOG_COUNT=0
+
+  [[ -d "$logs_dir" ]] || return 0
+  [[ "$keep" =~ ^[0-9]+$ ]] || keep=3
+
+  # Enumerate every rotated archive as: <mtime-epoch> <category> <path>
+  # category = first '-'-delimited token after the literal `monitor.log.` prefix.
+  # find -printf survives zsh NO_NOMATCH (no shell glob) and gives us mtime.
+  local rows
+  rows=$(find "$logs_dir" -maxdepth 1 -type f -name 'monitor.log.*-*' \
+           -printf '%T@ %f\n' 2>/dev/null)
+  [[ -z "$rows" ]] && return 0
+
+  # Build category list and, per category, sort newest-first by mtime, then
+  # delete everything past the keep-th entry.
+  local categories
+  categories=$(printf '%s\n' "$rows" \
+    | sed -E 's/^[0-9.]+ monitor\.log\.([^-]+)-.*$/\1/' \
+    | sort -u)
+
+  local cat line fname removed=0
+  while IFS= read -r cat; do
+    [[ -n "$cat" ]] || continue
+    # mtime descending; ties broken by filename descending for determinism.
+    # tail -n +<keep+1> drops the newest `keep`, leaving the surplus to delete.
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      fname="${line#* }"
+      rm -f "$logs_dir/$fname" 2>/dev/null && removed=$(( removed + 1 ))
+    done < <(printf '%s\n' "$rows" \
+               | grep -E " monitor\\.log\\.${cat}-" \
+               | sort -t' ' -k1,1rn -k2,2r \
+               | tail -n +$(( keep + 1 )))
+  done <<< "$categories"
+
+  PRUNED_LOG_COUNT="$removed"
+  return 0
+}

--- a/scripts/lib/test_eval_alarms_inbound_auth_severity.py
+++ b/scripts/lib/test_eval_alarms_inbound_auth_severity.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Regression tests for inbound-auth banner severity calibration (issue #3653).
+
+`inbound-auth-low` (threshold < 3) was severity WARN and flipped the monitor-tick
+banner to WARNING on ~90% of ticks for a structurally-expected, firewall-limited,
+consensus-non-impacting condition (alarm fatigue, #3653). The fix demotes the
+chronic < 3 floor to NONC (reported/filed Non-critical, banner-neutral) and adds
+a separate `inbound-auth-critical` (threshold < 1, WARN) so that genuine isolation
+(zero authenticated inbound) still escalates and flips the banner.
+
+These tests load the REAL catalog (.claude/skills/shared/metric-alarms.toml) and
+evaluate the two alarms against synthetic gauge values, asserting:
+  - inbound=2  → inbound-auth-low fires as NONC, inbound-auth-critical does NOT fire
+  - inbound=0  → inbound-auth-low fires as NONC, inbound-auth-critical fires as WARN
+  - inbound=3  → neither fires
+
+Fail-before / pass-after: on origin/main, inbound-auth-low is WARN and
+inbound-auth-critical does not exist → these tests fail.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# eval-alarms.py uses a hyphen, so we need importlib
+_spec = importlib.util.spec_from_file_location(
+    "eval_alarms",
+    Path(__file__).parent / "eval-alarms.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+eval_gauge = _mod.eval_gauge
+
+# Locate the catalog relative to this test file (scripts/lib/ → repo root).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CATALOG = _REPO_ROOT / ".claude" / "skills" / "shared" / "metric-alarms.toml"
+
+try:
+    import tomllib  # py3.11+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+
+def _load_alarm(name: str) -> dict:
+    with open(_CATALOG, "rb") as f:
+        catalog = tomllib.load(f)
+    for a in catalog.get("alarm", []):
+        if a.get("name") == name:
+            return a
+    raise AssertionError(f"alarm {name!r} not found in {_CATALOG}")
+
+
+def _current(inbound: float) -> dict:
+    """Build a parsed-prom dict with the inbound-authenticated gauge set."""
+    return {"stellar_overlay_inbound_authenticated": [({}, inbound)]}
+
+
+# ── inbound-auth-low: the benign chronic floor (< 3) is now NONC ─────────────
+
+def test_inbound_auth_low_is_nonc_not_warn():
+    """The chronic < 3 floor must NOT be WARN (would pin the banner; #3653)."""
+    alarm = _load_alarm("inbound-auth-low")
+    assert alarm["severity"] == "NONC", (
+        f"inbound-auth-low must be NONC (banner-neutral), got {alarm['severity']!r}"
+    )
+    assert alarm["threshold"] == 3
+    assert alarm["op"] == "<"
+
+
+def test_inbound_auth_low_fires_nonc_at_two():
+    """inbound=2 fires inbound-auth-low, and its firing severity is NONC."""
+    alarm = _load_alarm("inbound-auth-low")
+    r = eval_gauge(alarm, _current(2), {}, prev_prom_invalid=False)
+    assert r["state"] == "firing", r
+    assert r["severity"] == "NONC", r
+
+
+def test_inbound_auth_low_ok_at_three():
+    """inbound=3 does NOT fire (strict < 3)."""
+    alarm = _load_alarm("inbound-auth-low")
+    r = eval_gauge(alarm, _current(3), {}, prev_prom_invalid=False)
+    assert r["state"] == "ok", r
+    assert r["severity"] == "", r  # severity only set when firing
+
+
+# ── inbound-auth-critical: genuine isolation (< 1) still escalates to WARN ───
+
+def test_inbound_auth_critical_exists_and_is_warn():
+    """Escalation tier exists, is WARN, threshold < 1."""
+    alarm = _load_alarm("inbound-auth-critical")
+    assert alarm["severity"] == "WARN", alarm
+    assert alarm["threshold"] == 1
+    assert alarm["op"] == "<"
+
+
+def test_inbound_auth_critical_does_not_fire_at_two():
+    """The benign < 3 floor (inbound=2) must NOT trip the WARN escalation."""
+    alarm = _load_alarm("inbound-auth-critical")
+    r = eval_gauge(alarm, _current(2), {}, prev_prom_invalid=False)
+    assert r["state"] == "ok", r
+
+
+def test_inbound_auth_critical_fires_warn_at_zero():
+    """Zero authenticated inbound is genuine isolation → fires WARN."""
+    alarm = _load_alarm("inbound-auth-critical")
+    r = eval_gauge(alarm, _current(0), {}, prev_prom_invalid=False)
+    assert r["state"] == "firing", r
+    assert r["severity"] == "WARN", r
+
+
+# ── Combined banner-contract check at zero inbound ───────────────────────────
+
+def test_zero_inbound_low_nonc_critical_warn():
+    """At inbound=0 the benign tier stays NONC and the escalation tier is WARN.
+
+    The banner-contribution rule (SKILL.md, #3653) then keeps the NONC tier
+    banner-neutral while the WARN tier flips the banner — so genuine isolation
+    is never silenced by the demotion.
+    """
+    low = eval_gauge(_load_alarm("inbound-auth-low"), _current(0), {}, prev_prom_invalid=False)
+    crit = eval_gauge(_load_alarm("inbound-auth-critical"), _current(0), {}, prev_prom_invalid=False)
+    assert low["state"] == "firing" and low["severity"] == "NONC", low
+    assert crit["state"] == "firing" and crit["severity"] == "WARN", crit
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -45,7 +45,7 @@ cleanup  # ensure fresh state
 mkdir -p "$TEST_ROOT"
 
 # ── TAP state ────────────────────────────────────────────────────────────────
-TAP_PLAN=418
+TAP_PLAN=431
 TAP_CURRENT=0
 TAP_FAILURES=0
 
@@ -1369,6 +1369,107 @@ run_tests() {
   else
     tap_not_ok "crash-detect: mtime tie-break → lexicographic-last path" \
       "LATEST=$CRASH_LATEST_FILE MISMATCH=$CRASH_HASH_MISMATCH"
+  fi
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # prune_rotated_logs tests (#3616) — rotated-log retention by mtime, all cats
+  # Source: scripts/lib/monitor-decisions.sh — prune_rotated_logs
+  # mock_rotated_log LOGS_DIR FULL_SUFFIX MTIME_EPOCH (suffix incl. category)
+  # ════════════════════════════════════════════════════════════════════════════
+  mock_rotated_log() {
+    local logs_dir="$1" suffix="$2" mtime_epoch="$3"
+    mkdir -p "$logs_dir"
+    printf 'log\n' > "$logs_dir/monitor.log.$suffix"
+    touch -d "@$mtime_epoch" "$logs_dir/monitor.log.$suffix"
+  }
+
+  # ── Test 33a: Legacy categories ARE pruned (predeploy/coldcatchup/...) ──────
+  # On origin/main only preredeploy/crashed/stuck/frozen were covered, so these
+  # legacy categories accumulated unbounded (#3616). 5 predeploy → keep 3.
+  local lp1="$TEST_ROOT/prune-legacy/logs"
+  local i
+  for i in 1 2 3 4 5; do
+    mock_rotated_log "$lp1" "predeploy-2026060${i}T120000Z" $((NOW_EPOCH - 6000 + i*100))
+  done
+  mock_rotated_log "$lp1" "coldcatchup-a" $((NOW_EPOCH - 5000))
+  mock_rotated_log "$lp1" "stopped-a"     $((NOW_EPOCH - 5000))
+  prune_rotated_logs "$lp1" 3
+  local pre_kept
+  pre_kept=$(find "$lp1" -name 'monitor.log.predeploy-*' | wc -l | tr -d ' ')
+  if [[ "$pre_kept" -eq 3 && "$PRUNED_LOG_COUNT" -eq 2 \
+        && -f "$lp1/monitor.log.coldcatchup-a" && -f "$lp1/monitor.log.stopped-a" ]]; then
+    tap_ok "prune-logs: legacy 'predeploy' pruned to newest 3 (legacy categories covered)"
+  else
+    tap_not_ok "prune-logs: legacy 'predeploy' pruned to newest 3 (legacy categories covered)" \
+      "pre_kept=$pre_kept removed=$PRUNED_LOG_COUNT"
+  fi
+
+  # ── Test 33b: mtime ordering keeps RECENT, drops OLD infix variant ─────────
+  # crashed-knit2lcl-* sorts its 'k' ahead of bare crashed-2026… under sort -r,
+  # which on origin/main retained the OLD logs and deleted recent ones (#3616).
+  local lp2="$TEST_ROOT/prune-mtime/logs"
+  mock_rotated_log "$lp2" "crashed-knit2lcl-20260615T192932Z" $((NOW_EPOCH - 900000))  # OLD
+  mock_rotated_log "$lp2" "crashed-knit2lcl-20260602T133013Z" $((NOW_EPOCH - 990000))  # OLDER
+  mock_rotated_log "$lp2" "crashed-20260623T212302Z"          $((NOW_EPOCH - 100))     # RECENT
+  mock_rotated_log "$lp2" "crashed-20260623T203607Z"          $((NOW_EPOCH - 200))     # RECENT
+  mock_rotated_log "$lp2" "crashed-20260623T134735Z"          $((NOW_EPOCH - 300))     # RECENT
+  prune_rotated_logs "$lp2" 3
+  if [[ -f "$lp2/monitor.log.crashed-20260623T212302Z" \
+        && -f "$lp2/monitor.log.crashed-20260623T203607Z" \
+        && -f "$lp2/monitor.log.crashed-20260623T134735Z" \
+        && ! -f "$lp2/monitor.log.crashed-knit2lcl-20260615T192932Z" \
+        && ! -f "$lp2/monitor.log.crashed-knit2lcl-20260602T133013Z" \
+        && "$PRUNED_LOG_COUNT" -eq 2 ]]; then
+    tap_ok "prune-logs: mtime ordering keeps recent crashed, drops old knit2lcl infix"
+  else
+    tap_not_ok "prune-logs: mtime ordering keeps recent crashed, drops old knit2lcl infix" \
+      "removed=$PRUNED_LOG_COUNT files=$(ls "$lp2" | tr '\n' ',')"
+  fi
+
+  # ── Test 33c: Under-keep category untouched; covered category pruned ───────
+  local lp3="$TEST_ROOT/prune-mixed/logs"
+  mock_rotated_log "$lp3" "frozen-a" $((NOW_EPOCH - 100))
+  mock_rotated_log "$lp3" "frozen-b" $((NOW_EPOCH - 200))
+  mock_rotated_log "$lp3" "preredeploy-coldD-20260601T000000Z" $((NOW_EPOCH - 300))
+  mock_rotated_log "$lp3" "preredeploy-coldF-20260601T000100Z" $((NOW_EPOCH - 400))
+  mock_rotated_log "$lp3" "preredeploy-20260601T000200Z"       $((NOW_EPOCH - 500))
+  mock_rotated_log "$lp3" "preredeploy-20260601T000300Z"       $((NOW_EPOCH - 600))
+  prune_rotated_logs "$lp3" 3
+  local frozen_kept prered_kept
+  frozen_kept=$(find "$lp3" -name 'monitor.log.frozen-*' | wc -l | tr -d ' ')
+  prered_kept=$(find "$lp3" -name 'monitor.log.preredeploy-*' | wc -l | tr -d ' ')
+  if [[ "$frozen_kept" -eq 2 && "$prered_kept" -eq 3 && "$PRUNED_LOG_COUNT" -eq 1 ]]; then
+    tap_ok "prune-logs: under-keep 'frozen' kept whole; 'preredeploy-*' (incl. infix) pruned to 3"
+  else
+    tap_not_ok "prune-logs: under-keep 'frozen' kept whole; 'preredeploy-*' (incl. infix) pruned to 3" \
+      "frozen=$frozen_kept prered=$prered_kept removed=$PRUNED_LOG_COUNT"
+  fi
+
+  # ── Test 33d: Missing dir → no-op, count 0 ─────────────────────────────────
+  prune_rotated_logs "$TEST_ROOT/prune-missing/nope" 3
+  if [[ "$PRUNED_LOG_COUNT" -eq 0 ]]; then
+    tap_ok "prune-logs: missing dir → no-op (count 0)"
+  else
+    tap_not_ok "prune-logs: missing dir → no-op (count 0)" "removed=$PRUNED_LOG_COUNT"
+  fi
+
+  # ── Test 33e: Empty dir → no-op, count 0 ───────────────────────────────────
+  local lp5="$TEST_ROOT/prune-empty/logs"; mkdir -p "$lp5"
+  prune_rotated_logs "$lp5" 3
+  if [[ "$PRUNED_LOG_COUNT" -eq 0 ]]; then
+    tap_ok "prune-logs: empty dir → no-op (count 0)"
+  else
+    tap_not_ok "prune-logs: empty dir → no-op (count 0)" "removed=$PRUNED_LOG_COUNT"
+  fi
+
+  # ── Test 33f: SKILL.md calls prune_rotated_logs (not the old for-pat loop) ──
+  local prune_tick_file="$REPO_ROOT/.claude/skills/monitor-tick/SKILL.md"
+  if grep -q 'prune_rotated_logs' "$prune_tick_file" \
+     && ! grep -q 'for pat in preredeploy crashed stuck frozen' "$prune_tick_file"; then
+    tap_ok "prune-logs: SKILL.md uses prune_rotated_logs helper (no hardcoded for-pat loop)"
+  else
+    tap_not_ok "prune-logs: SKILL.md uses prune_rotated_logs helper (no hardcoded for-pat loop)" \
+      "tick_file must call prune_rotated_logs and drop the 'for pat in preredeploy crashed stuck frozen' loop"
   fi
 
   # ── Heartbeat helper tests ─────────────────────────────────────────────────


### PR DESCRIPTION
> **SELF-MODIFYING (monitor-tick) — requires operator approval before merge; do not auto-merge.**

Batches two non-critical monitor-tick calibration/tooling fixes.

## #3653 — `inbound-auth-low` pins the banner WARNING on ~90% of ticks

The chronic `stellar_overlay_inbound_authenticated < 3` condition is structurally expected on this firewall-limited host (non-standard `peer_port`, AWS SG exposes only 8009 — #1935) and is consensus-non-impacting (the node reaches all quorum orgs via outbound `preferred_peers`; `heard_from_quorum=true`/`gap=0`/`Validating` on every firing tick). As a WARN alarm it flipped the MONITOR banner to WARNING on ~90% of ticks → alarm fatigue that risks masking a genuine alarm.

**Fix (catalog + skill):**
- `metric-alarms.toml` `inbound-auth-low`: severity **WARN → NONC** (`baseline_version` 1→2, `semantic_change_date` set). NONC is still reported on the `metrics:` line and filed/commented as `Non-critical:`, but is **banner-neutral**.
- New alarm `inbound-auth-critical` (`< 1`, WARN, distinct `cooldown_key`, `allow_duplicate_cooldown`): zero authenticated inbound = genuine isolation, still **escalates** and flips the banner. Escalation is preserved.
- `monitor-tick/SKILL.md`: explicit, testable **banner-contribution-by-severity** rule — a firing NONC alarm does NOT flip the banner; WARN/SYNC/ACTION/OFFLINE still do.

## #3616 — rotated-log retention misses legacy categories + sorts by filename

The hardcoded `for pat in preredeploy crashed stuck frozen` + `sort -r` loop never pruned legacy categories (`predeploy`, `coldcatchup`, `stopped`, `prerestart`, `freshstart`) and sorted by filename — so an infixed variant `crashed-knit2lcl-*` sorted its `k` ahead of bare `crashed-2026…`, retaining OLD logs and deleting RECENT ones.

**Fix:** new shared `prune_rotated_logs LOGS_DIR [KEEP]` helper in `scripts/lib/monitor-decisions.sh` that discovers **all** `monitor.log.<category>-*` categories on disk and retains the newest N **per category by mtime**. `SKILL.md` check (5) now calls the helper.

## Tests (failing-before / passing-after)
- `scripts/lib/test_eval_alarms_inbound_auth_severity.py` (new): inbound=2 → `inbound-auth-low` fires **NONC**, `inbound-auth-critical` does not fire; inbound=0 → `inbound-auth-critical` fires **WARN**; inbound=3 → neither. **Fails on main** (alarm is WARN, critical alarm absent).
- `scripts/test-monitor-skill-snippets.sh`: 6 `prune_rotated_logs` cases (legacy categories pruned, mtime ordering / knit2lcl quirk, under-keep untouched, missing/empty dir, SKILL.md structural assertion). **Fails on main** (helper absent). TAP plan corrected to match emitted count.

Catalog validates (`eval-alarms.py --validate-only`) and passes `check-alarm-versions.py`. Changes mirrored across `.claude/` and `.agents/` skill copies; `metric-alarms.toml` kept byte-identical. The pre-existing `--strict`-mode structural drift and the `cleanup-guard` timing flake are unrelated and present on `main`.

Closes #3653
Closes #3616

🤖 Generated with [Claude Code](https://claude.com/claude-code)