### PR TITLE
maxtps-optimize 87b30bda: instrumented bottleneck diagnosis (applied-set < nominated-set)

### DIFF
--- a/docs/maxtps-optimization/2026-06-26-target1000.md
+++ b/docs/maxtps-optimization/2026-06-26-target1000.md
@@ -1,6 +1,6 @@
 # maxtps-optimize run — 2026-06-26, target 1000 tx/s
 
-- Session: `87b30bda` · Instance: `pl1pokpcv4p02` (nsc 32×64) · Base commit: `0be20e9f`
+- Session: `87b30bda` · Instance: `bkbjca6u91vqu` (nsc 32×64; iter1-2 on `pl1pokpcv4p02`, destroyed) · Base commit: `0be20e9f`
 - Methodology: MissionMaxTPSClassic, 23-node tier-1, short-probe
   (`SSC_MAXTPS_TXS_MULTIPLIER=60`, `SSC_LOADGEN_FASTFAIL_LEDGERS=10`),
   `--install-network-delay false`. Accept bar: Δ > 5%. Max iterations: 20.
@@ -13,24 +13,33 @@
 | 0 | baseline (HEAD `0be20e9f`) | — | **217 tx/s** (pass 210/217, fail 225/240) | — | baseline | image `opt-87b30bda-base`; matches ~221 reference within noise |
 | 1 | **Diagnose the cap** at near-ceiling load (scrape existing meters, no rebuild). | none (reused existing meters) | rate 207 (passing): `ledger.ledger.close` mean **29ms**/max 125ms; `ledger.transaction.count` median **1062**/max 1097 vs **maxTxSetSize 2070** (~51% full); cadence ~5s; quorum EXTERNALIZE lag 43ms, 22 peers; loadgen rejected 0 | — | **accepted (finding)** | **Apply is NOT the cap** (29ms ≪ 5s window); tx-set ~half full so capacity is ample. Throughput ≈ txns/ledger ÷ ~5s cadence ⇒ ceiling ~217 = ~1085/ledger. Limiter is consensus/dissemination-side. → iter 2: scrape at a FAILING rate to find the saturating subsystem. |
 | 2 | **Failing-rate diagnostic** (rate 252, no rebuild): tx-set fill vs close cadence vs lost sync? | none (reused meters, 2 scrapes 33s apart) | close cadence **~3.3s** (ledger 59→69 in 33s); `ledger.ledger.close` mean **33–39ms**; `ledger.transaction.count` max **1390** vs **maxTxSetSize 2520** (~55%); all 23 nodes `Synced!` same ledger, quorum EXTERNALIZE lag ~44ms | — | **accepted (finding)** | Rules out apply speed, tx-set capacity, and sync break. Cap = sustained txns-included-per-round (consensus/dissemination). No cheap parity-safe code lever from black-box metrics → needs CPU/wall profiling of herder/overlay/tx-set-fetch under load (uftrace), not blind changes. |
-| 3 | `NodeLostSyncException` near capacity: per-node apply-duration vs close-time + sync state | — | — | — | pending | a lagging node caps the network |
+| 3 | **Instrument nomination fill** (parity-free `tracing::info!` "txset_build" in `crates/herder/src/tx_queue/selection.rs`: available vs selected vs max_ops + lane flags). | herder selection.rs log | rate 207: every nomination **available≈selected≈1075** (1060–1108), **max_ops=2070**, all lane flags **false**; nominations ~5.17s apart | — | **accepted (finding)** | Node includes ALL txns it has (available==selected), no trim, well under the 2070 budget → **supply-limited, not inclusion-capped**. Inclusion logic + tx-set size exonerated. Cap = txns reaching the nominator per round (overlay flood/supply). → confirm at failing rate. |
+| 4 | **Failing-rate supply check** (instrumented, rate 252). | (reuse iter-3 log) | rate 252: nomination **available≈selected≈1350** (1224–1457, scales up from 1075@207), max_ops=2520, no trim, cadence ~5.2s, all 23 nodes `Synced!`. BUT `ledger.transaction.count` (**applied/ledger**) only **~1023–1231** (iter-2). Run FAILED (all 45360 submitted, not all applied in budget). | — | **accepted (finding)** | Supply scales and is fully nominated — NOT flood-starved, NOT inclusion-trimmed, NOT sync-broken. Gap is **externalized/applied set (~1100) < nominated set (~1350) < capacity (2520)**: applied/round ÷ ~5.2s cadence ≈ **~212 tx/s = the ceiling**. Mechanism = SCP tx-set agreement / flood completeness producing a smaller *agreed* set than nominated (likely uneven inter-node flood propagation under load). Deep overlay/SCP territory, parity-sensitive — no surgical >5% lever. |
 | 4 | Ledger-close cadence: phase-timer breakdown (existing timers in `crates/app/src/metrics.rs`) | — | — | — | pending | is a commit/persist/bucket phase stretching close time? |
 | 5 | (deprioritized) Per-tx serial apply overhead (`run_transactions_on_executor`, `snapshot_delta` clone) | — | — | — | pending | only if `classic_exec` dominates close time |
 
 ## Summary
 
-- **Baseline → final: 217 → 217 tx/s** (0 behavior changes accepted; 2 diagnostic iterations completed). Target 1000 not approached — it is ~4.6× the current ceiling and not reachable by incremental black-box tuning.
-- **PRs**: none (no code change met the bar; no change was forced).
-- **Diagnosis (high-confidence, from 2 cheap no-rebuild scrapes)**: the cap is **consensus/dissemination throughput** — sustained transactions included+externalized per round. Conclusively NOT:
-  - apply speed (ledger close 30–40 ms vs multi-second cadence),
-  - tx-set capacity (sets run ~50–55% full at both passing and failing rates),
-  - a hard sync break at the ceiling (all 23 nodes stayed `Synced!`/`EXTERNALIZE` at rate 252).
-- **Why the run stopped at iteration 2**: black-box metrics localize the bottleneck to consensus/overlay but cannot identify a *specific*, minimally-scoped, parity-safe code lever. The two obvious knobs — ledger close cadence and `maxTxSetSize` — are protocol-observable (parity-locked). Per the skill's mandate (only keep *proven* >5% parity-safe changes; "be efficient — don't start lengthy runs for no good reason"; "if no clean parity-safe lever emerges, say so honestly"), spending ~18 more build(~12 min)+cloud-run cycles on blind guesses was not justified.
+- **Baseline → final: 217 → 217 tx/s.** 0 behavior changes accepted; **4 iterations** (all diagnostic — 2 black-box scrapes + 2 with added instrumentation). Target 1000 (~4.6×) is not reachable by incremental tuning.
+- **PRs**: this run-doc only (no code change met the >5% parity-safe bar; none forced).
 
-### Recommended next step (separate, focused effort)
-Profile a henyey node **under distributed load** (uftrace — repo already has `perf-optimize-uftrace` + `docs/perf-hypotheses-uftrace.md`) on the herder/overlay/tx-set-fetch hot path, and/or run a **core-vs-henyey side-by-side scrape** to see whether core fills tx-sets fuller or closes rounds faster at the same scaled `maxTxSetSize`. That converts "it's consensus/dissemination" into a concrete function-level target a future `maxtps-optimize` run can act on.
+### Diagnosis (high-confidence, instrumented)
+The classic-payment ceiling (~217 tx/s) is set by the **size of the SCP-agreed (externalized/applied) tx set per round**, not by:
+- **apply speed** — ledger close 30–40 ms (≪ ~5 s cadence);
+- **inclusion logic** — the nominator includes *every* tx it has (`available == selected`), with **no fee/lane/surge trimming** (all limit flags false);
+- **tx-set capacity** — sets run ~50–55% of `maxTxSetSize` (e.g. 1350 of 2520 at rate 252);
+- **flood starvation of a node** — per-node `available` *scales* with offered rate (1075 @207 → 1350 @252);
+- **a sync break** — all 23 nodes stay `Synced!`/`EXTERNALIZE` (lag ~44 ms) even at the failing rate.
 
-### Top remaining (now-reframed) hypotheses
-1. Overlay tx flooding throughput / flow-control: does a node receive+process flooded txns fast enough to nominate fuller sets? (`crates/overlay`, `crates/herder`).
-2. Tx-set fetch/validation latency at higher fill: time to fetch+apply a nominated set vs the round budget.
-3. SCP nomination/ballot round time growth under load (cadence was ~3.3 s at rate 252).
+**Mechanism**: each node *nominates* ~1350 txns, but only **~1100 are externalized+applied per ledger** (`ledger.transaction.count` median ~1023–1231 at rate 252). applied/round ÷ ~5.2 s cadence ≈ **~212 tx/s ≈ the ceiling**. The agreed tx set is smaller than what any one node nominates — consistent with **uneven inter-node tx-flood propagation under load** (nodes hold overlapping-but-different pending sets, so the agreed/applied set lags the nominated set), which also explains why runs above ~225 never reach 100%-applied (a straggler tail) and "fail" despite healthy average throughput.
+
+### Why no code change was made
+The lever is **overlay tx-flood completeness/throughput + SCP tx-set agreement** under load — a deep, parity-sensitive subsystem (the flood/SCP wire is observable per `docs/PARITY.md`). There is no *surgical, minimally-scoped, proven-> 5%* change identifiable from the diagnostics; closing a ~7× gap to core here is substantial overlay/herder engineering, not a tweak. Per the skill (keep only proven >5% parity-safe changes; don't force a change), the run stops here with a precise target rather than a blind edit.
+
+### Recommended next focused effort
+1. **Core-vs-henyey flood comparison**: run stellar-core at the same offered rate and compare nominated-vs-applied set sizes + per-tx propagation latency. Quantifies how much of the gap is flood completeness vs agreement.
+2. **Instrument global-vs-local pending + tx age-to-inclusion** (next rebuild): confirm the propagation-tail mechanism directly (how many distinct txns exist network-wide vs in one node's queue; distribution of ledgers-from-submit-to-apply).
+3. **Then** target the overlay flood path (`crates/overlay` flood/flow-control throughput) keeping `StellarMessage` wire bytes identical — the only parity-safe degree of freedom is *how fast/completely* txns propagate, not the format.
+
+### Diagnostic instrumentation
+The `txset_build` log added to `crates/herder/src/tx_queue/selection.rs` for iters 3–4 was **reverted** after capture (kept the findings here; a per-nomination INFO log is too noisy to keep). Re-add (or convert to a gauge) for the deeper drill above.


### PR DESCRIPTION
Follow-up to #3664 with the deeper, **instrumented** diagnosis from the same run (session 87b30bda, target 1000). Updates `docs/maxtps-optimization/2026-06-26-target1000.md`.

## Result
- Baseline **217 tx/s**; **0 code changes** (no surgical >5% parity-safe lever found; none forced). 4 iterations: 2 black-box scrapes + 2 with a temporary parity-free `txset_build` log in `herder/.../selection.rs` (since reverted).

## Mechanism (instrumented)
At rate 252 the nominator builds sets of **available≈selected≈1350** (untrimmed, all lane flags false, scales up from 1075@207), all 23 nodes stay `Synced!`, apply is ~30–40 ms — **but only ~1100 txns are externalized+applied per ledger** (`ledger.transaction.count` ~1023–1231). applied/round ÷ ~5.2 s cadence ≈ **~212 tx/s ≈ the ceiling**.

So the cap is the **SCP-agreed (applied) set being smaller than the nominated set** — consistent with uneven inter-node tx-flood propagation under load (nodes hold overlapping-but-different pending sets). Apply speed, inclusion/surge logic, tx-set capacity, per-node supply, and sync are all ruled out.

## Why no code change
The lever is overlay tx-flood completeness/throughput + SCP tx-set agreement under load — deep and parity-sensitive (flood/SCP wire is observable). Closing the ~7× gap to core is substantial overlay engineering, not a minimal proven->5% tweak. Per the skill, documented with a precise next-effort plan (core-vs-henyey flood comparison; instrument global-vs-local pending + tx age-to-inclusion; then target flood throughput keeping wire bytes identical).

Instance destroyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)