### PR TITLE
maxtps-optimize run (target 1000): baseline 217 + bottleneck diagnosis

### DIFF
--- a/docs/maxtps-optimization/2026-06-26-target1000.md
+++ b/docs/maxtps-optimization/2026-06-26-target1000.md
@@ -1,0 +1,36 @@
+# maxtps-optimize run — 2026-06-26, target 1000 tx/s
+
+- Session: `87b30bda` · Instance: `pl1pokpcv4p02` (nsc 32×64) · Base commit: `0be20e9f`
+- Methodology: MissionMaxTPSClassic, 23-node tier-1, short-probe
+  (`SSC_MAXTPS_TXS_MULTIPLIER=60`, `SSC_LOADGEN_FASTFAIL_LEDGERS=10`),
+  `--install-network-delay false`. Accept bar: Δ > 5%. Max iterations: 20.
+- **Current best: 217 tx/s** (baseline, image `opt-87b30bda-base`) · Target: 1000
+
+## Hypotheses
+
+| # | hypothesis | instrumentation added | measurement | Δ vs best | status | notes / next |
+|---|------------|-----------------------|-------------|-----------|--------|--------------|
+| 0 | baseline (HEAD `0be20e9f`) | — | **217 tx/s** (pass 210/217, fail 225/240) | — | baseline | image `opt-87b30bda-base`; matches ~221 reference within noise |
+| 1 | **Diagnose the cap** at near-ceiling load (scrape existing meters, no rebuild). | none (reused existing meters) | rate 207 (passing): `ledger.ledger.close` mean **29ms**/max 125ms; `ledger.transaction.count` median **1062**/max 1097 vs **maxTxSetSize 2070** (~51% full); cadence ~5s; quorum EXTERNALIZE lag 43ms, 22 peers; loadgen rejected 0 | — | **accepted (finding)** | **Apply is NOT the cap** (29ms ≪ 5s window); tx-set ~half full so capacity is ample. Throughput ≈ txns/ledger ÷ ~5s cadence ⇒ ceiling ~217 = ~1085/ledger. Limiter is consensus/dissemination-side. → iter 2: scrape at a FAILING rate to find the saturating subsystem. |
+| 2 | **Failing-rate diagnostic** (rate 252, no rebuild): tx-set fill vs close cadence vs lost sync? | none (reused meters, 2 scrapes 33s apart) | close cadence **~3.3s** (ledger 59→69 in 33s); `ledger.ledger.close` mean **33–39ms**; `ledger.transaction.count` max **1390** vs **maxTxSetSize 2520** (~55%); all 23 nodes `Synced!` same ledger, quorum EXTERNALIZE lag ~44ms | — | **accepted (finding)** | Rules out apply speed, tx-set capacity, and sync break. Cap = sustained txns-included-per-round (consensus/dissemination). No cheap parity-safe code lever from black-box metrics → needs CPU/wall profiling of herder/overlay/tx-set-fetch under load (uftrace), not blind changes. |
+| 3 | `NodeLostSyncException` near capacity: per-node apply-duration vs close-time + sync state | — | — | — | pending | a lagging node caps the network |
+| 4 | Ledger-close cadence: phase-timer breakdown (existing timers in `crates/app/src/metrics.rs`) | — | — | — | pending | is a commit/persist/bucket phase stretching close time? |
+| 5 | (deprioritized) Per-tx serial apply overhead (`run_transactions_on_executor`, `snapshot_delta` clone) | — | — | — | pending | only if `classic_exec` dominates close time |
+
+## Summary
+
+- **Baseline → final: 217 → 217 tx/s** (0 behavior changes accepted; 2 diagnostic iterations completed). Target 1000 not approached — it is ~4.6× the current ceiling and not reachable by incremental black-box tuning.
+- **PRs**: none (no code change met the bar; no change was forced).
+- **Diagnosis (high-confidence, from 2 cheap no-rebuild scrapes)**: the cap is **consensus/dissemination throughput** — sustained transactions included+externalized per round. Conclusively NOT:
+  - apply speed (ledger close 30–40 ms vs multi-second cadence),
+  - tx-set capacity (sets run ~50–55% full at both passing and failing rates),
+  - a hard sync break at the ceiling (all 23 nodes stayed `Synced!`/`EXTERNALIZE` at rate 252).
+- **Why the run stopped at iteration 2**: black-box metrics localize the bottleneck to consensus/overlay but cannot identify a *specific*, minimally-scoped, parity-safe code lever. The two obvious knobs — ledger close cadence and `maxTxSetSize` — are protocol-observable (parity-locked). Per the skill's mandate (only keep *proven* >5% parity-safe changes; "be efficient — don't start lengthy runs for no good reason"; "if no clean parity-safe lever emerges, say so honestly"), spending ~18 more build(~12 min)+cloud-run cycles on blind guesses was not justified.
+
+### Recommended next step (separate, focused effort)
+Profile a henyey node **under distributed load** (uftrace — repo already has `perf-optimize-uftrace` + `docs/perf-hypotheses-uftrace.md`) on the herder/overlay/tx-set-fetch hot path, and/or run a **core-vs-henyey side-by-side scrape** to see whether core fills tx-sets fuller or closes rounds faster at the same scaled `maxTxSetSize`. That converts "it's consensus/dissemination" into a concrete function-level target a future `maxtps-optimize` run can act on.
+
+### Top remaining (now-reframed) hypotheses
+1. Overlay tx flooding throughput / flow-control: does a node receive+process flooded txns fast enough to nominate fuller sets? (`crates/overlay`, `crates/herder`).
+2. Tx-set fetch/validation latency at higher fill: time to fetch+apply a nominated set vs the round budget.
+3. SCP nomination/ballot round time growth under load (cadence was ~3.3 s at rate 252).


### PR DESCRIPTION
First autonomous `/maxtps-optimize` run (session 87b30bda, target 1000, cap 20). Adds the run log `docs/maxtps-optimization/2026-06-26-target1000.md`.

## Outcome
- **Baseline measured: 217 tx/s** (short-probe, matches the ~221 reference within noise).
- **0 code changes** — none met the >5% parity-safe bar; none were forced.
- Stopped after **2 diagnostic iterations** with a high-confidence bottleneck diagnosis (see below). Target 1000 (~4.6×) is not reachable by incremental black-box tuning.

## Diagnosis (2 cheap no-rebuild metric scrapes)
The cap is **consensus/dissemination throughput** (sustained txns included+externalized per round). Conclusively **not**:
- apply speed — ledger close ~30–40 ms vs multi-second cadence;
- tx-set capacity — sets run ~50–55% full at both passing (1062/2070) and failing (1390/2520) rates;
- a sync break at the ceiling — all 23 nodes stayed `Synced!`/`EXTERNALIZE` (lag ~44 ms) at rate 252.

## Why it stopped at iter 2 (honest, per the skill)
Black-box metrics localize the bottleneck to consensus/overlay but don't expose a *specific, minimally-scoped, parity-safe* code lever. The two obvious knobs (close cadence, `maxTxSetSize`) are protocol-observable → parity-locked. Per the skill's mandate (keep only *proven* >5% parity-safe changes; be efficient; say so honestly if no lever emerges), burning ~18 more ~12-min build + cloud-run cycles on blind guesses wasn't justified.

## Recommended next step
A focused profiling effort: **uftrace** the herder/overlay/tx-set-fetch hot path under distributed load (repo already has `perf-optimize-uftrace` + `docs/perf-hypotheses-uftrace.md`), and/or a **core-vs-henyey side-by-side scrape** to see whether core fills tx-sets fuller / closes rounds faster at the same scaled `maxTxSetSize`. That turns "it's consensus/dissemination" into a function-level target a follow-up run can act on.

Instance `pl1pokpcv4p02` destroyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)