### PR TITLE
Persist PayPregenerated reader index across loadgen runs (parity with core)

### DIFF
--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -1587,6 +1587,13 @@ impl LoadGenerator {
         self.tx_generator.reset();
     }
 
+    /// Number of pregenerated transactions consumed from the file so far.
+    /// Exposed for tests asserting cross-run alignment with the persistent
+    /// reader (see the PayPregenerated note in `start`).
+    pub fn curr_preloaded(&self) -> u64 {
+        self.curr_preloaded
+    }
+
     /// Initialize the account pool for a load generation run.
     ///
     /// Populates `accounts_available` with account IDs `[offset, offset + n_accounts)`.
@@ -1660,7 +1667,18 @@ impl LoadGenerator {
         // PayPregenerated: open the transactions file, preload accounts. No
         // account-pool allocation (the source accounts come from the file).
         if config.mode == LoadGenMode::PayPregenerated {
-            self.curr_preloaded = 0;
+            // Do NOT reset `curr_preloaded` here. The preloaded reader is opened
+            // once (below) and read sequentially across every `/generateload`
+            // run (e.g. each step of the MaxTPSClassic binary search reuses the
+            // same network and file). `curr_preloaded` is the round-robin account
+            // index (`curr_preloaded % n_accounts`) and MUST stay aligned with
+            // the reader's file position; resetting it to 0 while the reader
+            // continues from a later position misattributes each tx to the wrong
+            // account, so the loadgen tracks the wrong account's expected seq and
+            // `check_accounts_synced` falsely reports on-chain AHEAD of expected
+            // (capping/destabilizing the measured ceiling). Parity: stellar-core
+            // `mCurrPreloadedTransaction` is initialized once and never reset in
+            // `LoadGenerator::reset()` (LoadGenerator.cpp).
             if self.preloaded_reader.is_none() {
                 let path = config
                     .preloaded_transactions_file

--- a/crates/simulation/tests/loadgen_metrics.rs
+++ b/crates/simulation/tests/loadgen_metrics.rs
@@ -296,3 +296,113 @@ async fn test_generate_load_increments_loadgen_meters() {
 
     sim.stop_all_nodes().await.expect("stop standalone node");
 }
+
+/// Regression: across consecutive `generate_load` runs (each MaxTPSClassic
+/// binary-search step reuses the same network + pregenerated file), the
+/// PayPregenerated reader is opened once and read sequentially, so
+/// `curr_preloaded` (the round-robin account index `curr_preloaded % n`) MUST
+/// persist across runs to stay aligned with the reader's file position.
+///
+/// Previously `start()` reset `curr_preloaded` to 0 each run while the reader
+/// continued from a later position; a non-K-aligned step boundary then
+/// misattributed each tx to the wrong account, so the loadgen tracked the wrong
+/// account's expected seq and `check_accounts_synced` falsely reported on-chain
+/// AHEAD of expected — capping/destabilizing the measured max-TPS ceiling.
+/// Parity: stellar-core `mCurrPreloadedTransaction` is never reset in `reset()`.
+///
+/// FAILS on the buggy code: after step 2 `curr_preloaded` is 4 (reset+4) not 10,
+/// and accounts are not synced.
+#[tokio::test]
+#[serial]
+async fn pregenerated_curr_preloaded_persists_across_runs() {
+    use henyey_simulation::TxGenerator;
+
+    let mut sim = Simulation::with_network(SimulationMode::OverTcp, NETWORK_PASSPHRASE);
+    let seed = Hash256::hash(b"PREGEN_CURR_PRELOADED");
+    let secret = SecretKey::from_seed(&seed.0);
+    let quorum_set = henyey_app::config::QuorumSetConfig {
+        threshold_percent: 100,
+        validators: vec![secret.public_key().to_strkey()],
+        inner_sets: Vec::new(),
+    };
+    sim.add_app_node("node0", secret, quorum_set);
+    sim.start_all_nodes().await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(app) = sim.app("node0") {
+            if app.state().await == henyey_app::AppState::Validating {
+                break;
+            }
+        }
+        assert!(std::time::Instant::now() < deadline, "node0 not Validating");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let app = sim.app("node0").expect("node0 app exists");
+
+    const K: u64 = 8;
+    fund_loadgen_accounts(&sim, &app, K, 1_000_000_000).await;
+
+    // Pregenerated file (round-robin over the K funded accounts).
+    let dir = std::env::temp_dir().join(format!("pregen-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let out = dir.join("txs.xdr");
+    {
+        let mut txgen = TxGenerator::new(Arc::clone(&app), NETWORK_PASSPHRASE.to_string());
+        txgen
+            .generate_payment_txs_to_file(&out, 64, K as u32, 0)
+            .expect("generate pregenerated file");
+    }
+
+    let mut lg = LoadGenerator::new(Arc::clone(&app), NETWORK_PASSPHRASE.to_string());
+    let mk = |n_txs: u32| GeneratedLoadConfig {
+        mode: LoadGenMode::PayPregenerated,
+        n_accounts: K as u32,
+        offset: 0,
+        n_txs,
+        tx_rate: 100,
+        queue_full_max_tries: 5,
+        preloaded_transactions_file: Some(out.clone()),
+        ..Default::default()
+    };
+
+    let run_done = AtomicBool::new(false);
+    let run_done_ref = &run_done;
+    let sim_ref = &sim;
+    let closer = async {
+        for _ in 0..800 {
+            if run_done_ref.load(Ordering::Relaxed) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = sim_ref.manual_close_app_node("node0").await;
+        }
+    };
+    let work = async {
+        let stop = AtomicBool::new(false);
+        // Step 1: 6 txns (NOT a multiple of K, so a reset would misalign).
+        let mut c1 = mk(6);
+        lg.generate_load(&mut c1, &stop).await;
+        let curr1 = lg.curr_preloaded();
+        // Step 2: 4 more; the reader is at position 6.
+        let mut c2 = mk(4);
+        lg.generate_load(&mut c2, &stop).await;
+        let curr2 = lg.curr_preloaded();
+        run_done_ref.store(true, Ordering::Relaxed);
+        (curr1, curr2)
+    };
+    let ((curr1, curr2), _) = tokio::join!(work, closer);
+
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // curr_preloaded must persist across runs (parity with core
+    // mCurrPreloadedTransaction). The reader is read sequentially across both
+    // runs, so after reading 6 then 4 it is at 10. The bug reset it to 0 at the
+    // start of run 2 (-> 4), misaligning the round-robin account attribution.
+    assert_eq!(curr1, 6, "step 1 consumes 6 pregenerated txns");
+    assert_eq!(
+        curr2, 10,
+        "curr_preloaded must persist across runs; got {curr2} \
+         (bug resets each run -> 4, misattributing accounts)"
+    );
+}


### PR DESCRIPTION
## Problem

`LoadGenerator::start()` reset `curr_preloaded` to 0 at the start of every `/generateload` run, but the pregenerated-transactions reader is opened **once** and read sequentially across runs — each MaxTPSClassic binary-search step reuses the same network and file. `curr_preloaded` is the round-robin source-account index (`curr_preloaded % n_accounts`), so once the reader advanced past the first run, resetting the index **misattributed every subsequent tx to the wrong account**: the loadgen recorded the wrong account's expected sequence number while henyey correctly applied the real tx. `check_accounts_synced` then saw on-chain **ahead** of the mis-tracked expected seq and failed the run even though every submitted tx had applied.

## Impact (measurement, not node throughput)

Because the misattribution scales with how many prior runs executed, this both **capped** the measured ceiling and made it **band-dependent** — the same image measured 462 in one search band and 540 in another. Direct diagnostics showed henyey's real apply throughput at the "failing" rates was well above the measured ceiling:

- rate 550 (a "failure"): **~2900 tx/ledger applied (~580/s)**, more than offered, with CPU ~20%, ~83ms ledger close, nomination taking the whole queue.
- the failure manifested as `unsynced_accounts=1026, expected_vs_onchain=(2,3)` — on-chain ahead of the loadgen's expected, i.e. accounting drift, not lost txns.

## Fix

Do not reset `curr_preloaded` in `start()`, keeping it aligned with the persistent reader. **Parity:** stellar-core `mCurrPreloadedTransaction` is initialized once and never reset in `LoadGenerator::reset()`.

## Test

`pregenerated_curr_preloaded_persists_across_runs`: two PayPregenerated runs (6 then 4 txns — a non-K-aligned boundary). The index must end at **10** (fix) rather than **4** (bug resets each run). Verified it fails on the pre-fix code (`left: 4, right: 10`) and passes after.

Loadgen/test-harness code only — not the observable parity surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxnZVoi2JQ2NDqo3Hnm4T9