### PR TITLE
Use live ledger maxTxSetSize for tx-flood budget (parity with core)

### DIFF
--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1632,9 +1632,20 @@ impl Herder {
         }
     }
 
-    /// Get the maximum size of a transaction set (ops).
+    /// Get the maximum size of a transaction set (ops) from the LIVE ledger.
+    ///
+    /// Mirrors stellar-core `LedgerManager::getLastMaxTxSetSizeOps()`. This reads
+    /// the current (last-closed) ledger header, NOT static config, because
+    /// `maxTxSetSize` can be raised via `LedgerUpgrade::MaxTxSetSize` after
+    /// genesis. The previous config-based value went stale after an upgrade and
+    /// under-provisioned the transaction-flood budget (~2.4× too small under the
+    /// maxTPS mission's upgrade), causing flood-queue starvation: a few
+    /// locally-submitted txns were never advertised, aged out, stranded their
+    /// account, and failed the whole loadgen step via the all-or-nothing
+    /// completion check. Only flood/advert/demand sizing consumes this; tx-set
+    /// construction already uses the live header value.
     pub fn max_tx_set_size(&self) -> usize {
-        self.config.max_tx_set_size
+        self.ledger_manager.last_max_tx_set_size_ops()
     }
 
     /// Get the maximum queue size in ops for demand sizing.

--- a/crates/ledger/src/manager.rs
+++ b/crates/ledger/src/manager.rs
@@ -1617,6 +1617,28 @@ impl LedgerManager {
         self.state.read().header.clone()
     }
 
+    /// Live max tx-set size in ops, from the current (last-closed) ledger header.
+    ///
+    /// Mirrors stellar-core `LedgerManager::getLastMaxTxSetSizeOps()`: reads the
+    /// LCL header's `maxTxSetSize`. For protocol >= 11 that field is already an
+    /// ops count and is returned as-is; for the (henyey-unsupported) pre-v11
+    /// regime it would be `n * MAX_OPS_PER_TX`. henyey is protocol 24+ only, so
+    /// the pre-v11 branch is unreachable but kept for parity clarity.
+    ///
+    /// This MUST be read live rather than from static config: maxTxSetSize can be
+    /// raised via a `LedgerUpgrade::MaxTxSetSize`, and consumers such as the
+    /// transaction-flood budget (`compute_flood_ops_budget`) must track the
+    /// upgraded value or they under-provision and starve flooding under load.
+    pub fn last_max_tx_set_size_ops(&self) -> usize {
+        let state = self.state.read();
+        let n = state.header.max_tx_set_size as usize;
+        if state.header.ledger_version >= 11 {
+            n
+        } else {
+            n * 100 // MAX_OPS_PER_TX (pre-v11 only; unreachable on protocol 24+)
+        }
+    }
+
     /// Get the current header hash.
     pub fn current_header_hash(&self) -> Hash256 {
         self.state.read().header_hash
@@ -8140,6 +8162,46 @@ mod tests {
         for skip in &header.skip_list {
             assert_eq!(*skip, Hash([0u8; 32]));
         }
+    }
+
+    /// Regression: `last_max_tx_set_size_ops()` must reflect the LIVE ledger
+    /// header `maxTxSetSize`, not a static genesis value. Previously the flood
+    /// budget read static config; after a `LedgerUpgrade::MaxTxSetSize` raised
+    /// the on-chain limit, the stale config under-provisioned the budget ~2.4×
+    /// and starved transaction flooding (txns aged out un-advertised, stranding
+    /// accounts and failing maxTPS steps). Mirrors stellar-core
+    /// `getLastMaxTxSetSizeOps()` (protocol >= 11 returns the field as-is).
+    #[test]
+    fn test_last_max_tx_set_size_ops_tracks_live_header() {
+        use henyey_common::protocol::CURRENT_LEDGER_PROTOCOL_VERSION;
+
+        let manager = LedgerManager::new(
+            "Test SDF Network ; September 2015".to_string(),
+            LedgerManagerConfig {
+                validate_bucket_hash: false,
+                ..Default::default()
+            },
+        );
+
+        // Baseline: a protocol-24 header with the genesis-sized limit.
+        let mut header = manager.current_header();
+        header.ledger_version = CURRENT_LEDGER_PROTOCOL_VERSION;
+        header.max_tx_set_size = 100;
+        manager.set_header_for_test(header.clone(), Hash256::ZERO);
+        assert_eq!(
+            manager.last_max_tx_set_size_ops(),
+            100,
+            "must report the live header value (protocol >= 11: as-is)"
+        );
+
+        // Simulate a MaxTxSetSize upgrade raising the on-chain limit to 2500.
+        header.max_tx_set_size = 2500;
+        manager.set_header_for_test(header, Hash256::ZERO);
+        assert_eq!(
+            manager.last_max_tx_set_size_ops(),
+            2500,
+            "must track the upgraded header value, not stale config"
+        );
     }
 
     /// Parity: LedgerTests.cpp:15 "cannot close ledger with unsupported ledger version"

--- a/docs/maxtps-optimization/2026-06-29-silent-loss-rootcause.md
+++ b/docs/maxtps-optimization/2026-06-29-silent-loss-rootcause.md
@@ -1,0 +1,71 @@
+# Max-TPS ceiling root cause: stale flood budget (2026-06-29)
+
+Session 701dcf0a · instance bn2kosgj8jo3u (nsc 32×64) · MissionMaxTPSClassic.
+
+## TL;DR
+
+There is **no ~3% transaction loss**. Near the ceiling henyey applies **99.98–100%**
+of submitted txns, and ledger apply has **~20× headroom** (40–82 ms of a 5 s budget,
+`max_tx_set_size=2500` vs ~1135 txns/ledger used). The measured ceiling (~220 tx/s) was
+set by a **single un-propagated transaction** per step tripping the loadgen's
+all-or-nothing completion check.
+
+Root cause: the **transaction-flood budget was computed from stale static config**
+(`config.max_tx_set_size`) instead of the **live ledger header** value. The maxTPS
+mission upgrades `maxTxSetSize` on-chain (→ 2500), but the flood budget kept using the
+genesis config (~1025), making the per-flush advert budget **~2.4× too small**
+(observed `ops_budget=41`, should be ~100). Under load the advert drain was
+**100% budget-bound**, the flood queue backed up to ~1400, and a few locally-submitted
+txns were **never advertised** before aging out — stranding their accounts and failing
+the whole maxTPS step.
+
+This is a **parity bug**: stellar-core's flood budget uses
+`LedgerManager::getLastMaxTxSetSizeOps()` (the live LCL header).
+
+## Evidence chain (cross-node per-tx trace, all 23 nodes)
+
+1. **Coverage.** Aged-out/stranded txns reached **coverage=1** (origin only); applied
+   txns reached all 23. The loss is a propagation gap, not apply loss.
+2. **Magnitude.** rate 227: 13614/13615 applied (1 stranded). rate 250: 14991/14994
+   applied (3 stranded). All stranded = coverage 1 + **never-advertised** + aged-out.
+3. **Apply headroom.** During load each ledger carried ~1135–1277 txns with
+   `max_tx_set_size=2500`, apply time 40–82 ms; full load drained by ~ledger 32.
+4. **Completion check.** `wait_till_complete` failed with `unsynced_accounts=1`,
+   `expected_vs_onchain=[(1,0)]` — exactly the one un-propagated tx. The all-or-nothing
+   check (#3631, parity with core) turns 1 stranded tx into a whole-step failure.
+5. **Flush dynamics.** During each stranded tx's 15.5 s life its origin flushed 77×
+   (cadence fine, maxgap 0.29 s) but **77/77 budget-bound**; `ops_budget` collapsed
+   142→41 as `queue_len` ran to ~1400. Overall only ~18% budget-bound — saturation is
+   load-localized.
+6. **Stale budget.** `ops_budget=41` ⇒ maxOps≈1025; live ledger `max_tx_set_size=2500`.
+   `herder.max_tx_set_size()` returned `self.config.max_tx_set_size` (set once at
+   startup, never updated on `LedgerUpgrade::MaxTxSetSize`).
+
+## Fix
+
+- `LedgerManager::last_max_tx_set_size_ops()` — new accessor reading the live LCL header
+  (`crates/ledger/src/manager.rs`), mirroring core `getLastMaxTxSetSizeOps()`
+  (protocol ≥ 11 returns the field as-is; henyey is 24+).
+- `Herder::max_tx_set_size()` now delegates to it instead of static config
+  (`crates/herder/src/herder.rs`). All four callers are flood/advert/demand sizing in
+  `crates/app/src/app/tx_flooding.rs`; tx-set construction already used the live value.
+- Regression test `test_last_max_tx_set_size_ops_tracks_live_header` (manager.rs):
+  upgrading the header 100→2500 is reflected by the accessor.
+
+Parity: this aligns henyey with stellar-core; flood volume/cadence is on the divergeable
+surface (`docs/PARITY.md`) and does not affect hashes, tx-set selection, or wire format.
+
+## Validation (cloud, nsc 32×64, 23-node MaxTPSClassic)
+
+| Configuration | Max tx rate | Stranded txns | Aged-out (whole run) |
+|---|--:|--:|--:|
+| Baseline (before fix) | 220 | 1–3 per step | present |
+| **Flood-budget fix (this PR)** | **330** | **0** | **0** |
+| Flood-budget fix + per-peer rate-limit raise | 340 | 0 | 0 |
+
+The flood-budget fix alone raises the measured ceiling **220 → 330 (+50%)** with **zero**
+stranding (all 40,495 unique txns reached coverage 23 / advertised / applied). The
+additional per-peer rate-limit raise (a separate, henyey-only flow-control change) added
+only 330 → 340 (+3%, below the short-probe noise floor) and is **not** included here.
+Above the new ceiling (e.g. 350/360) there is still zero age-out — those steps now fail on
+honest apply/throughput, not on a propagation gap.


### PR DESCRIPTION
## Problem

henyey's measured MaxTPSClassic ceiling (~220 tx/s) was pinned far below its real
apply capacity. Investigation (per-tx cross-node trace across all 23 nodes) showed
there is **no meaningful transaction loss** — near the ceiling henyey applies
**99.98–100%** of submitted txns and ledger apply has **~20× headroom** (40–82 ms of a
5 s budget). Each "failed" step was caused by a **single un-propagated transaction**
stranding one account (out of ~23,000) and tripping the loadgen's all-or-nothing
completion check (`wait_till_complete`, parity with core #3631).

## Root cause (parity bug)

The transaction-flood budget read `Herder::max_tx_set_size()` = `self.config.max_tx_set_size`,
a static value captured at startup and **never updated** when `maxTxSetSize` is raised via
`LedgerUpgrade::MaxTxSetSize`. The maxTPS mission upgrades maxTxSetSize on-chain (→ 2500),
but the flood budget kept using the genesis value (~1025), making the per-flush advert
budget **~2.4× too small** (observed `ops_budget=41`, should be ~100). Under load the
advert drain was **100% budget-bound**, the flood queue backed up to ~1400, and a few
locally-submitted txns were **never advertised** (coverage = 1) before aging out at
`pending_depth=4` → stranded account → whole step fails.

stellar-core computes this budget from the **live** ledger via
`LedgerManager::getLastMaxTxSetSizeOps()`, so henyey had a parity gap.

## Fix

- Add `LedgerManager::last_max_tx_set_size_ops()` — reads the live LCL header
  (protocol ≥ 11 returns the field as-is, mirroring core; henyey is 24+).
- `Herder::max_tx_set_size()` now delegates to it instead of static config.
- All four callers are flood/advert/demand sizing (`tx_flooding.rs`); tx-set construction
  already used the live value.

Flood volume/cadence is on the divergeable surface (`docs/PARITY.md`) and does not affect
ledger hashes, tx-set selection, or wire format. This change *aligns* henyey with core.

## Validation (nsc 32×64, 23-node MaxTPSClassic)

| Configuration | Max tx rate | Stranded | Aged-out (whole run) |
|---|--:|--:|--:|
| Baseline | 220 | 1–3/step | present |
| **This PR** | **330** | **0** | **0** |

Measured ceiling **220 → 330 (+50%)**, zero stranded/aged-out txns across 40,495 unique
txns (all coverage 23 / advertised / applied). Steps above the new ceiling now fail on
honest apply/throughput, not on a propagation gap.

## Tests

- New regression `test_last_max_tx_set_size_ops_tracks_live_header` (manager.rs):
  upgrading the header 100 → 2500 is reflected by the accessor.
- `cargo test -p henyey-herder --lib` (1199), `-p henyey-ledger --lib manager::` (95),
  `-p henyey-app --lib flood` (59) all pass. clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxnZVoi2JQ2NDqo3Hnm4T9