### PR TITLE
Honor FLOOD_DEMAND_PERIOD_MS / FLOOD_DEMAND_BACKOFF_DELAY_MS compat keys

### DIFF
--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -3382,6 +3382,50 @@ FLOOD_ADVERT_PERIOD_MS=-1
         assert_eq!(config.overlay.flood_advert_period_ms, 100);
     }
 
+    #[test]
+    fn test_flood_demand_period_ms_parsed() {
+        let toml_str = r#"
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
+FLOOD_DEMAND_PERIOD_MS=350
+FLOOD_DEMAND_BACKOFF_DELAY_MS=750
+"#;
+        let raw: toml::Value = toml::from_str(toml_str).unwrap();
+        let config = translate_stellar_core_config(&raw).unwrap();
+        assert_eq!(config.overlay.flood_demand_period_ms, 350);
+        assert_eq!(config.overlay.flood_demand_backoff_delay_ms, 750);
+    }
+
+    #[test]
+    fn test_flood_demand_period_ms_default() {
+        let toml_str = r#"
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
+"#;
+        let raw: toml::Value = toml::from_str(toml_str).unwrap();
+        let config = translate_stellar_core_config(&raw).unwrap();
+        // Absent keys must preserve the henyey defaults, which match
+        // stellar-core (FLOOD_DEMAND_PERIOD_MS=200, FLOOD_DEMAND_BACKOFF_DELAY_MS=500).
+        assert_eq!(config.overlay.flood_demand_period_ms, 200);
+        assert_eq!(config.overlay.flood_demand_backoff_delay_ms, 500);
+    }
+
+    #[test]
+    fn test_flood_demand_period_ms_invalid_preserves_default() {
+        let toml_str = r#"
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+NODE_SEED="SBXTJSLKQ2VZUEQNYU5EC6ZGQOONCX3JCFBK57R56YLYMUW76B2FMCJH self"
+FLOOD_DEMAND_PERIOD_MS=0
+FLOOD_DEMAND_BACKOFF_DELAY_MS=-1
+"#;
+        let raw: toml::Value = toml::from_str(toml_str).unwrap();
+        let config = translate_stellar_core_config(&raw).unwrap();
+        // stellar-core parses both with readInt<int>(item, 1) (minimum 1), so
+        // values below 1 are invalid and the defaults are preserved.
+        assert_eq!(config.overlay.flood_demand_period_ms, 200);
+        assert_eq!(config.overlay.flood_demand_backoff_delay_ms, 500);
+    }
+
     // --- PEER_FLOOD_READING_CAPACITY_BYTES / FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES ---
 
     #[test]

--- a/crates/app/src/compat_config.rs
+++ b/crates/app/src/compat_config.rs
@@ -98,6 +98,8 @@ const SUPPORTED_KEYS: &[&str] = &[
     "FLOOD_ARB_TX_DAMPING_FACTOR",
     "FLOOD_TX_PERIOD_MS",
     "FLOOD_ADVERT_PERIOD_MS",
+    "FLOOD_DEMAND_PERIOD_MS",
+    "FLOOD_DEMAND_BACKOFF_DELAY_MS",
     "FAILURE_SAFETY",
     "UNSAFE_QUORUM",
     "SURVEYOR_KEYS",
@@ -367,6 +369,31 @@ pub fn translate_stellar_core_config(raw: &toml::Value) -> anyhow::Result<AppCon
         } else {
             tracing::warn!(
                 key = "FLOOD_ADVERT_PERIOD_MS",
+                value = v,
+                "Compat config key value must be >= 1"
+            );
+        }
+    }
+    // stellar-core parses FLOOD_DEMAND_PERIOD_MS / FLOOD_DEMAND_BACKOFF_DELAY_MS
+    // with readInt<int>(item, 1) (minimum 1); values below 1 are rejected
+    // (Config.cpp:1427-1441). Mirror that bound and fall back to the default.
+    if let Some(v) = get_i64(table, "FLOOD_DEMAND_PERIOD_MS") {
+        if v >= 1 {
+            config.overlay.flood_demand_period_ms = v as u64;
+        } else {
+            tracing::warn!(
+                key = "FLOOD_DEMAND_PERIOD_MS",
+                value = v,
+                "Compat config key value must be >= 1"
+            );
+        }
+    }
+    if let Some(v) = get_i64(table, "FLOOD_DEMAND_BACKOFF_DELAY_MS") {
+        if v >= 1 {
+            config.overlay.flood_demand_backoff_delay_ms = v as u64;
+        } else {
+            tracing::warn!(
+                key = "FLOOD_DEMAND_BACKOFF_DELAY_MS",
                 value = v,
                 "Compat config key value must be >= 1"
             );


### PR DESCRIPTION
Closes #3672

## Summary

`crates/app/src/compat_config.rs` translated `FLOOD_TX_PERIOD_MS` and `FLOOD_ADVERT_PERIOD_MS` from stellar-core-format configs but silently dropped `FLOOD_DEMAND_PERIOD_MS` and `FLOOD_DEMAND_BACKOFF_DELAY_MS`. A stellar-core config overriding those two keys was ignored and henyey ran at its defaults — a parity gap. This adds both keys to `SUPPORTED_KEYS` and translates them into `overlay.flood_demand_period_ms` / `overlay.flood_demand_backoff_delay_ms`.

The henyey config fields and their defaults already existed and match core (200ms / 500ms); only the compat translation was missing. The default-preserving path is unchanged when the keys are absent.

## Parity

stellar-core parses both keys with `readInt<int>(item, 1)` — minimum value 1 (`Config.cpp:1427-1441`). The translation mirrors that bound: values `>= 1` are applied, values below 1 warn and preserve the default, matching the existing `FLOOD_TX_PERIOD_MS` / `FLOOD_ADVERT_PERIOD_MS` handling.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] `cargo test -p henyey-app --lib compat_config` (154 passed)

## Regression test (kind: bug-fix)

- **Test:** `crates/app/src/compat_config.rs::test_flood_demand_period_ms_parsed` (plus `_default` and `_invalid_preserves_default`)
- **Pre-fix:** committed as `0fdee7ba` — `test_flood_demand_period_ms_parsed` FAILED with `assertion left == right failed: left: 200, right: 350` (override dropped, default retained)
- **Post-fix:** verified PASSES after `58304b9f`

## Deviations from plan

None. The issue premise was correct and verified against the pinned stellar-core v26.0.1 submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)