### PR TITLE
Refine parity definition to observed-behavior + interop

### DIFF
--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -208,7 +208,12 @@ Set `parity_relevant: false` on all Lane B findings.
 
 ### Lane C — Structure & dead code (parity-filtered)
 
-Apply the parity filter from the PARITY_STATUS.md File Mapping table (Stage 1):
+Apply the parity filter from the PARITY_STATUS.md File Mapping table (Stage 1).
+The filter protects the **observable / interop surface** (`docs/PARITY.md`), not
+internal structure: a refactor that produces identical observable output (same
+hashes, result/meta XDR, wire bytes, archive format, API responses) is allowed
+even on a parity-mapped file. The suppressions below exist only because those
+structural shapes often mirror upstream — they are not a blanket freeze.
 
 - If the file appears in the File Mapping table → set `parity_mapped_file` to
   the cpp counterpart and `parity_relevant: true`.
@@ -304,8 +309,10 @@ finding. Each returns exactly one verdict:
 
 - **`confirmed`** — finding is real, the proposed fix is feasible, no
   parity or behavior risk.
-- **`parity-risk`** — touches a parity-mapped section in a way that would
-  diverge from stellar-core. Reject.
+- **`parity-risk`** — touches a parity-mapped section in a way that could change
+  the observable / interop surface (`docs/PARITY.md`) — hashes, result/meta XDR,
+  wire bytes, archive format, API responses. Reject. (Internal-only refactors
+  with identical observable output are not parity-risk.)
 - **`behavior-change`** — the fix is correctness-significant, not pure
   cleanup. Route to `/code-review` instead.
 - **`infeasible`** — borrow checker, lifetimes, Send/Sync, or other

--- a/.claude/skills/parity-check/SKILL.md
+++ b/.claude/skills/parity-check/SKILL.md
@@ -80,9 +80,16 @@ test file.
 
 ### Step 5: Compute Parity
 
+Parity measures **observable-surface coverage** (`docs/PARITY.md`), not internal
+sameness. An item is a "gap" only if it affects the observable / interop surface
+(hashes, result/meta XDR, SCP/overlay wire, archive format, HTTP/RPC/CLI, crypto)
+and is missing or partial. An internal helper implemented differently but
+producing the same observable output is NOT a gap — record it under
+Architectural Differences.
+
 Count the functions/components from Step 3:
 - `implemented` = items marked Full
-- `gaps` = items marked None or Partial that are NOT intentional omissions
+- `gaps` = items marked None or Partial that affect the observable surface and are NOT intentional omissions
 - `omissions` = items deliberately excluded with documented rationale
 
 Parity % = `implemented / (implemented + gaps)` (omissions excluded from
@@ -222,6 +229,8 @@ transaction replay statistics, etc.
 - Must include a concrete rationale for each omission.
 - Common rationales: "SQLite only", "sequential execution only",
   "handled by <other crate>", "deprecated in protocol 23+".
+- A surface listed here must not be part of the observable / interop contract
+  (`docs/PARITY.md`); if it is, it is a real gap, not an omission.
 
 ### Gaps
 - Priority levels: High (blocks correctness), Medium (affects completeness),
@@ -231,6 +240,8 @@ transaction replay statistics, etc.
 ### Architectural Differences
 - Numbered list. Each item has stellar-core approach, Rust approach, and
   rationale.
+- These are divergeable-surface differences (`docs/PARITY.md`) — expected, and
+  never counted as gaps.
 - Focus on differences that affect how someone reads or maintains the code.
 - Do not list trivial language differences (e.g., "C++ uses classes, Rust
   uses structs").

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -53,7 +53,7 @@ Then explore the codebase to ground your plan:
 
 - Read the relevant crate's source files: at least the module-level docs, the function you'd be changing, and the surrounding context.
 - Read the most relevant existing tests in `crates/<crate>/tests/` to understand the testing patterns.
-- If the issue is parity-critical (touches `crates/scp/`, `crates/herder/`, `crates/ledger/`, `crates/tx/`, `crates/overlay/`), read the matching stellar-core code via the `stellar-core/` submodule.
+- If the issue is parity-critical (touches `crates/scp/`, `crates/herder/`, `crates/ledger/`, `crates/tx/`, `crates/overlay/` — the crates that own the observable/interop surface defined in `docs/PARITY.md`), read the matching stellar-core code via the `stellar-core/` submodule.
 
 Then post the draft:
 
@@ -77,8 +77,12 @@ control flow changes. Reference specific functions by name where appropriate.>
 - **Existing tests preserved**: explicit list of relevant existing tests that must keep passing (especially when refactoring touches shared code). These should be in `cargo test -p henyey-<crate>` and verified pre-/post- by `/do`.
 
 **Parity considerations:**
-<If parity-critical: which stellar-core function/file matches, what semantics
-must be preserved. If not parity-critical: write "n/a — non-parity path".>
+<Parity = the observable/interop surface in `docs/PARITY.md` (hashes, result/meta
+XDR, SCP/overlay wire, archive format, HTTP/RPC/CLI, crypto). If the plan changes
+that surface: which stellar-core function/file matches and what observable
+semantics must be preserved. If the change is internal-only (architecture,
+utilities, metrics, logging, admin endpoints, perf — same observable output),
+write "n/a — does not change the observable surface".>
 
 **Risks:**
 <Known unknowns, edge cases, things that might bite at review time. Be honest.>
@@ -198,12 +202,18 @@ Run three lens passes in sequence (correctness / parity / scope), each as its ow
 
 ### Critic B — Parity
 
-> Same setup as Critic A, but evaluate ONLY: does the plan match stellar-core's
-> behavior on this code path? Consult the stellar-core/ submodule. Identify the
-> matching stellar-core function(s). Compare semantics. Flag any divergence as
-> REVISE-MAJOR. If the plan is for a non-parity path (e.g. tooling, docs), say
-> so and APPROVE. Post as `## 🔍 Critic B (parity) — Round 1` with the same
-> structure as Critic A.
+> Same setup as Critic A, but evaluate ONLY parity as defined in
+> `docs/PARITY.md`: does the plan preserve the **observable / interop surface**
+> (ledger/bucket hashes, transaction result & meta XDR, SCP/overlay wire bytes,
+> history archive format, HTTP/RPC/CLI contracts, crypto outputs)? Consult the
+> stellar-core/ submodule and identify the matching function(s) only when the
+> plan touches that surface. Flag a divergence as REVISE-MAJOR **only** if it
+> changes the observable surface or breaks interop. Differences in internal
+> architecture, helper utilities, metrics, logging, admin/debug endpoints, or
+> performance are explicitly allowed — do NOT flag them as parity concerns
+> (other lenses cover correctness/scope). If the plan does not change the
+> observable surface, say so and APPROVE. Post as `## 🔍 Critic B (parity) —
+> Round 1` with the same structure as Critic A.
 
 ### Critic C — Scope
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -90,9 +90,12 @@ Evaluate the fix along these dimensions:
 - **Side effects**: Could the fix change behavior in any code path other than
   the one it targets? Check all callers of modified functions and all consumers
   of modified types.
-- **Parity**: If the fix touches protocol, consensus, or ledger logic, verify
-  that the fixed behavior matches stellar-core. Read the corresponding
-  stellar-core code to confirm.
+- **Parity**: If the fix changes the **observable / interop surface** defined in
+  `docs/PARITY.md` (hashes, result/meta XDR, SCP/overlay wire, archive format,
+  HTTP/RPC/CLI, crypto), verify the fixed behavior matches stellar-core — read
+  the corresponding stellar-core code to confirm. Internal-only changes
+  (architecture, utilities, metrics, logging, performance) with identical
+  observable output are not parity concerns.
 
 Classify the fix:
 - **SOUND**: Correctly addresses the root cause with no concerns.
@@ -214,7 +217,7 @@ not justify a type-system overhaul.
 - **Correctness**: Does it address the root cause?
 - **Design fit**: Is it consistent with the system's design?
 - **Edge cases**: Any cases not covered?
-- **Parity**: Does it maintain stellar-core parity? (if applicable)
+- **Parity**: Does it preserve the observable/interop surface (`docs/PARITY.md`)? (if applicable)
 - **Side effects**: Any unintended behavioral changes?
 - **Verdict**: SOUND / CONCERNS / INCOMPLETE / WRONG — summary
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -272,7 +272,7 @@ Inspect the PR's changed files:
 gh pr diff $PR_NUM --repo stellar-experimental/henyey --name-only
 ```
 
-If any path matches one of these prefixes, the PR is **parity-critical** — Reviewer B uses parity lens:
+If any path matches one of these prefixes, the PR is **parity-critical** — Reviewer B uses parity lens. These crates own the observable/interop surface defined in `docs/PARITY.md`:
 
 - `crates/scp/`
 - `crates/herder/`
@@ -424,12 +424,19 @@ Post via `gh pr comment $PR_NUM --repo stellar-experimental/henyey --body-file <
 **If parity-critical:**
 
 > Invoke /spec-adhere style audit on PR #$PR_NUM in stellar-experimental/henyey.
-> Focus on: does the change match stellar-core's behavior on this path?
-> Consult the `stellar-core/` submodule for the matching C++ implementation.
-> Identify any divergence in semantics, edge cases, or sequencing. Post your
-> verdict as a single PR-level comment via `gh pr comment`, headed
-> `## 🔍 Reviewer: Parity`, with `**Verdict:**` on its own line. Reviewer A
-> is doing correctness; you focus only on parity.
+> Focus on parity as defined in `docs/PARITY.md`: does the change preserve the
+> **observable / interop surface** — ledger/bucket hashes, transaction result &
+> meta XDR, SCP/overlay wire bytes, history archive format, HTTP/RPC/CLI
+> contracts, crypto outputs? Consult the `stellar-core/` submodule for the
+> matching C++ implementation. Raise a CHANGES_REQUESTED concern **only** for a
+> divergence in bytes that cross the network, land in an archive, or appear in
+> hashes/XDR/API responses — i.e. something a peer, Horizon, stellar-rpc, or an
+> archive consumer could observe. Differences in internal architecture, helper
+> utilities, metrics, logging, admin/debug endpoints, or performance are
+> explicitly allowed — do NOT flag them as parity concerns. Post your verdict as
+> a single PR-level comment via `gh pr comment`, headed `## 🔍 Reviewer: Parity`,
+> with `**Verdict:**` on its own line. Reviewer A is doing correctness; you
+> focus only on observable-surface parity.
 >
 > **Cycle-awareness (same discipline as Reviewer A):** Before writing your
 > review, fetch your own prior comments via

--- a/.claude/skills/spec-adhere/SKILL.md
+++ b/.claude/skills/spec-adhere/SKILL.md
@@ -27,7 +27,8 @@ every MUST / SHALL / MUST NOT / SHALL NOT statement, every
 protocol-version branch, and every error-code mapping is checked.
 This is the inverse of `/spec-from-core` and complements
 `/parity-check` (which compares Rust against C++ headers, not
-against the specs).
+against the specs). Both serve the observable / interop parity
+contract defined in `docs/PARITY.md`.
 
 ## Spec ↔ Crate Mapping
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -101,7 +101,7 @@ If ALL of these hold:
 
 - Size estimate is **XS**.
 - Single-file change.
-- No protocol / consensus / parity implications (does not touch `crates/scp/`, `crates/herder/`, `crates/ledger/`, `crates/tx/`, `crates/overlay/`).
+- No observable-surface / interop implications (does not touch `crates/scp/`, `crates/herder/`, `crates/ledger/`, `crates/tx/`, `crates/overlay/` — the crates that own the observable surface defined in `docs/PARITY.md`).
 - Test impact is obvious (no new test file needed, or one assertion in an existing test).
 
 Then mark the issue trivial. Post a `## Triage Report` comment with the structure below, including an `## Implementation Notes` section that names the exact file path and the precise change. `/do` will use these notes as the plan and skip `/plan` entirely.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ This codebase is under heavy construction. Don't be afraid to make significant c
 
 ## Determinism & Parity
 
-- Any observable behavior must be deterministic and identical to stellar-core (v25.x / p25).
-- Align behavior by comparing against stellar-core test vectors and edge cases; do not introduce new semantics.
+- Parity has two tiers (see `docs/PARITY.md` for the full definition). The **observable / interop surface MUST match** stellar-core: ledger/bucket hashes, transaction result & meta XDR, SCP/overlay wire bytes, history archive format, HTTP/RPC/CLI contracts, and crypto outputs. You **MAY deviate freely** on internal architecture, helper utilities, metrics, logging, admin/debug endpoints, and performance.
+- Behavior on the observable surface must be deterministic; do not introduce new *observable* semantics. Internal redesigns are welcome — compare against stellar-core test vectors and edge cases for the observable surface.
 - For protocol or consensus behavior, consult `stellar-core/` to mirror upstream decisions and sequencing.
 - Update the relevant crate's `PARITY_STATUS.md` and the parity column in the main `README.md` Crate Overview when implementing or removing functionality that affects stellar-core parity.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@
 
 ## Determinism & Parity
 
-- Any observable behavior must be deterministic and identical to stellar-core (v25.x / p25).
-- Align behavior by comparing against stellar-core test vectors and edge cases; do not introduce new semantics.
+- Parity has two tiers (see `docs/PARITY.md` for the full definition). The **observable / interop surface MUST match** stellar-core: ledger/bucket hashes, transaction result & meta XDR, SCP/overlay wire bytes, history archive format, HTTP/RPC/CLI contracts, and crypto outputs. You **MAY deviate freely** on internal architecture, helper utilities, metrics, logging, admin/debug endpoints, and performance.
+- Behavior on the observable surface must be deterministic; do not introduce new *observable* semantics. Internal redesigns are welcome — compare against stellar-core test vectors and edge cases for the observable surface.
 - For protocol or consensus behavior, consult `stellar-core/` to mirror upstream decisions and sequencing.
 - Update the relevant crate's `PARITY_STATUS.md` and the parity column in the main `README.md` Crate Overview when implementing or removing functionality that affects stellar-core parity.
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,8 @@ henyey/
 
 ## Crate Overview
 
+Parity % measures observable-surface coverage against upstream, not internal sameness — see [docs/PARITY.md](docs/PARITY.md).
+
 ### Core Infrastructure
 
 | Crate | Purpose | Parity |
@@ -549,7 +551,7 @@ This implementation intentionally limits scope:
 |------------|-----------|
 | **Protocol 24+ only** | Focus on current protocol behavior |
 | **SQLite-only** | Simplicity over PostgreSQL support |
-| **Deterministic** | Observable behavior must match stellar-core |
+| **Deterministic** | Observable surface (hashes, XDR, wire, API) must match stellar-core; internal design, metrics, perf may differ — see [docs/PARITY.md](docs/PARITY.md) |
 
 ## Development
 
@@ -589,7 +591,7 @@ RUST_LOG=henyey_scp=debug,henyey_herder=debug ./target/release/henyey ...
 
 ## Contributing
 
-- Keep behavior deterministic and aligned with stellar-core v25.x
+- Keep the observable surface aligned with stellar-core (see [docs/PARITY.md](docs/PARITY.md)); internal architecture, metrics, and performance may differ
 - Add or update tests when behavior changes
 - Update crate READMEs when modifying subsystem behavior
 - Run `cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings`, and focused tests for touched crates before committing

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -1,0 +1,75 @@
+# Parity with stellar-core
+
+henyey is a Rust reimplementation of stellar-core. "Parity" here does **not**
+mean a line-by-line or structure-by-structure copy of the C++. It means henyey
+behaves identically to stellar-core *where it is observable*, while remaining
+free to differ everywhere it is not.
+
+This document is the single source of truth for what parity requires. Other
+docs (`CLAUDE.md`, `AGENTS.md`, `README.md`) and the project-loop skills
+(`.claude/skills/`) reference it instead of restating the definition.
+
+## The two hard requirements (MUST hold)
+
+1. **Observed-behavior parity** — henyey produces bit-for-bit identical output
+   to stellar-core on the observable surface enumerated below.
+2. **Interoperability** — a henyey node can join a network alongside
+   stellar-core nodes and reach identical consensus and ledger state, and any
+   external consumer (peer, Horizon, stellar-rpc, archive reader) cannot
+   distinguish it from a core node by the bytes it emits.
+
+Reference is the pinned `stellar-core/` submodule. Protocol support is 24+.
+
+## Observable / interop surface — MUST match
+
+| Surface | Owning crates |
+|---|---|
+| Ledger header & hashes (`LedgerHeader`, ledger hash, bucket-list hash) | ledger, bucket |
+| BucketList ordering, merge results, bucket hashes, archived bucket bytes | bucket |
+| Transaction results (`TransactionResult` codes & XDR) | tx, ledger |
+| Transaction/ledger meta (`LedgerCloseMeta` / `TransactionMeta` XDR) | ledger, tx, app |
+| Classic & Soroban event XDR + ordering | tx |
+| SCP wire (`SCPEnvelope`/`SCPStatement` signed bytes, nomination/balloting sequencing, quorum decisions) | scp, herder |
+| Overlay P2P wire (`StellarMessage` framing, auth handshake, flood/flow-control observable to peers) | overlay, herder |
+| History archive format (checkpoint layout, `.xdr` framing, HAS files, file naming) | history, historywork |
+| HTTP API contract (`/info`, `/tx`, `/getledgerentry`, upgrades, surveys) | app |
+| JSON-RPC contract (method request/response schemas) | rpc |
+| CLI contract (subcommands consumed by external tooling) | henyey |
+| Crypto outputs (signatures, hashes, strkey encodings) | crypto |
+
+**Rule of thumb:** *if a core node, Horizon, stellar-rpc, an archive consumer,
+or a peer could tell henyey apart by observing bytes on a wire, on disk in an
+archive, or in an API response — it must NOT differ.*
+
+## Divergeable surface — MAY differ freely
+
+The following are **not** parity concerns. Changes here are subject to the
+normal correctness / scope / risk review, but they are never flagged as parity
+violations:
+
+- **Internal architecture** — module/crate boundaries, type layout, the
+  threading/async model, savepoint vs. nested-`LedgerTxn` strategy, SQLite-only
+  storage, and any other implementation structure.
+- **Helper utilities** — internal helpers and abstractions with no upstream
+  counterpart, as long as their observable output matches.
+- **Metrics** — metric names, labels, existence, and values.
+- **Logging** — log formats, levels, and content.
+- **Admin / debug endpoints** not consumed by core, Horizon, stellar-rpc, or
+  peers.
+- **Performance** — optimizations of any kind, provided the observable surface
+  and interop are preserved.
+
+## Mapping to `PARITY_STATUS.md`
+
+Each crate's `PARITY_STATUS.md` already encodes these tiers:
+
+- **Intentional Omissions** — parts of the divergeable surface deliberately not
+  built. Excluded from the parity %. (If something listed here is actually part
+  of the observable/interop contract, it is a real gap, not an omission.)
+- **Architectural Differences** — divergeable-surface differences with a
+  rationale. Expected, and never counted as gaps.
+
+Parity % (`implemented / (implemented + gaps)`) measures **observable-surface
+coverage** against upstream — not internal sameness. An internal helper
+implemented differently but producing the same observable output is not a gap;
+it belongs under Architectural Differences.


### PR DESCRIPTION
Closes #3659

## What

Replaces the over-strict "identical to stellar-core" parity rule with an explicit **two-tier** definition:

- **MUST match** — the *observable / interop surface*: ledger/bucket hashes, transaction result & meta XDR, SCP/overlay wire bytes, history archive format, HTTP/RPC/CLI contracts, crypto outputs.
- **MAY deviate freely** — internal architecture, helper utilities, metrics, logging, admin/debug endpoints, performance.

## Changes

- **`docs/PARITY.md`** (new) — single source of truth, with a per-surface→crate table and the rule of thumb: *if a peer, Horizon, stellar-rpc, or an archive consumer could tell henyey apart by observed bytes, it must NOT differ.*
- **`CLAUDE.md` / `AGENTS.md`** — §Determinism & Parity reworded (dropped "identical to stellar-core" / "do not introduce new semantics"), kept byte-identical, link to `docs/PARITY.md`.
- **`README.md`** — Design Constraints, Contributing, and Crate Overview intro point at `docs/PARITY.md`.
- **Project-loop gates (`.claude/skills/`)** — `plan` Critic B and `review-pr` Reviewer B now flag divergence **only** on the observable surface; `review-fix`, `triage`, `cleanup` (parity-risk redefined as observable-surface risk), `parity-check`, and `spec-adhere` scoped/pointed accordingly.

## Notes / scope

- `parity-check`'s `implemented/(implemented+gaps)` formula is **unchanged** — only the wording clarifies that a "gap" is an observable-surface gap. The 18 existing `PARITY_STATUS.md` files stay valid.
- `.agents/skills/` (Codex tree) intentionally **not** touched; unifying the two skill trees is a separate effort.

## Tests

Documentation/process change only — no code paths affected. Verified: `docs/PARITY.md` exists and all 10 docs/skills reference it; `CLAUDE.md` and `AGENTS.md` parity sections remain identical; no lingering "identical to stellar-core" / "do not introduce new semantics" prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)