### PR TITLE
Sustained-load fixes: syncing-gate parity, stranded-tx re-flood, advert budget refund

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2522,6 +2522,19 @@ impl App {
             );
             if !is_success {
                 failed_hashes.push(Hash256::hash_xdr(tx));
+                // [maxtps_ban] failed-at-apply txs get banned post-close; under
+                // the sustained-load investigation these bans exploded (~20k/min)
+                // and poisoned live accounts. Log the result-code discriminant
+                // (sampled: first 3 per close) to attribute the failure mode.
+                if failed_hashes.len() <= 3 {
+                    tracing::info!(
+                        target: "maxtps_ban",
+                        ledger_seq = pending.ledger_seq,
+                        result = format!("{:?}", tx_result.result.result).chars().take(60).collect::<String>(),
+                        seq_num,
+                        "failed_apply"
+                    );
+                }
             }
         }
         timer.mark("build_persist_inputs_ms");
@@ -2779,9 +2792,13 @@ impl App {
                 close_time,
             );
             if !failed_hashes_for_ban.is_empty() {
-                tracing::debug!(
+                // [maxtps_ban] info-level so the sustain investigation can see
+                // per-close ban volume by site (site 1 = failed at apply).
+                tracing::info!(
+                    target: "maxtps_ban",
+                    ledger_seq,
                     failed_count = failed_hashes_for_ban.len(),
-                    "Banning failed transactions"
+                    "ban_site1_failed_apply"
                 );
                 herder.tx_queue().ban(&failed_hashes_for_ban);
             }
@@ -2898,6 +2915,13 @@ impl App {
                     let invalid_hashes: Vec<Hash256> =
                         invalid.iter().map(|htx| htx.hash()).collect();
                     invalid_banned = invalid_hashes.len();
+                    // [maxtps_ban] site 2 = queued txs stateful-invalid after close.
+                    tracing::info!(
+                        target: "maxtps_ban",
+                        ledger_seq,
+                        invalid_banned,
+                        "ban_site2_revalidation"
+                    );
                     herder.tx_queue().ban(&invalid_hashes);
                 }
                 crate::metrics::CLOSE_TX_QUEUE_INVALIDATION_SECONDS

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -1393,15 +1393,36 @@ fn collect_adverts_for_peers(
     });
 
     // Phase 2 (no store lock): per-peer dedup against the advert history.
+    // Candidates already advertised to EVERY peer get their budget REFUNDED
+    // (sustain fix): after a peer reconnect, `rebroadcast()` re-marks the
+    // whole queue for flooding, and without the refund those already-seen
+    // candidates consumed the ops budget for several consecutive periods,
+    // starving adverts for NEW txs — a stranded new tx misses ~4 ledgers,
+    // its account's next submission gets TryAgainLater, and a
+    // PayPregenerated load-run insta-fails (parity #3638). The refund lands
+    // in the carryover, so the next 200 ms period drains the backlog with
+    // compounded budget. Net budget accounting matches the pre-split
+    // single-pass semantics (seen-by-all == Skipped == budget-neutral).
     let mut per_peer: HashMap<henyey_overlay::PeerId, Vec<Hash256>> = HashMap::new();
     for candidate in &candidates {
+        let mut new_to_any_peer = false;
         for peer_id in peer_ids {
             if let Some(adverts) = adverts_by_peer.get(peer_id) {
                 if !adverts.seen_advert(&candidate.hash) {
+                    new_to_any_peer = true;
                     per_peer
                         .entry(peer_id.clone())
                         .or_default()
                         .push(candidate.hash);
+                }
+            }
+        }
+        if !new_to_any_peer {
+            let ops = candidate.op_count as usize;
+            budget.ops_remaining = budget.ops_remaining.saturating_add(ops);
+            if candidate.is_dex {
+                if let Some(dex) = budget.dex_ops_remaining.as_mut() {
+                    *dex = dex.saturating_add(ops);
                 }
             }
         }
@@ -1805,13 +1826,12 @@ mod tests {
         let per_peer = collect_adverts_for_peers(&queue, &mut budget, &peer_ids, &adverts);
 
         assert!(per_peer.is_empty(), "no peer should receive a known tx");
-        // maxtps iter 8: the drain phase consumes budget for every candidate
-        // (including all-peers-seen ones) so the per-peer advert-history
-        // checks can run OUTSIDE the tx-queue store lock. See
-        // collect_adverts_for_peers for the rationale + headroom analysis.
+        // Sustain fix: the two-phase collector REFUNDS budget for candidates
+        // already advertised to every peer, restoring the original
+        // budget-neutral semantics (see collect_adverts_for_peers phase 2).
         assert_eq!(
-            budget.ops_remaining, 9,
-            "drained candidate consumes budget even when all peers know it"
+            budget.ops_remaining, 10,
+            "budget must be unchanged (seen-by-all is budget-neutral via refund)"
         );
     }
 
@@ -1888,13 +1908,9 @@ mod tests {
 
         let _per_peer = collect_adverts_for_peers(&queue, &mut budget, &peer_ids, &adverts);
 
-        // maxtps iter 8: both drained candidates consume budget (the per-peer
-        // seen-check moved outside the store lock, so the drain can no longer
-        // distinguish known-to-all txs). Carryover absorbs the difference.
-        assert_eq!(
-            budget.ops_remaining, 8,
-            "both drained candidates consume budget"
-        );
+        // Sustain fix: tx_known is refunded (seen by the only peer), tx_new
+        // consumed — net matches the original single-pass semantics.
+        assert_eq!(budget.ops_remaining, 9, "only tx_new should consume budget");
     }
 
     #[test]
@@ -1922,16 +1938,15 @@ mod tests {
         let per_peer = collect_adverts_for_peers(&queue, &mut budget, &peer_ids, &adverts);
 
         assert!(per_peer.is_empty(), "known DEX tx should not be advertised");
-        // maxtps iter 8: the drain consumes budget for the known DEX tx too
-        // (seen-checks moved outside the store lock).
+        // Sustain fix: the known DEX tx is refunded on both budgets.
         assert_eq!(
-            budget.ops_remaining, 9,
-            "drained DEX tx consumes generic budget"
+            budget.ops_remaining, 10,
+            "generic budget untouched (refund)"
         );
         assert_eq!(
             budget.dex_ops_remaining,
-            Some(4),
-            "drained DEX tx consumes DEX budget"
+            Some(5),
+            "DEX budget untouched (refund)"
         );
     }
 

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -5748,6 +5748,27 @@ mod tests {
         );
     }
 
+    /// Sustain fix: a momentary Tracking→Syncing blip must NOT bounce
+    /// submissions at the herder gate — stellar-core's `recvTransaction`
+    /// always forwards to the queue regardless of tracking state. (For
+    /// `PAY_PREGENERATED` loadgen, a bounced submission aborts the whole run,
+    /// parity #3638.) Only `Booting` still defers.
+    #[test]
+    fn test_receive_transaction_while_syncing_forwards_to_queue() {
+        let herder = make_test_herder();
+        herder.set_state(HerderState::Syncing);
+        assert!(herder.state().can_receive_transactions());
+
+        // With an empty queue there is no account-pending conflict, so any
+        // TryAgainLater could only come from the (removed) state gate.
+        let result = herder.receive_transaction(make_minimal_tx_envelope());
+        assert!(
+            !matches!(result, TxQueueResult::TryAgainLater),
+            "Syncing must forward to the queue, not bounce at the state gate; got {:?}",
+            result
+        );
+    }
+
     /// Parity: when the herder is Tracking and the queue already has a pending
     /// tx from a source, submitting an opposite-type tx from the same source
     /// must return TryAgainLater (stellar-core HerderImpl.cpp:627-645).

--- a/crates/herder/src/state.rs
+++ b/crates/herder/src/state.rs
@@ -46,8 +46,20 @@ impl HerderState {
     }
 
     /// Check if the herder is in a state where it can receive transactions.
+    ///
+    /// Includes `Syncing` (sustain fix): stellar-core's
+    /// `HerderImpl::recvTransaction` never gates on tracking state — it always
+    /// forwards to the queue. henyey previously required `Tracking`, so a
+    /// momentary Tracking→Syncing blip (e.g. a slow slot or connection churn)
+    /// made in-flight submissions fail with `TryAgainLater`; for
+    /// `PAY_PREGENERATED` load generation ANY non-Added result aborts the run
+    /// (parity #3638), which capped sustained-load tests ~20% below the burst
+    /// ceiling. Only `Booting` still defers: the ledger manager may not be
+    /// initialized yet, and the queue would reject with `txINTERNAL_ERROR`
+    /// (aborting well-behaved clients such as friendbot) instead of a
+    /// retryable signal.
     pub fn can_receive_transactions(&self) -> bool {
-        matches!(self, HerderState::Tracking)
+        matches!(self, HerderState::Syncing | HerderState::Tracking)
     }
 
     /// Check if the herder is fully synchronized with the network.
@@ -112,7 +124,9 @@ mod tests {
         let syncing = state.next_state().unwrap();
         assert!(syncing.is_syncing());
         assert!(syncing.can_receive_scp());
-        assert!(!syncing.can_receive_transactions());
+        // Sustain fix: Syncing forwards transactions to the queue (core
+        // parity — recvTransaction never gates on tracking state).
+        assert!(syncing.can_receive_transactions());
 
         let tracking = syncing.next_state().unwrap();
         assert!(tracking.is_tracking());

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -3062,6 +3062,23 @@ impl TransactionQueue {
             if let Some(ref queued_tx) = state.transaction {
                 state.age += 1;
 
+                // Sustain fix: re-mark a pending tx for flooding when it has
+                // aged 2 ledgers without applying. A tx is erased from the
+                // flood queue the first time it is advertised; if that advert
+                // was lost (peer outbound overflow, connection churn) the tx
+                // is stranded on this node — it only applies when THIS node's
+                // nomination candidate wins (~1/23 ledgers on the 23-node
+                // maxtps topology, ≈2 minutes), by which time its account's
+                // next submission collides with the pending tx
+                // (TryAgainLater) and a PayPregenerated load-run insta-fails.
+                // Re-marking is cheap and precise: the per-peer advert history
+                // ensures only peers that never received the advert get it.
+                // Exactly-once per age level (fires on the 2→ transition).
+                if state.age == 2 {
+                    store.flood_queue.mark_for_flood(queued_tx, ledger_version);
+                    metrics::counter!("stellar_herder_tx_reflooded_total").increment(1);
+                }
+
                 // Auto-ban at pending_depth
                 if state.age >= self.pending_depth {
                     // Add to banned set
@@ -10801,6 +10818,46 @@ mod broadcast_visitor_tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].hash, Hash256::hash_xdr(&tx1));
         assert_eq!(budget.ops_remaining, 0);
+    }
+
+    /// Sustain fix: a pending tx that ages 2 ledgers without applying is
+    /// re-marked for flooding by `shift()` — exactly once, on the 2→
+    /// transition — so a tx whose first advert was lost is not stranded on
+    /// the submitting node until the 4-ledger auto-ban.
+    #[test]
+    fn test_shift_refloods_pending_tx_at_age_two() {
+        let config = TxQueueConfig {
+            max_size: 10,
+            ..Default::default()
+        };
+        let queue = TransactionQueue::new(config);
+
+        let mut tx = make_test_envelope(100, 1);
+        set_source(&mut tx, 1);
+        let hash = Hash256::hash_xdr(&tx);
+        assert_eq!(queue.try_add(tx), TxQueueResult::Added);
+
+        // First broadcast drains the flood queue (advert sent, entry erased).
+        let (entries, _) = visit_all_processed(&queue, 100, None);
+        assert_eq!(entries.len(), 1, "initial flood visit sees the tx");
+        let (entries, _) = visit_all_processed(&queue, 100, None);
+        assert!(entries.is_empty(), "flood queue drained after first visit");
+
+        // Age 1: not re-flooded yet.
+        queue.shift();
+        let (entries, _) = visit_all_processed(&queue, 100, None);
+        assert!(entries.is_empty(), "age 1 must not re-flood");
+
+        // Age 2: re-marked for flooding.
+        queue.shift();
+        let (entries, _) = visit_all_processed(&queue, 100, None);
+        assert_eq!(entries.len(), 1, "age 2 must re-flood the pending tx");
+        assert_eq!(entries[0].hash, hash);
+
+        // Age 3: fires only once (2→ transition), no repeat.
+        queue.shift();
+        let (entries, _) = visit_all_processed(&queue, 100, None);
+        assert!(entries.is_empty(), "re-flood fires exactly once at age 2");
     }
 
     #[test]

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -2232,7 +2232,18 @@ impl LoadGenerator {
             let envelope = match tx_result {
                 Ok((_source_id, env)) => env,
                 Err(e) => {
-                    warn!("Failed to build tx (mode={:?}): {}", config.mode, e);
+                    // [maxtps_ban] the OTHER run-fatal path besides the submit
+                    // reject: tx generation failed (pregenerated-file reader
+                    // error, account lookup, etc.). Under the sustain
+                    // investigation, post-fix mid-submission deaths were
+                    // silent at the submit-reject site — tag this one too.
+                    tracing::warn!(
+                        target: "maxtps_ban",
+                        error = %e,
+                        mode = ?config.mode,
+                        source_account_id,
+                        "generate_tx fatal error — failing the run"
+                    );
                     self.failed = true;
                     return SubmitOutcome::NotAccepted;
                 }

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -2246,6 +2246,9 @@ impl LoadGenerator {
             // re-enters execute() on each retry (#3569).
             mark_tx_meters(config.mode, &envelope);
 
+            // [maxtps_ban] capture identifying details before the envelope is
+            // consumed, for the fatal-reject diagnostic below.
+            let diag_seq = envelope_seq_num(&envelope);
             let result = self.tx_generator.app.submit_transaction(envelope).await;
 
             // PayPregenerated does not re-submit on failure: each tx is read
@@ -2264,6 +2267,8 @@ impl LoadGenerator {
                     tracing::warn!(
                         target: "maxtps_ban",
                         result = ?result,
+                        source_account_id,
+                        tx_seq = diag_seq,
                         "pay_pregenerated fatal reject — failing the run"
                     );
                     app_metrics::LOADGEN_TXN_REJECTED.increment(1.0);

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -2256,6 +2256,16 @@ impl LoadGenerator {
             // (#3638).
             if config.mode == LoadGenMode::PayPregenerated {
                 if pay_pregenerated_reject_fails(&result) {
+                    // [maxtps_ban] THE run-fatal reject (parity #3638: any
+                    // non-Added result aborts a PayPregenerated run). Under the
+                    // sustained-load investigation runs died mid-submission
+                    // with no visible cause — log the queue verdict that killed
+                    // the run.
+                    tracing::warn!(
+                        target: "maxtps_ban",
+                        result = ?result,
+                        "pay_pregenerated fatal reject — failing the run"
+                    );
                     app_metrics::LOADGEN_TXN_REJECTED.increment(1.0);
                     self.failed = true;
                     return SubmitOutcome::NotAccepted;

--- a/docs/maxtps-optimization/2026-07-02-target2000.md
+++ b/docs/maxtps-optimization/2026-07-02-target2000.md
@@ -107,13 +107,28 @@ Root-cause chain established by live capture (fatal-reject WARN instrumentation,
    BENIGN (applied txs enter the ban buckets by design, core parity).
 
 **Result: the sustained ceiling did NOT move (1126 → 1132)** — the fixes are
-correctness/parity wins but something further binds. The most visible residual
-is the **reused-network insta-fail**: after any passing 5-min step, SSC reuses
-the network and the next step dies ~60 s in (observed pre- AND post-fix;
-repro + capture in progress at time of writing). The #3705 model (any
-100%-completion criterion drives the passing rate toward the true sustained
-drain rate D as window→∞) remains the parsimonious explanation for the
-~1130 asymptote itself.
+correctness/parity wins but something further binds.
+
+**Post-fix killer captured** (5 s-resolution capture, single-step repro @1120):
+`pay_pregenerated fatal reject result=TryAgainLater tx_seq=14` (cq-0, 94% into
+submission) — the QUEUE-level account-pending collision: one tx's inclusion
+latency exceeded its account's ~21 s submission cycle, so the account's next
+pregenerated tx bounced, and any bounce kills the run (#3638). A contributing
+amplifier: peers BAN early-arriving chained txs (a tx with seq N+1 arriving
+before seq N applied is invalid-at-admission and gets banned, observed as
+`demand_unfulfilled_banned_total` climbing) — so a delayed tx's successor can
+be cross-node banned, extending the stall past the ban depth.
+
+**Final verdict: the ~1130 sustained ceiling is the closed-loop TAIL-LATENCY
+asymptote** — the rate at which P(any one of ~2.3 M txs delayed > one account
+cycle across 300 s × 7 loadgen nodes) ≈ 1. It is a max-latency criterion, not
+a throughput wall (the same network drains 1489+ tx/s for 60 s cleanly). This
+is exactly the #3705 "D" model; the 1-min probe simply gives the guillotine 5×
+fewer chances to fire. Closing the burst↔sustained gap further requires either
+(a) driving worst-case inclusion latency below ~20 s at all times (remaining
+tail sources: rare slow slots, cross-node early-arrival bans, connection
+churn), or (b) the open-loop applied-rate measurement #3705 recommended —
+a harness change, shared with stellar-core.
 
 ## Summary
 - **Baseline → final: 1413 → 1523 tx/s (+7.8%) in the controlled same-instance

--- a/docs/maxtps-optimization/2026-07-02-target2000.md
+++ b/docs/maxtps-optimization/2026-07-02-target2000.md
@@ -79,6 +79,42 @@ Per-slot phase decomposition on loaded ledgers (~7.5–8.3 k tx), all 23 nodes:
 | 11 | POWERED VERDICT on the accumulated stack: interleaved A/B single-steps | — | @1520: 0/4 (both fail); @1490: 0/4 — **including base, which passed 1487 in the morning** | — | done (instance drift detected) | the 5 h-old instance drifted below its own morning baseline → cross-time comparisons unsound; single-step A/B at a drifting edge has no power |
 | 12 | clean same-hardware verdict: FRESH instance (jl11dhckpjc5e), back-to-back full-band searches (1400–1620), base vs full stack | — | **base: 1413** (1455✗ 1427✗ 1413✓ 1420✗) · **stack: 1523** (1510✓ 1565✗ 1537✗ 1523✓) | **+7.8%** | **ACCEPTED** | decisive same-instance comparison; stack = iters 6–10 commits (advert-flush offload, flood consumer, peer-task SCP dedup, lock-hold shrink, prebuild, ping expiry) |
 
+## Sustained-load follow-up (operator request, 2026-07-02 afternoon)
+
+Question: is the 1523 burst number sustainable? **NO — the 5-minute probe
+(SSC_MAXTPS_TXS_MULTIPLIER=300) sustains only ~1126–1132, −24% below the 1-min
+burst ceiling** (same-instance: burst 1489, sustained 1153 on the morning
+instance; clean fresh-instance A/B: pre-fix 1126 / post-fix 1132).
+
+Root-cause chain established by live capture (fatal-reject WARN instrumentation,
+`maxtps_ban` target):
+1. **PayPregenerated dies on the FIRST non-Added submit** (parity #3638) — the
+   5-min window gives tail events ~5× more chances to produce one.
+2. Captured killer (3×, pre-fix): **`TryAgainLater` from the herder's
+   receive_transaction gate** — henyey returned it whenever the node was not
+   `Tracking`, a documented divergence (core's `recvTransaction` never gates on
+   tracking state). A momentary Tracking→Syncing blip on any of the 7 loadgen
+   nodes killed the run. **Fixed** (`can_receive_transactions` now includes
+   Syncing; Booting still defers).
+3. Two more real defects found & fixed en route: **stranded-tx no-reflood** (a
+   tx whose first advert is lost strands until the submitting node's own
+   candidate wins nomination, ~2 min on 23 nodes; now re-marked for flooding at
+   pending-age 2 — `test_shift_refloods_pending_tx_at_age_two`) and an
+   **advert-budget regression** from the iter-8 lock split (seen-by-all
+   rebroadcast candidates consumed the ops budget after peer reconnects,
+   starving new-tx adverts; now refunded).
+4. Red herring documented: `tx_queue_banned` exploding ~20k/min under load is
+   BENIGN (applied txs enter the ban buckets by design, core parity).
+
+**Result: the sustained ceiling did NOT move (1126 → 1132)** — the fixes are
+correctness/parity wins but something further binds. The most visible residual
+is the **reused-network insta-fail**: after any passing 5-min step, SSC reuses
+the network and the next step dies ~60 s in (observed pre- AND post-fix;
+repro + capture in progress at time of writing). The #3705 model (any
+100%-completion criterion drives the passing rate toward the true sustained
+drain rate D as window→∞) remains the parsimonious explanation for the
+~1130 asymptote itself.
+
 ## Summary
 - **Baseline → final: 1413 → 1523 tx/s (+7.8%) in the controlled same-instance
   back-to-back comparison** (fresh nsc 32×64, identical band 1400–1620).


### PR DESCRIPTION
## Summary

Follow-up to #3706, answering: **is the +7.8% burst ceiling sustainable?** No — the 5-minute probe (`SSC_MAXTPS_TXS_MULTIPLIER=300`) sustains only **~1126–1132 tx/s, −24% below the 1-minute burst ceiling (1489–1523)**. This PR lands the three real defects found while root-causing that gap, plus the diagnostic instrumentation and the full writeup.

### The captured root-cause chain
`PAY_PREGENERATED` load runs die on the FIRST non-Added submit (parity #3638). Live capture (`maxtps_ban` WARN) caught the killers:

1. **Syncing-gate `TryAgainLater` (fixed, core parity)** — `receive_transaction` bounced submissions whenever the herder wasn't `Tracking`, a documented divergence (stellar-core's `recvTransaction` never gates on tracking state). A momentary Tracking→Syncing blip on any of 7 loadgen nodes killed the run — captured 3× live. `can_receive_transactions` now includes `Syncing`; `Booting` still defers (LM may be uninitialized; keeps the friendbot-safe retryable signal).
2. **Stranded-tx no-re-flood (fixed)** — a tx is erased from the flood queue on first advert; if that advert is lost the tx strands on the submitting node until that node's own nomination candidate wins (~2 min on 23 nodes). `shift()` now re-marks a pending tx for flooding when it ages 2 ledgers (exactly once; per-peer advert history limits re-sends to peers that never got it). Test: `test_shift_refloods_pending_tx_at_age_two`.
3. **Advert budget regression from the #3706 lock split (fixed)** — seen-by-all rebroadcast candidates consumed the ops budget after peer reconnects, starving new-tx adverts for seconds. The two-phase collector now refunds their budget, restoring the original budget-neutral semantics (assertions restored).

### Honest outcome
Same-hardware pre/post-fix long-probe A/B: **1126 → 1132 (no change)**. The fixes are correctness/parity wins, but the sustained ceiling is set by a deeper mechanism, captured on the final repro: a queue-level account-pending `TryAgainLater` — one tx's inclusion latency exceeded its account's ~21s submission cycle. **The ~1130 sustained ceiling is the closed-loop tail-latency asymptote** (the #3705 "D"): a max-latency criterion, not a throughput wall (the same network drains 1489+ tx/s cleanly for 60s). Full analysis in the run doc, including the cross-node early-arrival-ban amplifier and the benign-`tx_queue_banned` red herring.

### Also included
- `maxtps_ban` diagnostic instrumentation (ban-site attribution, fatal-reject detail incl. account+seq, generate_tx fatal path) — logging only.
- Run-doc sustain section (`docs/maxtps-optimization/2026-07-02-target2000.md`).

## Parity
Queue/flood scheduling internals (divergeable) except the syncing-gate change, which REMOVES a divergence (core parity). Wire bytes and observable semantics unchanged.

## Tests
henyey-herder 1203, henyey-app 1146, henyey-simulation 108 — all green. New regression tests for the re-flood, gate, and budget semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Hj1rEJT613ZxV5avQiLUj