### PR TITLE
Delay maintainer first tick + instrument WAL write-lock holders (#3702)

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -185,6 +185,14 @@ impl LedgerPersistInputs {
             .to_json()
             .map_err(|e| anyhow::anyhow!("Failed to serialize HAS: {}", e))?;
 
+        // Instrument the WAL write-lock hold for this close persist so a long
+        // hold is self-naming in the logs (#3702). Instrumentation only — the
+        // transaction scope below is unchanged.
+        let _write_ctx = henyey_common::WriteCtxGuard::new(format!(
+            "ledger-close-persist seq={}",
+            self.header.ledger_seq
+        ));
+
         db.transaction(|conn| {
             conn.store_ledger_header(&self.header, &header_xdr)?;
             conn.store_tx_history_entry(self.header.ledger_seq, &self.tx_history_entry)?;

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -1720,7 +1720,17 @@ impl App {
         tokio::task::spawn_blocking(move || {
             while let Some(event) = peer_event_rx.blocking_recv() {
                 if let Err(err) = update_peer_record(&db, event) {
-                    tracing::warn!(?err, "Failed to update peer record");
+                    // This writer is the classic `database is locked` victim
+                    // when another connection pins SQLite's single WAL write
+                    // lock past the busy-timeout (#3702). Tag it with
+                    // `db_write_ctx` so it correlates in log aggregation with
+                    // the holder-side `WriteCtxGuard` events that name the
+                    // long-holding writer.
+                    tracing::warn!(
+                        db_write_ctx = "peer-record-update",
+                        ?err,
+                        "Failed to update peer record"
+                    );
                 }
             }
         });

--- a/crates/app/src/maintainer.rs
+++ b/crates/app/src/maintainer.rs
@@ -191,8 +191,7 @@ impl Maintainer {
             );
         }
 
-        let mut interval = tokio::time::interval(self.config.period);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut interval = build_maintenance_interval(self.config.period);
 
         loop {
             tokio::select! {
@@ -293,6 +292,26 @@ impl Maintainer {
     }
 }
 
+/// Build the periodic maintenance interval.
+///
+/// Unlike `tokio::time::interval`, whose first `tick()` resolves
+/// **immediately** (firing a full 50k-row DELETE maintenance cycle at
+/// startup), this uses `interval_at(now + period, period)` so the first
+/// maintenance runs one full `period` in. This keeps the maintainer's write
+/// burst from coinciding with the startup near-tip back-fill on the
+/// restore-from-disk path, where per-slot `scp-persist-{slot}` purge txns +
+/// back-to-back per-ledger close persists already contend for SQLite's single
+/// WAL writer (see #3702).
+///
+/// This shifts only **when** periodic pruning first runs — the period value,
+/// missed-tick behavior, and all pruning semantics are unchanged. There is no
+/// consensus/hash/ledger effect (maintenance cadence only).
+fn build_maintenance_interval(period: Duration) -> tokio::time::Interval {
+    let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    interval
+}
+
 /// Core maintenance logic shared between `App::perform_maintenance` and `Maintainer`.
 ///
 /// Deletes old data from the database to prevent unbounded growth.
@@ -318,6 +337,11 @@ pub fn run_maintenance(
     rpc_retention_window: Option<u32>,
     count: u32,
 ) {
+    // Instrument the WAL write-lock hold for the maintenance delete burst so a
+    // long hold is self-naming in the logs (#3702). Instrumentation only — the
+    // delete sequence and its transaction boundaries below are unchanged.
+    let _write_ctx = henyey_common::WriteCtxGuard::new("maintenance-delete");
+
     // Evict stale publish queue entries when publishing is enabled.
     // Fail closed: on any DB error, keep the original min_queued to avoid
     // over-pruning.
@@ -419,6 +443,69 @@ pub fn run_maintenance(
 mod tests {
     use super::*;
     use tokio::sync::watch;
+
+    /// Regression test for #3702: the maintainer's first maintenance cycle
+    /// must NOT fire immediately at startup.
+    ///
+    /// `tokio::time::interval(period)` resolves its first `tick()` immediately,
+    /// which would fire the 50k-row DELETE maintenance burst right as the node
+    /// enters the live loop — colliding with the startup near-tip back-fill on
+    /// the restore-from-disk path and pinning SQLite's single WAL writer.
+    ///
+    /// This asserts that the first `tick()` of the interval built by
+    /// `build_maintenance_interval` resolves only after ~`period` elapses.
+    /// Written against the factored helper so it is deterministic under
+    /// tokio's virtual clock. It FAILS on `tokio::time::interval` (immediate
+    /// first tick) and PASSES with the `interval_at(now + period, period)`
+    /// construction. The `assert_first_tick_immediate` sibling documents the
+    /// pre-fix behavior it guards against.
+    #[tokio::test(start_paused = true)]
+    async fn test_maintenance_first_tick_is_delayed() {
+        let period = Duration::from_secs(4 * 60 * 60);
+        let mut interval = build_maintenance_interval(period);
+
+        // The first tick must NOT be ready immediately. With virtual time
+        // paused, a `select!` biased to a zero-duration timer proves the
+        // interval's first tick is not already resolved at t=0.
+        tokio::select! {
+            biased;
+            _ = interval.tick() => {
+                panic!("maintenance first tick fired immediately at startup (#3702)");
+            }
+            _ = tokio::time::sleep(Duration::ZERO) => {}
+        }
+
+        // Advancing to just before `period` still must not fire.
+        tokio::time::advance(period - Duration::from_secs(1)).await;
+        tokio::select! {
+            biased;
+            _ = interval.tick() => {
+                panic!("maintenance first tick fired before one full period elapsed");
+            }
+            _ = tokio::time::sleep(Duration::ZERO) => {}
+        }
+
+        // After a full period has elapsed, the first tick fires.
+        tokio::time::advance(Duration::from_secs(1)).await;
+        interval.tick().await;
+    }
+
+    /// Sanity check documenting the pre-fix hazard: `tokio::time::interval`
+    /// (used on origin/main before #3702) fires its first tick immediately.
+    /// This is the exact behavior `build_maintenance_interval` avoids.
+    #[tokio::test(start_paused = true)]
+    async fn test_bare_interval_first_tick_is_immediate() {
+        let period = Duration::from_secs(4 * 60 * 60);
+        let mut interval = tokio::time::interval(period);
+        // First tick of a bare interval resolves immediately with no time advance.
+        tokio::select! {
+            biased;
+            _ = interval.tick() => {}
+            _ = tokio::time::sleep(Duration::ZERO) => {
+                panic!("expected bare interval first tick to be immediate");
+            }
+        }
+    }
 
     #[test]
     fn test_maintenance_config_default() {

--- a/crates/common/src/db_write_ctx.rs
+++ b/crates/common/src/db_write_ctx.rs
@@ -1,0 +1,98 @@
+//! Write-lock hold instrumentation for the SQLite single-writer path.
+//!
+//! SQLite in WAL mode serializes **all** write transactions through one
+//! global write lock. Under the restore-from-disk near-tip back-fill path
+//! (see #3702), several logical writers contend for that single lock:
+//!
+//! - per-slot `scp-persist-{slot}` purge / persist transactions,
+//! - back-to-back per-ledger close persists,
+//! - the maintainer's row-delete cycle.
+//!
+//! When one of these pins the write lock for a long time, other writers (e.g.
+//! the peer-record writer) log `database is locked` after the busy-timeout,
+//! but the log gives no clue *which* logical writer held it. [`WriteCtxGuard`]
+//! attaches a stable `db_write_ctx` label + timing to each holder-side write
+//! transaction so a long hold becomes self-naming in the logs.
+//!
+//! This is **instrumentation only** — it changes no transaction scope,
+//! ordering, or semantics, and adds no locks. Overhead is a couple of tracing
+//! events plus one `Instant::now()` per guarded transaction.
+
+use std::time::{Duration, Instant};
+
+use tracing::{debug, warn};
+
+/// Threshold above which a write-lock hold is considered long enough to warn
+/// about. Chosen well below the 30s SQLite busy-timeout so a warn is emitted
+/// before a *victim* writer times out with `database is locked`.
+pub const LONG_WRITE_HOLD_WARN: Duration = Duration::from_secs(5);
+
+/// RAII guard that times a logical DB write transaction and names its context.
+///
+/// Construct one at the start of a holder-side write transaction with a stable
+/// `context` label (e.g. `"scp-persist-purge slot=63281545"`,
+/// `"ledger-close-persist seq=63281546"`, `"maintenance-delete"`). On drop
+/// (transaction end), it logs the elapsed hold at `debug!`, and — if the hold
+/// exceeded [`LONG_WRITE_HOLD_WARN`] — at `warn!`, naming the context so the
+/// next wedge identifies the dominant WAL write-lock holder.
+///
+/// The `context` is owned (`String`) so callers can embed a slot/seq without
+/// juggling lifetimes; construction is off any hot inner loop (once per txn).
+#[must_use = "the guard must be held for the duration of the write transaction"]
+pub struct WriteCtxGuard {
+    context: String,
+    start: Instant,
+}
+
+impl WriteCtxGuard {
+    /// Begin timing a guarded write transaction, emitting a `debug!` start
+    /// event tagged with `db_write_ctx=<context>`.
+    pub fn new(context: impl Into<String>) -> Self {
+        let context = context.into();
+        debug!(db_write_ctx = %context, "db write txn begin");
+        Self {
+            context,
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for WriteCtxGuard {
+    fn drop(&mut self) {
+        let elapsed = self.start.elapsed();
+        if elapsed >= LONG_WRITE_HOLD_WARN {
+            warn!(
+                db_write_ctx = %self.context,
+                elapsed_ms = elapsed.as_millis() as u64,
+                "db write txn held the WAL write lock a long time \
+                 (candidate `database is locked` cause, #3702)"
+            );
+        } else {
+            debug!(
+                db_write_ctx = %self.context,
+                elapsed_ms = elapsed.as_millis() as u64,
+                "db write txn end"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_guard_constructs_and_drops() {
+        // Smoke: construction + drop must not panic and must record context.
+        let g = WriteCtxGuard::new("test-ctx");
+        assert_eq!(g.context, "test-ctx");
+        drop(g);
+    }
+
+    #[test]
+    fn test_guard_accepts_owned_context() {
+        let slot = 63281545u64;
+        let g = WriteCtxGuard::new(format!("scp-persist-purge slot={slot}"));
+        assert!(g.context.contains("63281545"));
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -52,6 +52,7 @@
 pub mod asset;
 pub mod checked_types;
 pub mod config;
+pub mod db_write_ctx;
 pub mod error;
 pub mod fs_utils;
 pub mod header_validation;
@@ -78,6 +79,7 @@ pub mod xdr_stream;
 // Re-export key types at crate root for convenience
 pub use asset::LIQUIDITY_POOL_FEE_V18;
 pub use config::{BucketListDbConfig, Config};
+pub use db_write_ctx::{WriteCtxGuard, LONG_WRITE_HOLD_WARN};
 pub use error::{Error, Result};
 pub use ledger_type_utils::*;
 pub use meta::*;

--- a/crates/db/src/scp_persistence.rs
+++ b/crates/db/src/scp_persistence.rs
@@ -118,6 +118,12 @@ impl SqliteScpPersistence {
         // entire read-then-delete sequence — blocks concurrent `save_tx_set`
         // / `save_scp_state` on other pool connections so we cannot delete a
         // tx-set that a writer is in the middle of registering. See #2770.
+        //
+        // Instrument the hold: this BEGIN IMMEDIATE spans full-table reads of
+        // `storestate`, so a long hold here is a prime `database is locked`
+        // suspect during near-tip back-fill (#3702). Instrumentation only —
+        // no change to the txn scope acquired above.
+        let _write_ctx = henyey_common::WriteCtxGuard::new("scp-persist-purge");
         self.db
             .transaction_immediate(|tx| tx.purge_unreferenced_tx_sets_atomic())
             .map_err(Self::map_error)

--- a/crates/herder/src/persistence.rs
+++ b/crates/herder/src/persistence.rs
@@ -526,6 +526,11 @@ impl ScpPersistenceManager {
             state.add_quorum_set(quorum_set)?;
         }
 
+        // Instrument the WAL write-lock hold so a long persist is self-naming
+        // in the logs (#3702). Instrumentation only — no txn-scope change.
+        let _write_ctx =
+            henyey_common::WriteCtxGuard::new(format!("scp-persist-write slot={slot}"));
+
         // Save transaction sets
         for (hash, tx_set) in tx_sets {
             if !self.storage.has_tx_set(hash)? {


### PR DESCRIPTION
## Root cause (from #3702)

Restore-from-disk near-tip back-fill wedges the validator via SQLite WAL single-writer lock contention. On the restore path the node sets Synced at a **stale** slot and back-fills **inside the live loop**, so per-slot `scp-persist-{slot}` purge/persist txns, back-to-back per-ledger close persists, and the maintainer's **immediate first-tick 50k-row DELETE** all collide on SQLite's one WAL writer. A holder pins the write lock >30s, the peer-record writer (`lifecycle.rs`) logs `database is locked` after the 30s `BUSY_TIMEOUT`, the loop goes silent, and peers age past the 120s straggler timeout. `FRESH_START` cold catchup escapes it (offloaded catchup pipeline runs before the loop spawns). This PR is the **operator-approved partial mitigation + instrumentation** — options A + B.

## (A) Delay maintainer first tick — parity-neutral

`build_maintenance_interval` now uses `tokio::time::interval_at(now + period, period)` instead of `tokio::time::interval(period)`, whose first `tick()` resolves **immediately** and fired the 50k-row DELETE burst at startup. The first maintenance now runs one full `period` in, never coinciding with startup near-tip back-fill.

**Why parity-neutral:** this shifts only *when* periodic DB pruning first runs. The `period` value, `MissedTickBehavior::Skip`, and all pruning thresholds/semantics are unchanged. No consensus/hash/ledger effect (maintenance cadence only).

## (B) Write-context instrumentation — instrumentation only

New `henyey_common::WriteCtxGuard` (RAII) logs a stable `db_write_ctx` label + elapsed hold at txn end, escalating to `warn!` when a hold exceeds 5s (below the 30s busy-timeout, so the warn precedes any victim's `database is locked`). Applied to the three holder-side write transactions:

| context tag | site |
|---|---|
| `scp-persist-write slot=<n>` | `herder::persistence::persist_scp_state` |
| `scp-persist-purge` | `db::scp_persistence::purge_unreferenced_tx_sets_atomic` (`BEGIN IMMEDIATE`) |
| `ledger-close-persist seq=<n>` | `app::ledger_close::serialize_and_write_to_db` |
| `maintenance-delete` | `app::maintainer::run_maintenance` |

The peer-record-update victim log in `lifecycle.rs` is tagged `db_write_ctx="peer-record-update"` so it correlates in aggregation with the holder that just named itself. **On the next repro the logs name the dominant WAL write-lock holder directly**, instead of going silent.

No transaction scope/ordering/semantic change, no locks added; overhead is a couple of tracing events + one `Instant::now()` per guarded txn. The SCP-purge `LIKE` query semantics are **not** changed (the separate option the operator did not pick).

## Failing-test-first (CLAUDE.md)

`maintainer::tests::test_maintenance_first_tick_is_delayed` asserts the first `tick()` resolves only after ~`period` under tokio virtual time (`start_paused`).
- **Pre-fix** (`interval(period)`): FAILS — verified locally by temporarily reverting the helper body; panics `maintenance first tick fired immediately at startup (#3702)`.
- **Post-fix** (`interval_at`): PASSES.

`test_bare_interval_first_tick_is_immediate` documents the pre-fix hazard. `WriteCtxGuard` has construction/drop smoke tests.

## Tests run

- `henyey-app` lib: **1146 passed**, 0 failed (maintainer 27, ledger_close 40 included)
- `henyey-herder` persistence: 19 passed
- `henyey-db` lib: 111 passed
- `henyey-common` `db_write_ctx`: 2 passed
- `cargo clippy` clean on `henyey-common`, `henyey-db`, `henyey-herder`, `henyey-app`; pre-commit fmt + clippy passed.

## Status

**Partial mitigation + diagnostic.** #3702 stays **OPEN** until a runtime repro confirms the dominant holder is cleared (the `WriteCtxGuard` warns will name it). Toward #3702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)