### PR TITLE
Fix tx-pull stranding under sustained load: discard owned/banned demands (core parity) + defer full-channel demand responses

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -790,6 +790,10 @@ pub struct App {
 
     /// Per-peer advert tracking and queues for demand scheduling.
     tx_adverts_by_peer: RwLock<HashMap<henyey_overlay::PeerId, PeerTxAdverts>>,
+    /// Per-peer demand responses deferred because the peer's outbound channel
+    /// was full. Drained each flood tick; stellar-core parity: core queues
+    /// demand responses in its per-peer write queue and never drops them.
+    tx_deferred_demand_responses: RwLock<HashMap<henyey_overlay::PeerId, VecDeque<Hash256>>>,
     /// Demand history for transaction pulls.
     tx_demand_history: RwLock<HashMap<Hash256, TxDemandHistory>>,
     /// Pending demand hashes in FIFO order for retention.
@@ -1565,6 +1569,7 @@ impl App {
             broadcast_op_carryover: AtomicUsize::new(0),
             broadcast_dex_op_carryover: AtomicUsize::new(0),
             tx_adverts_by_peer: RwLock::new(HashMap::new()),
+            tx_deferred_demand_responses: RwLock::new(HashMap::new()),
             tx_demand_history: RwLock::new(HashMap::new()),
             tx_pending_demands: RwLock::new(VecDeque::new()),
             tx_set_dont_have: RwLock::new(HashMap::new()),

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -360,6 +360,58 @@ impl App {
                 }
             }
         }
+
+        self.log_stranded_tx_diag(&peer_ids).await;
+    }
+
+    /// Diagnostic (maxtps_tail): log the flood state of the oldest queued
+    /// transactions. A queued tx older than ~2 ledgers means the flood path
+    /// failed to deliver it to the rotating leaders — `sent_to` splits
+    /// "origin never adverted it" (0) from "adverted everywhere but the
+    /// demand/response side lost it" (== peers). Rate-limited to one scan
+    /// per 2 s; instrumentation only.
+    async fn log_stranded_tx_diag(&self, peer_ids: &[henyey_overlay::PeerId]) {
+        use std::sync::atomic::AtomicU64;
+        use std::sync::OnceLock;
+        static EPOCH: OnceLock<std::time::Instant> = OnceLock::new();
+        static LAST_MS: AtomicU64 = AtomicU64::new(0);
+        let epoch = *EPOCH.get_or_init(std::time::Instant::now);
+        let now_ms = epoch.elapsed().as_millis() as u64;
+        let last = LAST_MS.load(Ordering::Relaxed);
+        if now_ms.saturating_sub(last) < 2_000
+            || LAST_MS
+                .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+                .is_err()
+        {
+            return;
+        }
+
+        let aged = self
+            .herder
+            .tx_queue()
+            .sample_aged_txs(Duration::from_secs(8), 3);
+        if aged.is_empty() {
+            return;
+        }
+        let adverts_by_peer = self.tx_adverts_by_peer.read().await;
+        for (hash, age_ms) in aged {
+            let sent_to = peer_ids
+                .iter()
+                .filter(|pid| {
+                    adverts_by_peer
+                        .get(*pid)
+                        .is_some_and(|a| a.seen_advert(&hash))
+                })
+                .count();
+            tracing::info!(
+                target: "maxtps_tail",
+                hash8 = %&hash.to_hex()[..16],
+                age_ms,
+                sent_to,
+                peers = peer_ids.len(),
+                "stranded queued tx"
+            );
+        }
     }
 
     /// Store carry-over budgets (capped) for the next flood period.
@@ -692,7 +744,20 @@ impl App {
         let entry = adverts_by_peer
             .entry(peer_id.clone())
             .or_insert_with(PeerTxAdverts::new);
-        entry.queue_incoming(&advert.tx_hashes.0, ledger_seq, max_ops);
+        let dropped = entry.queue_incoming(&advert.tx_hashes.0, ledger_seq, max_ops);
+        if dropped > 0 {
+            // A dropped pending demand is remembered-but-never-demanded: this
+            // peer will not re-advert it, so the tx is stranded on this node
+            // until another peer adverts it or advert history expires.
+            tracing::info!(
+                target: "maxtps_tail",
+                peer = %peer_id,
+                dropped,
+                batch = advert.tx_hashes.0.len(),
+                max_ops,
+                "advert demand-queue overflow"
+            );
+        }
     }
 
     pub(super) async fn handle_flood_demand(

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -231,6 +231,11 @@ impl App {
     const MAX_CARRYOVER_OPS: usize = 101; // MAX_OPS_PER_TX (100) + 1
 
     pub(super) async fn flush_tx_adverts(&self) {
+        // Retry demand responses that couldn't be sent (channel full) first —
+        // peers are already waiting on these, and their re-demand backoff
+        // penalizes us if they stay undelivered.
+        self.flush_deferred_demand_responses().await;
+
         let ops_budget = self.compute_flood_ops_budget();
         let dex_ops_budget = self.compute_dex_flood_ops_budget();
 
@@ -775,25 +780,41 @@ impl App {
         };
 
         // Use non-blocking try_send_to to avoid stalling the event loop
-        // when the peer's outbound channel is full.  The peer will re-request
-        // any transactions it still needs.
+        // when the peer's outbound channel is full. Undeliverable responses
+        // are NOT dropped: they are deferred to `tx_deferred_demand_responses`
+        // and drained on subsequent flood ticks. stellar-core queues demand
+        // responses in its per-peer write queue and never drops them; the old
+        // drop-rest-of-batch-on-full behavior stranded txs for 2+ ledgers
+        // (demander retries burn its per-period demand budget), wedging
+        // accounts under sustained load (maxtps_tail forensics, 2026-07-03).
         //
         // Match stellar-core: only send Transaction messages for found hashes.
         // Do NOT send DontHave for unfulfilled demands — stellar-core just
         // logs/meters misses without any outbound response.
         let mut sent = 0u32;
-        let mut dropped = 0u32;
+        let mut deferred = 0u32;
         let mut banned = 0u32;
         let mut unknown = 0u32;
+        let mut channel_full = false;
+        let mut to_defer: Vec<Hash256> = Vec::new();
         for hash in demand.tx_hashes.0.iter() {
             let hash256 = Hash256::from(hash.clone());
+            if channel_full {
+                if self.herder.tx_queue().get(&hash256).is_some() {
+                    to_defer.push(hash256);
+                    deferred += 1;
+                }
+                continue;
+            }
             if let Some(tx) = self.herder.tx_queue().get(&hash256) {
                 match overlay.try_send_to(peer_id, StellarMessage::Transaction(tx.into_envelope()))
                 {
                     Ok(()) => sent += 1,
                     Err(_) => {
-                        dropped += 1;
-                        break; // Channel full — stop sending to this peer
+                        // Channel full — defer this and the rest of the batch.
+                        channel_full = true;
+                        to_defer.push(hash256);
+                        deferred += 1;
                     }
                 }
             } else if self.herder.tx_queue().is_banned(&hash256) {
@@ -802,15 +823,24 @@ impl App {
                 unknown += 1;
             }
         }
-        if sent > 0 || dropped > 0 || banned > 0 || unknown > 0 {
+        if !to_defer.is_empty() {
+            const MAX_DEFERRED_PER_PEER: usize = 4_000;
+            let mut deferred_map = self.tx_deferred_demand_responses.write().await;
+            let queue = deferred_map.entry(peer_id.clone()).or_default();
+            queue.extend(to_defer);
+            while queue.len() > MAX_DEFERRED_PER_PEER {
+                queue.pop_front();
+            }
+        }
+        if sent > 0 || deferred > 0 || banned > 0 || unknown > 0 {
             // [maxtps_diag] Fulfiller-side demand outcome counters — pinpoint why
             // demands go unfulfilled (driving the demander's re-demand /
             // demand-timeout). `unknown` = hash not in our queue when demanded
-            // (advert/include race); `dropped` = peer outbound channel full.
+            // (advert/include race); `deferred` = peer outbound channel full,
+            // response queued for the next flood tick.
             // stellar-core fulfils ~100% (overlay.flood.unfulfilled-*=0).
             metrics::counter!("stellar_overlay_demand_fulfilled_total").increment(sent as u64);
-            metrics::counter!("stellar_overlay_demand_unfulfilled_dropped_total")
-                .increment(dropped as u64);
+            metrics::counter!("stellar_overlay_demand_deferred_total").increment(deferred as u64);
             metrics::counter!("stellar_overlay_demand_unfulfilled_banned_total")
                 .increment(banned as u64);
             metrics::counter!("stellar_overlay_demand_unfulfilled_unknown_total")
@@ -818,12 +848,56 @@ impl App {
             tracing::debug!(
                 peer = %peer_id,
                 sent,
-                dropped,
+                deferred,
                 banned,
                 unknown,
                 total = demand.tx_hashes.0.len(),
                 "Flood demand served"
             );
+        }
+    }
+
+    /// Drain deferred demand responses (peer outbound channel was full when
+    /// the demand arrived). Called each flood tick. Hashes whose tx has left
+    /// the queue (applied or banned) are skipped — the demander's own retry
+    /// logic covers them. Stops per peer as soon as the channel is full
+    /// again; disconnected peers' queues are dropped.
+    pub(super) async fn flush_deferred_demand_responses(&self) {
+        let Some(overlay) = self.overlay().await else {
+            return;
+        };
+        let mut deferred_map = self.tx_deferred_demand_responses.write().await;
+        if deferred_map.is_empty() {
+            return;
+        }
+        let connected: HashSet<henyey_overlay::PeerId> = overlay
+            .peer_snapshots()
+            .iter()
+            .map(|s| s.info.peer_id.clone())
+            .collect();
+        deferred_map.retain(|peer, _| connected.contains(peer));
+
+        let mut sent_total = 0u32;
+        for (peer_id, queue) in deferred_map.iter_mut() {
+            while let Some(hash) = queue.front().copied() {
+                let Some(tx) = self.herder.tx_queue().get(&hash) else {
+                    queue.pop_front();
+                    continue;
+                };
+                match overlay.try_send_to(peer_id, StellarMessage::Transaction(tx.into_envelope()))
+                {
+                    Ok(()) => {
+                        queue.pop_front();
+                        sent_total += 1;
+                    }
+                    Err(_) => break, // still full — try next tick
+                }
+            }
+        }
+        deferred_map.retain(|_, queue| !queue.is_empty());
+        if sent_total > 0 {
+            metrics::counter!("stellar_overlay_demand_deferred_flushed_total")
+                .increment(sent_total as u64);
         }
     }
 
@@ -2484,5 +2558,103 @@ mod tests {
                  instead of tracking_consensus_ledger_index (5)."
             );
         }
+    }
+
+    /// Regression test (maxtps iter 9): demand responses that hit a full
+    /// outbound channel must be DEFERRED and delivered on the next flood
+    /// tick, not dropped. The old drop-rest-of-batch behavior stranded txs
+    /// for 2+ ledgers under sustained load (the demander's retry backoff
+    /// burned its per-period demand budget), wedging accounts.
+    #[tokio::test]
+    async fn test_handle_flood_demand_defers_on_full_channel_and_flushes() {
+        let (_dir, app) = create_test_app_with_overlay().await;
+        let overlay = app.overlay().await.unwrap();
+
+        // Channel capacity 1: only the first response fits.
+        let peer_id = make_peer_id(43);
+        let mut receiver = overlay.inject_test_peer(peer_id.clone(), 1);
+
+        let mut hashes = Vec::new();
+        for i in 1..=3u8 {
+            let mut env = make_envelope(100 * i as u32, 1);
+            set_source(&mut env, i);
+            let hash = Hash256::hash_xdr(&env);
+            assert!(app.herder.tx_queue().insert_for_test(env));
+            hashes.push(hash);
+        }
+
+        let demand = FloodDemand {
+            tx_hashes: TxDemandVector(
+                hashes
+                    .iter()
+                    .map(|h| Hash(*h.as_bytes()))
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap(),
+            ),
+        };
+        app.handle_flood_demand(&peer_id, demand).await;
+
+        // Exactly one Transaction fit the channel.
+        assert!(matches!(
+            receiver.try_recv().expect("first response"),
+            StellarMessage::Transaction(_)
+        ));
+        assert!(receiver.try_recv().is_none(), "channel had capacity 1");
+
+        // The remaining two must be deferred, not dropped.
+        {
+            let deferred = app.tx_deferred_demand_responses.read().await;
+            assert_eq!(
+                deferred.get(&peer_id).map(|q| q.len()),
+                Some(2),
+                "undeliverable responses must be deferred"
+            );
+        }
+
+        // Drain the channel, then flush: both remaining txs must arrive.
+        app.flush_deferred_demand_responses().await;
+        assert!(matches!(
+            receiver.try_recv().expect("second response after flush"),
+            StellarMessage::Transaction(_)
+        ));
+        // Capacity 1: the third needs one more flush after the channel drains.
+        app.flush_deferred_demand_responses().await;
+        assert!(matches!(
+            receiver.try_recv().expect("third response after flush"),
+            StellarMessage::Transaction(_)
+        ));
+        let deferred = app.tx_deferred_demand_responses.read().await;
+        assert!(
+            deferred.is_empty(),
+            "deferred map must be empty after full drain"
+        );
+    }
+
+    /// Deferred responses whose tx has left the queue (applied/banned) are
+    /// skipped at flush time rather than sent.
+    #[tokio::test]
+    async fn test_flush_deferred_skips_txs_gone_from_queue() {
+        let (_dir, app) = create_test_app_with_overlay().await;
+        let overlay = app.overlay().await.unwrap();
+        let peer_id = make_peer_id(44);
+        let mut receiver = overlay.inject_test_peer(peer_id.clone(), 16);
+
+        // A hash that is not (or no longer) in the queue.
+        let gone = Hash256::from_bytes([0xBB; 32]);
+        app.tx_deferred_demand_responses
+            .write()
+            .await
+            .entry(peer_id.clone())
+            .or_default()
+            .push_back(gone);
+
+        app.flush_deferred_demand_responses().await;
+
+        assert!(receiver.try_recv().is_none(), "nothing must be sent");
+        assert!(
+            app.tx_deferred_demand_responses.read().await.is_empty(),
+            "stale entries must be pruned"
+        );
     }
 }

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -558,6 +558,18 @@ impl App {
     ) -> DemandStatus {
         const MAX_RETRY_COUNT: usize = 15;
 
+        // stellar-core parity (TxDemandsManager::demandStatus:71-74): never
+        // demand a tx we already have queued or banned. Without this check a
+        // fulfilled hash keeps cycling as RetryLater through every other
+        // peer's advert/retry queue until the 60 s retention prune — at
+        // ~1500 tx/s that permanently saturates the per-peer demand queues
+        // (observed full at max_ops with 100-240 drops per advert batch),
+        // starving demands for genuinely-new txs and stranding accounts
+        // (maxtps_tail forensics, 2026-07-03).
+        if self.herder.tx_queue().contains(&hash) || self.herder.tx_queue().is_banned(&hash) {
+            return DemandStatus::Discard;
+        }
+
         if self.herder.tx_queue().contains(&hash) {
             return DemandStatus::Discard;
         }
@@ -2656,5 +2668,47 @@ mod tests {
             app.tx_deferred_demand_responses.read().await.is_empty(),
             "stale entries must be pruned"
         );
+    }
+
+    /// stellar-core parity (TxDemandsManager::demandStatus:71-74): a tx we
+    /// already have queued — or have banned — must never be demanded.
+    /// Regression: without this, fulfilled hashes cycled as RetryLater
+    /// through every peer's queue for the 60 s retention window, saturating
+    /// the demand queues under load.
+    #[tokio::test]
+    async fn test_demand_status_discards_owned_and_banned_txs() {
+        use std::collections::HashMap;
+        let (_dir, app) = create_test_app_with_overlay().await;
+        let peer = make_peer_id(45);
+        let history: HashMap<Hash256, TxDemandHistory> = HashMap::new();
+        let now = std::time::Instant::now();
+
+        // Owned: in the tx queue.
+        let mut env = make_envelope(100, 1);
+        set_source(&mut env, 7);
+        let owned_hash = Hash256::hash_xdr(&env);
+        assert!(app.herder.tx_queue().insert_for_test(env));
+        assert!(matches!(
+            app.demand_status(owned_hash, &peer, now, &history),
+            DemandStatus::Discard
+        ));
+
+        // Banned.
+        let mut env_b = make_envelope(200, 1);
+        set_source(&mut env_b, 8);
+        let banned_hash = Hash256::hash_xdr(&env_b);
+        assert!(app.herder.tx_queue().insert_for_test(env_b));
+        app.herder.tx_queue().ban(&[banned_hash]);
+        assert!(matches!(
+            app.demand_status(banned_hash, &peer, now, &history),
+            DemandStatus::Discard
+        ));
+
+        // Unknown: still demanded.
+        let unknown = Hash256::from_bytes([0xCC; 32]);
+        assert!(matches!(
+            app.demand_status(unknown, &peer, now, &history),
+            DemandStatus::Demand
+        ));
     }
 }

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -849,20 +849,31 @@ impl PeerTxAdverts {
         self.history.remember(hash, ledger_seq);
     }
 
-    pub fn queue_incoming(&mut self, hashes: &[Hash], ledger_seq: u32, max_ops: usize) {
+    /// Queue an incoming advert batch for demanding.
+    ///
+    /// Returns the number of hashes DROPPED from the pending-demand queue
+    /// (either truncated from an oversized batch or evicted as oldest when
+    /// the queue exceeds `max_ops`). Dropped hashes are still `remember`ed,
+    /// so this peer will not re-advert them — a dropped demand is only
+    /// recovered by another peer's advert or the sender's advert-history
+    /// expiry (maxtps_tail diagnostic).
+    pub fn queue_incoming(&mut self, hashes: &[Hash], ledger_seq: u32, max_ops: usize) -> usize {
         for hash in hashes {
             let hash256 = Hash256(hash.0);
             self.remember(hash256, ledger_seq);
         }
 
         let start = hashes.len().saturating_sub(max_ops);
+        let mut dropped = start;
         for hash in hashes.iter().skip(start) {
             self.incoming.push_back(Hash256(hash.0));
         }
 
         while self.size() > max_ops {
             self.pop_advert();
+            dropped += 1;
         }
+        dropped
     }
 
     pub fn retry_incoming(&mut self, hashes: Vec<Hash256>, max_ops: usize) {

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -2748,6 +2748,27 @@ impl TransactionQueue {
         self.store.read().len()
     }
 
+    /// Sample the oldest queued transactions at least `min_age` old.
+    ///
+    /// Returns `(hash, age_ms)` pairs, oldest first, capped at `cap`.
+    /// Diagnostic helper for stranded-tx attribution (maxtps_tail): a queued
+    /// tx older than a couple of ledgers indicates the flood path failed to
+    /// deliver it to the rotating leaders.
+    pub fn sample_aged_txs(&self, min_age: std::time::Duration, cap: usize) -> Vec<(Hash256, u64)> {
+        let store = self.store.read();
+        let now = Instant::now();
+        let mut aged: Vec<(Hash256, u64)> = store
+            .values()
+            .filter_map(|tx| {
+                let age = now.saturating_duration_since(tx.received_at());
+                (age >= min_age).then(|| (tx.hash(), age.as_millis() as u64))
+            })
+            .collect();
+        aged.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+        aged.truncate(cap);
+        aged
+    }
+
     /// Check if the queue is empty.
     pub fn is_empty(&self) -> bool {
         self.store.read().is_empty()


### PR DESCRIPTION
## What

Three commits fixing the transaction pull (advert/demand/response) path that was wedging accounts under sustained MaxTPS load:

1. **maxtps_tail diagnostics** (instrumentation): origin-side stranded-tx advert coverage + receiver-side advert demand-queue overflow logging.
2. **Defer demand responses on full peer channels**: `handle_flood_demand` dropped the rest of a demanded batch when a peer's outbound channel was full; the demander's retry backoff then burned its per-period demand budget. stellar-core queues demand responses in its per-peer write queue and never drops them. Undeliverable responses now go to a per-peer deferred queue (cap 4000, drop-oldest) drained each flood tick.
3. **Discard demands for txs already queued or banned** — a straight stellar-core parity gap: `TxDemandsManager::demandStatus` (TxDemandsManager.cpp:71-74) discards demands for txs it already has; henyey's `demand_status` was missing the check, so every fulfilled hash kept cycling as RetryLater through the other ~21 peers' advert/retry queues for the 60 s retention window.

## Why it wedged

At ~1500 tx/s the redundant retries permanently saturated the per-peer demand queues (observed full at max_ops=14790 with 100-240 hashes dropped per 200 ms advert batch). New txs waited 2+ ledgers to be demanded anywhere; with the one-tx-per-account queue rule, the wedged account's next submission got TryAgainLater and PayPregenerated load runs insta-failed.

## Measurements (MissionMaxTPSClassic, 23-node tier-1, nsc 32×64, same-instance A/B)

- Sustained edge: **1472 → 1516 tx/s (+3.0%)**; stellar-core reference on the same instance: 1526 (gap now 0.7%).
- Advert demand-queue overflow events during a 5-min sustained step: **1227 → 0**.
- The pre-fix death mode (fatal reject at pending_age=2-3 on a stranded account) no longer reproduces below the new edge.

## Tests

- `test_demand_status_discards_owned_and_banned_txs` (core-parity check)
- `test_handle_flood_demand_defers_on_full_channel_and_flushes` (capacity-1 channel: 1 sent, 2 deferred, both delivered across flushes)
- `test_flush_deferred_skips_txs_gone_from_queue`
- Full henyey-app lib suite green; clippy green.

Run doc: `docs/maxtps-optimization/2026-07-03-frontier.md` (campaign branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzuKRiPrevW9qizRBw3oK7