### PR TITLE
Fix the overlay churn engine: never re-dial peers with a live connection (burst gap to core closed to −1.3%)

### DIFF
--- a/crates/overlay/src/manager/mod.rs
+++ b/crates/overlay/src/manager/mod.rs
@@ -261,7 +261,7 @@ impl PreferredPeerSet {
     ///
     /// After DNS resolution, resolved entries have canonical IP addresses,
     /// eliminating hostname/IP aliasing in `retry_after` and
-    /// `has_outbound_connection_to`. Peers that failed DNS resolution are
+    /// `has_connection_to`. Peers that failed DNS resolution are
     /// omitted from dialing (they will be retried on the next DNS cycle).
     pub(super) fn shuffled_dial_entries(&self, rng: &mut impl Rng) -> Vec<PeerAddress> {
         if self.resolved.is_empty() {
@@ -1826,16 +1826,27 @@ impl OverlayManager {
         info.address == addr
     }
 
-    pub(super) fn has_outbound_connection_to(
+    /// True if ANY live connection (inbound or outbound) matches `addr`.
+    ///
+    /// Used as the pre-dial filter by the connection tick. This MUST consider
+    /// both directions (parity: stellar-core `getConnectedPeer(address)`
+    /// searches the inbound AND outbound authenticated maps before
+    /// `connectTo`): after a mutual-dial tie-break, the lower-node-id side of
+    /// a pair keeps an INBOUND connection — with an outbound-only filter it
+    /// re-dialed that peer forever, and every re-dial raced the handshake
+    /// path, occasionally REPLACING the healthy connection via the tie-break
+    /// and leaving the replaced socket to idle out (30 s) and reset the
+    /// remote. Measured on MissionMaxTPSClassic: 2294 reject/drop/reset
+    /// events per node per mission vs stellar-core's 6, and a sustained
+    /// (5-min-window) ceiling of ~1087 tx/s vs core's 1522 on identical
+    /// hardware. Inbound connections are full-duplex peers; there is nothing
+    /// to gain by dialing them again.
+    pub(super) fn has_connection_to(
         peer_info_cache: &DashMap<PeerId, PeerInfo>,
         addr: &PeerAddress,
     ) -> bool {
         peer_info_cache.iter().any(|entry| {
             let info = entry.value();
-            // Only consider outbound connections (we called them)
-            if !info.direction.we_called_remote() {
-                return false;
-            }
             Self::peer_info_matches_address(info, addr)
         })
     }

--- a/crates/overlay/src/manager/tick.rs
+++ b/crates/overlay/src/manager/tick.rs
@@ -480,7 +480,7 @@ impl OverlayManager {
                 }
             }
 
-            if Self::has_outbound_connection_to(&shared.peer_info_cache, addr) {
+            if Self::has_connection_to(&shared.peer_info_cache, addr) {
                 continue;
             }
 
@@ -552,7 +552,7 @@ impl OverlayManager {
                 }
             }
 
-            if Self::has_outbound_connection_to(&shared.peer_info_cache, addr) {
+            if Self::has_connection_to(&shared.peer_info_cache, addr) {
                 continue;
             }
 
@@ -696,7 +696,7 @@ impl OverlayManager {
 
             // Re-check under the loop: an earlier promotion in this tick may
             // have created the outbound connection we're about to dial.
-            if Self::has_outbound_connection_to(&shared.peer_info_cache, addr) {
+            if Self::has_connection_to(&shared.peer_info_cache, addr) {
                 continue;
             }
 
@@ -965,8 +965,19 @@ mod tests {
 
     // ---- §10.4 promote-inbound tests ----
 
+    /// DIVERGENCE from stellar-core (deliberate, sustained-load fix): core's
+    /// promotion pass re-dials live inbound peers to convert them to
+    /// outbound, protected by the peer-DB dial backoff (minutes) and by
+    /// never replacing an authenticated connection. henyey's promotion
+    /// re-dialed every few seconds and its mutual-dial tie-break could
+    /// REPLACE the healthy connection, producing constant handshake churn
+    /// (2294 reject/drop events per node per mission vs core's 6) and a
+    /// sustained-TPS collapse (~1087 vs core's 1522). Until promotion is
+    /// reintroduced with core-style backoff + reject-newcomer semantics, the
+    /// pre-dial filter (`has_connection_to`, any direction) suppresses
+    /// dialing peers we are already connected to.
     #[tokio::test]
-    async fn test_promote_inbound_dials_inbound_peer_address() {
+    async fn test_promote_inbound_does_not_redial_live_inbound_peer() {
         let factory = Arc::new(RecordingConnectionFactory::default());
         let manager = OverlayManager::new_with_connection_factory(
             OverlayConfig::default(),
@@ -987,11 +998,9 @@ mod tests {
         OverlayManager::promote_inbound_peers(1, &manager.outbound_pool, &shared, &ctx).await;
 
         let dialed = factory.dialed();
-        assert_eq!(dialed.len(), 1, "should dial exactly the one inbound peer");
-        assert_eq!(
-            dialed[0],
-            "10.0.0.5:11625".parse::<SocketAddr>().unwrap(),
-            "should dial the inbound peer's advertised listening address"
+        assert!(
+            dialed.is_empty(),
+            "must NOT re-dial a live inbound peer (was the churn engine); got {dialed:?}"
         );
     }
 

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -949,6 +949,43 @@ impl TxGenerator {
         self.accounts.clear();
     }
 
+    /// [maxtps_ban] Forensic dump of up to `limit` unsynced accounts
+    /// (expected vs on-ledger sequence) when a run fails the completion wait.
+    /// `delta = expected - on_ledger`: `1` means exactly one tx never
+    /// applied; larger deltas mean a chain wedged earlier; `None` on-ledger
+    /// means the account is unloadable.
+    pub fn log_unsynced_sample(&self, limit: usize) {
+        let mut shown = 0usize;
+        let mut total = 0usize;
+        for account in self.accounts.values() {
+            let on_ledger = self
+                .app
+                .load_account_sequence(&account.account_id)
+                .ok()
+                .flatten();
+            if on_ledger == Some(account.sequence_number) {
+                continue;
+            }
+            total += 1;
+            if shown < limit {
+                tracing::warn!(
+                    target: "maxtps_ban",
+                    account = %account.account_id,
+                    expected_seq = account.sequence_number,
+                    on_ledger_seq = ?on_ledger,
+                    delta = on_ledger.map(|s| account.sequence_number - s),
+                    "unsynced account at completion-wait failure"
+                );
+                shown += 1;
+            }
+        }
+        tracing::warn!(
+            target: "maxtps_ban",
+            total_unsynced = total,
+            "completion-wait failure: unsynced account total"
+        );
+    }
+
     /// Build CreateAccount operations for a range of accounts.
     ///
     /// Matches stellar-core `TxGenerator::createAccounts()`.
@@ -2003,6 +2040,14 @@ impl LoadGenerator {
                     // past the real one (a 23-node single-VM run "passed" 2753
                     // tx/s with >90% empty ledgers while core honestly failed at
                     // ~1531). (#3631)
+                    //
+                    // [maxtps_ban] the third (previously silent) run-fatal
+                    // path: submission finished but accounts never synced
+                    // within the ledger budget. Log a forensic sample of the
+                    // unsynced accounts (expected vs on-ledger seq) so the
+                    // sustained-load investigation can see WHERE the
+                    // unapplied txs are stuck.
+                    self.tx_generator.log_unsynced_sample(8);
                     self.failed = true;
                     return;
                 }

--- a/docs/maxtps-optimization/2026-07-02-target2000.md
+++ b/docs/maxtps-optimization/2026-07-02-target2000.md
@@ -173,3 +173,46 @@ a harness change, shared with stellar-core.
 - Baseline → final: TBD
 - PRs: TBD
 - Top remaining pending hypotheses: TBD
+
+## Core-vs-henyey 2×2 + the churn engine (operator-mandated, 2026-07-02 evening)
+
+Operator challenge: "there is no reason for henyey to do worse than core aside
+from a buggy implementation." Measured the full 2×2 on ONE fresh instance,
+identical bands, stellar-core v27.0.0 (pinned BUILD_TESTS image == submodule):
+
+| | burst (1-min) | sustained (5-min) | window gap |
+|---|--:|--:|--:|
+| stellar-core v27 | 1530 | **1522** | −0.5% |
+| henyey (pre-churn-fix) | 1420 | 1087 | −23% |
+| henyey (churn fix) | **1510** | 1106–1150 (searches/single-steps; 1150✓ 1200✗) | ~−25% |
+
+**This REFUTES the earlier "window-dependence is shared with core" claim
+(#3703) and the "tail-latency asymptote is inherent" framing: core sustains
+its full burst ceiling.** The prior sessions asserted core symmetry from code
+reading; measuring it showed otherwise. henyey's sustained deficit is henyey
+bugs.
+
+**Churn engine found & fixed (the day's biggest bug):** after a mutual-dial
+tie-break, the lower-node-id side keeps an INBOUND connection; the pre-dial
+filter only counted OUTBOUND connections, so the tick re-dialed that peer
+every few seconds forever (preferred pass + inbound-promotion pass). Re-dials
+raced the handshake path; the tie-break sometimes REPLACED the healthy
+connection, and the replaced socket idled out (30 s) resetting the remote:
+**2,294 reject/drop/reset events per node per mission vs stellar-core's 6.**
+Fix: `has_connection_to` (any direction) as the pre-dial filter — core parity
+(`getPeersToConnectTo`'s keep-predicate uses `getConnectedPeer`, both maps);
+core's inbound-promotion re-dials are additionally protected by peer-DB dial
+backoff and never-replace semantics that henyey lacks, so promotion-by-dialing
+is suppressed (documented divergence). Post-fix: 55 boot-window events, ZERO
+steady-state. **Burst gap closed: 1420 → 1510 (−1.3% vs core)** — the scattered
+henyey burst numbers all along were churn luck.
+
+**Surviving sustained killer (open):** captured twice at the new edge
+(single-steps: 1150 ✓, 1200 ✗): a queue-level account-pending `TryAgainLater`
+— ONE tx (seq 14/15 of its account, ~95% into the window) pending longer than
+the ~19-21 s account cycle. Loadgen pacing verified steady (no stall-burst);
+pending-age gauges on OTHER nodes show age2=0 — the wedged tx is a genuine
+per-tx inclusion-latency outlier. Next diagnostic (named, not yet run): on the
+failing node at death, dump the colliding account's pending tx state (age,
+in-flood-queue?, which peers hold it) to separate demand-response loss from
+selection exclusion. Note: eliminating this tail is worth +~25% sustained.


### PR DESCRIPTION
## Summary

Follow-up to #3706/#3709, answering the operator challenge: *"there is no reason for henyey to do worse than core aside from a buggy implementation."* Measured the full core-vs-henyey 2×2 on one fresh nsc 32×64 instance, identical bands, stellar-core v27.0.0 (pinned image == henyey's submodule):

| | burst (1-min) | sustained (5-min) |
|---|--:|--:|
| stellar-core v27 | 1530 | **1522** (−0.5% window gap) |
| henyey pre-fix | 1420 | 1087 |
| **henyey with this fix** | **1510** (−1.3% vs core) | 1106–1150 (edge: 1150 ✓ / 1200 ✗) |

**This refutes the #3703-era claim that the probe-window dependence is "shared with core": core sustains its full burst ceiling.** henyey's deficits are henyey bugs.

## The bug (the churn engine)

After a mutual-dial tie-break, the lower-node-id side of a peer pair keeps an **inbound** connection. The pre-dial filter (`has_outbound_connection_to`) only counted **outbound** connections, so the connection tick — both the preferred pass and the inbound-promotion pass — **re-dialed that peer every few seconds, forever**. Each re-dial raced the handshake path; the mutual-dial tie-break then sometimes **replaced the healthy connection**, and the replaced socket idled out (30s) and reset the remote.

Measured on MissionMaxTPSClassic: **2,294 reject/drop/reset overlay events per node per mission vs stellar-core's 6**, producing recurring waves of tx-set fetch exhaustion, `NodeLostSyncException`, multi-second nomination stalls, and wildly variable step outcomes (henyey burst measured 1413–1523 across runs — churn luck).

## The fix

`has_connection_to` now matches **any live connection direction** (parity: core's `getPeersToConnectTo` keep-predicate uses `getConnectedPeer`, which searches both the inbound and outbound maps). Core's inbound→outbound promotion re-dials are additionally protected by the peer-DB dial backoff and never-replace-authenticated semantics that henyey doesn't yet have, so promotion-by-dialing is suppressed as a **documented divergence** (test updated to the new contract with the rationale).

Post-fix: 55 boot-window events, **zero steady-state churn**; burst 1420 → 1510.

## Also included
- Forensic instrumentation for the completion-wait failure path (`log_unsynced_sample`): the surviving sustained-load killer is a single-tx inclusion-latency outlier (~19s+, captured twice as an account-pending `TryAgainLater` at seq 14/15 ~95% into the window) — next diagnostic documented in the run doc.
- Run-doc section with the full 2×2 + methodology.

## Tests
henyey-overlay 479, henyey-simulation 108 green (plus full-workspace gates on the predecessor branches today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Hj1rEJT613ZxV5avQiLUj
