### PR TITLE
Heal sole-advertiser tx strands: same-peer re-demand after expiry + tail diagnostics

### DIFF
--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -395,27 +395,57 @@ impl App {
             .herder
             .tx_queue()
             .sample_aged_txs(Duration::from_secs(8), 3);
-        if aged.is_empty() {
-            return;
+        if !aged.is_empty() {
+            let adverts_by_peer = self.tx_adverts_by_peer.read().await;
+            for (hash, age_ms) in aged {
+                let sent_to = peer_ids
+                    .iter()
+                    .filter(|pid| {
+                        adverts_by_peer
+                            .get(*pid)
+                            .is_some_and(|a| a.seen_advert(&hash))
+                    })
+                    .count();
+                tracing::info!(
+                    target: "maxtps_tail",
+                    hash8 = %&hash.to_hex()[..16],
+                    age_ms,
+                    sent_to,
+                    peers = peer_ids.len(),
+                    "stranded queued tx"
+                );
+            }
         }
-        let adverts_by_peer = self.tx_adverts_by_peer.read().await;
-        for (hash, age_ms) in aged {
-            let sent_to = peer_ids
-                .iter()
-                .filter(|pid| {
-                    adverts_by_peer
-                        .get(*pid)
-                        .is_some_and(|a| a.seen_advert(&hash))
-                })
-                .count();
-            tracing::info!(
-                target: "maxtps_tail",
-                hash8 = %&hash.to_hex()[..16],
-                age_ms,
-                sent_to,
-                peers = peer_ids.len(),
-                "stranded queued tx"
-            );
+
+        // Demander-side companion: demands we issued that stayed unfulfilled
+        // for 5+ s. `peers_demanded` = how many peers we demanded from and
+        // got no usable response; a hash stranded on its origin but ABSENT
+        // from every other node's unfulfilled list was never demanded at all
+        // (advert admission problem, not response loss).
+        {
+            let now = self.clock.now();
+            let history = self.tx_demand_history.read().await;
+            let mut logged = 0;
+            for (hash, entry) in history.iter() {
+                if entry.latency_recorded {
+                    continue;
+                }
+                let age = now.saturating_duration_since(entry.first_demanded);
+                if age < Duration::from_secs(5) {
+                    continue;
+                }
+                tracing::info!(
+                    target: "maxtps_tail",
+                    hash8 = %&hash.to_hex()[..16],
+                    age_ms = age.as_millis() as u64,
+                    peers_demanded = entry.peers.len(),
+                    "unfulfilled demand"
+                );
+                logged += 1;
+                if logged >= 3 {
+                    break;
+                }
+            }
         }
     }
 

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -608,8 +608,23 @@ impl App {
             return DemandStatus::Demand;
         };
 
-        if entry.peers.contains_key(peer) {
-            return DemandStatus::Discard;
+        if let Some(demanded_at) = entry.peers.get(peer) {
+            // stellar-core never re-demands from the same peer — safe there
+            // because its demand responses are never lost. Henyey divergence
+            // (overlay-internal, wire-compatible): when a tx has a SOLE
+            // advertiser (warmup, or an account's first tx), a single lost
+            // response permanently strands it under core's rule — no other
+            // peer will ever advert it. Allow re-demanding from the same
+            // peer after a generous expiry so sole-holder strands self-heal
+            // within ~2 s instead of wedging the account (2026-07-03
+            // maxtps_tail forensics: unfulfilled demands stuck at
+            // peers_demanded=1 for 14+ s).
+            const SAME_PEER_REDEMAND_DELAY: Duration = Duration::from_millis(2_000);
+            if now.duration_since(*demanded_at) < SAME_PEER_REDEMAND_DELAY {
+                return DemandStatus::Discard;
+            }
+            // Fall through: eligible for re-demand from this peer; the
+            // retry-count and backoff checks below still apply.
         }
 
         let num_demanded = entry.peers.len();
@@ -2738,6 +2753,45 @@ mod tests {
         let unknown = Hash256::from_bytes([0xCC; 32]);
         assert!(matches!(
             app.demand_status(unknown, &peer, now, &history),
+            DemandStatus::Demand
+        ));
+    }
+
+    /// Sole-advertiser strand self-heal: after SAME_PEER_REDEMAND_DELAY, a
+    /// hash may be re-demanded from a peer we already demanded from (henyey
+    /// divergence from stellar-core, which never re-demands per peer — safe
+    /// only when responses are never lost).
+    #[tokio::test]
+    async fn test_demand_status_allows_same_peer_redemand_after_expiry() {
+        use std::collections::HashMap;
+        use std::time::{Duration, Instant};
+        let (_dir, app) = create_test_app_with_overlay().await;
+        let peer = make_peer_id(46);
+        let hash = Hash256::from_bytes([0xDD; 32]);
+        let now = Instant::now();
+
+        let mut history: HashMap<Hash256, TxDemandHistory> = HashMap::new();
+        let demanded_at = now - Duration::from_millis(500);
+        history.insert(
+            hash,
+            TxDemandHistory {
+                first_demanded: demanded_at,
+                last_demanded: demanded_at,
+                peers: [(peer.clone(), demanded_at)].into_iter().collect(),
+                latency_recorded: false,
+            },
+        );
+
+        // Within the expiry window: still discarded.
+        assert!(matches!(
+            app.demand_status(hash, &peer, now, &history),
+            DemandStatus::Discard
+        ));
+
+        // Past the expiry window (and past the retry backoff): re-demand.
+        let late = now + Duration::from_millis(2_500);
+        assert!(matches!(
+            app.demand_status(hash, &peer, late, &history),
             DemandStatus::Demand
         ));
     }

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -2986,6 +2986,21 @@ impl TransactionQueue {
                     if queued_tx.sequence_number() <= *applied_seq {
                         // Remove from store
                         let removed_hash = queued_tx.hash;
+                        // [maxtps_tail] interleaving diagnostic: a drop where
+                        // the queued hash differs from the applied hash means
+                        // a same-account duplicate raced (loadgen rebuild or
+                        // flood echo) — cap the log to the first few per call.
+                        let applied_hash = Hash256::hash_xdr(envelope);
+                        if removed_hash != applied_hash && removed_hashes.len() < 3 {
+                            tracing::info!(
+                                target: "maxtps_tail",
+                                queued_hash8 = %&removed_hash.to_hex()[..16],
+                                applied_hash8 = %&applied_hash.to_hex()[..16],
+                                queued_seq = queued_tx.sequence_number(),
+                                applied_seq = *applied_seq,
+                                "remove_applied dropped superseded duplicate"
+                            );
+                        }
                         store.remove(&removed_hash, ledger_version);
                         removed_hashes.push(removed_hash);
 

--- a/crates/simulation/src/loadgen.rs
+++ b/crates/simulation/src/loadgen.rs
@@ -2324,7 +2324,25 @@ impl LoadGenerator {
             // consumed, for the fatal-reject diagnostic below.
             let diag_seq = envelope_seq_num(&envelope);
             let diag_account = envelope_source_account_id(&envelope);
+            // [maxtps_tail] account-0 submit timeline: the recurring run-fatal
+            // wedge is always this account; log every submission (hash, seq)
+            // so the failing interleaving (admission vs close vs removal) is
+            // reconstructable from one run.
+            let diag_hash = if source_account_id == 0 {
+                Some(henyey_common::Hash256::hash_xdr(&envelope))
+            } else {
+                None
+            };
             let result = self.tx_generator.app.submit_transaction(envelope).await;
+            if let Some(hash) = diag_hash {
+                tracing::info!(
+                    target: "maxtps_tail",
+                    hash8 = %&hash.to_hex()[..16],
+                    tx_seq = ?diag_seq,
+                    result = ?result,
+                    "account0 submit"
+                );
+            }
 
             // PayPregenerated does not re-submit on failure: each tx is read
             // once from the file, so a retry would consume the *next* tx


### PR DESCRIPTION
## What

Follow-up to #3717 (three commits):

1. **Demander-side unfulfilled-demand diagnostics** (maxtps_tail): log demand-history entries unfulfilled for 5+ s with their per-peer demand count.
2. **Account-0 submit timeline + remove_applied duplicate-drop diagnostics**: reconstructable interleaving of admission vs close vs removal for the recurring load-run wedge.
3. **Same-peer re-demand after expiry**: `demand_status` permanently discarded a peer after one demand (stellar-core parity). That is safe in core because its demand responses are never lost; in henyey a tx with a **sole advertiser** (network warmup, an account's first tx) wedged its account permanently when the single demand went unfulfilled — no other peer ever adverts the hash, and the per-peer discard blocked the only retry path (observed: unfulfilled demands stuck at `peers_demanded=1` for 14+ s; the stranded tx applied ~2 ledgers late; the account's next submission fatal-rejected the load run). Wire-compatible overlay-internal divergence: allow re-demanding from an already-demanded peer after 2 s, still subject to the existing retry-count cap and backoff.

## Measurements (MissionMaxTPSClassic, 23-node tier-1, nsc 32×64, same instance)

- Sustained 1560 tx/s re-verified green on this stack (campaign best; core reference on the same instance: 1526).
- 1600 tx/s still fails its warmup lottery — the residual compound (sole-holder strand + pipelined post-close queue-cleanup race) is documented in `docs/maxtps-optimization/2026-07-03-frontier.md` with full forensics; follow-up issue filed separately.

## Tests

- `test_demand_status_allows_same_peer_redemand_after_expiry` (new)
- `test_demand_status_discards_owned_and_banned_txs`, deferred-response tests still green; full workspace suite green; clippy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzuKRiPrevW9qizRBw3oK7