### PR TITLE
Coalesce outbound flood batch into a single write

### DIFF
--- a/crates/overlay/src/connection.rs
+++ b/crates/overlay/src/connection.rs
@@ -229,6 +229,44 @@ impl Connection {
         }
     }
 
+    /// maxtps (T2): write a pre-concatenated buffer of already length-prefixed,
+    /// encoded messages in a SINGLE `write_all`. This coalesces what the
+    /// per-message [`send`] path would otherwise issue as one syscall + (with
+    /// TCP_NODELAY) one TCP segment per message. The bytes on the wire are
+    /// byte-for-byte identical — each message is still `[len(4)|xdr_body]` in
+    /// order; TCP is a stream, so only the grouping into syscalls/segments
+    /// changes. Observable-surface-safe.
+    pub async fn send_encoded_batch(&mut self, buf: &[u8]) -> Result<()> {
+        if self.closed {
+            return Err(OverlayError::PeerDisconnected(
+                "connection closed".to_string(),
+            ));
+        }
+        if buf.is_empty() {
+            return Ok(());
+        }
+        const SEND_TIMEOUT_SECS: u64 = 10;
+        match timeout(
+            Duration::from_secs(SEND_TIMEOUT_SECS),
+            self.framed.get_mut().write_all(buf),
+        )
+        .await
+        {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => {
+                self.closed = true;
+                Err(OverlayError::Io(e))
+            }
+            Err(_) => {
+                self.closed = true;
+                Err(OverlayError::ConnectionTimeout(format!(
+                    "send timeout after {}s to {}",
+                    SEND_TIMEOUT_SECS, self.remote_addr
+                )))
+            }
+        }
+    }
+
     /// Receives the next message from the peer.
     ///
     /// Returns `Ok(None)` if the connection was closed cleanly by the peer.

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -1652,32 +1652,30 @@ impl OverlayManager {
             });
         }
 
-        // Group sent messages by priority for process_sent_messages
+        // #3643 straggler parity: track the MAX `time_emplaced` over messages
+        // ACTUALLY written. maxtps (T2): the batch is now written as a SINGLE
+        // coalesced `send_batch` (one syscall/segment for the whole batch)
+        // instead of one write per message, so the send is all-or-nothing:
+        // either every message goes out (advance to the batch max) or none does
+        // (error → peer dropped by caller, stamp moot).
+        let messages: Vec<StellarMessage> = batch.iter().map(|q| q.message.clone()).collect();
+        let newest_emplaced: Option<Instant> = batch
+            .iter()
+            .fold(None, |acc, q| fold_newest_emplaced(acc, q.time_emplaced));
+
+        if let Err(e) = peer.send_batch(&messages).await {
+            // Nothing was sent (single write_all); drop with no partial stamp.
+            metrics.errors_write.inc();
+            return Err(e);
+        }
+
+        // Group the sent messages by priority for process_sent_messages.
         let mut sent_by_priority: Vec<Vec<StellarMessage>> =
             vec![Vec::new(); MessagePriority::COUNT];
-
-        // #3643 straggler parity: track the MAX `time_emplaced` over messages
-        // ACTUALLY written (advance only on successful send, per message — like
-        // core's `messageSender` loop reassigning `mEnqueueTimeOfLastWrite` for
-        // each message it writes). On a mid-batch send error we keep the max of
-        // what was already written, matching core's per-message advance.
-        let mut newest_emplaced: Option<Instant> = None;
-
-        for queued in batch {
-            let priority = MessagePriority::from_message(&queued.message);
-            let emplaced = queued.time_emplaced;
-            if let Err(e) = peer.send(queued.message.clone()).await {
-                // Send failed — process what we've sent so far, then propagate
-                // the error. A send failure drops the peer (the caller breaks
-                // the loop), so the straggler stamp is moot on this path.
-                flow_control.process_sent_messages(&sent_by_priority);
-                metrics.errors_write.inc();
-                return Err(e);
-            }
+        for msg in messages {
             metrics.messages_written.inc();
-            newest_emplaced = fold_newest_emplaced(newest_emplaced, emplaced);
-            if let Some(p) = priority {
-                sent_by_priority[p as usize].push(queued.message);
+            if let Some(p) = MessagePriority::from_message(&msg) {
+                sent_by_priority[p as usize].push(msg);
             }
         }
 

--- a/crates/overlay/src/peer.rs
+++ b/crates/overlay/src/peer.rs
@@ -836,6 +836,53 @@ impl Peer {
         Ok(())
     }
 
+    /// maxtps (T2): send a batch of messages in a SINGLE coalesced write.
+    /// Wraps + encodes each message in order (preserving the auth sequence),
+    /// concatenates them, and issues one `Connection::send_encoded_batch` —
+    /// collapsing N syscalls/TCP-segments into one. Per-message metrics/stats
+    /// are applied after a successful write. On error nothing was sent (the
+    /// whole buffer is one `write_all`), and the peer is dropped by the caller.
+    pub async fn send_batch(&mut self, messages: &[StellarMessage]) -> Result<()> {
+        if self.state != PeerState::Authenticated {
+            return Err(OverlayError::PeerDisconnected(
+                "not authenticated".to_string(),
+            ));
+        }
+        if messages.is_empty() {
+            return Ok(());
+        }
+
+        let mut buf: Vec<u8> = Vec::new();
+        let mut kinds = Vec::with_capacity(messages.len());
+        let mut total_body_size = 0u64;
+        let mut total_wire_size = 0u64;
+        for message in messages {
+            let kind = OverlayMessageKind::from_stellar_message(message);
+            self.last_sent_msg_type = helpers::message_type_name(message);
+            total_body_size += msg_body_size(message);
+            let auth_msg = self.auth.wrap_message(message.clone())?;
+            let encoded = crate::codec::MessageCodec::encode_message(&auth_msg)?;
+            total_wire_size += (encoded.len() - 4) as u64;
+            buf.extend_from_slice(&encoded);
+            kinds.push(kind);
+        }
+
+        self.connection.send_encoded_batch(&buf).await?;
+
+        for kind in kinds {
+            self.metrics.record_send(kind);
+        }
+        self.metrics.bytes_written.add(total_wire_size);
+        self.metrics.async_write.inc();
+        self.stats
+            .messages_sent
+            .fetch_add(messages.len() as u64, Ordering::Relaxed);
+        self.stats
+            .bytes_sent
+            .fetch_add(total_body_size, Ordering::Relaxed);
+        Ok(())
+    }
+
     /// Receive a message from this peer.
     pub async fn recv(&mut self) -> Result<Option<StellarMessage>> {
         if self.state != PeerState::Authenticated {


### PR DESCRIPTION
## What

`OverlayManager::send_flow_controlled_batch` issued **one `write_all` per message** in the flood batch — one syscall, and with `TCP_NODELAY` one TCP segment, per message. This adds `Peer::send_batch` / `Connection::send_encoded_batch`, which wrap+encode every message in the batch **in order** (preserving the auth MAC sequence) and write the concatenated buffer in a **single `write_all`**.

## Parity

**Observable-surface-safe.** The bytes on the wire are byte-for-byte identical — each message is still `[len(4) | xdr_body]` in the same order, wrapped with the same auth MAC sequence numbers (the wrap loop runs sequentially over the batch, exactly as before). TCP is a stream, so only the grouping into syscalls/segments changes, not the bytes a peer reads. Overlay wire format is on the parity surface; this doesn't touch it.

## Why land it (it does not change maxtps)

This produces **no maxtps change on the single-host Supercluster rig** — measured directly: loopback there has ~950× byte and ~150× packet headroom with a 64 KB MTU, so the per-message segment count was never near the wall (documented in `docs/maxtps-optimization/2026-06-30-target-core.md`, PR #3700). It's landed as **general efficiency hygiene**: on real-NIC / 1500-MTU validator deployments, collapsing N syscalls + N segments per flood batch into one is a genuine reduction in send-path overhead.

## Reviewer note — `#3643` straggler stamp

The send is now **all-or-nothing per batch** (single `write_all`):
- On success, the straggler stamp advances to the batch's max `time_emplaced` — same result as the previous per-message loop.
- On error, nothing was written and the caller drops the peer, so the previous per-message *partial*-stamp path is moot.

A reviewer familiar with #3643 should confirm the all-or-nothing semantics are acceptable (I believe they are, since a mid-batch write error already dropped the peer).

## Tests

- `cargo test -p henyey-overlay` — 478 pass.
- `cargo fmt` + `cargo clippy -p henyey-overlay` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxnZVoi2JQ2NDqo3Hnm4T9