### PR TITLE
Skip LedgerCloseMeta persistence on validators without JSON-RPC

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2513,10 +2513,21 @@ impl App {
             &result.tx_results,
             tx_metas.as_deref(),
         );
-        let meta_xdr = result
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.to_xdr(stellar_xdr::Limits::none()).ok());
+        // The full LedgerCloseMeta XDR blob serves only the JSON-RPC
+        // getLedgers path (`ledger_close_meta` table). Skip both the
+        // serialization (multi-MB per ledger on the event loop under load)
+        // and the SQLite write when this node stores no RPC data — it is the
+        // single largest write stream at high tx rates (~70% of DB bytes,
+        // 2026-07-03 frontier run), and without an RPC retention window the
+        // table is never pruned.
+        let meta_xdr = if self.config.store_rpc_data() {
+            result
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.to_xdr(stellar_xdr::Limits::none()).ok())
+        } else {
+            None
+        };
 
         // Build (envelope, seq_num) pairs for all txs (applied + failed) so
         // sequence-based removal drops superseded queued txs for the same account.

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -909,13 +909,15 @@ pub struct DatabaseConfig {
     #[serde(skip)]
     pub in_memory: bool,
 
-    /// Whether to store per-transaction RPC-serving rows in SQLite: the
-    /// `transactions` table (per-tx body/result/meta XDR) and the `events`
-    /// table (contract events). These tables serve only the JSON-RPC
-    /// endpoints (`getTransaction`, `getTransactions`, `getEvents`); ledger
-    /// close, history publish, and catchup never read them (publish reads the
-    /// whole-ledger `tx_history_entry`/`tx_result_entry` blobs, which are
-    /// always written).
+    /// Whether to store RPC-serving data in SQLite: the `transactions` table
+    /// (per-tx body/result/meta XDR), the `events` table (contract events),
+    /// and the `ledger_close_meta` table (full LedgerCloseMeta XDR per
+    /// ledger — the single largest write stream under load). These tables
+    /// serve only the JSON-RPC endpoints (`getTransaction`,
+    /// `getTransactions`, `getEvents`, `getLedgers`); ledger close, history
+    /// publish, and catchup never read them (publish reads the whole-ledger
+    /// `tx_history_entry`/`tx_result_entry` blobs, which are always
+    /// written).
     ///
     /// Default (unset): automatic — disabled on validators that do not serve
     /// JSON-RPC (`node.is_validator = true` and `rpc.enabled = false`),


### PR DESCRIPTION
## What

Follow-up to #3714. Extends the `database.store_rpc_data` gate to the `ledger_close_meta` table: the full `LedgerCloseMeta` XDR blob per ledger, which serves only the JSON-RPC `getLedgers` path. When the node stores no RPC data, both the XDR serialization (multi-MB per ledger, on the event loop) and the SQLite write are skipped.

## Why

Under MaxTPS load (~1480 tx/s) this table was **70% of all DB bytes** — 409 MB of a 589 MB database after ~11 minutes (~4.5 MB/ledger). Worse, the maintainer only prunes `ledger_close_meta` when an RPC retention window is configured, so on a validator without RPC the table **grows without bound** — a disk leak independent of any benchmark.

Same-instance A/B (MissionMaxTPSClassic, 23-node tier-1, nsc 32×64): VM-wide disk writes dropped from ~150 MB/s to ~55 MB/s at comparable rates (stellar-core reference on the same instance: ~40 MB/s). Sustained TPS edge unchanged (~1472; the remaining binder is tx inclusion-tail dynamics, tracked separately) — this PR is a persistence-footprint/robustness fix, not a claimed TPS win.

## Tests

- Config resolution covered by the #3714 test suite (same flag).
- Persist path with `meta_xdr = None` covered by existing persist tests.
- `cargo test -p henyey-app --lib store_rpc` green; clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzuKRiPrevW9qizRBw3oK7