### PR TITLE
De-load the consensus event loop and nomination critical path (+7.8% max TPS)

### DIFF
--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -473,6 +473,26 @@ impl App {
             ct_offset_secs,
             "Armed event-driven consensus trigger timer (setupTriggerNextLedger)"
         );
+
+        // Prebuild the nomination value ~300 ms ahead of the trigger (maxtps
+        // iter 9): the ~150-200 ms tx-set build otherwise runs between the
+        // trigger firing and `scp.nominate`, on the network's nomination-
+        // convergence critical path. A plain sleep task (not a managed timer)
+        // suffices: `prebuild_nomination_value` self-gates on slot/LCL/
+        // nomination state, so a stale or duplicate firing is a cheap no-op.
+        const PREBUILD_LEAD: std::time::Duration = std::time::Duration::from_millis(300);
+        if self.is_validator && delay > PREBUILD_LEAD + std::time::Duration::from_millis(100) {
+            let herder = std::sync::Arc::clone(&self.herder);
+            let lead_delay = delay - PREBUILD_LEAD;
+            tokio::spawn(async move {
+                tokio::time::sleep(lead_delay).await;
+                let _ =
+                    henyey_common::spawn_blocking_logged("prebuild_nomination_value", move || {
+                        herder.prebuild_nomination_value(next_slot as u32)
+                    })
+                    .await;
+            });
+        }
     }
 
     /// Perform out-of-sync recovery matching stellar-core's outOfSyncRecovery().

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -243,11 +243,8 @@ impl App {
             let last_slot = current_ledger as u64;
             let last_ballot_start = self.herder.prepare_start(last_slot);
             let now_instant = std::time::Instant::now();
-            // Early-trigger compensation (kept in lock-step with
-            // `setup_trigger_next_ledger`, see rationale there).
-            let comp = self.trigger_overhead_compensation(expected_close);
             let trigger_time = match last_ballot_start {
-                Some(ballot_start) => ballot_start + expected_close - comp,
+                Some(ballot_start) => ballot_start + expected_close,
                 None => now_instant,
             };
             if trigger_time > now_instant {
@@ -419,24 +416,6 @@ impl App {
         self.setup_trigger_next_ledger().await;
     }
 
-    /// Early-trigger compensation: the tracked per-slot nomination overhead
-    /// (tx-set build + SCP convergence), clamped to `expected_close / 5`
-    /// (1 s at the 5 s target — the round-1 nomination timeout) so a single
-    /// outlier observation can never pull the trigger drastically early.
-    /// Subtracted from the trigger instant by BOTH trigger sites
-    /// (`setup_trigger_next_ledger` and the `try_trigger_consensus` gate) so
-    /// the timer and the safety-net always agree on timing. Returns 0 until
-    /// the first slot completes nomination.
-    fn trigger_overhead_compensation(
-        &self,
-        expected_close: std::time::Duration,
-    ) -> std::time::Duration {
-        self.herder
-            .nomination_overhead_estimate()
-            .unwrap_or_default()
-            .min(expected_close / 5)
-    }
-
     pub(super) async fn setup_trigger_next_ledger(&self) {
         // Parity: MANUAL_CLOSE skips arming the trigger timer.
         if self.config.node.manual_close {
@@ -453,24 +432,21 @@ impl App {
 
         // Compute the trigger instant exactly as `try_trigger_consensus` does
         // (kept in lock-step so the timer and the safety-net agree on timing).
+        //
+        // NOTE (maxtps iteration 2, 2026-07-02, REJECTED experiment): arming
+        // this trigger EARLY by the measured nomination overhead (EWMA of
+        // trigger→ballot-start) does work mechanically — loaded cadence drops
+        // from ~5.5 s to ~4.95 s (+17% ledger rate) — but does NOT raise the
+        // max-TPS ceiling: ledgers arrive proportionally emptier and the
+        // loadgen's per-account inclusion-latency guillotine does not relax
+        // (measured max 1460-1470 vs 1487 baseline). Do not re-attempt without
+        // a mechanism that raises per-WALL-SECOND drain, not ledger rate.
+        // See docs/maxtps-optimization/2026-07-02-target2000.md iteration 2.
         let expected_close = self.herder.ledger_close_duration();
         let last_slot = current_ledger as u64;
         let now_instant = std::time::Instant::now();
-        // DIVERGENCE (performance, internal scheduling — not on the observable
-        // parity surface): stellar-core arms the trigger at
-        // `prepareStart + expectedClose` and only THEN builds the tx set and
-        // runs SCP nomination, so its real ledger cadence is
-        // `expectedClose + build + convergence` (~5.5 s at a 5 s target under
-        // load — it undershoots the network's declared close-time target by
-        // ~10%). henyey compensates: the trigger is armed EARLY by the EWMA of
-        // the measured overhead, so ballot starts land on the declared
-        // `expectedClose` grid. Wire bytes, close-time values, and tx-set
-        // semantics are unchanged; only the moment we start nominating moves.
-        // The compensation is clamped to expectedClose/2 as a safety bound and
-        // is 0 until the first slot completes (cold start = core behavior).
-        let comp = self.trigger_overhead_compensation(expected_close);
         let trigger_time = match self.herder.prepare_start(last_slot) {
-            Some(ballot_start) => ballot_start + expected_close - comp,
+            Some(ballot_start) => ballot_start + expected_close,
             None => now_instant,
         };
         // Base delay from prepareStart + expectedClose, clamped to "now".
@@ -494,7 +470,6 @@ impl App {
         tracing::debug!(
             next_slot,
             delay_ms = delay.as_millis(),
-            comp_ms = comp.as_millis(),
             ct_offset_secs,
             "Armed event-driven consensus trigger timer (setupTriggerNextLedger)"
         );

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -243,8 +243,11 @@ impl App {
             let last_slot = current_ledger as u64;
             let last_ballot_start = self.herder.prepare_start(last_slot);
             let now_instant = std::time::Instant::now();
+            // Early-trigger compensation (kept in lock-step with
+            // `setup_trigger_next_ledger`, see rationale there).
+            let comp = self.trigger_overhead_compensation(expected_close);
             let trigger_time = match last_ballot_start {
-                Some(ballot_start) => ballot_start + expected_close,
+                Some(ballot_start) => ballot_start + expected_close - comp,
                 None => now_instant,
             };
             if trigger_time > now_instant {
@@ -416,6 +419,22 @@ impl App {
         self.setup_trigger_next_ledger().await;
     }
 
+    /// Early-trigger compensation: the EWMA of the per-slot nomination
+    /// overhead (tx-set build + SCP convergence), clamped to
+    /// `expected_close / 2`. Subtracted from the trigger instant by BOTH
+    /// trigger sites (`setup_trigger_next_ledger` and the
+    /// `try_trigger_consensus` gate) so the timer and the safety-net always
+    /// agree on timing. Returns 0 until the first slot completes nomination.
+    fn trigger_overhead_compensation(
+        &self,
+        expected_close: std::time::Duration,
+    ) -> std::time::Duration {
+        self.herder
+            .nomination_overhead_estimate()
+            .unwrap_or_default()
+            .min(expected_close / 2)
+    }
+
     pub(super) async fn setup_trigger_next_ledger(&self) {
         // Parity: MANUAL_CLOSE skips arming the trigger timer.
         if self.config.node.manual_close {
@@ -435,8 +454,21 @@ impl App {
         let expected_close = self.herder.ledger_close_duration();
         let last_slot = current_ledger as u64;
         let now_instant = std::time::Instant::now();
+        // DIVERGENCE (performance, internal scheduling — not on the observable
+        // parity surface): stellar-core arms the trigger at
+        // `prepareStart + expectedClose` and only THEN builds the tx set and
+        // runs SCP nomination, so its real ledger cadence is
+        // `expectedClose + build + convergence` (~5.5 s at a 5 s target under
+        // load — it undershoots the network's declared close-time target by
+        // ~10%). henyey compensates: the trigger is armed EARLY by the EWMA of
+        // the measured overhead, so ballot starts land on the declared
+        // `expectedClose` grid. Wire bytes, close-time values, and tx-set
+        // semantics are unchanged; only the moment we start nominating moves.
+        // The compensation is clamped to expectedClose/2 as a safety bound and
+        // is 0 until the first slot completes (cold start = core behavior).
+        let comp = self.trigger_overhead_compensation(expected_close);
         let trigger_time = match self.herder.prepare_start(last_slot) {
-            Some(ballot_start) => ballot_start + expected_close,
+            Some(ballot_start) => ballot_start + expected_close - comp,
             None => now_instant,
         };
         // Base delay from prepareStart + expectedClose, clamped to "now".
@@ -460,6 +492,7 @@ impl App {
         tracing::debug!(
             next_slot,
             delay_ms = delay.as_millis(),
+            comp_ms = comp.as_millis(),
             ct_offset_secs,
             "Armed event-driven consensus trigger timer (setupTriggerNextLedger)"
         );

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -419,12 +419,14 @@ impl App {
         self.setup_trigger_next_ledger().await;
     }
 
-    /// Early-trigger compensation: the EWMA of the per-slot nomination
-    /// overhead (tx-set build + SCP convergence), clamped to
-    /// `expected_close / 2`. Subtracted from the trigger instant by BOTH
-    /// trigger sites (`setup_trigger_next_ledger` and the
-    /// `try_trigger_consensus` gate) so the timer and the safety-net always
-    /// agree on timing. Returns 0 until the first slot completes nomination.
+    /// Early-trigger compensation: the tracked per-slot nomination overhead
+    /// (tx-set build + SCP convergence), clamped to `expected_close / 5`
+    /// (1 s at the 5 s target — the round-1 nomination timeout) so a single
+    /// outlier observation can never pull the trigger drastically early.
+    /// Subtracted from the trigger instant by BOTH trigger sites
+    /// (`setup_trigger_next_ledger` and the `try_trigger_consensus` gate) so
+    /// the timer and the safety-net always agree on timing. Returns 0 until
+    /// the first slot completes nomination.
     fn trigger_overhead_compensation(
         &self,
         expected_close: std::time::Duration,
@@ -432,7 +434,7 @@ impl App {
         self.herder
             .nomination_overhead_estimate()
             .unwrap_or_default()
-            .min(expected_close / 2)
+            .min(expected_close / 5)
     }
 
     pub(super) async fn setup_trigger_next_ledger(&self) {

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -364,7 +364,7 @@ impl App {
         // Get message receiver from overlay
         let message_rx = self.overlay().await.map(|o| o.subscribe());
 
-        let mut message_rx = match message_rx {
+        let message_rx = match message_rx {
             Some(rx) => rx,
             None => {
                 tracing::warn!("Overlay not started, running without network");
@@ -373,6 +373,22 @@ impl App {
                 drop(tx);
                 rx
             }
+        };
+
+        // Dedicated inbound-flood consumer (maxtps iter 6): bulk overlay
+        // traffic (Transaction / FloodAdvert / FloodDemand / peer chatter) is
+        // consumed on its own spawned task instead of a main-select arm. At
+        // the ~1470 tx/s ceiling this arm did ~20 s of inline work per 30 s
+        // window (maxtps_loop: broadcast ≈ 0.5 ms × 36-44 k msgs), starving
+        // SCP intake (median 92-109 ms channel wait) and the close/trigger
+        // path. SCP envelopes and fetch responses keep their dedicated
+        // channels + select arms; only the broadcast-channel firehose moves.
+        // The task holds a Weak<App> (upgrade per message) so it never keeps
+        // the App alive after shutdown; it exits on channel close or upgrade
+        // failure and is aborted on loop exit.
+        let flood_consumer_task = {
+            let weak = { self.self_arc.read().await.clone() };
+            tokio::spawn(Self::run_flood_consumer(weak, message_rx))
         };
 
         // Get dedicated SCP message receiver (never drops messages)
@@ -1000,68 +1016,9 @@ impl App {
                 // SCP, fetch-response, and fetch-request messages no longer arrive here —
                 // they are routed exclusively to dedicated channels at the overlay layer.
                 // The skip guards below are kept as defensive fallbacks.
-                msg = message_rx.recv() => {
-                    self.set_phase(3); // 3 = broadcast
-                    match msg {
-                        Ok(overlay_msg) => {
-                            // Skip SCP messages from broadcast channel — they are already
-                            // handled via the dedicated SCP channel above.
-                            if matches!(overlay_msg.message, StellarMessage::ScpMessage(_)) {
-                                continue;
-                            }
-                            // Skip fetch response and request messages from broadcast channel —
-                            // they are handled via the dedicated fetch channel above.
-                            if matches!(
-                                overlay_msg.message,
-                                StellarMessage::GeneralizedTxSet(_)
-                                    | StellarMessage::TxSet(_)
-                                    | StellarMessage::DontHave(_)
-                                    | StellarMessage::ScpQuorumset(_)
-                                    | StellarMessage::GetScpState(_)
-                                    | StellarMessage::GetScpQuorumset(_)
-                                    | StellarMessage::GetTxSet(_)
-                            ) {
-                                continue;
-                            }
-                            let delivery_latency = overlay_msg.received_at.elapsed();
-                            let msg_type = match &overlay_msg.message {
-                                StellarMessage::ScpMessage(_) => "SCP",
-                                StellarMessage::Transaction(_) => "TX",
-                                StellarMessage::TxSet(_) => "TxSet",
-                                StellarMessage::GeneralizedTxSet(_) => {
-                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for GeneralizedTxSet");
-                                    "GeneralizedTxSet"
-                                },
-                                StellarMessage::ScpQuorumset(_) => {
-                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for ScpQuorumset");
-                                    "ScpQuorumset"
-                                },
-                                StellarMessage::GetTxSet(_) => "GetTxSet",
-                                StellarMessage::Hello(_) => "Hello",
-                                StellarMessage::Peers(_) => "Peers",
-                                _ => "Other",
-                            };
-                            tracing::debug!(msg_type, latency_ms = delivery_latency.as_millis(), "Received overlay message");
-                            self.handle_overlay_message(overlay_msg).await;
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            // Only non-critical messages (TX floods) flow through the
-                            // broadcast channel now, so lag is expected under load.
-                            // [maxtps_diag] Count dropped flood messages — under load
-                            // these are demanded txs the node never receives, forcing
-                            // re-demands (stellar_overlay_demand_timeout_total) and
-                            // leaving the agreed set short. Core never drops flooded
-                            // txs (flow-controlled per-peer queues).
-                            metrics::counter!("stellar_overlay_broadcast_lagged_dropped_total")
-                                .increment(n);
-                            tracing::debug!(skipped = n, "Overlay broadcast receiver lagged (non-critical messages only)");
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            tracing::info!("Overlay broadcast channel closed");
-                            break;
-                        }
-                    }
-                }
+                // NOTE (maxtps iter 6): the broadcast-channel (inbound flood)
+                // arm that lived here moved to the dedicated
+                // `run_flood_consumer` task spawned before this loop.
 
                 // Broadcast outbound SCP envelopes
                 envelope = scp_rx.recv() => {
@@ -1608,6 +1565,10 @@ impl App {
         // thread and resets tick_ms to 0.
         drop(watchdog_guard);
 
+        // Stop the dedicated flood consumer (maxtps iter 6) — covers every
+        // loop-exit path, not just the shutdown-signal arm.
+        flood_consumer_task.abort();
+
         // Clean up pending catchup on shutdown
         if let Some(pending) = pending_catchup.take() {
             tracing::info!(
@@ -2088,6 +2049,76 @@ impl App {
             _ => {
                 // Other message types (Hello, Auth, etc.) are handled by overlay
                 tracing::trace!(msg_type = ?std::mem::discriminant(&msg.message), "Ignoring message type");
+            }
+        }
+    }
+
+    /// Dedicated consumer for the overlay broadcast channel (inbound flood:
+    /// Transaction / FloodAdvert / FloodDemand / peer chatter). See the spawn
+    /// site in [`Self::run_event_loop`] for the rationale (maxtps iter 6 —
+    /// bulk flood work off the consensus event loop). SCP messages and fetch
+    /// responses are filtered out here exactly as the old select arm did:
+    /// they arrive via their dedicated channels and are handled on the loop.
+    ///
+    /// Holds only a `Weak<App>`; exits when the channel closes or the app is
+    /// dropped. Processing stays strictly serial (one message at a time),
+    /// preserving the old arm's ordering semantics — it just no longer
+    /// competes with SCP/close work for the main loop.
+    async fn run_flood_consumer(
+        weak: std::sync::Weak<Self>,
+        mut rx: tokio::sync::broadcast::Receiver<OverlayMessage>,
+    ) {
+        loop {
+            match rx.recv().await {
+                Ok(overlay_msg) => {
+                    // Skip SCP messages — handled via the dedicated SCP channel.
+                    if matches!(overlay_msg.message, StellarMessage::ScpMessage(_)) {
+                        continue;
+                    }
+                    // Skip fetch response/request messages — handled via the
+                    // dedicated fetch channel.
+                    if matches!(
+                        overlay_msg.message,
+                        StellarMessage::GeneralizedTxSet(_)
+                            | StellarMessage::TxSet(_)
+                            | StellarMessage::DontHave(_)
+                            | StellarMessage::ScpQuorumset(_)
+                            | StellarMessage::GetScpState(_)
+                            | StellarMessage::GetScpQuorumset(_)
+                            | StellarMessage::GetTxSet(_)
+                    ) {
+                        continue;
+                    }
+                    let Some(app) = weak.upgrade() else {
+                        tracing::info!("Flood consumer exiting: app dropped");
+                        return;
+                    };
+                    let delivery_latency = overlay_msg.received_at.elapsed();
+                    tracing::debug!(
+                        latency_ms = delivery_latency.as_millis(),
+                        "Received overlay message (flood consumer)"
+                    );
+                    app.handle_overlay_message(overlay_msg).await;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    // Only non-critical messages (TX floods) flow through the
+                    // broadcast channel now, so lag is expected under load.
+                    // [maxtps_diag] Count dropped flood messages — under load
+                    // these are demanded txs the node never receives, forcing
+                    // re-demands (stellar_overlay_demand_timeout_total) and
+                    // leaving the agreed set short. Core never drops flooded
+                    // txs (flow-controlled per-peer queues).
+                    metrics::counter!("stellar_overlay_broadcast_lagged_dropped_total")
+                        .increment(n);
+                    tracing::debug!(
+                        skipped = n,
+                        "Overlay broadcast receiver lagged (non-critical messages only)"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    tracing::info!("Overlay broadcast channel closed; flood consumer exiting");
+                    return;
+                }
             }
         }
     }

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -1561,6 +1561,18 @@ impl App {
                 phase_dispatch_start.elapsed(),
                 self.event_loop_phase.load(Ordering::Relaxed),
             );
+            // [maxtps_loop] accumulate per-phase busy time for the stats-tick
+            // dump (which arm occupies the event loop under load).
+            {
+                let ph = self.event_loop_phase.load(Ordering::Relaxed) as usize;
+                if ph < self.phase_time_us.len() {
+                    self.phase_time_us[ph].fetch_add(
+                        phase_dispatch_start.elapsed().as_micros() as u64,
+                        Ordering::Relaxed,
+                    );
+                    self.phase_count[ph].fetch_add(1, Ordering::Relaxed);
+                }
+            }
         }
 
         // Event loop has exited — stop the watchdog immediately (before
@@ -2054,6 +2066,44 @@ impl App {
 
     /// Log current stats.
     async fn log_stats(&self) {
+        // [maxtps_loop] drain + dump per-phase event-loop busy time since the
+        // last stats tick; one line listing phases with >50 ms accumulated.
+        {
+            let mut parts: Vec<String> = Vec::new();
+            let mut total_ms = 0u64;
+            for ph in 0..self.phase_time_us.len() {
+                let us = self.phase_time_us[ph].swap(0, Ordering::Relaxed);
+                let n = self.phase_count[ph].swap(0, Ordering::Relaxed);
+                let ms = us / 1000;
+                total_ms += ms;
+                if ms > 50 {
+                    parts.push(format!(
+                        "{}={}ms/{}",
+                        super::event_loop_phase_name(ph as u64),
+                        ms,
+                        n
+                    ));
+                }
+            }
+            if !parts.is_empty() {
+                parts.sort_by_key(|p| {
+                    std::cmp::Reverse(
+                        p.split('=')
+                            .nth(1)
+                            .and_then(|v| v.split("ms").next())
+                            .and_then(|v| v.parse::<u64>().ok())
+                            .unwrap_or(0),
+                    )
+                });
+                tracing::info!(
+                    target: "maxtps_loop",
+                    total_busy_ms = total_ms,
+                    breakdown = parts.join(" "),
+                    "loop_busy"
+                );
+            }
+        }
+
         let stats = self.herder.stats();
         let ledger = self.current_ledger_seq();
 

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -603,20 +603,7 @@ impl App {
             // WARNs below.
             let phase_dispatch_start = std::time::Instant::now();
             tokio::select! {
-                // `biased;` (maxtps iteration 4): poll arms in written order so
-                // SCP envelopes, consensus timer events, and interval ticks
-                // preempt bulk flood processing. Under ~1450 tx/s flood load the
-                // unbiased select gave the dedicated SCP channel ~1/N of
-                // pickups, adding a measured median 92 ms / p99 273 ms of queue
-                // wait per envelope hop (target maxtps_scp) — 3-4 sequential
-                // hops of that is the entire slow-nomination tail. The flood
-                // arm (message_rx) now sits at the BOTTOM of the select; every
-                // other arm is rate-bounded (SCP ~hundreds/slot, ticks ≤10/s),
-                // so flood intake cannot be starved, it just yields priority.
-                // (An earlier un-ordered `biased;` was removed because it
-                // starved timers — the cure is ordering ticks ABOVE the flood
-                // arm, not removing bias.)
-                biased;
+                // NOTE: Removed biased; to ensure timers get fair polling
 
                 // Await pending ledger close or persist completion.
                 // The pipeline is a state machine: at most one operation is
@@ -1006,6 +993,69 @@ impl App {
                 // SCP, fetch-response, and fetch-request messages no longer arrive here —
                 // they are routed exclusively to dedicated channels at the overlay layer.
                 // The skip guards below are kept as defensive fallbacks.
+                msg = message_rx.recv() => {
+                    self.set_phase(3); // 3 = broadcast
+                    match msg {
+                        Ok(overlay_msg) => {
+                            // Skip SCP messages from broadcast channel — they are already
+                            // handled via the dedicated SCP channel above.
+                            if matches!(overlay_msg.message, StellarMessage::ScpMessage(_)) {
+                                continue;
+                            }
+                            // Skip fetch response and request messages from broadcast channel —
+                            // they are handled via the dedicated fetch channel above.
+                            if matches!(
+                                overlay_msg.message,
+                                StellarMessage::GeneralizedTxSet(_)
+                                    | StellarMessage::TxSet(_)
+                                    | StellarMessage::DontHave(_)
+                                    | StellarMessage::ScpQuorumset(_)
+                                    | StellarMessage::GetScpState(_)
+                                    | StellarMessage::GetScpQuorumset(_)
+                                    | StellarMessage::GetTxSet(_)
+                            ) {
+                                continue;
+                            }
+                            let delivery_latency = overlay_msg.received_at.elapsed();
+                            let msg_type = match &overlay_msg.message {
+                                StellarMessage::ScpMessage(_) => "SCP",
+                                StellarMessage::Transaction(_) => "TX",
+                                StellarMessage::TxSet(_) => "TxSet",
+                                StellarMessage::GeneralizedTxSet(_) => {
+                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for GeneralizedTxSet");
+                                    "GeneralizedTxSet"
+                                },
+                                StellarMessage::ScpQuorumset(_) => {
+                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for ScpQuorumset");
+                                    "ScpQuorumset"
+                                },
+                                StellarMessage::GetTxSet(_) => "GetTxSet",
+                                StellarMessage::Hello(_) => "Hello",
+                                StellarMessage::Peers(_) => "Peers",
+                                _ => "Other",
+                            };
+                            tracing::debug!(msg_type, latency_ms = delivery_latency.as_millis(), "Received overlay message");
+                            self.handle_overlay_message(overlay_msg).await;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            // Only non-critical messages (TX floods) flow through the
+                            // broadcast channel now, so lag is expected under load.
+                            // [maxtps_diag] Count dropped flood messages — under load
+                            // these are demanded txs the node never receives, forcing
+                            // re-demands (stellar_overlay_demand_timeout_total) and
+                            // leaving the agreed set short. Core never drops flooded
+                            // txs (flow-controlled per-peer queues).
+                            metrics::counter!("stellar_overlay_broadcast_lagged_dropped_total")
+                                .increment(n);
+                            tracing::debug!(skipped = n, "Overlay broadcast receiver lagged (non-critical messages only)");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            tracing::info!("Overlay broadcast channel closed");
+                            break;
+                        }
+                    }
+                }
+
                 // Broadcast outbound SCP envelopes
                 envelope = scp_rx.recv() => {
                     self.set_phase(4); // 4 = scp_broadcast
@@ -1496,72 +1546,6 @@ impl App {
                                 tracking_slot,
                                 "Out-of-sync recovery: purged old slots"
                             );
-                        }
-                    }
-                }
-
-                // Flood/broadcast intake (tx floods, adverts, demands). Lowest
-                // priority under `biased;`: SCP envelopes, consensus timers, and
-                // ticks preempt bulk flood processing (see note at the select head).
-                msg = message_rx.recv() => {
-                    self.set_phase(3); // 3 = broadcast
-                    match msg {
-                        Ok(overlay_msg) => {
-                            // Skip SCP messages from broadcast channel — they are already
-                            // handled via the dedicated SCP channel above.
-                            if matches!(overlay_msg.message, StellarMessage::ScpMessage(_)) {
-                                continue;
-                            }
-                            // Skip fetch response and request messages from broadcast channel —
-                            // they are handled via the dedicated fetch channel above.
-                            if matches!(
-                                overlay_msg.message,
-                                StellarMessage::GeneralizedTxSet(_)
-                                    | StellarMessage::TxSet(_)
-                                    | StellarMessage::DontHave(_)
-                                    | StellarMessage::ScpQuorumset(_)
-                                    | StellarMessage::GetScpState(_)
-                                    | StellarMessage::GetScpQuorumset(_)
-                                    | StellarMessage::GetTxSet(_)
-                            ) {
-                                continue;
-                            }
-                            let delivery_latency = overlay_msg.received_at.elapsed();
-                            let msg_type = match &overlay_msg.message {
-                                StellarMessage::ScpMessage(_) => "SCP",
-                                StellarMessage::Transaction(_) => "TX",
-                                StellarMessage::TxSet(_) => "TxSet",
-                                StellarMessage::GeneralizedTxSet(_) => {
-                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for GeneralizedTxSet");
-                                    "GeneralizedTxSet"
-                                },
-                                StellarMessage::ScpQuorumset(_) => {
-                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for ScpQuorumset");
-                                    "ScpQuorumset"
-                                },
-                                StellarMessage::GetTxSet(_) => "GetTxSet",
-                                StellarMessage::Hello(_) => "Hello",
-                                StellarMessage::Peers(_) => "Peers",
-                                _ => "Other",
-                            };
-                            tracing::debug!(msg_type, latency_ms = delivery_latency.as_millis(), "Received overlay message");
-                            self.handle_overlay_message(overlay_msg).await;
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            // Only non-critical messages (TX floods) flow through the
-                            // broadcast channel now, so lag is expected under load.
-                            // [maxtps_diag] Count dropped flood messages — under load
-                            // these are demanded txs the node never receives, forcing
-                            // re-demands (stellar_overlay_demand_timeout_total) and
-                            // leaving the agreed set short. Core never drops flooded
-                            // txs (flow-controlled per-peer queues).
-                            metrics::counter!("stellar_overlay_broadcast_lagged_dropped_total")
-                                .increment(n);
-                            tracing::debug!(skipped = n, "Overlay broadcast receiver lagged (non-critical messages only)");
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            tracing::info!("Overlay broadcast channel closed");
-                            break;
                         }
                     }
                 }

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -908,6 +908,19 @@ impl App {
                         latency_ms = scp_msg.received_at.elapsed().as_millis(),
                         "SCP message arrived via dedicated channel"
                     );
+                    // [maxtps_scp] time spent queued in the dedicated SCP
+                    // channel before the event loop picked it up (slow-only).
+                    {
+                        let intake_ms = scp_msg.received_at.elapsed().as_millis() as u64;
+                        if intake_ms > 50 {
+                            tracing::info!(
+                                target: "maxtps_scp",
+                                slot = scp_slot,
+                                intake_ms,
+                                "slow_intake"
+                            );
+                        }
+                    }
                     self.pump_scp_intake(scp_msg, &mut verified_rx).await;
                     // After processing an SCP message (which may buffer an
                     // EXTERNALIZE), kick off a buffered close if none is running.
@@ -2608,6 +2621,24 @@ impl App {
             .fetch_add(verify_latency_us, Ordering::Relaxed);
         self.scp_verify_latency_count
             .fetch_add(1, Ordering::Relaxed);
+
+        // [maxtps_scp] full-pipeline latency for one SCP envelope: overlay
+        // recv → dedicated channel → intake → verify worker → this dispatch.
+        // Only slow envelopes are logged (bounds volume); used to attribute
+        // the nomination-convergence tail (slow slots) to pipeline queueing
+        // vs fetch service time. Parity-irrelevant logging.
+        if let Some(recv_at) = ve.intake.received_at() {
+            let total_ms = recv_at.elapsed().as_millis() as u64;
+            if total_ms > 50 {
+                tracing::info!(
+                    target: "maxtps_scp",
+                    slot,
+                    total_ms,
+                    verify_us = verify_latency_us,
+                    "slow_pipeline"
+                );
+            }
+        }
 
         // SCP latency bookkeeping.
         //

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -603,7 +603,20 @@ impl App {
             // WARNs below.
             let phase_dispatch_start = std::time::Instant::now();
             tokio::select! {
-                // NOTE: Removed biased; to ensure timers get fair polling
+                // `biased;` (maxtps iteration 4): poll arms in written order so
+                // SCP envelopes, consensus timer events, and interval ticks
+                // preempt bulk flood processing. Under ~1450 tx/s flood load the
+                // unbiased select gave the dedicated SCP channel ~1/N of
+                // pickups, adding a measured median 92 ms / p99 273 ms of queue
+                // wait per envelope hop (target maxtps_scp) — 3-4 sequential
+                // hops of that is the entire slow-nomination tail. The flood
+                // arm (message_rx) now sits at the BOTTOM of the select; every
+                // other arm is rate-bounded (SCP ~hundreds/slot, ticks ≤10/s),
+                // so flood intake cannot be starved, it just yields priority.
+                // (An earlier un-ordered `biased;` was removed because it
+                // starved timers — the cure is ordering ticks ABOVE the flood
+                // arm, not removing bias.)
+                biased;
 
                 // Await pending ledger close or persist completion.
                 // The pipeline is a state machine: at most one operation is
@@ -993,69 +1006,6 @@ impl App {
                 // SCP, fetch-response, and fetch-request messages no longer arrive here —
                 // they are routed exclusively to dedicated channels at the overlay layer.
                 // The skip guards below are kept as defensive fallbacks.
-                msg = message_rx.recv() => {
-                    self.set_phase(3); // 3 = broadcast
-                    match msg {
-                        Ok(overlay_msg) => {
-                            // Skip SCP messages from broadcast channel — they are already
-                            // handled via the dedicated SCP channel above.
-                            if matches!(overlay_msg.message, StellarMessage::ScpMessage(_)) {
-                                continue;
-                            }
-                            // Skip fetch response and request messages from broadcast channel —
-                            // they are handled via the dedicated fetch channel above.
-                            if matches!(
-                                overlay_msg.message,
-                                StellarMessage::GeneralizedTxSet(_)
-                                    | StellarMessage::TxSet(_)
-                                    | StellarMessage::DontHave(_)
-                                    | StellarMessage::ScpQuorumset(_)
-                                    | StellarMessage::GetScpState(_)
-                                    | StellarMessage::GetScpQuorumset(_)
-                                    | StellarMessage::GetTxSet(_)
-                            ) {
-                                continue;
-                            }
-                            let delivery_latency = overlay_msg.received_at.elapsed();
-                            let msg_type = match &overlay_msg.message {
-                                StellarMessage::ScpMessage(_) => "SCP",
-                                StellarMessage::Transaction(_) => "TX",
-                                StellarMessage::TxSet(_) => "TxSet",
-                                StellarMessage::GeneralizedTxSet(_) => {
-                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for GeneralizedTxSet");
-                                    "GeneralizedTxSet"
-                                },
-                                StellarMessage::ScpQuorumset(_) => {
-                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for ScpQuorumset");
-                                    "ScpQuorumset"
-                                },
-                                StellarMessage::GetTxSet(_) => "GetTxSet",
-                                StellarMessage::Hello(_) => "Hello",
-                                StellarMessage::Peers(_) => "Peers",
-                                _ => "Other",
-                            };
-                            tracing::debug!(msg_type, latency_ms = delivery_latency.as_millis(), "Received overlay message");
-                            self.handle_overlay_message(overlay_msg).await;
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            // Only non-critical messages (TX floods) flow through the
-                            // broadcast channel now, so lag is expected under load.
-                            // [maxtps_diag] Count dropped flood messages — under load
-                            // these are demanded txs the node never receives, forcing
-                            // re-demands (stellar_overlay_demand_timeout_total) and
-                            // leaving the agreed set short. Core never drops flooded
-                            // txs (flow-controlled per-peer queues).
-                            metrics::counter!("stellar_overlay_broadcast_lagged_dropped_total")
-                                .increment(n);
-                            tracing::debug!(skipped = n, "Overlay broadcast receiver lagged (non-critical messages only)");
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            tracing::info!("Overlay broadcast channel closed");
-                            break;
-                        }
-                    }
-                }
-
                 // Broadcast outbound SCP envelopes
                 envelope = scp_rx.recv() => {
                     self.set_phase(4); // 4 = scp_broadcast
@@ -1546,6 +1496,72 @@ impl App {
                                 tracking_slot,
                                 "Out-of-sync recovery: purged old slots"
                             );
+                        }
+                    }
+                }
+
+                // Flood/broadcast intake (tx floods, adverts, demands). Lowest
+                // priority under `biased;`: SCP envelopes, consensus timers, and
+                // ticks preempt bulk flood processing (see note at the select head).
+                msg = message_rx.recv() => {
+                    self.set_phase(3); // 3 = broadcast
+                    match msg {
+                        Ok(overlay_msg) => {
+                            // Skip SCP messages from broadcast channel — they are already
+                            // handled via the dedicated SCP channel above.
+                            if matches!(overlay_msg.message, StellarMessage::ScpMessage(_)) {
+                                continue;
+                            }
+                            // Skip fetch response and request messages from broadcast channel —
+                            // they are handled via the dedicated fetch channel above.
+                            if matches!(
+                                overlay_msg.message,
+                                StellarMessage::GeneralizedTxSet(_)
+                                    | StellarMessage::TxSet(_)
+                                    | StellarMessage::DontHave(_)
+                                    | StellarMessage::ScpQuorumset(_)
+                                    | StellarMessage::GetScpState(_)
+                                    | StellarMessage::GetScpQuorumset(_)
+                                    | StellarMessage::GetTxSet(_)
+                            ) {
+                                continue;
+                            }
+                            let delivery_latency = overlay_msg.received_at.elapsed();
+                            let msg_type = match &overlay_msg.message {
+                                StellarMessage::ScpMessage(_) => "SCP",
+                                StellarMessage::Transaction(_) => "TX",
+                                StellarMessage::TxSet(_) => "TxSet",
+                                StellarMessage::GeneralizedTxSet(_) => {
+                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for GeneralizedTxSet");
+                                    "GeneralizedTxSet"
+                                },
+                                StellarMessage::ScpQuorumset(_) => {
+                                    tracing::debug!(latency_ms = delivery_latency.as_millis(), "Overlay delivery latency for ScpQuorumset");
+                                    "ScpQuorumset"
+                                },
+                                StellarMessage::GetTxSet(_) => "GetTxSet",
+                                StellarMessage::Hello(_) => "Hello",
+                                StellarMessage::Peers(_) => "Peers",
+                                _ => "Other",
+                            };
+                            tracing::debug!(msg_type, latency_ms = delivery_latency.as_millis(), "Received overlay message");
+                            self.handle_overlay_message(overlay_msg).await;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            // Only non-critical messages (TX floods) flow through the
+                            // broadcast channel now, so lag is expected under load.
+                            // [maxtps_diag] Count dropped flood messages — under load
+                            // these are demanded txs the node never receives, forcing
+                            // re-demands (stellar_overlay_demand_timeout_total) and
+                            // leaving the agreed set short. Core never drops flooded
+                            // txs (flow-controlled per-peer queues).
+                            metrics::counter!("stellar_overlay_broadcast_lagged_dropped_total")
+                                .increment(n);
+                            tracing::debug!(skipped = n, "Overlay broadcast receiver lagged (non-critical messages only)");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            tracing::info!("Overlay broadcast channel closed");
+                            break;
                         }
                     }
                 }

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -1546,15 +1546,21 @@ impl App {
                 phase_dispatch_start.elapsed(),
                 self.event_loop_phase.load(Ordering::Relaxed),
             );
-            // [maxtps_loop] accumulate per-phase busy time for the stats-tick
-            // dump (which arm occupies the event loop under load).
+            // [maxtps_loop] accumulate per-phase BODY time for the stats-tick
+            // dump (which arm occupies the event loop under load). Measured
+            // from the arm's `set_phase` stamp — NOT from the loop top — so
+            // the select-wait is excluded (the first version attributed idle
+            // waits to whichever arm fired next, misattributing up to 60% of
+            // a window). Capped at the whole-iteration elapsed in case the
+            // fired arm never stamped a phase (stale stamp guard).
             {
                 let ph = self.event_loop_phase.load(Ordering::Relaxed) as usize;
                 if ph < self.phase_time_us.len() {
-                    self.phase_time_us[ph].fetch_add(
-                        phase_dispatch_start.elapsed().as_micros() as u64,
-                        Ordering::Relaxed,
-                    );
+                    let now_ns = self.start_instant.elapsed().as_nanos() as u64;
+                    let entered = self.phase_entered_ns.load(Ordering::Relaxed);
+                    let body_us = now_ns.saturating_sub(entered) / 1_000;
+                    let iter_us = phase_dispatch_start.elapsed().as_micros() as u64;
+                    self.phase_time_us[ph].fetch_add(body_us.min(iter_us), Ordering::Relaxed);
                     self.phase_count[ph].fetch_add(1, Ordering::Relaxed);
                 }
             }

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -490,6 +490,13 @@ impl App {
         // tick if a prior round is still running) and is aborted on shutdown.
         let mut peer_maintenance_task: Option<tokio::task::JoinHandle<()>> = None;
 
+        // In-flight guard for the offloaded batched tx-advert flush (maxtps
+        // iter 6). Same coalesced serial pattern as peer maintenance above:
+        // one flush at a time, skipped ticks re-run next period, aborted on
+        // shutdown (the flush is periodic + idempotent-enough: an aborted
+        // flush leaves un-adverted hashes queued for the next period).
+        let mut tx_advert_flush_task: Option<tokio::task::JoinHandle<()>> = None;
+
         // Get mutable access to SCP envelope receiver
         let mut scp_rx = self.scp_envelope_rx.lock().await;
 
@@ -1273,11 +1280,27 @@ impl App {
                     self.log_stats().await;
                 }
 
-                // Batched tx advert flush (parity: ignoreIfOutOfSync)
+                // Batched tx advert flush (parity: ignoreIfOutOfSync).
+                // Offloaded off the event loop (maxtps iter 6): at the ~1470
+                // tx/s ceiling one flush costs ~100 ms inline (22-peer ×
+                // per-hash advert bookkeeping under the tx-queue store lock),
+                // occupying up to 60% of the loop and starving SCP intake
+                // (measured via maxtps_loop: tx_advert_flush up to 18.3 s per
+                // 30 s window). Same coalesced fire-and-not-awaited pattern as
+                // dispatch_peer_maintenance: strictly serial via the in-flight
+                // guard, skipped tick re-runs next period, abort on shutdown.
                 _ = tx_advert_interval.tick() => {
                     if self.herder.is_tracking() {
                         self.set_phase(21); // 21 = tx_advert_flush
-                        self.flush_tx_adverts().await;
+                        // Upgrade the self Weak into an owned Arc for the
+                        // detached task (same mechanism as peer maintenance).
+                        let app = self.self_arc.read().await.upgrade();
+                        if let Some(app) = app {
+                            dispatch_peer_maintenance(
+                                async move { app.flush_tx_adverts().await },
+                                &mut tx_advert_flush_task,
+                            );
+                        }
                     }
                 }
 
@@ -1415,6 +1438,11 @@ impl App {
                     // and best-effort reconnects, so an abort mid-flight is
                     // harmless — a skipped round simply re-runs on next startup.
                     if let Some(h) = peer_maintenance_task.take() {
+                        h.abort();
+                    }
+                    // Abort any in-flight advert flush (maxtps iter 6) — the
+                    // process is exiting; un-flushed adverts are moot.
+                    if let Some(h) = tx_advert_flush_task.take() {
                         h.abort();
                     }
                     break;

--- a/crates/app/src/app/lifecycle.rs
+++ b/crates/app/src/app/lifecycle.rs
@@ -1768,6 +1768,14 @@ impl App {
         overlay.set_scp_callback(Arc::new(super::HerderScpCallback {
             herder: Arc::clone(&self.herder),
         }));
+        // In-flight SCP dedup in the peer tasks (maxtps iter 7): share the
+        // scheduled cache with the overlay so duplicate flood copies are
+        // dropped before they transit the dedicated SCP channel. Parity:
+        // stellar-core `checkScheduledAndCache` runs in the peer thread.
+        {
+            let scheduled = Arc::clone(&self.scp_scheduled);
+            overlay.set_scp_inbound_filter(Arc::new(move |hash| scheduled.check_and_insert(*hash)));
+        }
         match self.banned_peers().await {
             Ok(peers) => {
                 for peer_id in peers {
@@ -2588,10 +2596,15 @@ impl App {
         self.scp_verify_output_backlog
             .store(verified_rx.len() as u64, Ordering::Relaxed);
 
-        // Compute the FloodGate message hash BEFORE destructuring — the hash
-        // covers the full StellarMessage XDR, which is lost once we extract
-        // the inner ScpEnvelope.
-        let flood_msg_hash = henyey_overlay::compute_message_hash(&scp_msg.message);
+        // Reuse the hash + in-flight token claimed by the overlay peer task's
+        // dedup filter (maxtps iter 7) when present; compute/claim locally
+        // otherwise (locally-sourced envelopes, overlay without the filter,
+        // tests). The hash covers the full StellarMessage XDR, so it must be
+        // taken BEFORE destructuring.
+        let peer_task_token = scp_msg.scp_inflight_token.take();
+        let flood_msg_hash = scp_msg
+            .message_hash
+            .unwrap_or_else(|| henyey_overlay::compute_message_hash(&scp_msg.message));
 
         // Capture overlay arrival time before destructuring — used for
         // receive-to-relay latency histogram (#2648).
@@ -2613,9 +2626,15 @@ impl App {
         // checkScheduledAndCache (Peer.cpp:1113-1117, OverlayManagerImpl.cpp:1190-1212).
         // The returned Arc<()> token keeps the cache entry alive; dropping it
         // (on pre-filter reject, channel close, or end of processing) auto-expires
-        // the entry.
-        let Some(inflight_token) = self.scp_scheduled.check_and_insert(flood_msg_hash) else {
-            return;
+        // the entry. When the overlay peer task already claimed the token via
+        // the inbound filter (maxtps iter 7), reuse it instead of re-checking
+        // — re-checking would see our own live entry and self-reject.
+        let inflight_token = match peer_task_token {
+            Some(token) => token,
+            None => match self.scp_scheduled.check_and_insert(flood_msg_hash) {
+                Some(token) => token,
+                None => return,
+            },
         };
 
         let mut drained: usize = 0;

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -717,7 +717,9 @@ pub struct App {
     scp_verify_latency_us_sum: AtomicU64,
     scp_verify_latency_count: AtomicU64,
     /// In-flight SCP envelope dedup cache. See [`scp_dedup::ScpScheduledCache`].
-    scp_scheduled: scp_dedup::ScpScheduledCache,
+    /// `Arc` so the overlay peer tasks share it via the inbound SCP dedup
+    /// filter (maxtps iter 7, `set_scp_inbound_filter`).
+    scp_scheduled: Arc<scp_dedup::ScpScheduledCache>,
     /// Sampled depth of the verified-output channel (verified_rx.len()).
     /// Updated by the event loop each time it touches `verified_rx`, so
     /// `/metrics` reflects the true output-side backlog.
@@ -1528,7 +1530,7 @@ impl App {
             scp_pv_counters: henyey_herder::scp_verify::PostVerifyCounters::default(),
             scp_verify_latency_us_sum: AtomicU64::new(0),
             scp_verify_latency_count: AtomicU64::new(0),
-            scp_scheduled: scp_dedup::ScpScheduledCache::new(),
+            scp_scheduled: Arc::new(scp_dedup::ScpScheduledCache::new()),
             scp_verify_output_backlog: AtomicU64::new(0),
             fetch_channel_depth: Arc::new(AtomicI64::new(0)),
             fetch_channel_depth_max: Arc::new(AtomicI64::new(0)),

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -1050,6 +1050,12 @@ pub struct App {
     /// drained and logged by the stats tick. Diagnostic only.
     phase_time_us: Arc<[AtomicU64; 40]>,
     phase_count: Arc<[AtomicU64; 40]>,
+    /// [maxtps_loop] nanoseconds since `start_instant` when the current
+    /// event-loop arm stamped its phase (written by `set_phase`). Lets the
+    /// loop-bottom accounting measure the arm BODY only, excluding the
+    /// select-wait (the first accounting version attributed idle waits to
+    /// whichever arm fired next, which misattributed up to 60% of a window).
+    phase_entered_ns: Arc<AtomicU64>,
 
     /// Fine-grained sub-phase code for pinpointing a stall inside a
     /// coarse phase. See [`phase`](super::phase) for the `PHASE_6_*`
@@ -1627,6 +1633,7 @@ impl App {
             event_loop_phase: Arc::new(AtomicU64::new(0)),
             phase_time_us: Arc::new(std::array::from_fn(|_| AtomicU64::new(0))),
             phase_count: Arc::new(std::array::from_fn(|_| AtomicU64::new(0))),
+            phase_entered_ns: Arc::new(AtomicU64::new(0)),
             event_loop_phase_sub: Arc::new(AtomicU32::new(0)),
         })
     }
@@ -3535,6 +3542,11 @@ impl App {
     fn set_phase(&self, phase: u64) {
         self.event_loop_phase.store(phase, Ordering::Relaxed);
         self.event_loop_phase_sub.store(0, Ordering::Relaxed);
+        // [maxtps_loop] stamp arm-body start for body-only accounting.
+        self.phase_entered_ns.store(
+            self.start_instant.elapsed().as_nanos() as u64,
+            Ordering::Relaxed,
+        );
     }
 
     /// Stamp the fine-grained sub-phase. Read alongside

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -1042,6 +1042,12 @@ pub struct App {
     ///        32=scp_verified (draining verified envelopes),
     ///        33=tx_set_gc (purge unreferenced persisted tx sets)
     event_loop_phase: Arc<AtomicU64>,
+    /// [maxtps_loop] cumulative busy time (µs) and dispatch count per
+    /// event-loop phase (indexed by the coarse phase code, see
+    /// `WATCHDOG_PHASE_LEGEND`). Accumulated after every select-arm dispatch;
+    /// drained and logged by the stats tick. Diagnostic only.
+    phase_time_us: Arc<[AtomicU64; 40]>,
+    phase_count: Arc<[AtomicU64; 40]>,
 
     /// Fine-grained sub-phase code for pinpointing a stall inside a
     /// coarse phase. See [`phase`](super::phase) for the `PHASE_6_*`
@@ -1617,6 +1623,8 @@ impl App {
             watchdog_shutdown: Arc::new(AtomicBool::new(false)),
             watchdog_condvar: Arc::new((std::sync::Mutex::new(()), std::sync::Condvar::new())),
             event_loop_phase: Arc::new(AtomicU64::new(0)),
+            phase_time_us: Arc::new(std::array::from_fn(|_| AtomicU64::new(0))),
+            phase_count: Arc::new(std::array::from_fn(|_| AtomicU64::new(0))),
             event_loop_phase_sub: Arc::new(AtomicU32::new(0)),
         })
     }

--- a/crates/app/src/app/peers.rs
+++ b/crates/app/src/app/peers.rs
@@ -220,7 +220,19 @@ impl App {
     }
 
     pub(super) async fn send_peer_pings(&self) {
-        const PING_TIMEOUT: Duration = Duration::from_secs(60);
+        // Outstanding-ping expiry. MUST be well under the 30 s peer idle-drop
+        // timeout (peer_loop PEER_TIMEOUT, core parity): with the 5 s ping
+        // interval, a ping whose reply is lost (e.g. the fulfiller's DontHave
+        // dropped on a full outbound channel during a burst) previously
+        // silenced the pair for 60 s — no further pings are sent while one is
+        // outstanding — so BOTH sides aged past the 30 s idle timeout and
+        // dropped the connection. At network boot this produced a mass drop
+        // wave ~30 s before load start, and the reconnect storm overlapped
+        // the first loaded ledgers (maxtps iter 10; observed as
+        // "All peers exhausted for tx set", NodeLostSyncException, and
+        // multi-second nomination stalls near the max-TPS ceiling).
+        // 10 s keeps at most ~15 s between writes on a healthy link.
+        const PING_TIMEOUT: Duration = Duration::from_secs(10);
 
         // Phase 1: Collect snapshots (no long-lived lock needed).
         let snapshots = {

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -843,6 +843,20 @@ impl App {
             "Processing GeneralizedTxSet"
         );
 
+        // [maxtps_fetch] tx-set fetch service latency: first GetTxSet request
+        // sent → GeneralizedTxSet received. Logged once per fetched set.
+        {
+            let map = self.tx_set_last_request.read().await;
+            if let Some(state) = map.get(&hash) {
+                tracing::info!(
+                    target: "maxtps_fetch",
+                    elapsed_ms = state.first_requested.elapsed().as_millis() as u64,
+                    tx_count = internal_tx_set.len(),
+                    "got"
+                );
+            }
+        }
+
         // Time-wrapped (#1759 diagnostics): acquires
         // `Herder::scp_driver.needs_tx_set`'s internal
         // parking_lot::RwLock on every inbound GeneralizedTxSet.

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -1371,13 +1371,33 @@ fn collect_adverts_for_peers(
         "collect_adverts_for_peers: every peer_id must have an entry in adverts_by_peer"
     );
 
-    let mut per_peer: HashMap<henyey_overlay::PeerId, Vec<Hash256>> = HashMap::new();
+    // Phase 1 (maxtps iter 8 — SHORT tx-queue store-lock hold): destructively
+    // drain every budget-fitting candidate under the lock, deferring the
+    // per-peer advert-history checks to phase 2. The old single-pass visitor
+    // ran candidate × 22-peer `seen_advert` lookups INSIDE
+    // `broadcast_with_visitor`'s `store.write()` guard — ~100 ms per 200 ms
+    // flood period at the max-TPS ceiling, i.e. the tx queue was write-locked
+    // ~50% of the time, stalling loadgen submits, flooded-tx admission, and
+    // the nomination tx-set build.
+    //
+    // Budget-accounting delta: candidates already advertised to every peer
+    // were previously `Skipped` (budget-neutral); now they consume budget.
+    // Visited entries are erased either way (`visit_top_txs`), the measured
+    // budget headroom is ~2.6× at the ceiling (ops_used 271 vs budget 716),
+    // and unused budget carries over — flood pacing is divergeable overlay
+    // internals, not parity surface.
+    let mut candidates: Vec<henyey_herder::BroadcastCandidate> = Vec::new();
     queue.broadcast_with_visitor(budget, |candidate| {
-        let mut new_to_any_peer = false;
+        candidates.push(candidate.clone());
+        BroadcastVisitResult::Processed
+    });
+
+    // Phase 2 (no store lock): per-peer dedup against the advert history.
+    let mut per_peer: HashMap<henyey_overlay::PeerId, Vec<Hash256>> = HashMap::new();
+    for candidate in &candidates {
         for peer_id in peer_ids {
             if let Some(adverts) = adverts_by_peer.get(peer_id) {
                 if !adverts.seen_advert(&candidate.hash) {
-                    new_to_any_peer = true;
                     per_peer
                         .entry(peer_id.clone())
                         .or_default()
@@ -1385,12 +1405,7 @@ fn collect_adverts_for_peers(
                 }
             }
         }
-        if new_to_any_peer {
-            BroadcastVisitResult::Processed
-        } else {
-            BroadcastVisitResult::Skipped
-        }
-    });
+    }
     per_peer
 }
 
@@ -1790,9 +1805,13 @@ mod tests {
         let per_peer = collect_adverts_for_peers(&queue, &mut budget, &peer_ids, &adverts);
 
         assert!(per_peer.is_empty(), "no peer should receive a known tx");
+        // maxtps iter 8: the drain phase consumes budget for every candidate
+        // (including all-peers-seen ones) so the per-peer advert-history
+        // checks can run OUTSIDE the tx-queue store lock. See
+        // collect_adverts_for_peers for the rationale + headroom analysis.
         assert_eq!(
-            budget.ops_remaining, 10,
-            "budget must be unchanged (skip is budget-neutral)"
+            budget.ops_remaining, 9,
+            "drained candidate consumes budget even when all peers know it"
         );
     }
 
@@ -1869,8 +1888,13 @@ mod tests {
 
         let _per_peer = collect_adverts_for_peers(&queue, &mut budget, &peer_ids, &adverts);
 
-        // tx_known was Skipped (budget-neutral), tx_new was Processed (1 op consumed).
-        assert_eq!(budget.ops_remaining, 9, "only tx_new should consume budget");
+        // maxtps iter 8: both drained candidates consume budget (the per-peer
+        // seen-check moved outside the store lock, so the drain can no longer
+        // distinguish known-to-all txs). Carryover absorbs the difference.
+        assert_eq!(
+            budget.ops_remaining, 8,
+            "both drained candidates consume budget"
+        );
     }
 
     #[test]
@@ -1898,8 +1922,17 @@ mod tests {
         let per_peer = collect_adverts_for_peers(&queue, &mut budget, &peer_ids, &adverts);
 
         assert!(per_peer.is_empty(), "known DEX tx should not be advertised");
-        assert_eq!(budget.ops_remaining, 10, "generic budget untouched");
-        assert_eq!(budget.dex_ops_remaining, Some(5), "DEX budget untouched");
+        // maxtps iter 8: the drain consumes budget for the known DEX tx too
+        // (seen-checks moved outside the store lock).
+        assert_eq!(
+            budget.ops_remaining, 9,
+            "drained DEX tx consumes generic budget"
+        );
+        assert_eq!(
+            budget.dex_ops_remaining,
+            Some(4),
+            "drained DEX tx consumes DEX budget"
+        );
     }
 
     #[test]

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1604,14 +1604,6 @@ impl Herder {
         self.scp_driver.prepare_start(slot)
     }
 
-    /// EWMA estimate of the per-slot nomination overhead (trigger/first
-    /// activity → ballot start). Used by the app layer to arm the consensus
-    /// trigger early so ballot starts track the declared close-time target
-    /// (see `ScpDriver::nom_overhead_ewma_ms` for the divergence rationale).
-    pub fn nomination_overhead_estimate(&self) -> Option<std::time::Duration> {
-        self.scp_driver.nomination_overhead_estimate()
-    }
-
     /// Get the LCL close time from the current ledger header.
     pub fn lcl_close_time(&self) -> u64 {
         self.ledger_manager.current_header().scp_value.close_time.0

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -1604,6 +1604,14 @@ impl Herder {
         self.scp_driver.prepare_start(slot)
     }
 
+    /// EWMA estimate of the per-slot nomination overhead (trigger/first
+    /// activity → ballot start). Used by the app layer to arm the consensus
+    /// trigger early so ballot starts track the declared close-time target
+    /// (see `ScpDriver::nom_overhead_ewma_ms` for the divergence rationale).
+    pub fn nomination_overhead_estimate(&self) -> Option<std::time::Duration> {
+        self.scp_driver.nomination_overhead_estimate()
+    }
+
     /// Get the LCL close time from the current ledger header.
     pub fn lcl_close_time(&self) -> u64 {
         self.ledger_manager.current_header().scp_value.close_time.0
@@ -2955,6 +2963,11 @@ impl Herder {
 
         // Record when we first started processing this slot (for timing metrics).
         self.scp_driver.record_slot_activity(slot);
+
+        // [maxtps_cad] per-slot cadence decomposition stamp: trigger accepted →
+        // tx-set build begins. Joined offline (by slot) with the nominate /
+        // ballot / externalize / close stamps. Parity-irrelevant logging.
+        tracing::info!(target: "maxtps_cad", slot, "trig");
 
         let t0 = std::time::Instant::now();
 

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -2892,6 +2892,66 @@ impl Herder {
     ///
     /// This is entirely synchronous (parking_lot locks + CPU). It was
     /// previously declared `async` but had no `.await` points.
+    /// Pre-build and cache the nomination value for `ledger_seq` ahead of the
+    /// consensus trigger (maxtps iter 9). The tx-set build costs ~150-200 ms
+    /// and normally runs INSIDE `trigger_next_ledger`, serialized between the
+    /// trigger timer firing and `scp.nominate` — i.e. on the network's
+    /// nomination-convergence critical path. The app arms this ~300 ms before
+    /// the trigger so the trigger finds the value already cached and starts
+    /// nominating within ~1 ms.
+    ///
+    /// The value snapshot is ≤300 ms staler than a trigger-time build: txs
+    /// arriving in that window ride the next ledger (bounded extra latency
+    /// for a small fraction of txs). `close_time` has whole-second
+    /// granularity, so the prebuilt value almost always carries the same
+    /// close time a trigger-time build would.
+    ///
+    /// Self-gating: no-ops (returns false) unless tracking, a validator, LCL
+    /// still matches, nomination hasn't started, and no value is already
+    /// cached for the slot. All the trigger-time gates re-run in
+    /// `trigger_next_ledger`, so a stale prebuild is harmless.
+    pub fn prebuild_nomination_value(&self, ledger_seq: u32) -> bool {
+        if !self.is_tracking() || !self.is_validator() {
+            return false;
+        }
+        let slot = ledger_seq as u64;
+        if let Some(state) = self.scp.get_slot_state(slot) {
+            if state.is_nominating {
+                return false;
+            }
+        }
+        if !self.lcl_matches_slot(slot) {
+            return false;
+        }
+        if self
+            .cached_nomination_value
+            .read()
+            .as_ref()
+            .is_some_and(|(s, _)| *s == slot)
+        {
+            return false;
+        }
+        let now_secs = self.scp_driver.now_seconds();
+        let lcl_close_time = self.lcl_close_time();
+        let next_close_time = now_secs.max(lcl_close_time.saturating_add(1));
+        if next_close_time > now_secs.saturating_add(MAX_TIME_SLIP_SECONDS) {
+            return false;
+        }
+        let Some(value) = self.build_nomination_value(next_close_time) else {
+            return false;
+        };
+        // Publish any envelopes that were waiting on the just-cached tx set,
+        // mirroring the trigger path's post-build drain.
+        self.process_ready_fetching_envelopes();
+        // Discard if the world moved while building.
+        if !self.lcl_matches_slot(slot) || self.is_applying() {
+            return false;
+        }
+        *self.cached_nomination_value.write() = Some((slot, value));
+        tracing::debug!(slot, "prebuilt nomination value cached");
+        true
+    }
+
     pub fn trigger_next_ledger(&self, ledger_seq: u32) -> Result<TriggerOutcome> {
         if !self.is_tracking() {
             return Err(HerderError::NotValidating);
@@ -3010,7 +3070,21 @@ impl Herder {
         }
 
         // --- Validator path ---
-        let value = match self.build_nomination_value(next_close_time) {
+        // Reuse a prebuilt nomination value when the prebuild timer already
+        // cached one for this slot (maxtps iter 9) — skips the ~150-200 ms
+        // tx-set build on the nomination-convergence critical path. The
+        // prebuild ran the same gates and cached the tx set for fetchers.
+        let prebuilt = {
+            let cached = self.cached_nomination_value.read();
+            cached
+                .as_ref()
+                .filter(|(cached_slot, _)| *cached_slot == slot)
+                .map(|(_, v)| v.clone())
+        };
+        if prebuilt.is_some() {
+            tracing::debug!(slot, "trigger using prebuilt nomination value");
+        }
+        let value = match prebuilt.or_else(|| self.build_nomination_value(next_close_time)) {
             Some(v) => v,
             None => {
                 // build_nomination_value returns None when LCL advanced
@@ -6653,6 +6727,72 @@ mod tests {
         assert!(
             slot_state.map_or(true, |s| !s.is_nominating),
             "stale slot must not be in nominating state"
+        );
+    }
+
+    /// maxtps iter 9: `prebuild_nomination_value` caches the nomination value
+    /// ahead of the trigger; a second prebuild for the same slot is a no-op;
+    /// a stale slot is refused; and the trigger consumes the cached value.
+    #[test]
+    fn test_prebuild_nomination_value_caches_and_trigger_reuses() {
+        let seed = [43u8; 32];
+        let secret = SecretKey::from_seed(&seed);
+        let public = secret.public_key();
+        let local_node_id = stellar_xdr::NodeId(stellar_xdr::PublicKey::PublicKeyTypeEd25519(
+            stellar_xdr::Uint256(*public.as_bytes()),
+        ));
+        let quorum_set = ScpQuorumSet {
+            threshold: 1,
+            validators: vec![local_node_id].try_into().unwrap(),
+            inner_sets: vec![].try_into().unwrap(),
+        };
+        let config = HerderConfig {
+            is_validator: true,
+            node_public_key: public,
+            local_quorum_set: Some(quorum_set),
+            ..HerderConfig::default()
+        };
+        let herder = Herder::with_secret_key(
+            config,
+            secret,
+            make_lm_at_seq_for_stale_test(1),
+            TimerManagerHandle::no_op(),
+        );
+        herder.bootstrap(1);
+        let next = 2u32;
+
+        // Stale slot refused (LCL+1 == 2, so 3 is stale-ahead).
+        assert!(
+            !herder.prebuild_nomination_value(next + 1),
+            "prebuild must refuse a slot != LCL+1"
+        );
+        assert!(herder.cached_nomination_value.read().is_none());
+
+        // Prebuild for the correct slot caches a value.
+        assert!(
+            herder.prebuild_nomination_value(next),
+            "prebuild must cache for LCL+1"
+        );
+        let cached = herder.cached_nomination_value.read().clone();
+        assert!(
+            matches!(cached, Some((slot, _)) if slot == next as u64),
+            "cached value must be keyed by the prebuilt slot"
+        );
+
+        // A duplicate prebuild is a no-op.
+        assert!(
+            !herder.prebuild_nomination_value(next),
+            "second prebuild for the same slot must be a no-op"
+        );
+
+        // The trigger consumes the cached value and starts nomination
+        // (solo 1-of-1 quorum: nomination self-externalizes synchronously).
+        let outcome = herder
+            .trigger_next_ledger(next)
+            .expect("trigger must succeed with a prebuilt value");
+        assert!(
+            !matches!(outcome, TriggerOutcome::SkippedStale),
+            "trigger must not skip a fresh prebuilt slot, got {outcome:?}"
         );
     }
 

--- a/crates/herder/src/lib.rs
+++ b/crates/herder/src/lib.rs
@@ -160,8 +160,8 @@ pub use scp_driver::{
 };
 pub use state::HerderState;
 pub use tx_queue::{
-    BroadcastBudget, BroadcastVisitResult, SorobanTxLimits, TransactionQueue, TransactionSet,
-    TxQueueConfig, TxQueueResult, SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER,
+    BroadcastBudget, BroadcastCandidate, BroadcastVisitResult, SorobanTxLimits, TransactionQueue,
+    TransactionSet, TxQueueConfig, TxQueueResult, SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER,
     TRANSACTION_QUEUE_SIZE_MULTIPLIER,
 };
 

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -533,22 +533,6 @@ pub struct ScpDriver {
     test_clock: Arc<AtomicU64>,
     /// Per-slot timing for metrics (first-seen, nomination start, ballot start).
     slot_timing: RwLock<HashMap<SlotIndex, SlotTimingState>>,
-    /// EWMA (milliseconds) of the per-slot nomination overhead — the time from
-    /// a slot's first activity (`first_seen`, stamped when our trigger runs or
-    /// the first peer nomination arrives, whichever is earlier) to its ballot
-    /// start. This is the [5 s wait]→[ballot start] serialization cost:
-    /// tx-set build + SCP nomination convergence.
-    ///
-    /// Consumed by the app layer's `setup_trigger_next_ledger` to arm the next
-    /// consensus trigger EARLY by this amount, so ballot starts land on the
-    /// network's declared `expectedLedgerCloseTime` grid instead of
-    /// `expectedClose + overhead` (DIVERGENCE from stellar-core, which
-    /// serializes the overhead after the full wait and therefore closes
-    /// ledgers ~10% slower than the declared target under load; trigger
-    /// *scheduling* is internal timing, not on the observable parity surface).
-    ///
-    /// `0` = no estimate yet (updates store `max(1)` to disambiguate).
-    nom_overhead_ewma_ms: std::sync::atomic::AtomicU64,
     /// Timing snapshot for the highest externalized slot (monotonically updated).
     last_externalize_timing: RwLock<Option<ExternalizeTimingSnapshot>>,
     /// Externalize lag tracker for per-node lag statistics.
@@ -659,7 +643,6 @@ impl ScpDriver {
             tracking_state,
             test_clock: Arc::new(AtomicU64::new(0)),
             slot_timing: RwLock::new(HashMap::new()),
-            nom_overhead_ewma_ms: std::sync::atomic::AtomicU64::new(0),
             last_externalize_timing: RwLock::new(None),
             externalize_lag: RwLock::new(ExternalizeLagTracker::new()),
             deferred_slots: Mutex::new(HashMap::new()),
@@ -1189,47 +1172,10 @@ impl ScpDriver {
         if state.ballot_start.is_none() {
             // [maxtps_cad] nomination converged → ballot protocol begins.
             tracing::info!(target: "maxtps_cad", slot, "ballot");
-            // Fold this slot's nomination overhead (first activity → ballot
-            // start) into the EWMA consumed by the early-trigger scheduler
-            // (see `nom_overhead_ewma_ms`). Outliers ≥ 5 s are skipped: those
-            // are stalled/catchup slots, not steady-state overhead, and would
-            // poison the estimate.
-            if let Some(fs) = state.first_seen {
-                let overhead_ms = fs.elapsed().as_millis() as u64;
-                const OUTLIER_MS: u64 = 5_000;
-                if overhead_ms < OUTLIER_MS {
-                    use std::sync::atomic::Ordering;
-                    let prev = self.nom_overhead_ewma_ms.load(Ordering::Relaxed);
-                    // Asymmetric tracker: jump UP to a larger observation
-                    // immediately (load onset must be compensated within one
-                    // slot — a slow ramp leaves several ledgers running at the
-                    // uncompensated ~5.5 s cadence), decay DOWN with alpha=1/4
-                    // (a few idle slots after a burst briefly over-compensate,
-                    // which only closes ledgers marginally faster than the
-                    // declared target until the estimate settles).
-                    let next = if prev == 0 || overhead_ms > prev {
-                        overhead_ms
-                    } else {
-                        (3 * prev + overhead_ms) / 4
-                    };
-                    self.nom_overhead_ewma_ms
-                        .store(next.max(1), Ordering::Relaxed);
-                }
-            }
         }
         state
             .ballot_start
             .get_or_insert_with(std::time::Instant::now);
-    }
-
-    /// Current EWMA estimate of the per-slot nomination overhead (first
-    /// activity → ballot start): tx-set build + SCP nomination convergence.
-    /// `None` until the first slot completes nomination.
-    pub fn nomination_overhead_estimate(&self) -> Option<std::time::Duration> {
-        let ms = self
-            .nom_overhead_ewma_ms
-            .load(std::sync::atomic::Ordering::Relaxed);
-        (ms > 0).then(|| std::time::Duration::from_millis(ms))
     }
 
     /// Get the ballot start instant for a slot.
@@ -4396,54 +4342,6 @@ mod tests {
         assert!(!externalized.contains_key(&5));
         assert!(externalized.contains_key(&6));
         assert!(externalized.contains_key(&10));
-    }
-
-    /// The early-trigger EWMA (`nom_overhead_ewma_ms`) seeds on the first
-    /// slot that reaches ballot start and converges toward subsequent
-    /// observations (alpha = 1/4). Slots without a `first_seen` stamp (pure
-    /// catchup) must NOT update the estimate.
-    #[test]
-    fn test_nomination_overhead_ewma() {
-        let driver = make_test_driver();
-
-        // No estimate before any slot completes nomination.
-        assert!(driver.nomination_overhead_estimate().is_none());
-
-        // Ballot start WITHOUT slot activity (catchup path): still no estimate.
-        driver.record_ballot_start(99);
-        assert!(
-            driver.nomination_overhead_estimate().is_none(),
-            "slot without first_seen must not seed the EWMA"
-        );
-
-        // Normal flow: activity → ballot start seeds the estimate.
-        driver.record_slot_activity(100);
-        std::thread::sleep(std::time::Duration::from_millis(2));
-        driver.record_ballot_start(100);
-        let e1 = driver
-            .nomination_overhead_estimate()
-            .expect("estimate seeded after first nominated slot");
-        assert!(e1 >= std::time::Duration::from_millis(1));
-        assert!(
-            e1 < std::time::Duration::from_secs(5),
-            "outlier guard bound"
-        );
-
-        // A second slot folds in with alpha=1/4: the estimate stays within
-        // the envelope of the two observations.
-        driver.record_slot_activity(101);
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        driver.record_ballot_start(101);
-        let e2 = driver.nomination_overhead_estimate().expect("still Some");
-        assert!(e2 >= e1, "EWMA must move toward the larger observation");
-        assert!(
-            e2 < std::time::Duration::from_millis(100),
-            "EWMA must stay near the observations, got {e2:?}"
-        );
-
-        // Re-recording ballot start for an already-stamped slot is a no-op.
-        driver.record_ballot_start(100);
-        assert_eq!(driver.nomination_overhead_estimate(), Some(e2));
     }
 
     #[test]

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -1200,8 +1200,14 @@ impl ScpDriver {
                 if overhead_ms < OUTLIER_MS {
                     use std::sync::atomic::Ordering;
                     let prev = self.nom_overhead_ewma_ms.load(Ordering::Relaxed);
-                    // EWMA alpha = 1/4; seed with the first observation.
-                    let next = if prev == 0 {
+                    // Asymmetric tracker: jump UP to a larger observation
+                    // immediately (load onset must be compensated within one
+                    // slot — a slow ramp leaves several ledgers running at the
+                    // uncompensated ~5.5 s cadence), decay DOWN with alpha=1/4
+                    // (a few idle slots after a burst briefly over-compensate,
+                    // which only closes ledgers marginally faster than the
+                    // declared target until the estimate settles).
+                    let next = if prev == 0 || overhead_ms > prev {
                         overhead_ms
                     } else {
                         (3 * prev + overhead_ms) / 4

--- a/crates/herder/src/scp_driver.rs
+++ b/crates/herder/src/scp_driver.rs
@@ -533,6 +533,22 @@ pub struct ScpDriver {
     test_clock: Arc<AtomicU64>,
     /// Per-slot timing for metrics (first-seen, nomination start, ballot start).
     slot_timing: RwLock<HashMap<SlotIndex, SlotTimingState>>,
+    /// EWMA (milliseconds) of the per-slot nomination overhead — the time from
+    /// a slot's first activity (`first_seen`, stamped when our trigger runs or
+    /// the first peer nomination arrives, whichever is earlier) to its ballot
+    /// start. This is the [5 s wait]→[ballot start] serialization cost:
+    /// tx-set build + SCP nomination convergence.
+    ///
+    /// Consumed by the app layer's `setup_trigger_next_ledger` to arm the next
+    /// consensus trigger EARLY by this amount, so ballot starts land on the
+    /// network's declared `expectedLedgerCloseTime` grid instead of
+    /// `expectedClose + overhead` (DIVERGENCE from stellar-core, which
+    /// serializes the overhead after the full wait and therefore closes
+    /// ledgers ~10% slower than the declared target under load; trigger
+    /// *scheduling* is internal timing, not on the observable parity surface).
+    ///
+    /// `0` = no estimate yet (updates store `max(1)` to disambiguate).
+    nom_overhead_ewma_ms: std::sync::atomic::AtomicU64,
     /// Timing snapshot for the highest externalized slot (monotonically updated).
     last_externalize_timing: RwLock<Option<ExternalizeTimingSnapshot>>,
     /// Externalize lag tracker for per-node lag statistics.
@@ -643,6 +659,7 @@ impl ScpDriver {
             tracking_state,
             test_clock: Arc::new(AtomicU64::new(0)),
             slot_timing: RwLock::new(HashMap::new()),
+            nom_overhead_ewma_ms: std::sync::atomic::AtomicU64::new(0),
             last_externalize_timing: RwLock::new(None),
             externalize_lag: RwLock::new(ExternalizeLagTracker::new()),
             deferred_slots: Mutex::new(HashMap::new()),
@@ -1169,9 +1186,44 @@ impl ScpDriver {
     pub fn record_ballot_start(&self, slot: SlotIndex) {
         let mut map = self.slot_timing.write();
         let state = map.entry(slot).or_default();
+        if state.ballot_start.is_none() {
+            // [maxtps_cad] nomination converged → ballot protocol begins.
+            tracing::info!(target: "maxtps_cad", slot, "ballot");
+            // Fold this slot's nomination overhead (first activity → ballot
+            // start) into the EWMA consumed by the early-trigger scheduler
+            // (see `nom_overhead_ewma_ms`). Outliers ≥ 5 s are skipped: those
+            // are stalled/catchup slots, not steady-state overhead, and would
+            // poison the estimate.
+            if let Some(fs) = state.first_seen {
+                let overhead_ms = fs.elapsed().as_millis() as u64;
+                const OUTLIER_MS: u64 = 5_000;
+                if overhead_ms < OUTLIER_MS {
+                    use std::sync::atomic::Ordering;
+                    let prev = self.nom_overhead_ewma_ms.load(Ordering::Relaxed);
+                    // EWMA alpha = 1/4; seed with the first observation.
+                    let next = if prev == 0 {
+                        overhead_ms
+                    } else {
+                        (3 * prev + overhead_ms) / 4
+                    };
+                    self.nom_overhead_ewma_ms
+                        .store(next.max(1), Ordering::Relaxed);
+                }
+            }
+        }
         state
             .ballot_start
             .get_or_insert_with(std::time::Instant::now);
+    }
+
+    /// Current EWMA estimate of the per-slot nomination overhead (first
+    /// activity → ballot start): tx-set build + SCP nomination convergence.
+    /// `None` until the first slot completes nomination.
+    pub fn nomination_overhead_estimate(&self) -> Option<std::time::Duration> {
+        let ms = self
+            .nom_overhead_ewma_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+        (ms > 0).then(|| std::time::Duration::from_millis(ms))
     }
 
     /// Get the ballot start instant for a slot.
@@ -3972,6 +4024,8 @@ impl SCPDriver for HerderScpCallback {
     }
 
     fn value_externalized(&self, slot_index: u64, value: &Value) {
+        // [maxtps_cad] slot externalized (before apply/close).
+        tracing::info!(target: "maxtps_cad", slot = slot_index, "ext");
         // Record first-externalize baseline BEFORE processing.
         // Mirrors stellar-core line 915: recordSCPExternalizeEvent(self, false)
         let now = self.driver.record_self_externalize_event(slot_index);
@@ -4336,6 +4390,54 @@ mod tests {
         assert!(!externalized.contains_key(&5));
         assert!(externalized.contains_key(&6));
         assert!(externalized.contains_key(&10));
+    }
+
+    /// The early-trigger EWMA (`nom_overhead_ewma_ms`) seeds on the first
+    /// slot that reaches ballot start and converges toward subsequent
+    /// observations (alpha = 1/4). Slots without a `first_seen` stamp (pure
+    /// catchup) must NOT update the estimate.
+    #[test]
+    fn test_nomination_overhead_ewma() {
+        let driver = make_test_driver();
+
+        // No estimate before any slot completes nomination.
+        assert!(driver.nomination_overhead_estimate().is_none());
+
+        // Ballot start WITHOUT slot activity (catchup path): still no estimate.
+        driver.record_ballot_start(99);
+        assert!(
+            driver.nomination_overhead_estimate().is_none(),
+            "slot without first_seen must not seed the EWMA"
+        );
+
+        // Normal flow: activity → ballot start seeds the estimate.
+        driver.record_slot_activity(100);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        driver.record_ballot_start(100);
+        let e1 = driver
+            .nomination_overhead_estimate()
+            .expect("estimate seeded after first nominated slot");
+        assert!(e1 >= std::time::Duration::from_millis(1));
+        assert!(
+            e1 < std::time::Duration::from_secs(5),
+            "outlier guard bound"
+        );
+
+        // A second slot folds in with alpha=1/4: the estimate stays within
+        // the envelope of the two observations.
+        driver.record_slot_activity(101);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        driver.record_ballot_start(101);
+        let e2 = driver.nomination_overhead_estimate().expect("still Some");
+        assert!(e2 >= e1, "EWMA must move toward the larger observation");
+        assert!(
+            e2 < std::time::Duration::from_millis(100),
+            "EWMA must stay near the observations, got {e2:?}"
+        );
+
+        // Re-recording ballot start for an already-stamped slot is a no-op.
+        driver.record_ballot_start(100);
+        assert_eq!(driver.nomination_overhead_estimate(), Some(e2));
     }
 
     #[test]

--- a/crates/overlay/src/manager/connection.rs
+++ b/crates/overlay/src/manager/connection.rs
@@ -2599,6 +2599,7 @@ mod tests {
             SharedPeerState {
                 peers: Arc::new(DashMap::new()),
                 flood_gate: Arc::new(crate::flood::FloodGate::new()),
+                scp_inbound_filter: Arc::new(RwLock::new(None)),
                 running: Arc::new(AtomicBool::new(true)),
                 message_tx,
                 scp_message_tx,

--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -104,6 +104,15 @@ const BROADCAST_CHANNEL_SIZE: usize = 4096;
 /// credit-based byte bound is the follow-up tracked in #3625.
 pub const SCP_CHANNEL_CAPACITY: usize = 8192;
 
+/// In-flight dedup filter for inbound SCP envelopes, provided by the app and
+/// run in the overlay peer tasks (maxtps iter 7; parity: stellar-core
+/// `checkScheduledAndCache`, Peer.cpp:1113-1117). Input is the full-message
+/// hash. Returns `Some(token)` when the envelope is new (the token must ride
+/// the message and be dropped when processing completes, expiring the cache
+/// entry) or `None` when a copy is already in flight (drop the message).
+pub type ScpInboundFilter =
+    dyn Fn(&henyey_common::Hash256) -> Option<std::sync::Arc<()>> + Send + Sync;
+
 /// Bound on the dedicated **fetch-response/-request** intake channel
 /// (`fetch_response_tx` → event-loop `fetch_response_rx`).
 ///
@@ -580,6 +589,15 @@ pub struct OverlayMessage {
     /// the single SCP-routed copy that reaches the app consumer; released when
     /// that consumer drains the envelope. Never cloned (see the `Clone` impl).
     pub(crate) flow_release: Option<FlowControlRelease>,
+    /// In-flight scheduled-cache token claimed by the peer task's SCP dedup
+    /// filter (maxtps iter 7; parity: core `checkScheduledAndCache`). Rides
+    /// only the SCP-routed copy; the app consumer moves it into the intake so
+    /// the cache entry expires when processing completes. Never cloned.
+    pub scp_inflight_token: Option<std::sync::Arc<()>>,
+    /// Full-message hash precomputed by the peer task's flood-gate path for
+    /// flood-tracked messages (currently attached for SCP envelopes only).
+    /// Lets the app consumer skip recomputing the SHA-256.
+    pub message_hash: Option<henyey_common::Hash256>,
 }
 
 impl Clone for OverlayMessage {
@@ -590,6 +608,9 @@ impl Clone for OverlayMessage {
             received_at: self.received_at,
             // The release obligation is never duplicated.
             flow_release: None,
+            // The in-flight marker rides only the SCP-routed original.
+            scp_inflight_token: None,
+            message_hash: self.message_hash,
         }
     }
 }
@@ -611,6 +632,8 @@ impl OverlayMessage {
             message,
             received_at,
             flow_release: None,
+            scp_inflight_token: None,
+            message_hash: None,
         }
     }
 
@@ -860,6 +883,12 @@ pub(super) struct SharedPeerState {
     pub(super) running: Arc<AtomicBool>,
     pub(super) message_tx: broadcast::Sender<OverlayMessage>,
     pub(super) scp_message_tx: mpsc::Sender<OverlayMessage>,
+    /// App-provided in-flight dedup filter for inbound SCP envelopes, run in
+    /// the peer task (maxtps iter 7; parity: core `checkScheduledAndCache` in
+    /// `Peer::recvAuthenticatedMessage`). `None` (e.g. overlay-only tests)
+    /// falls back to the app-side dedup in `pump_scp_intake`. Shared with
+    /// [`OverlayManager::scp_inbound_filter`].
+    pub(super) scp_inbound_filter: Arc<RwLock<Option<Arc<ScpInboundFilter>>>>,
     /// Bounded ([`FETCH_CHANNEL_CAPACITY`]) so a wedged event loop cannot grow
     /// RSS unbounded via accumulated multi-MB tx-sets (#3661). Drops on full.
     pub(super) fetch_response_tx: mpsc::Sender<OverlayMessage>,
@@ -1112,8 +1141,13 @@ impl SharedPeerState {
             let from_peer = msg.from_peer.clone();
             match self.scp_message_tx.try_send(msg) {
                 Ok(()) => {}
-                Err(mpsc::error::TrySendError::Full(_)) => {
+                Err(mpsc::error::TrySendError::Full(_dropped)) => {
                     self.metrics.messages_dropped.add(1);
+                    // `_dropped` carries the in-flight scheduled-cache token
+                    // (maxtps iter 7); dropping it here expires the cache
+                    // entry, so a later duplicate copy from another peer is
+                    // treated as new and re-forwarded — the retry path a full
+                    // channel relies on.
                     debug!(
                         "SCP channel full (cap {}); dropping envelope from peer {} (recoverable: peers re-flood)",
                         SCP_CHANNEL_CAPACITY, from_peer
@@ -1232,6 +1266,10 @@ pub struct OverlayManager {
     pub(super) fetch_response_tx: mpsc::Sender<OverlayMessage>,
     /// Receiver end of the fetch response channel. Taken once via `subscribe_fetch_responses()`.
     fetch_response_rx: Arc<TokioMutex<Option<mpsc::Receiver<OverlayMessage>>>>,
+    /// App-provided in-flight SCP dedup filter (see [`ScpInboundFilter`]).
+    /// Shared with every [`SharedPeerState`] snapshot; settable before or
+    /// after start via [`Self::set_scp_inbound_filter`].
+    scp_inbound_filter: Arc<RwLock<Option<Arc<ScpInboundFilter>>>>,
     /// Dynamic extra subscribers for catchup-critical messages (SCP + TxSet).
     /// Created on demand via `subscribe_catchup()` and cleaned up when dropped.
     /// Uses parking_lot::RwLock for minimal contention in the hot path (read-heavy).
@@ -1380,6 +1418,7 @@ impl OverlayManager {
             extra_subscribers: Arc::new(RwLock::new(Vec::new())),
             last_closed_ledger: Arc::new(AtomicU32::new(0)),
             scp_callback: None,
+            scp_inbound_filter: Arc::new(RwLock::new(None)),
             is_tracking: Arc::new(AtomicBool::new(false)),
             is_synced: Arc::new(AtomicBool::new(false)),
             connection_factory,
@@ -1405,6 +1444,7 @@ impl OverlayManager {
             running: Arc::clone(&self.running),
             message_tx: self.message_tx.clone(),
             scp_message_tx: self.scp_message_tx.clone(),
+            scp_inbound_filter: Arc::clone(&self.scp_inbound_filter),
             fetch_response_tx: self.fetch_response_tx.clone(),
             peer_handles: Arc::clone(&self.peer_handles),
             advertised_outbound_peers: Arc::clone(&self.advertised_outbound_peers),
@@ -1975,6 +2015,15 @@ impl OverlayManager {
     /// eviction and nomination/ballot replacement).
     pub fn set_scp_callback(&mut self, callback: Arc<dyn ScpQueueCallback>) {
         self.scp_callback = Some(callback);
+    }
+
+    /// Install the app's in-flight SCP dedup filter, run by the peer tasks on
+    /// every inbound SCP envelope (see [`ScpInboundFilter`]). Duplicate
+    /// copies of an envelope whose first copy is still queued/processing are
+    /// dropped in the peer task instead of transiting the dedicated SCP
+    /// channel (maxtps iter 7; parity: core `checkScheduledAndCache`).
+    pub fn set_scp_inbound_filter(&self, filter: Arc<ScpInboundFilter>) {
+        *self.scp_inbound_filter.write() = Some(filter);
     }
 
     /// Update the tracking-consensus flag.
@@ -3049,6 +3098,7 @@ pub(crate) mod tests {
         SharedPeerState {
             peers: Arc::new(DashMap::new()),
             flood_gate: Arc::new(FloodGate::new()),
+            scp_inbound_filter: Arc::new(RwLock::new(None)),
             running: Arc::new(AtomicBool::new(true)),
             message_tx,
             scp_message_tx,
@@ -3576,6 +3626,7 @@ pub(crate) mod tests {
         let shared = SharedPeerState {
             peers: Arc::new(DashMap::new()),
             flood_gate: Arc::new(FloodGate::new()),
+            scp_inbound_filter: Arc::new(RwLock::new(None)),
             running: Arc::new(AtomicBool::new(true)),
             message_tx,
             scp_message_tx,
@@ -3670,6 +3721,7 @@ pub(crate) mod tests {
         let shared = SharedPeerState {
             peers: Arc::new(DashMap::new()),
             flood_gate: Arc::new(FloodGate::new()),
+            scp_inbound_filter: Arc::new(RwLock::new(None)),
             running: Arc::new(AtomicBool::new(true)),
             message_tx,
             scp_message_tx,
@@ -4374,6 +4426,7 @@ pub(crate) mod tests {
         let shared = SharedPeerState {
             peers: Arc::new(DashMap::new()),
             flood_gate: Arc::new(FloodGate::with_ttl(std::time::Duration::from_secs(30))),
+            scp_inbound_filter: Arc::new(RwLock::new(None)),
             running: Arc::new(AtomicBool::new(true)),
             message_tx,
             scp_message_tx: scp_tx,
@@ -4449,6 +4502,7 @@ pub(crate) mod tests {
         let shared = SharedPeerState {
             peers: Arc::new(DashMap::new()),
             flood_gate: Arc::new(FloodGate::with_ttl(std::time::Duration::from_secs(30))),
+            scp_inbound_filter: Arc::new(RwLock::new(None)),
             running: Arc::new(AtomicBool::new(true)),
             message_tx,
             scp_message_tx: scp_tx,
@@ -4554,6 +4608,7 @@ pub(crate) mod tests {
         let shared = SharedPeerState {
             peers: Arc::new(DashMap::new()),
             flood_gate: Arc::new(FloodGate::new()),
+            scp_inbound_filter: Arc::new(RwLock::new(None)),
             running: Arc::new(AtomicBool::new(true)),
             message_tx,
             scp_message_tx,
@@ -4687,6 +4742,40 @@ pub(crate) mod tests {
             "expected >= {} dropped SCP envelopes, got {}",
             OVERFLOW,
             metrics.messages_dropped
+        );
+    }
+
+    /// Regression test for the maxtps-iter-7 duplicate-drop safety invariant:
+    /// an SCP envelope dropped on a FULL SCP channel must release its
+    /// in-flight scheduled-cache token (by dropping the message, which owns
+    /// it), so a later duplicate copy from another peer re-enters the peer
+    /// task's dedup filter as new and is re-forwarded. Without the release,
+    /// the peer-task dedup would suppress every retry copy of a lost
+    /// envelope.
+    #[tokio::test]
+    async fn test_scp_channel_full_drop_releases_inflight_token() {
+        let (shared, _rx) = shared_state_with_scp_receiver();
+
+        // Fill the channel to capacity with filler envelopes.
+        for slot in 0..SCP_CHANNEL_CAPACITY as u64 {
+            shared.route_to_subscribers(make_scp_msg(slot));
+        }
+
+        // The target envelope carries an in-flight token, exactly as the
+        // peer task attaches it after a successful dedup-filter claim.
+        let token = std::sync::Arc::new(());
+        let watch = std::sync::Arc::downgrade(&token);
+        let mut target = make_scp_msg(999_999);
+        target.scp_inflight_token = Some(token);
+
+        // Route it — the channel is full, so the message (and its token) is
+        // dropped.
+        shared.route_to_subscribers(target);
+
+        assert!(
+            watch.upgrade().is_none(),
+            "a full-channel drop must release the in-flight token so a later \
+             duplicate copy passes the peer-task dedup filter"
         );
     }
 

--- a/crates/overlay/src/manager/peer_loop.rs
+++ b/crates/overlay/src/manager/peer_loop.rs
@@ -930,6 +930,13 @@ impl OverlayManager {
 
         let msg_type = helpers::message_type_name(message);
 
+        // Set inside the flood-gate-tracked block for SCP envelopes; threaded
+        // onto the routed `OverlayMessage` so the app consumer reuses the
+        // already-computed hash and the already-claimed in-flight token
+        // (maxtps iter 7).
+        let mut scp_msg_hash: Option<henyey_common::Hash256> = None;
+        let mut scp_inflight_token: Option<std::sync::Arc<()>> = None;
+
         // Parity: Peer.cpp:1164-1171 — drop flood messages when not synced.
         // During catchup, tx are rejected by herder and flood-pull responses
         // reference messages the node can't use. Early shedding avoids
@@ -1056,20 +1063,42 @@ impl OverlayManager {
                         }
                     },
                 );
-                // FloodGate-tracked messages (SCP and Transaction) are NEVER
-                // dropped at the overlay/FloodGate layer.
+                // FloodGate-tracked messages are NEVER dropped based on the
+                // FloodGate record (issues #2317, #2327 — see the self-echo
+                // regression): relay accounting above runs for every copy so
+                // the gate knows which peers already have the message.
                 //
-                // `record_inbound_relay` returns () — there is no relay status
-                // value to branch on, preventing the c6118f2c bug class.
-                // Actual dedup happens downstream:
-                // - SCP: `scp_scheduled_envelopes` in `pump_scp_intake`
-                // - Tx: herder `receive_transaction` / tx queue dedup
-                //
-                // stellar-core parity:
-                // - SCP: Peer.cpp:1667-1673 — unconditional recvSCPEnvelope
-                // - Tx:  OverlayManagerImpl.cpp:1215-1248 — unconditional
-                //   recvTransaction (Peer.cpp:1524-1533)
-                // See issues #2317, #2327.
+                // In-flight dedup for SCP envelopes DOES happen here, in the
+                // peer task, via the app-provided scheduled-cache filter
+                // (maxtps iter 7; parity: stellar-core drops already-scheduled
+                // messages in the peer thread via `checkScheduledAndCache`,
+                // Peer.cpp:1113-1117 → OverlayManagerImpl.cpp:1190-1212).
+                // The filter is the SAME `ScpScheduledCache` the app's
+                // `pump_scp_intake` used to consult on the main event loop —
+                // token-lifetime semantics are unchanged (a duplicate is only
+                // dropped while its first copy is still queued/processing;
+                // after the token drops, a re-delivery is forwarded again, so
+                // the #2317 self-echo and post-processing retries survive).
+                // Moving the check upstream keeps the ~22-peer duplicate storm
+                // (~3000 channel messages per slot per node at the max-TPS
+                // ceiling) out of the dedicated SCP channel, whose slot-start
+                // burst previously took the event loop 80-110 ms (median) to
+                // drain — the dominant component of the slow-nomination tail.
+                if matches!(message, StellarMessage::ScpMessage(_)) {
+                    scp_msg_hash = Some(hash);
+                    if let Some(filter) = state.scp_inbound_filter.read().as_ref() {
+                        match filter(&hash) {
+                            Some(token) => scp_inflight_token = Some(token),
+                            None => {
+                                // In-flight duplicate: drop in the peer task.
+                                // `flow_release` (if any) drops here, releasing
+                                // the held capacity immediately — same as the
+                                // other early-drop paths.
+                                return Some(true);
+                            }
+                        }
+                    }
+                }
             } else {
                 // Pull-control messages (FloodAdvert/FloodDemand) use flow-control
                 // capacity but are NOT globally deduplicated or tracked in FloodGate.
@@ -1094,6 +1123,8 @@ impl OverlayManager {
             message: message.clone(),
             received_at: Instant::now(),
             flow_release: flow_release.take(),
+            scp_inflight_token,
+            message_hash: scp_msg_hash,
         };
         let is_scp = state.route_to_subscribers(overlay_msg);
         Some(is_scp)

--- a/docs/maxtps-optimization/2026-07-02-target2000.md
+++ b/docs/maxtps-optimization/2026-07-02-target2000.md
@@ -1,0 +1,124 @@
+# maxtps-optimize run — 2026-07-02, target 2000 tx/s
+
+- Session: b0db5fda · Instance: rs80hgfgtrl6m (nsc 32×64) · Base commit: 27ad52c5 (origin/main)
+- Methodology: MissionMaxTPSClassic, 23-node tier-1, short-probe
+  (SSC_MAXTPS_TXS_MULTIPLIER=60, SSC_LOADGEN_FASTFAIL_LEDGERS=10),
+  --install-network-delay false. Accept bar: Δ > 5% (short-probe).
+- **Current best: 1487 tx/s** @ 27ad52c5 · Target: 2000 (needs +34.5%)
+- Context: prior run (2026-06-30-target-core.md) ended at ~1446–1510 (~95–98% of
+  core's ~1531) with verdict "no fixable bottleneck remains; ceiling = shared 5 s
+  cadence". Target 2000 exceeds core itself, so this run must find levers that
+  make henyey *faster than core*, not just match it. NOTE: short-probe numbers
+  over-report sustainable TPS (probe-window dependence, see prior doc §probe-window);
+  all comparisons here are same-window relative A/Bs, which remain valid.
+
+## Known-refuted levers (prior run — do not re-test without new evidence)
+
+apply/persist close pipeline (overlaps the 5 s wait, ~10× headroom), SQLite
+synchronous=NORMAL, tx-set cap 15000 (fill ~67%), flow-control static-10000 trim
+(live value regresses −3%), loadgen offer path (T1), tx-set selection (T6),
+advert-flood budget (T3), per-message write syscalls (T2 coalescing, 0 gain),
+dissemination timing knobs (T5, aggressive regresses), broadcast batch-drain
+(T7, 0 gain), raw networking (T8: ~950× byte / ~150× pps headroom), SCP
+convergence at sustainable rates (~30–60 ms post-#3691).
+
+## Prime open lead (from prior run's own data, not pursued there)
+
+At passing 1430, measured **cadence ≈ 5.83 s/ledger vs the 5.0 s close-time
+target** — ~0.8 s/ledger (~16%) unattributed, *after* the trigger-spin fix and
+with nomination at ~30–60 ms. Prior agent attributed the ceiling to "the shared
+5 s cadence" but their own numbers show henyey is not running at 5.0 s. Where do
+the extra ~800 ms come from (trigger anchoring? externalize→trigger-arm path?
+close-time stamping?), and what is core's cadence at the same rate?
+
+## Hypotheses
+
+| # | hypothesis | instrumentation added | measurement | Δ vs best | status | notes / next |
+|---|------------|-----------------------|-------------|-----------|--------|--------------|
+| 0 | baseline @ 27ad52c5 | — | **1487** (1495✗/1487✓) | — | done | image opt-b0db5fda-base; matches prior ~1490 |
+| 1 | cadence overhead: loaded ledgers ~5.9–6.0 s (offline log analysis of prior runs) vs core 5.5 s; decompose the extra ~0.45 s (wait/build/nomconv/ballot/close) | 3 log stamps (trig/ballot/ext, `maxtps_cad`) + existing nominate/close INFO lines; image opt-b0db5fda-cad | 1475 (instr.) vs 1487 clean — negligible cost | — | **done (diagnostic)** | see "Iteration 1 findings" below |
+| 2 | adaptive early trigger: arm TriggerNextLedger at prepareStart+5s−EWMA(trigger→ballot overhead) so ballot starts land on a true 5 s grid; cadence 5.5→~5.05 s | reuses maxtps_cad stamps | **full band: max 1470** vs 1487 baseline (screens at 1562 ✗×2) | **−1.1%** | **rejected, reverted** (d6f33d27) | commits 4b2edbf1+6c3c7af2 then revert. MECHANISM PROVEN (triggers −800..−999 ms, loaded cadence 4.95 s, +17% ledger rate) but max TPS unmoved: ledgers proportionally emptier; the binder is NOT cadence. KEY FACT found: PayPregenerated hard-fails the run on ANY queue reject (parity #3638) → ceiling = max-inclusion-latency criterion (account cycle ~15 s, 1-pending-per-account queue). Levers must cut WALL-TIME inclusion tails, not ledger rate |
+| 3 | nomination tail spikes (0.8–1.7 s on ~25% of loaded slots) are tx-set FETCH stalls | `maxtps_fetch` got + `maxtps_scp` slow_intake/slow_pipeline (>50 ms only) | fetch REFUTED: med 51 ms p90 124 max 309. **Pipeline queueing CONFIRMED: SCP envelopes wait med 92 ms / p99 273 ms in the dedicated channel** (230 k slow events; verify worker med 0 ms) | — | **done (diagnostic)** | the unbiased main select! serves the flood firehose while SCP hops queue; 3–4 sequential hops × 90–270 ms = the whole tail. Also checked en route: fetch protocol asks the SENDING peer inline (core-parity), DontHave cascade fast, query rate limit (300/window) never hit, ItemFetcher+process_fetching are dead code (app drives fetches) |
+| 4 | prioritize SCP over flood: `biased;` select with flood arm moved to the bottom | reuses maxtps_scp stamps | screen 1562 ✗; **intake wait UNCHANGED (med 88 ms / p99 239 vs 92/273 baseline)**; nomtot worse on the failing step | — | **rejected, reverted** (39a1dcbb) | decisive: the SCP queue wait is HANDLER OCCUPANCY (loop busy inside arms, e.g. ~300 ms inline handle_generalized_tx_set — matches slow_pipeline max 349 ms), not arm-selection order. Prior session's H1b hypothesis now tested and refuted |
+| 5 | which arm occupies the loop? per-phase busy-time accounting at the ceiling | `maxtps_loop` per-phase cum-ms/count dump each stats tick (30 s) | **loop 100% BUSY (29.93 s/30 s)**: tx_advert_flush up to 18.3 s/30 s (~100 ms × 150 ticks!), broadcast (inbound flood) up to 21.7 s (0.46 ms × 40 k+), fetch_response 1.7–7.2 s, maybe_buffered_catchup 2.3–4.3 s (~75 ms × 40); ALL SCP arms ≤ 3 s | — | **done (diagnostic)** | the single saturated event loop IS the henyey ceiling; everything else queues behind it |
+| 6 | de-load the consensus event loop: (a) offload advert flush (~100 ms/200 ms tick) via coalesced dispatch; (b) move inbound-flood consumption (broadcast arm, ~20 s work/30 s window) to a dedicated `run_flood_consumer` task | reuses maxtps_loop + maxtps_scp | (a) alone: screen 1562 ✗, intake wait unchanged (broadcast arm still saturates loop); composite (a)+(b) testing | — | testing | phase-accounting caveat found: dispatch elapsed includes select WAIT, so post-(a) "tx_advert_flush=15 s" was misattributed idle time — i.e. (a) DID free the loop; the remaining occupant is genuine broadcast work |
+| 2 | txns/ledger headroom: to reach 2000 need ~10 k applied/ledger sustained; find what degrades above ~7.5 k | queue/admission/ban counters at high rate | — | — | pending | queue capacity × ban dynamics from probe-window analysis |
+| 3 | trigger anchoring: core anchors mTriggerTimer to lastTriggerTime (absolute grid); henyey to prepare_start Instant — drift accumulates? | wall-clock trigger grid log | — | — | pending | parity-sensitive; check core VirtualTimer semantics |
+
+## Iteration 1 findings (cadence decomposition, image opt-b0db5fda-cad, step @1481)
+
+Per-slot phase decomposition on loaded ledgers (~7.5–8.3 k tx), all 23 nodes:
+
+| phase | median | tail | core equivalent |
+|---|--:|--:|--|
+| trigger lateness vs prevBallot+5 s | 1–2 ms | 12 ms | punctual (post-#3691) |
+| trig→ballot (build+nom convergence) | 442–455 ms | 0.77–1.4 s on ~25% of slots | ~490 ms (build ~80 + nominated 414) |
+| ballot→externalize | ~210 ms | 290 ms | 43 ms |
+| externalize→closed (apply) | ~500 ms | 1.1 s | ~100–190 ms (off critical path) |
+| cadence (close-to-close) | 5.6–6.0 s | 6.9 s | 5.50 s loaded |
+
+- cadence = 5000 ms + lateness + (trig→ballot), exactly. Ballot/close phases overlap the wait.
+- Convergence is network-wide (ballot spread across nodes 100–330 ms; no laggard node).
+- Slow slots (19/23/24: 773–1350 ms) are network-wide; slot 23 crossed the 1 s round-1
+  timeout (9 nomination emitters = round escalation). Trigger spread (166–347 ms)
+  self-perpetuates: each node anchors its next trigger to its OWN ballot start.
+- Failure mode at the ceiling is a **latency tail, not throughput saturation**: at the
+  failing 1481 step the final backlog TRICKLED out (last loaded ledgers 68, 37, 0 txs) —
+  per-account seq chains drain one-per-ledger; the 10-ledger fastfail expires waiting.
+  1487 hard-failed mid-submission ("Loadgen failed!"), consistent with queue
+  eviction/ban dynamics (#3705).
+- **Structural conclusion: BOTH implementations serialize [5 s wait]+[~0.5 s overhead] →
+  ~5.5 s real cadence, undershooting the declared 5 s close-time target ~10%.** The 5 s
+  target is NOT the binding cap; the serialization is. Nothing on the parity surface
+  requires the overhead to serialize after the wait → iteration 2.
+
+| 7 | SCP duplicate storm: in-flight dedup (ScpScheduledCache) ran on the main loop, so ~22 duplicate flood copies of every envelope (~3000 msgs/slot/node) transited the dedicated SCP channel; core runs checkScheduledAndCache in the PEER thread | reuses maxtps_scp | stack (iters 6+7): screen 1562 ✓ once, then full-band **max 1500** (1541 ✗, 1514 ✗ NodeLostSync, 1507 ✗); slow_intake events ↓5× (17 k vs 87–98 k) | **+0.9% (sub-bar)** | **kept on branch, NOT accepted** | mechanisms independently verified (loop freed, SCP channel volume ↓22×, intake waits ↓5×) but ceiling moved ≤+1–5% with huge step variance; the 1562 pass was boundary luck. Precedent: hygiene-value commits stay on branch (cf. #3701), no maxtps claim. First attempt (floodgate-drop) broke #2317 self-echo tests → reworked to core-exact token-lifetime semantics |
+| 8 | tx-queue store WRITE lock held ~100 ms per 200 ms flood period (50% duty!) by collect_adverts_for_peers (candidate × 22-peer seen-checks inside broadcast_with_visitor's store.write()) — stalls loadgen submits, flood admission, AND nomination tx-set builds | body-only loop accounting (fixed wait-misattribution) | screen 1562 ✗ (submission reached 88%, was 70-75%); **loop now ~94-99% IDLE (243 ms–1.8 s busy/30 s vs 29.9 s pre-stack!)**; maybe_buffered_catchup was misattribution (~2.6 ms real) | — | **kept on branch (sub-bar alone)** | de-loading campaign complete & verified; residual convergence: trig→ballot med 580 ms max 1666 ms (round-2 escalations) with fetch clean (55 ms med) and idle loop → remaining critical path = leader-trigger spread (~350 ms) + leader BUILD (~200 ms) burning the 1000 ms round-1 clock |
+| 9 | leader's ~150-200 ms tx-set build serialized after the trigger on the convergence critical path; prebuild it ~300 ms early (sleep task → prebuild_nomination_value; trigger reuses cache; close_time whole-second granularity ⇒ ~identical values) | — | screen 1562 ✗ but **trig→ballot median 580→320 ms** (fast slots now 137-240 ms); tail persists (max 3570 ms) | — | **kept on branch (mechanism proven, sub-bar alone)** | tail investigation → found the REAL stall: slot-25's 3.5 s = peer-connection collapse ("All peers exhausted", total_peers=1, reset storm) |
+| 10 | **mass idle-timeout peer-drop wave at boot** (~130-166 drops/run, ALL 20-30 s before load, PRESENT ON BASELINE): lost ping reply → 60 s outstanding-ping expiry > 30 s idle-drop deadline → mutual silence → drop; reconnect storm overlaps first loaded ledgers | drop-wave timestamps vs load window | screen 1562 ✗, **drops unchanged (153)** → ping expiry was NOT the quiet mechanism; wave persists with ledgers closing every 5 s through the window ⇒ drops are mostly SHADOW duplicate connections (per-PeerId routing sends nothing on the losing connection of a double-connected pair; cleanup_peer is generation-guarded so active handles are safe) | — | fix kept (harmless, still shortens real lost-reply gaps) but **wave ≠ binder** (baseline passes 1487 with the same wave) | slot-25 reset storm remains rare/unexplained; deprioritized |
+| 11 | POWERED VERDICT on the accumulated stack: interleaved A/B single-steps | — | @1520: 0/4 (both fail); @1490: 0/4 — **including base, which passed 1487 in the morning** | — | done (instance drift detected) | the 5 h-old instance drifted below its own morning baseline → cross-time comparisons unsound; single-step A/B at a drifting edge has no power |
+| 12 | clean same-hardware verdict: FRESH instance (jl11dhckpjc5e), back-to-back full-band searches (1400–1620), base vs full stack | — | **base: 1413** (1455✗ 1427✗ 1413✓ 1420✗) · **stack: 1523** (1510✓ 1565✗ 1537✗ 1523✓) | **+7.8%** | **ACCEPTED** | decisive same-instance comparison; stack = iters 6–10 commits (advert-flush offload, flood consumer, peer-task SCP dedup, lock-hold shrink, prebuild, ping expiry) |
+
+## Summary
+- **Baseline → final: 1413 → 1523 tx/s (+7.8%) in the controlled same-instance
+  back-to-back comparison** (fresh nsc 32×64, identical band 1400–1620).
+  Morning-instance numbers (base 1487, stack ~1500-1562) were confounded by
+  instance drift — the same base image measured 1487 at 01:30 and 1413 at 06:20
+  on different instances, and FAILED 1490 on the drifted one; absolute numbers
+  across instances/time are not comparable, same-instance deltas are.
+- Accepted change = the iteration 6–10 stack (one cohesive theme: **get
+  everything except SCP/close off the consensus event loop, and everything
+  serial off the convergence critical path**):
+  1. advert-flush offload (was ~100 ms inline per 200 ms tick);
+  2. dedicated inbound-flood consumer task (was ~20 s of loop work per 30 s);
+  3. in-flight SCP dedup moved to overlay peer tasks (core
+     `checkScheduledAndCache` placement; ~22× duplicate volume off the SCP
+     channel);
+  4. tx-queue store-lock hold shrink in advert collection (was ~50% write-lock
+     duty);
+  5. nomination-value prebuild ~300 ms before the trigger (convergence median
+     580→320 ms);
+  6. ping-expiry 60→10 s (hardening; the boot drop-wave itself proved to be
+     benign shadow-connection cleanup).
+  Combined effect on internals: event loop 100%→~5% busy at the ceiling; SCP
+  intake slow-waits ↓5×; submission progress at failing steps 70→88%.
+- Rejected/reverted with measurement: early-trigger compensation (iter 2:
+  cadence 5.5→4.95 s proven but ceiling −1%: cadence is NOT the binder);
+  biased select (iter 4: queue wait is handler occupancy, not arm order).
+- Diagnostics landed: maxtps_cad/scp/fetch stamps, per-phase body-only loop
+  accounting; measurement-methodology lessons: single-step pass/fail near the
+  edge is stochastic (±3-4%), instances drift over hours — only same-instance
+  interleaved or back-to-back comparisons are valid.
+- Target 2000 NOT reached (needs +31% over final; core itself measured ~1531 on
+  the healthiest instance seen). Top remaining hypotheses: (a) worst-slot
+  round-2 nomination escalations (1.4-3.5 s) — leader-trigger spread ~200-350 ms
+  inherited via own-ballot anchoring burns the 1000 ms round-1 clock; a
+  network-synchronized trigger anchor is the next big swing; (b) the rare
+  connection-reset storm (slot-25 case); (c) per-envelope process_verified cost
+  (~350 µs at load) → batch/inline verify; (d) the loadgen guillotine itself
+  (per-account 1-pending + instant-fail) makes the harness verdict
+  tail-dominated — an open-loop applied-rate measurement would decouple
+  optimization from tail luck.
+- Baseline → final: TBD
+- PRs: TBD
+- Top remaining pending hypotheses: TBD


### PR DESCRIPTION
## Summary

Raises henyey's distributed max TPS (Supercluster `MissionMaxTPSClassic`, 23-node tier-1 on one nsc 32×64 VM) by de-loading the main consensus event loop and the SCP nomination critical path. **Controlled same-instance back-to-back full-band comparison on a fresh instance: base 1413 → stack 1523 tx/s (+7.8%).**

Diagnosis (full narrative in `docs/maxtps-optimization/2026-07-02-target2000.md`): at the ceiling the single event loop was **100.0% busy** (measured 29.93s of every 30s window) and SCP envelopes waited a median 92ms per hop in the dedicated channel, producing 0.8–3.5s nomination-convergence tails that trip the loadgen's per-account completion guillotine.

### Accepted changes (one cohesive theme)
1. **Advert flush off the loop** — was ~100ms inline per 200ms flood tick (up to 60% of the loop), now a coalesced background task (same pattern as peer maintenance #3690).
2. **Dedicated inbound-flood consumer task** — Transaction/FloodAdvert/FloodDemand processing (~20s of work per 30s window) moves off the select loop; SCP and fetch keep their dedicated channels/arms.
3. **In-flight SCP dedup in overlay peer tasks** — core parity: `checkScheduledAndCache` runs in core's peer thread (Peer.cpp:1113-1117); henyey ran it on the main loop, so ~22 duplicate flood copies of every envelope (~3000 msgs/slot/node) transited the SCP channel. Same `ScpScheduledCache`, same token-lifetime semantics (#2317 self-echo preserved — overlay integration tests pass unchanged; new regression test for token release on full-channel drop).
4. **Tx-queue store-lock shrink** — advert collection held the store write lock ~50% of the time (candidate × 22-peer seen-checks in-lock); now a short-lock drain + lock-free per-peer dedup (budget-accounting delta documented in-code; 2.6× measured headroom).
5. **Nomination-value prebuild** — the ~150-200ms tx-set build ran between the trigger and `scp.nominate`, on the network convergence critical path; now prebuilt ~300ms early and reused (convergence median 580→320ms). `close_time` has whole-second granularity so values are ~always identical.
6. **Ping-expiry 60s→10s** — a lost ping reply could silence a peer pair past the 30s idle-drop deadline.

Also includes parity-irrelevant diagnostics (`maxtps_cad`/`maxtps_scp`/`maxtps_fetch` slow-only log stamps, per-phase body-only event-loop accounting) and two measured-and-reverted experiments kept in history for the record (early-trigger compensation; biased select — both documented in the run doc with refutation data).

### Measured effects on internals
- Event loop at ceiling: 100% → ~5% busy.
- SCP channel slow-waits: ↓5× count.
- Nomination convergence median: 580 → 320ms.
- Loadgen submission progress at failing steps: 70% → 88%.

### Measurement honesty
Morning-session numbers (baseline 1487) are NOT comparable to the final A/B: the 5h-old instance drifted below its own morning baseline (same base image: 1487 at 01:30, 1413 at 06:20 on a fresh instance, and failing 1490 on the drifted one). The accepted +7.8% is from the same-instance, back-to-back, identical-band comparison — the only valid protocol we found. Short-probe caveats from #3703/#3705 still apply to absolute numbers.

## Parity
Wire bytes, tx-set semantics, close-time semantics, and observable surfaces unchanged; all changes are internal scheduling/threading (explicitly divergeable per `docs/PARITY.md`). SCP dedup placement matches stellar-core more closely than before.

## Tests
- `cargo test --all`: green (full workspace).
- henyey-app 1146, henyey-herder 1202, henyey-overlay 479+8+3+1 (incl. #2317 self-echo + duplicate-forwarding integration tests unchanged).
- New: prebuild cache/reuse test, SCP-channel token-release regression test, budget-accounting tests updated with rationale.

Run doc: `docs/maxtps-optimization/2026-07-02-target2000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Hj1rEJT613ZxV5avQiLUj