### PR TITLE
Parallelize per-tx tx-set validation across cores

### DIFF
--- a/crates/herder/src/tx_set_utils.rs
+++ b/crates/herder/src/tx_set_utils.rs
@@ -917,6 +917,57 @@ pub fn get_invalid_hashed_tx_list(
     )
 }
 
+/// Outcome of the independent per-transaction pass-1 validation. Carries the
+/// fee contribution for valid txs so the cross-tx `account_fee_map` can be
+/// accumulated deterministically after a (possibly parallel) validation pass.
+enum Pass1Outcome {
+    /// Transaction failed pass-1 validation.
+    Invalid,
+    /// Transaction is valid and a fee balance provider is present.
+    Valid {
+        fee_source: AccountId,
+        full_fee: i64,
+    },
+    /// Transaction is valid but no fee provider — no fee accumulation needed.
+    ValidNoFee,
+}
+
+/// Run the independent pass-1 validation closure over `txs`, in parallel across
+/// the available cores for large sets and serially for small ones.
+///
+/// The closure must be pure w.r.t. shared state (it only reads the validation
+/// context and the `Send + Sync` ledger-state providers), so results depend only
+/// on the input transaction — order-independent. Results are returned in input
+/// order, so the caller's serial merge is deterministic and parity-preserving.
+fn parallel_validate_pass1(
+    txs: &[HashedTx],
+    outcome_of: &(impl Fn(&HashedTx) -> Pass1Outcome + Sync),
+) -> Vec<Pass1Outcome> {
+    // Below this size the thread-spawn overhead outweighs the work.
+    const PARALLEL_THRESHOLD: usize = 96;
+    if txs.len() < PARALLEL_THRESHOLD {
+        return txs.iter().map(outcome_of).collect();
+    }
+    let n_threads = std::thread::available_parallelism()
+        .map(|v| v.get())
+        .unwrap_or(1)
+        .clamp(1, 16);
+    if n_threads <= 1 {
+        return txs.iter().map(outcome_of).collect();
+    }
+    let chunk_size = txs.len().div_ceil(n_threads);
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = txs
+            .chunks(chunk_size)
+            .map(|chunk| scope.spawn(move || chunk.iter().map(outcome_of).collect::<Vec<_>>()))
+            .collect();
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().expect("tx-set validation worker panicked"))
+            .collect()
+    })
+}
+
 /// Private core: validates transactions and returns invalid ones with hashes.
 ///
 /// Accepts pre-hashed transactions. In pass 1, caches `fee_source_id` from the
@@ -946,7 +997,16 @@ fn get_invalid_hashed_core(
     // Pass-1 fee_source cache: avoids TransactionFrame construction in pass 2.
     let mut fee_source_cache: HashMap<Hash256, AccountId> = HashMap::new();
 
-    for htx in txs {
+    // Pass-1 per-tx validation is independent across transactions: a generalized
+    // tx-set forbids multiple txs per source account (checked upstream), so there
+    // are no intra-set sequence or fee dependencies in this pass. The per-tx
+    // stateful validation (account load + signature verification) is the
+    // consensus-path bottleneck under high load while CPU sits idle, so we run it
+    // across the available cores. Outcomes are merged below in deterministic tx
+    // order, so the returned invalid set and accumulated `account_fee_map` are
+    // identical to the serial computation — observable consensus output is
+    // unchanged (parity-preserving). See docs/maxtps-optimization/.
+    let outcome_of = |htx: &HashedTx| -> Pass1Outcome {
         let frame = TransactionFrame::with_network(htx.envelope.clone(), ctx.network_id);
 
         // Stateless structural + per-op validation (shared with queue admission).
@@ -958,56 +1018,68 @@ fn get_invalid_hashed_core(
         )
         .is_err()
         {
-            seen_invalid.insert(htx.hash);
-            invalid_txs.push(htx.clone());
-            continue;
+            return Pass1Outcome::Invalid;
         }
 
         // Per-op structural validation (isOpSupported + doCheckValid).
         // This is stateless and always runs, even when account_provider is None.
         if !validate_ops_structure(&frame, ctx.protocol_version, ctx.ledger_flags) {
-            seen_invalid.insert(htx.hash);
-            invalid_txs.push(htx.clone());
-            continue;
+            return Pass1Outcome::Invalid;
         }
 
         // Validate with upper bound close time (catches max_time violations).
-        let upper_result = validate_basic(&frame, &upper_ledger_ctx);
-
-        if upper_result.is_err() {
-            seen_invalid.insert(htx.hash);
-            invalid_txs.push(htx.clone());
-            continue;
+        if validate_basic(&frame, &upper_ledger_ctx).is_err() {
+            return Pass1Outcome::Invalid;
         }
 
         // If offsets differ, also validate with lower bound close time.
         if need_lower_check {
             let lower_ledger_ctx = ctx.to_ledger_context(lower_close_time);
             if validate_basic(&frame, &lower_ledger_ctx).is_err() {
-                seen_invalid.insert(htx.hash);
-                invalid_txs.push(htx.clone());
-                continue;
+                return Pass1Outcome::Invalid;
             }
         }
 
         // Stateful validation: sequence, auth, and signature checks.
         if let Some(provider) = account_provider {
             if !validate_tx_for_tx_set(&frame, ctx, lower_close_time, provider) {
-                seen_invalid.insert(htx.hash);
-                invalid_txs.push(htx.clone());
-                continue;
+                return Pass1Outcome::Invalid;
             }
         }
 
-        // Transaction passed basic validation — accumulate fee for fee source.
+        // Transaction passed basic validation — record fee for fee source.
         if fee_balance_provider.is_some() {
-            let fee_source = frame.fee_source_account_id();
-            let full_fee = frame.total_fee().as_i64();
-            let entry = account_fee_map.entry(fee_source.clone()).or_insert(0i64);
-            // Saturating add to avoid overflow (matches stellar-core).
-            *entry = entry.saturating_add(full_fee);
-            // Cache fee_source for pass-2 lookup.
-            fee_source_cache.insert(htx.hash, fee_source);
+            Pass1Outcome::Valid {
+                fee_source: frame.fee_source_account_id(),
+                full_fee: frame.total_fee().as_i64(),
+            }
+        } else {
+            Pass1Outcome::ValidNoFee
+        }
+    };
+
+    let outcomes = parallel_validate_pass1(txs, &outcome_of);
+
+    // Deterministic serial merge in tx order: produces a byte-identical result to
+    // the previous serial loop (invalid set membership and fee-map sums are
+    // order-independent / commutative).
+    for (htx, outcome) in txs.iter().zip(outcomes) {
+        match outcome {
+            Pass1Outcome::Invalid => {
+                seen_invalid.insert(htx.hash);
+                invalid_txs.push(htx.clone());
+            }
+            Pass1Outcome::ValidNoFee => {}
+            Pass1Outcome::Valid {
+                fee_source,
+                full_fee,
+            } => {
+                let entry = account_fee_map.entry(fee_source.clone()).or_insert(0i64);
+                // Saturating add to avoid overflow (matches stellar-core).
+                *entry = entry.saturating_add(full_fee);
+                // Cache fee_source for pass-2 lookup.
+                fee_source_cache.insert(htx.hash, fee_source);
+            }
         }
     }
 

--- a/docs/maxtps-optimization/2026-06-26-deep-investigation.md
+++ b/docs/maxtps-optimization/2026-06-26-deep-investigation.md
@@ -1,0 +1,55 @@
+# maxtps deep investigation — 2026-06-26 (iter 9)
+
+- Session `c66d03b4` · Instance `93i67d9uejjg0` (nsc 32×64) · Branch `maxtps/opt-c66d03b4`
+- Goal: find the real henyey↔core throughput gap (core ~1531 vs henyey ~230 tx/s, ~6.6×) via live profiling, then a big-swing parity-safe fix.
+- Method: instrumented images add parity-free `tracing::info!(target:"maxtps_diag")` logs — `nominate_build` (selected/max_ops), `agreed_set` (agreed), `txset_validate` (tx_count/us). Per-thread CPU via `/proc/PID/task/*/stat` deltas. All measurements on one reused instance.
+
+## What was ruled out (live-measured)
+
+| Hypothesis | Verdict | Evidence |
+|---|---|---|
+| Serial event-loop CPU bound | **Refuted** | Process CPU **1–19% of one core** during load; nothing pegged. Node *waits*, not computes. |
+| Agreement-convergence loss (combineCandidates) | **Refuted at low rate** | At rate 230, `agreed == nominated` (~1150). |
+| Inclusion/surge trim | **Refuted** | `selected` (~1150) ≪ `max_ops` budget (2300+). |
+| Cadence stretch under load | **Refuted** | Cadence stable ~5s even at rate 650. |
+| Propagation-throughput plateau | **Refuted** | Nomination *scales* with rate (650 → nominated ~3000–3447 ≈ offered×5s). |
+| Propagation skew between nodes | **Refuted** | At rate 462, all 7 orgs nominate *similar* sizes (~2100–2700). |
+
+## Root cause: agreement efficiency under load
+
+`agreed` falls below `nominated` as offered rate rises:
+
+| offered | nominated (per node) | agreed | applied ≈ agreed/5s | gap |
+|---|---|---|---|---|
+| 230 | ~1150 | ~1150 | ~230/s | 0% |
+| 462 | ~2100–2700 | ~2000–2300 | ~440/s | ~8% |
+| 525 | ~2500–2850 | ~1840–2340 | ~440/s | ~20% |
+| 650 | ~3000–3447 | ~2300–2820 | ~500/s | ~20–25% |
+
+`combineCandidates` picks the biggest candidate tx-set that reaches **quorum-acceptance**. A node accepts a peer's candidate only after **validating** it — full per-tx stateful checks (`get_invalid_hashed_core`: account load via O(log n) bucket-list traversal + ed25519 sig verify), run **serially** in a `for htx in txs` loop, scaling with set size. Under load the biggest candidate sets validate too slowly to win quorum within the round → a smaller set wins → `agreed < nominated`. Idle CPU = the serial validation waits while 31 cores sit unused. Core runs the same logic (`TxSetUtils.cpp:199`) but isn't capped — henyey's serial-on-one-thread validation is the divergence.
+
+**Why this is the lever:** `agreed = nominated = offered×cadence ⇒ applied = offered` — sustainable at any rate up to propagation/apply limits (not hit at 650). Closing the agreement deficit (efficiency→1) could push max TPS from ~230 toward ~650+ — multiplicative, toward core's range.
+
+## Fix (iter 9): parallelize per-tx tx-set validation
+
+`crates/herder/src/tx_set_utils.rs` — `get_invalid_hashed_core` pass-1 is independent per tx (generalized sets forbid multiple txs per source ⇒ no intra-set seq/fee deps). Run it across cores with `std::thread::scope`; merge outcomes in tx order. **Parity-exact**: invalid-set membership and `account_fee_map` sums are order-independent; observable consensus output unchanged. Both ledger-state providers are `Send + Sync`; snapshot `get_entry` is concurrent-read-safe. 120 `tx_set_utils` tests pass.
+
+## Result — NEGATIVE (validation speed was not the gate)
+
+Built `opt-c66d03b4-pval` (parallel validation + `txset_validate` timing). Live results:
+- Validation got **16× faster**: `txset_validate` ~10–25 ms for 1300–2600-tx sets (parallel) vs ~400 ms serial (~150 µs/tx).
+- **But max TPS = 238**, vs same-instance baseline ~230 — **no meaningful change** (+3.5%, within noise; below the 5% bar).
+- `agreed/nominated` ratio (~85–100%) **unchanged** from the serial run.
+
+**Conclusion:** validation speed / event-loop blocking by validation is **not** the gate. The agreement deficit persists with fast validation.
+
+## Revised root cause: an agreement-efficiency cliff (~238)
+
+`eff = agreed/nominated` is ~1.0 at R ≤ 238 and drops below 1.0 just above it (cliff, not gradual). At R ≤ 238 all nodes converge on the full offered set within the 5 s round; just above, intra-round tx **propagation completeness** breaks — nodes nominate slightly divergent sets, so the SCP-agreed (round-leader) set is smaller than offered×cadence, `applied < offered`, backlog grows, run fails. At overload the network still *applies* up to ~500/s, but can only *sustain* ~238 (where eff≈1). This is consistent with the earlier `flood_tx_period_ms=100` win (+13%): faster propagation raised the eff-cliff. Persist/close ruled out (cadence stable ~5 s even at overload).
+
+The remaining lever is **intra-round propagation completeness / SCP nomination timing** — a faithful-port flood path plus parity-sensitive SCP timing. No further *clean, parity-safe, henyey-specific* lever was found; flood-period tuning is shared-config (already exploited).
+
+## Disposition
+
+The parallel-validation change is **parity-exact and a genuine 16× validation speedup** (exploits the idle cores; helps catchup/sync and higher-limit networks), but it is **not a max-TPS win** and is therefore rejected against the >5% maxtps bar. Kept on branch `maxtps/opt-c66d03b4` as a standalone perf optimization for separate consideration.
+


### PR DESCRIPTION
Closes #3673.

`get_invalid_hashed_core`'s pass-1 per-tx validation (account load + signature verify) is independent across txs (generalized sets forbid multiple txs/source ⇒ no intra-set deps). Run it across cores via `std::thread::scope`, merging outcomes in tx order — invalid-set membership and `account_fee_map` sums are byte-identical to serial (parity-preserving). ~16x faster validation for large sets; exploits otherwise-idle cores (helps catchup/sync and higher-limit networks). 120 tx_set_utils tests pass. Includes the deep-investigation write-up documenting that this is a perf win, not itself a max-TPS lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxnZVoi2JQ2NDqo3Hnm4T9