### PR TITLE
Expose henyey native Prometheus metrics in Supercluster deployments

### DIFF
--- a/.claude/skills/maxtps-optimize/SKILL.md
+++ b/.claude/skills/maxtps-optimize/SKILL.md
@@ -112,7 +112,18 @@ runs to the cap (or target) by construction.
 ### Diagnosis escalation ladder (use when no >5% code lever is ready)
 Each rung is a valid iteration; climb it until a concrete, diagnosed,
 parity-safe lever emerges, then implement+measure it:
-1. **Scrape existing meters** (`/metrics`, `/info`) at passing and failing rates.
+1. **Scrape existing meters** at passing and failing rates. Two endpoints (via
+   `nsc kubectl <inst> exec <pod> -c stellar-core-run -- curl -s localhost:<port>/...`):
+   - `:11626` `/metrics` (compat **medida JSON**, `/info`) — curated core-compat
+     set (ledger close, tx count, etc.); this is what Supercluster itself reads.
+   - `:11628` `/metrics` (native **Prometheus** registry) — the FULL set incl. the
+     overlay/SCP propagation metrics absent from the medida JSON:
+     `stellar_overlay_tx_pull_latency_seconds` (mean = `_sum`/`_count`),
+     `stellar_overlay_demand_timeout_total`, `stellar_scp_timing_nominated_*`.
+     Enabled in SSC via the `RS_STELLAR_CORE_NATIVE_METRICS_PORT` env var
+     (Supercluster sets `11628`; see `StellarKubeSpecs.fs`). Use this for the
+     henyey-vs-core propagation comparison (core's overlay metrics are in its
+     medida `:11626` JSON, e.g. `overlay.flood.tx-pull-latency`).
 2. **Add metrics** (`crates/app/src/metrics.rs` catalog + refresh) for the
    suspected subsystem.
 3. **Add targeted logs** (e.g. `tracing::info!(target:"maxtps_diag", …)`) on the

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -982,6 +982,13 @@ impl App {
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                             // Only non-critical messages (TX floods) flow through the
                             // broadcast channel now, so lag is expected under load.
+                            // [maxtps_diag] Count dropped flood messages — under load
+                            // these are demanded txs the node never receives, forcing
+                            // re-demands (stellar_overlay_demand_timeout_total) and
+                            // leaving the agreed set short. Core never drops flooded
+                            // txs (flow-controlled per-peer queues).
+                            metrics::counter!("stellar_overlay_broadcast_lagged_dropped_total")
+                                .increment(n);
                             tracing::debug!(skipped = n, "Overlay broadcast receiver lagged (non-critical messages only)");
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -738,6 +738,18 @@ impl App {
             }
         }
         if sent > 0 || dropped > 0 || banned > 0 || unknown > 0 {
+            // [maxtps_diag] Fulfiller-side demand outcome counters — pinpoint why
+            // demands go unfulfilled (driving the demander's re-demand /
+            // demand-timeout). `unknown` = hash not in our queue when demanded
+            // (advert/include race); `dropped` = peer outbound channel full.
+            // stellar-core fulfils ~100% (overlay.flood.unfulfilled-*=0).
+            metrics::counter!("stellar_overlay_demand_fulfilled_total").increment(sent as u64);
+            metrics::counter!("stellar_overlay_demand_unfulfilled_dropped_total")
+                .increment(dropped as u64);
+            metrics::counter!("stellar_overlay_demand_unfulfilled_banned_total")
+                .increment(banned as u64);
+            metrics::counter!("stellar_overlay_demand_unfulfilled_unknown_total")
+                .increment(unknown as u64);
             tracing::debug!(
                 peer = %peer_id,
                 sent,

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -612,6 +612,12 @@ impl App {
                         match self.demand_status(hash, peer_id, now, &history) {
                             DemandStatus::Demand => {
                                 demand.push(hash);
+                                // An existing history entry means this hash was
+                                // demanded before and its prior demand(s) went
+                                // unfulfilled past the retry delay — i.e. a
+                                // timeout-driven re-demand. Mirrors stellar-core's
+                                // `overlay.demand.timeout` meter.
+                                let is_redemand = history.contains_key(&hash);
                                 let entry = history.entry(hash).or_insert_with(|| {
                                     pending.push_back(hash);
                                     TxDemandHistory {
@@ -623,6 +629,10 @@ impl App {
                                 });
                                 entry.peers.insert(peer_id.clone(), now);
                                 entry.last_demanded = now;
+                                if is_redemand {
+                                    metrics::counter!("stellar_overlay_demand_timeout_total")
+                                        .increment(1);
+                                }
                                 added_new = true;
                                 any_new_demand = true;
                             }
@@ -1366,6 +1376,58 @@ mod tests {
 
     fn ms(v: u64) -> Duration {
         Duration::from_millis(v)
+    }
+
+    /// `demand_status` returns `Demand` for a first demand and again — after the
+    /// retry delay — for a re-demand, which is the timeout-driven path that
+    /// increments `stellar_overlay_demand_timeout_total` in `run_tx_demands`.
+    #[tokio::test]
+    async fn test_demand_status_redemand_after_retry_delay() {
+        use std::collections::HashMap;
+        use std::time::Instant;
+
+        let (_dir, app) = create_test_app_with_overlay().await;
+        let peer_a = make_peer_id(1);
+        let peer_b = make_peer_id(2);
+        // A hash that is NOT in the tx queue (so it isn't Discarded).
+        let hash = Hash256::from_bytes([0x11; 32]);
+
+        // No history → first demand (not a timeout; counter would NOT fire).
+        let empty: HashMap<Hash256, TxDemandHistory> = HashMap::new();
+        assert!(matches!(
+            app.demand_status(hash, &peer_a, Instant::now(), &empty),
+            DemandStatus::Demand
+        ));
+
+        // Prior demand from peer_a at t0.
+        let t0 = Instant::now();
+        let mut history: HashMap<Hash256, TxDemandHistory> = HashMap::new();
+        let mut peers = HashMap::new();
+        peers.insert(peer_a.clone(), t0);
+        history.insert(
+            hash,
+            TxDemandHistory {
+                first_demanded: t0,
+                last_demanded: t0,
+                peers,
+                latency_recorded: false,
+            },
+        );
+
+        // Before the retry delay elapses → RetryLater (no re-demand).
+        assert!(matches!(
+            app.demand_status(hash, &peer_b, t0, &history),
+            DemandStatus::RetryLater
+        ));
+
+        // After the retry delay → Demand. In `run_tx_demands` this is the branch
+        // where `history.contains_key(&hash)` is true, so the demand-timeout
+        // counter is incremented.
+        let later = t0 + app.retry_delay_demand(1) + Duration::from_millis(1);
+        assert!(matches!(
+            app.demand_status(hash, &peer_b, later, &history),
+            DemandStatus::Demand
+        ));
     }
 
     #[test]

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -54,6 +54,9 @@
 //! - `RS_STELLAR_CORE_NETWORK_PASSPHRASE` - Network passphrase
 //! - `RS_STELLAR_CORE_DATABASE_PATH` - Database file path
 //! - `RS_STELLAR_CORE_LOG_LEVEL` - Log level (trace, debug, info, warn, error)
+//! - `RS_STELLAR_CORE_NATIVE_METRICS_PORT` - Enable the native Prometheus
+//!   `/metrics` server on this port (distinct from the compat HTTP port), so the
+//!   full registry (overlay/SCP metrics) is reachable; unset = disabled.
 
 use anyhow::Context;
 use henyey_common::BucketListDbConfig;
@@ -2021,6 +2024,7 @@ impl AppConfig {
     /// - RS_STELLAR_CORE_NETWORK_PASSPHRASE
     /// - RS_STELLAR_CORE_DATABASE_PATH
     /// - RS_STELLAR_CORE_OVERLAY_PEER_PORT
+    /// - RS_STELLAR_CORE_NATIVE_METRICS_PORT
     pub fn from_file_with_env(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let mut config = Self::from_file(path)?;
         config.apply_env_overrides()?;
@@ -2094,6 +2098,39 @@ impl AppConfig {
                      must be a valid u16 (0–65535)"
                 )
             })?;
+        }
+
+        // Native Prometheus metrics server override.
+        //
+        // When set to a nonzero u16, (re-)enable the native henyey HTTP server on
+        // that port so the full Prometheus registry — including overlay/SCP
+        // metrics omitted from the stellar-core-compat medida `/metrics` — is
+        // reachable. This is needed because `translate_stellar_core_config`
+        // disables the native server whenever `HTTP_PORT` is set (the compat
+        // server takes that port), which is always the case under Supercluster.
+        // Env overrides apply *after* compat translation, so this re-enables it.
+        // Errors on a collision with the compat port (two servers cannot share a
+        // port). Unset ⇒ behavior unchanged. Metrics endpoints are divergeable
+        // (`docs/PARITY.md`).
+        if let Some(val) = lookup("RS_STELLAR_CORE_NATIVE_METRICS_PORT")? {
+            let port = val.parse::<u16>().with_context(|| {
+                format!(
+                    "RS_STELLAR_CORE_NATIVE_METRICS_PORT: invalid port '{val}', \
+                     must be a valid u16 (0–65535)"
+                )
+            })?;
+            if port != 0 {
+                if self.compat_http.enabled && port == self.compat_http.port {
+                    anyhow::bail!(
+                        "RS_STELLAR_CORE_NATIVE_METRICS_PORT ({port}) must differ \
+                         from the compat HTTP port ({})",
+                        self.compat_http.port
+                    );
+                }
+                self.http.enabled = true;
+                self.http.port = port;
+                self.http.address = "127.0.0.1".to_string();
+            }
         }
 
         // Logging overrides
@@ -4855,6 +4892,74 @@ name = "test"
             msg.contains("RS_STELLAR_CORE_OVERLAY_PEER_PORT"),
             "error should mention the env var name: {msg}"
         );
+    }
+
+    #[test]
+    fn test_env_override_native_metrics_port_enables_native_server() {
+        // Simulate a Supercluster deployment: compat on 11626, native disabled
+        // (as translate_stellar_core_config leaves it when HTTP_PORT is set).
+        // The env override must re-enable the native server on the distinct port.
+        let mut config = AppConfig::default();
+        config.http.enabled = false;
+        config.compat_http.enabled = true;
+        config.compat_http.port = 11626;
+        config
+            .apply_env_overrides_from(map_lookup(HashMap::from([(
+                "RS_STELLAR_CORE_NATIVE_METRICS_PORT",
+                "11628",
+            )])))
+            .unwrap();
+        assert!(config.http.enabled, "native server should be re-enabled");
+        assert_eq!(config.http.port, 11628);
+        assert_eq!(config.http.address, "127.0.0.1");
+        // Compat server is untouched.
+        assert!(config.compat_http.enabled);
+        assert_eq!(config.compat_http.port, 11626);
+    }
+
+    #[test]
+    fn test_env_override_native_metrics_port_collision_errors() {
+        let mut config = AppConfig::default();
+        config.compat_http.enabled = true;
+        config.compat_http.port = 11626;
+        let err = config
+            .apply_env_overrides_from(map_lookup(HashMap::from([(
+                "RS_STELLAR_CORE_NATIVE_METRICS_PORT",
+                "11626",
+            )])))
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("RS_STELLAR_CORE_NATIVE_METRICS_PORT"),
+            "error should mention the env var name: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_env_override_native_metrics_port_invalid_errors() {
+        let mut config = AppConfig::default();
+        let err = config
+            .apply_env_overrides_from(map_lookup(HashMap::from([(
+                "RS_STELLAR_CORE_NATIVE_METRICS_PORT",
+                "abc",
+            )])))
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("RS_STELLAR_CORE_NATIVE_METRICS_PORT"));
+    }
+
+    #[test]
+    fn test_env_override_native_metrics_port_zero_noop() {
+        // 0 = explicit "off": leave the native server as-is (disabled here).
+        let mut config = AppConfig::default();
+        config.http.enabled = false;
+        config
+            .apply_env_overrides_from(map_lookup(HashMap::from([(
+                "RS_STELLAR_CORE_NATIVE_METRICS_PORT",
+                "0",
+            )])))
+            .unwrap();
+        assert!(!config.http.enabled, "port 0 should not enable the server");
     }
 
     #[test]

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -684,6 +684,21 @@ metric_catalog! {
         OVERLAY_DEMAND_TIMEOUT_TOTAL = "stellar_overlay_demand_timeout_total"
             => "Total tx demands re-issued after a prior demand timed out";
 
+        // [maxtps_diag] Fulfiller-side demand outcomes (why a demand we receive
+        // is/ isn't answered). Recorded by string in app::tx_flooding.
+        OVERLAY_DEMAND_FULFILLED_TOTAL = "stellar_overlay_demand_fulfilled_total"
+            => "Total demanded txs we answered (sent the tx)";
+        OVERLAY_DEMAND_UNFULFILLED_DROPPED_TOTAL = "stellar_overlay_demand_unfulfilled_dropped_total"
+            => "Total demanded txs not answered because the peer outbound channel was full";
+        OVERLAY_DEMAND_UNFULFILLED_BANNED_TOTAL = "stellar_overlay_demand_unfulfilled_banned_total"
+            => "Total demanded txs not answered because the tx is banned";
+        OVERLAY_DEMAND_UNFULFILLED_UNKNOWN_TOTAL = "stellar_overlay_demand_unfulfilled_unknown_total"
+            => "Total demanded txs not answered because the hash is not in our queue";
+        // [maxtps_diag] Flood messages (TX) dropped by the lossy broadcast
+        // receive channel when the event loop falls behind under load.
+        OVERLAY_BROADCAST_LAGGED_DROPPED_TOTAL = "stellar_overlay_broadcast_lagged_dropped_total"
+            => "Total flood messages dropped due to broadcast-channel lag on receive";
+
         // Stage F.1: Overlay connection lifecycle counters (issue #2236).
         OVERLAY_INBOUND_ATTEMPT_TOTAL = "stellar_overlay_inbound_attempt_total"
             => "Total inbound connection accepts (TCP listener.accept() Ok)";

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -676,6 +676,14 @@ metric_catalog! {
         OVERLAY_ASYNC_WRITE_TOTAL = "stellar_overlay_async_write_total"
             => "Total successful send I/O operations";
 
+        // Tx-demand timeout: a tx demand went unfulfilled past the retry delay
+        // and was re-issued to a peer. Mirrors stellar-core's
+        // `overlay.demand.timeout`. Recorded by string in
+        // `app::tx_flooding::run_tx_demands`; cataloged here for HELP/TYPE +
+        // pre-registration (same pattern as the tx-pull-latency histogram).
+        OVERLAY_DEMAND_TIMEOUT_TOTAL = "stellar_overlay_demand_timeout_total"
+            => "Total tx demands re-issued after a prior demand timed out";
+
         // Stage F.1: Overlay connection lifecycle counters (issue #2236).
         OVERLAY_INBOUND_ATTEMPT_TOTAL = "stellar_overlay_inbound_attempt_total"
             => "Total inbound connection accepts (TCP listener.accept() Ok)";
@@ -2249,7 +2257,6 @@ mod tests {
             "stellar_overlay_authenticated_peers",
             "stellar_overlay_flood_demanded_total",
             "stellar_overlay_flood_fulfilled_total",
-            "stellar_overlay_demand_timeout_total",
             "stellar_overlay_connection_latency_us_sum",
             "stellar_overlay_connection_latency_us_count",
             "stellar_overlay_tx_pull_latency_us_sum",
@@ -2262,6 +2269,14 @@ mod tests {
                 name
             );
         }
+
+        // demand-timeout now HAS a producer (app::tx_flooding::run_tx_demands)
+        // and is cataloged, so it must be registered/described.
+        assert!(
+            output.contains("# HELP stellar_overlay_demand_timeout_total"),
+            "stellar_overlay_demand_timeout_total should be registered now that it \
+             has a producer"
+        );
     }
 
     #[test]

--- a/vendor/supercluster/src/FSLibrary/StellarCoreCfg.fs
+++ b/vendor/supercluster/src/FSLibrary/StellarCoreCfg.fs
@@ -20,6 +20,12 @@ open StellarDotnetSdk.Accounts
 module CfgVal =
     let httpPort = 11626
     let prometheusExporterPort = 9473
+    // henyey-only: native Prometheus /metrics server port (distinct from
+    // httpPort, which the compat medida server occupies). Set via the
+    // RS_STELLAR_CORE_NATIVE_METRICS_PORT env var so the full registry
+    // (overlay/SCP metrics) is reachable via pod-exec. Real stellar-core
+    // ignores this env var.
+    let henyeyNativeMetricsPort = 11628
     let labels = Map.ofSeq [ "app", "stellar-core" ]
     let labelSelector = "app = stellar-core"
     let stellarCoreBinPath = "stellar-core"

--- a/vendor/supercluster/src/FSLibrary/StellarKubeSpecs.fs
+++ b/vendor/supercluster/src/FSLibrary/StellarKubeSpecs.fs
@@ -302,6 +302,15 @@ let CoreContainerForCommand
             value = defaultArg asanOptions CfgVal.asanOptionsEnvVarDefaultValue
         )
 
+    // henyey-only: enable the native Prometheus /metrics server on a distinct
+    // port so overlay/SCP metrics are reachable via pod-exec. Real stellar-core
+    // ignores this env var.
+    let henyeyMetricsEnvVar =
+        V1EnvVar(
+            name = "RS_STELLAR_CORE_NATIVE_METRICS_PORT",
+            value = string CfgVal.henyeyNativeMetricsPort
+        )
+
     let cfgWords = cfgFileArgs configOpt MainCoreContainer
     let containerName = CfgVal.stellarCoreContainerName (Array.get command 0)
 
@@ -340,7 +349,7 @@ let CoreContainerForCommand
         image = imageName,
         command = [| "/bin/sh" |],
         args = [| "-x"; "-c"; allCmdsAndCleanup.ToString() |],
-        env = [| peerNameEnvVar; asanOptionsEnvVar |],
+        env = [| peerNameEnvVar; asanOptionsEnvVar; henyeyMetricsEnvVar |],
         resources = res,
         securityContext = V1SecurityContext(capabilities = V1Capabilities(add = [| "NET_ADMIN" |])),
         volumeMounts = CoreContainerVolumeMounts peerOrJobNames configOpt


### PR DESCRIPTION
Closes #3671.

## Problem
henyey's detailed overlay/SCP metrics (tx-pull-latency, SCP nomination timing) are recorded in the Prometheus registry but unreachable in Supercluster: `translate_stellar_core_config` disables the native Prometheus server when `HTTP_PORT` is set (SSC always sets it), leaving only the compat medida-JSON server on :11626 — which omits those metrics.

## Change (metrics/test-tooling only; divergeable per docs/PARITY.md)
- Opt-in `RS_STELLAR_CORE_NATIVE_METRICS_PORT` env override (applied after compat translation) re-enables the native Prometheus `/metrics` on a distinct port (127.0.0.1), erroring on collision with the compat port. Default behavior unchanged.
- Supercluster sets it (`CfgVal.henyeyNativeMetricsPort=11628`) on the core container, so the full registry is scrapeable via pod-exec: `curl localhost:11628/metrics`.
- Record the previously-unproduced `stellar_overlay_demand_timeout_total`; add fulfiller-side counters (fulfilled/unfulfilled unknown/dropped/banned, mirroring core's overlay.flood.*) and a broadcast-lag drop counter.
- maxtps-optimize skill: diagnosis ladder points at :11628.

## Verification
Unit tests (env-override enable/collision/invalid/zero, demand-timeout gating, cataloged metrics); henyey-app + Supercluster build clean. Verified live on a deployed SSC node: :11628 serves the full registry incl. the overlay/SCP families with real values; :11626 medida unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxnZVoi2JQ2NDqo3Hnm4T9