### PR TITLE
Fix #3719: self-heal stale pending txs at submission + undo failed demand-send bookkeeping

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -794,6 +794,11 @@ pub struct App {
     /// was full. Drained each flood tick; stellar-core parity: core queues
     /// demand responses in its per-peer write queue and never drops them.
     tx_deferred_demand_responses: RwLock<HashMap<henyey_overlay::PeerId, VecDeque<Hash256>>>,
+    /// Watched stranded-tx hashes (#3719 part-1 wire tracing): populated by
+    /// the tail scanner for txs aged 8+ s in the local queue; the flood
+    /// demand/response paths log every event touching a watched hash.
+    /// Diagnostic only; bounded (see TAIL_WATCH_CAP).
+    tail_watch: RwLock<HashSet<Hash256>>,
     /// Demand history for transaction pulls.
     tx_demand_history: RwLock<HashMap<Hash256, TxDemandHistory>>,
     /// Pending demand hashes in FIFO order for retention.
@@ -1570,6 +1575,7 @@ impl App {
             broadcast_dex_op_carryover: AtomicUsize::new(0),
             tx_adverts_by_peer: RwLock::new(HashMap::new()),
             tx_deferred_demand_responses: RwLock::new(HashMap::new()),
+            tail_watch: RwLock::new(HashSet::new()),
             tx_demand_history: RwLock::new(HashMap::new()),
             tx_pending_demands: RwLock::new(VecDeque::new()),
             tx_set_dont_have: RwLock::new(HashMap::new()),

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -2736,6 +2736,39 @@ impl App {
         }
 
         let result = self.herder.receive_transaction(tx.clone());
+
+        // Stale-pending self-heal (#3719). Ledger state (account seq)
+        // advances at apply, but the queue's remove_applied/shift run in a
+        // later spawn_blocking — a submission landing in that window sees a
+        // pending entry whose sequence the ledger just consumed and gets
+        // TryAgainLater. stellar-core cannot observe this state (its queue
+        // cleanup is synchronous with close), and PayPregenerated load runs
+        // treat any reject as fatal (#3638 parity), so the transient window
+        // was run-fatal under sustained load. If the reject was caused by a
+        // pending tx whose seq is already consumed on-ledger, drop the stale
+        // entry and re-admit once.
+        if matches!(result, henyey_herder::TxQueueResult::TryAgainLater) {
+            let network_id =
+                henyey_common::NetworkId::from_passphrase(&self.config.network.passphrase);
+            let frame =
+                henyey_tx::TransactionFrame::from_owned_with_network(tx.clone(), network_id);
+            let account_id = frame.inner_source_account_id();
+            if let Some((_, pending_seq, _)) =
+                self.herder.tx_queue().account_pending_info(&account_id)
+            {
+                if let Ok(Some(on_ledger_seq)) = self.load_account_sequence(&account_id) {
+                    if pending_seq <= on_ledger_seq
+                        && self
+                            .herder
+                            .tx_queue()
+                            .drop_stale_pending(&account_id, on_ledger_seq)
+                    {
+                        return self.herder.receive_transaction(tx);
+                    }
+                }
+            }
+        }
+
         // No explicit advert enqueue needed — flush_tx_adverts() reads
         // the herder's queue in priority order each flood period.
         result

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -396,8 +396,15 @@ impl App {
             .tx_queue()
             .sample_aged_txs(Duration::from_secs(8), 3);
         if !aged.is_empty() {
+            const TAIL_WATCH_CAP: usize = 32;
             let adverts_by_peer = self.tx_adverts_by_peer.read().await;
+            let mut watch = self.tail_watch.write().await;
             for (hash, age_ms) in aged {
+                // Arm wire tracing for this stranded hash (#3719 part 1):
+                // the demand/response paths below log every event touching it.
+                if watch.len() < TAIL_WATCH_CAP {
+                    watch.insert(hash);
+                }
                 let sent_to = peer_ids
                     .iter()
                     .filter(|pid| {
@@ -557,6 +564,18 @@ impl App {
             // Parity: stellar-core mTxPullLatency (OverlayMetrics.h:115).
             metrics::histogram!("stellar_overlay_tx_pull_latency_seconds")
                 .record(delta.as_secs_f64());
+            // [maxtps_tail] #3719 part-1: a pull that took 3+ s means the tx
+            // eventually arrived after stranding — log so the demander side of
+            // a strand's timeline is reconstructable at info level.
+            if delta.as_secs() >= 3 {
+                tracing::info!(
+                    target: "maxtps_tail",
+                    hash8 = %&hash.to_hex()[..16],
+                    latency_ms = delta.as_millis() as u64,
+                    peers = entry.peers.len(),
+                    "slow tx pull completed"
+                );
+            }
             tracing::debug!(
                 hash = %hash.to_hex(),
                 latency_ms = delta.as_millis(),
@@ -868,6 +887,14 @@ impl App {
         // Match stellar-core: only send Transaction messages for found hashes.
         // Do NOT send DontHave for unfulfilled demands — stellar-core just
         // logs/meters misses without any outbound response.
+        let watch = {
+            let w = self.tail_watch.read().await;
+            if w.is_empty() {
+                None
+            } else {
+                Some(w.clone())
+            }
+        };
         let mut sent = 0u32;
         let mut deferred = 0u32;
         let mut banned = 0u32;
@@ -876,28 +903,71 @@ impl App {
         let mut to_defer: Vec<Hash256> = Vec::new();
         for hash in demand.tx_hashes.0.iter() {
             let hash256 = Hash256::from(hash.clone());
+            let watched = watch.as_ref().is_some_and(|w| w.contains(&hash256));
             if channel_full {
                 if self.herder.tx_queue().get(&hash256).is_some() {
                     to_defer.push(hash256);
                     deferred += 1;
+                    if watched {
+                        tracing::info!(
+                            target: "maxtps_tail",
+                            hash8 = %&hash256.to_hex()[..16],
+                            peer = %peer_id,
+                            "watched demand DEFERRED (channel full)"
+                        );
+                    }
                 }
                 continue;
             }
             if let Some(tx) = self.herder.tx_queue().get(&hash256) {
                 match overlay.try_send_to(peer_id, StellarMessage::Transaction(tx.into_envelope()))
                 {
-                    Ok(()) => sent += 1,
+                    Ok(()) => {
+                        sent += 1;
+                        if watched {
+                            tracing::info!(
+                                target: "maxtps_tail",
+                                hash8 = %&hash256.to_hex()[..16],
+                                peer = %peer_id,
+                                "watched demand SERVED"
+                            );
+                        }
+                    }
                     Err(_) => {
                         // Channel full — defer this and the rest of the batch.
                         channel_full = true;
                         to_defer.push(hash256);
                         deferred += 1;
+                        if watched {
+                            tracing::info!(
+                                target: "maxtps_tail",
+                                hash8 = %&hash256.to_hex()[..16],
+                                peer = %peer_id,
+                                "watched demand DEFERRED (channel full)"
+                            );
+                        }
                     }
                 }
             } else if self.herder.tx_queue().is_banned(&hash256) {
                 banned += 1;
+                if watched {
+                    tracing::info!(
+                        target: "maxtps_tail",
+                        hash8 = %&hash256.to_hex()[..16],
+                        peer = %peer_id,
+                        "watched demand BANNED-here"
+                    );
+                }
             } else {
                 unknown += 1;
+                if watched {
+                    tracing::info!(
+                        target: "maxtps_tail",
+                        hash8 = %&hash256.to_hex()[..16],
+                        peer = %peer_id,
+                        "watched demand UNKNOWN-here"
+                    );
+                }
             }
         }
         if !to_defer.is_empty() {
@@ -954,6 +1024,14 @@ impl App {
             .collect();
         deferred_map.retain(|peer, _| connected.contains(peer));
 
+        let watch = {
+            let w = self.tail_watch.read().await;
+            if w.is_empty() {
+                None
+            } else {
+                Some(w.clone())
+            }
+        };
         let mut sent_total = 0u32;
         for (peer_id, queue) in deferred_map.iter_mut() {
             while let Some(hash) = queue.front().copied() {
@@ -966,6 +1044,14 @@ impl App {
                     Ok(()) => {
                         queue.pop_front();
                         sent_total += 1;
+                        if watch.as_ref().is_some_and(|w| w.contains(&hash)) {
+                            tracing::info!(
+                                target: "maxtps_tail",
+                                hash8 = %&hash.to_hex()[..16],
+                                peer = %peer_id,
+                                "watched deferred response FLUSHED"
+                            );
+                        }
                     }
                     Err(_) => break, // still full — try next tick
                 }

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -333,7 +333,25 @@ impl App {
         }
 
         // Phase 2: Send adverts and mark successfully sent hashes.
+        let advert_watch = {
+            let w = self.tail_watch.read().await;
+            if w.is_empty() {
+                None
+            } else {
+                Some(w.clone())
+            }
+        };
         for (peer_id, hashes) in &per_peer {
+            if let Some(w) = advert_watch.as_ref() {
+                for hash in hashes.iter().filter(|h| w.contains(h)) {
+                    tracing::info!(
+                        target: "maxtps_tail",
+                        hash8 = %&hash.to_hex()[..16],
+                        peer = %peer_id,
+                        "watched hash RE-ADVERTED"
+                    );
+                }
+            }
             for chunk in hashes.chunks(max_chunk_size) {
                 let tx_hashes = match TxAdvertVector::try_from(
                     chunk
@@ -394,7 +412,7 @@ impl App {
         let aged = self
             .herder
             .tx_queue()
-            .sample_aged_txs(Duration::from_secs(8), 3);
+            .sample_aged_txs(Duration::from_secs(3), 3);
         if !aged.is_empty() {
             const TAIL_WATCH_CAP: usize = 32;
             let adverts_by_peer = self.tx_adverts_by_peer.read().await;

--- a/crates/app/src/app/tx_flooding.rs
+++ b/crates/app/src/app/tx_flooding.rs
@@ -775,7 +775,7 @@ impl App {
 
         for (peer_id, hashes) in to_send {
             let tx_hashes = match TxDemandVector::try_from(
-                hashes.into_iter().map(Hash::from).collect::<Vec<_>>(),
+                hashes.iter().copied().map(Hash::from).collect::<Vec<_>>(),
             ) {
                 Ok(vec) => vec,
                 Err(_) => {
@@ -786,6 +786,26 @@ impl App {
             let demand = FloodDemand { tx_hashes };
             if let Err(e) = overlay.try_send_to(&peer_id, StellarMessage::FloodDemand(demand)) {
                 tracing::warn!(peer = %peer_id, error = %e, "Failed to send flood demand");
+                // The demand never left this node — undo its bookkeeping so
+                // the next round retries instead of believing these hashes
+                // were demanded (#3719: for a sole-advertiser tx, a phantom
+                // demand record blocked the only pull path). Two parts:
+                // unmark the per-peer demand records, and re-queue the hashes
+                // onto the peer's retry queue (they were destructively popped
+                // during selection, so without this nothing would ever pop
+                // them again).
+                {
+                    let mut history = self.tx_demand_history.write().await;
+                    for hash in &hashes {
+                        if let Some(entry) = history.get_mut(hash) {
+                            entry.peers.remove(&peer_id);
+                        }
+                    }
+                }
+                let mut adverts_by_peer = self.tx_adverts_by_peer.write().await;
+                if let Some(adverts) = adverts_by_peer.get_mut(&peer_id) {
+                    adverts.retry_incoming(hashes, max_queue_size);
+                }
             }
         }
     }
@@ -2794,5 +2814,72 @@ mod tests {
             app.demand_status(hash, &peer, late, &history),
             DemandStatus::Demand
         ));
+    }
+
+    /// #3719: a demand whose SEND fails (peer channel full) must not leave a
+    /// phantom per-peer demand record — the bookkeeping is undone and the
+    /// hashes re-queued, so the next round retries instead of believing the
+    /// demand was made (fatal for sole-advertiser txs).
+    #[tokio::test]
+    async fn test_failed_demand_send_is_unmarked_and_requeued() {
+        let (_dir, app) = create_test_app_with_overlay().await;
+        let overlay = app.overlay().await.unwrap();
+
+        // Capacity-1 channel, pre-filled so the demand send fails.
+        let peer_id = make_peer_id(47);
+        let mut receiver = overlay.inject_test_peer(peer_id.clone(), 1);
+        overlay
+            .try_send_to(
+                &peer_id,
+                StellarMessage::DontHave(stellar_xdr::DontHave {
+                    type_: stellar_xdr::MessageType::TxSet,
+                    req_hash: stellar_xdr::Uint256([0u8; 32]),
+                }),
+            )
+            .expect("pre-fill message fits");
+
+        // Advertise a hash from that peer so the demand loop selects it.
+        let hash = Hash256::from_bytes([0xEE; 32]);
+        let advert = FloodAdvert {
+            tx_hashes: TxAdvertVector(vec![Hash(*hash.as_bytes())].try_into().unwrap()),
+        };
+        app.handle_flood_advert(&peer_id, advert).await;
+
+        app.run_tx_demands().await;
+
+        // Send failed: no phantom demand record for this peer...
+        {
+            let history = app.tx_demand_history.read().await;
+            let marked = history
+                .get(&hash)
+                .is_some_and(|e| e.peers.contains_key(&peer_id));
+            assert!(!marked, "failed demand send must not mark the peer");
+        }
+        // ...and the hash is back in the peer's queue for the next round.
+        {
+            let adverts = app.tx_adverts_by_peer.read().await;
+            let requeued = adverts
+                .get(&peer_id)
+                .is_some_and(|a| a.retry.contains(&hash) || a.incoming.contains(&hash));
+            assert!(requeued, "failed demand hashes must be re-queued");
+        }
+
+        // Drain the channel; the next round must actually send the demand.
+        let _ = receiver.try_recv();
+        app.run_tx_demands().await;
+        let mut saw_demand = false;
+        while let Some(msg) = receiver.try_recv() {
+            if matches!(msg, StellarMessage::FloodDemand(_)) {
+                saw_demand = true;
+            }
+        }
+        assert!(saw_demand, "retry round must send the demand");
+        let history = app.tx_demand_history.read().await;
+        assert!(
+            history
+                .get(&hash)
+                .is_some_and(|e| e.peers.contains_key(&peer_id)),
+            "successful demand must be marked"
+        );
     }
 }

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -2833,6 +2833,10 @@ impl Herder {
             return TxQueueResult::TryAgainLater;
         }
 
+        // Cheap identifier for the sampled rejection diagnostic below,
+        // captured before `tx` moves into try_add.
+        let diag_seq = henyey_tx::envelope_sequence_number(&tx);
+
         // Add to transaction queue
         let result = self.tx_queue.try_add(tx);
 
@@ -2860,6 +2864,27 @@ impl Herder {
             }
             TxQueueResult::TryAgainLater => {
                 debug!("Transaction rejected: account already has pending transaction");
+            }
+        }
+
+        // [maxtps_tail] #3719 part-1 attribution: a flooded/pulled tx that is
+        // rejected here dies silently — the demander has already recorded the
+        // pull as fulfilled, so nothing retries and a sole-advertiser tx
+        // strands. Sample the rare terminal outcomes (Duplicate and Added are
+        // the normal flood cases and stay quiet).
+        if matches!(
+            result,
+            TxQueueResult::Banned | TxQueueResult::Invalid(_) | TxQueueResult::TryAgainLater
+        ) {
+            use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+            static LOGGED: AtomicU64 = AtomicU64::new(0);
+            if LOGGED.fetch_add(1, AtomicOrdering::Relaxed) % 16 == 0 {
+                tracing::info!(
+                    target: "maxtps_tail",
+                    tx_seq = diag_seq,
+                    result = ?result,
+                    "tx admission rejected (sampled 1/16)"
+                );
             }
         }
 

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -2872,20 +2872,31 @@ impl Herder {
         // pull as fulfilled, so nothing retries and a sole-advertiser tx
         // strands. Sample the rare terminal outcomes (Duplicate and Added are
         // the normal flood cases and stay quiet).
-        if matches!(
-            result,
-            TxQueueResult::Banned | TxQueueResult::Invalid(_) | TxQueueResult::TryAgainLater
-        ) {
-            use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-            static LOGGED: AtomicU64 = AtomicU64::new(0);
-            if LOGGED.fetch_add(1, AtomicOrdering::Relaxed) % 16 == 0 {
+        match result {
+            // Banned/TryAgainLater are rare enough (~tens per run) to log
+            // unsampled — and they are exactly the flooded-copy rejections
+            // that can strand a sole-advertiser tx (#3719 part 1).
+            TxQueueResult::Banned | TxQueueResult::TryAgainLater => {
                 tracing::info!(
                     target: "maxtps_tail",
                     tx_seq = diag_seq,
                     result = ?result,
-                    "tx admission rejected (sampled 1/16)"
+                    "tx admission rejected"
                 );
             }
+            TxQueueResult::Invalid(_) => {
+                use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+                static LOGGED: AtomicU64 = AtomicU64::new(0);
+                if LOGGED.fetch_add(1, AtomicOrdering::Relaxed) % 16 == 0 {
+                    tracing::info!(
+                        target: "maxtps_tail",
+                        tx_seq = diag_seq,
+                        result = ?result,
+                        "tx admission rejected (sampled 1/16)"
+                    );
+                }
+            }
+            _ => {}
         }
 
         result

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -2872,31 +2872,23 @@ impl Herder {
         // pull as fulfilled, so nothing retries and a sole-advertiser tx
         // strands. Sample the rare terminal outcomes (Duplicate and Added are
         // the normal flood cases and stay quiet).
-        match result {
-            // Banned/TryAgainLater are rare enough (~tens per run) to log
-            // unsampled — and they are exactly the flooded-copy rejections
-            // that can strand a sole-advertiser tx (#3719 part 1).
-            TxQueueResult::Banned | TxQueueResult::TryAgainLater => {
+        // [maxtps_tail] #3719 attribution aid: sampled log of terminal
+        // admission rejections (a rejected flooded/pulled tx dies silently —
+        // the demander already recorded the pull as fulfilled).
+        if matches!(
+            result,
+            TxQueueResult::Banned | TxQueueResult::Invalid(_) | TxQueueResult::TryAgainLater
+        ) {
+            use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+            static LOGGED: AtomicU64 = AtomicU64::new(0);
+            if LOGGED.fetch_add(1, AtomicOrdering::Relaxed) % 16 == 0 {
                 tracing::info!(
                     target: "maxtps_tail",
                     tx_seq = diag_seq,
                     result = ?result,
-                    "tx admission rejected"
+                    "tx admission rejected (sampled 1/16)"
                 );
             }
-            TxQueueResult::Invalid(_) => {
-                use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-                static LOGGED: AtomicU64 = AtomicU64::new(0);
-                if LOGGED.fetch_add(1, AtomicOrdering::Relaxed) % 16 == 0 {
-                    tracing::info!(
-                        target: "maxtps_tail",
-                        tx_seq = diag_seq,
-                        result = ?result,
-                        "tx admission rejected (sampled 1/16)"
-                    );
-                }
-            }
-            _ => {}
         }
 
         result

--- a/crates/herder/src/tx_queue/mod.rs
+++ b/crates/herder/src/tx_queue/mod.rs
@@ -3272,6 +3272,81 @@ impl TransactionQueue {
         Some((tx.hash, envelope_sequence_number(&tx.envelope), state.age))
     }
 
+    /// Drop the account's pending transaction if it is stale: its sequence
+    /// number is `<= on_ledger_seq`, i.e. the ledger has already consumed
+    /// that sequence slot, so the pending entry can never apply again.
+    ///
+    /// Self-heal for #3719: ledger state (account seq) advances at apply,
+    /// but `remove_applied`/`shift` run in a later `spawn_blocking` — a
+    /// submission landing in that window (or racing a duplicate that applied
+    /// via another node) sees a just-consumed pending entry and gets
+    /// `TryAgainLater`. stellar-core cannot observe this state (its queue
+    /// cleanup is synchronous with close on the main thread), so dropping the
+    /// stale entry and re-admitting matches core-observable behavior.
+    ///
+    /// The staleness condition is re-checked under the store/account locks so
+    /// a concurrent `remove_applied` cannot double-release fees. The hash is
+    /// NOT banned here — if the tx applied, `remove_applied` bans it on its
+    /// own schedule. Returns `true` if a stale entry was dropped.
+    pub fn drop_stale_pending(&self, account_id: &AccountId, on_ledger_seq: i64) -> bool {
+        let key = account_key_from_account_id(account_id);
+
+        // Lock order: store → account_states (canonical; see remove_applied).
+        let mut store = self.store.write();
+        let mut account_states = self.account_states.write();
+        let ledger_version = self.validation_context.read().protocol_version;
+
+        let Some(state) = account_states.get_mut(&key) else {
+            return false;
+        };
+        let Some(ref queued_tx) = state.transaction else {
+            return false;
+        };
+        if queued_tx.sequence_number() > on_ledger_seq {
+            return false;
+        }
+
+        let removed_hash = queued_tx.hash;
+        let tx_fee = queued_tx.total_fee as i64;
+        let tx_fee_source_key = self::fee_source_key(&queued_tx.envelope);
+        let tx_is_soroban = henyey_tx::envelope_utils::is_soroban_envelope(&queued_tx.envelope);
+
+        store.remove(&removed_hash, ledger_version);
+        state.transaction = None;
+        state.age = 0;
+        if state.is_empty() {
+            account_states.remove(&key);
+        }
+
+        // Release the reserved fee on the fee-source account (mirrors
+        // remove_applied's fee-release bookkeeping).
+        if let Some(fee_state) = account_states.get_mut(&tx_fee_source_key) {
+            fee_state.total_fees = fee_state.total_fees.saturating_sub(tx_fee);
+            if tx_is_soroban {
+                fee_state.soroban_fee_tx_count = fee_state.soroban_fee_tx_count.saturating_sub(1);
+            } else {
+                fee_state.classic_fee_tx_count = fee_state.classic_fee_tx_count.saturating_sub(1);
+            }
+            if fee_state.is_empty() {
+                account_states.remove(&tx_fee_source_key);
+            }
+        }
+
+        drop(account_states);
+        drop(store);
+
+        self.seen.write().remove(&removed_hash);
+        self.eviction_thresholds.reset_all();
+
+        tracing::info!(
+            target: "maxtps_tail",
+            hash8 = %&removed_hash.to_hex()[..16],
+            on_ledger_seq,
+            "dropped stale pending tx (seq already consumed on-ledger, #3719)"
+        );
+        true
+    }
+
     pub fn banned_count(&self) -> usize {
         let banned = self.banned_transactions.read();
         banned.iter().map(|s| s.len()).sum()
@@ -5536,6 +5611,81 @@ mod tests {
         assert!(
             !queue.contains(&queued_hash),
             "queued tx with seq=1 should be removed when applied tx has seq=7"
+        );
+        assert_eq!(queue.len(), 0);
+    }
+
+    /// #3719 self-heal: a pending tx whose sequence the ledger has already
+    /// consumed is dropped by drop_stale_pending, and the account can then
+    /// admit its next tx (previously TryAgainLater until remove_applied /
+    /// revalidation caught up).
+    #[test]
+    fn test_drop_stale_pending_unblocks_account() {
+        let queue = TransactionQueue::with_defaults();
+
+        let mut stale = make_test_envelope(200, 1);
+        set_source(&mut stale, 44);
+        if let TransactionEnvelope::Tx(ref mut env) = stale {
+            env.tx.seq_num = SequenceNumber(7);
+        }
+        assert_eq!(queue.try_add(stale.clone()), TxQueueResult::Added);
+        let account = account_id_from_envelope(&stale);
+        let stale_hash = full_hash(&stale);
+
+        // The bug scenario: account already at seq 7 on-ledger; the next
+        // submission (seq 8) is rejected because of the stale pending.
+        let mut next = make_test_envelope(200, 1);
+        set_source(&mut next, 44);
+        if let TransactionEnvelope::Tx(ref mut env) = next {
+            env.tx.seq_num = SequenceNumber(8);
+        }
+        assert_eq!(queue.try_add(next.clone()), TxQueueResult::TryAgainLater);
+
+        // Self-heal: drop the stale entry, then the next tx admits.
+        assert!(queue.drop_stale_pending(&account, 7));
+        assert!(!queue.contains(&stale_hash), "stale entry must be removed");
+        assert_eq!(queue.try_add(next), TxQueueResult::Added);
+        assert_eq!(queue.len(), 1);
+    }
+
+    /// drop_stale_pending must NOT touch a genuinely-pending tx (seq above
+    /// the account's on-ledger seq).
+    #[test]
+    fn test_drop_stale_pending_keeps_live_pending() {
+        let queue = TransactionQueue::with_defaults();
+
+        let mut pending = make_test_envelope(200, 1);
+        set_source(&mut pending, 45);
+        if let TransactionEnvelope::Tx(ref mut env) = pending {
+            env.tx.seq_num = SequenceNumber(8);
+        }
+        assert_eq!(queue.try_add(pending.clone()), TxQueueResult::Added);
+        let account = account_id_from_envelope(&pending);
+        let hash = full_hash(&pending);
+
+        // Account at seq 7: the seq-8 pending is live.
+        assert!(!queue.drop_stale_pending(&account, 7));
+        assert!(queue.contains(&hash), "live pending must be kept");
+    }
+
+    /// drop_stale_pending releases the reserved fee so subsequent
+    /// fee-accounting starts clean (mirrors remove_applied bookkeeping).
+    #[test]
+    fn test_drop_stale_pending_releases_fee_state() {
+        let queue = TransactionQueue::with_defaults();
+
+        let mut stale = make_test_envelope(200, 1);
+        set_source(&mut stale, 46);
+        assert_eq!(queue.try_add(stale.clone()), TxQueueResult::Added);
+        let account = account_id_from_envelope(&stale);
+
+        assert!(queue.drop_stale_pending(&account, 1));
+        assert!(
+            !queue
+                .account_states
+                .read()
+                .contains_key(&account_key(&stale)),
+            "account state must be fully cleaned up after the stale drop"
         );
         assert_eq!(queue.len(), 0);
     }


### PR DESCRIPTION
Fixes #3719 (both mechanisms).

## Part 2 — post-close queue-cleanup race (the run-fatal wedge)

Ledger state (account seq) advances at apply, but the queue's `remove_applied`/`shift`/revalidation run in a later `spawn_blocking`. A submission landing in that window (observed 58 ms after close in the campaign forensics) sees a pending tx whose sequence the ledger just consumed → `TryAgainLater` → PayPregenerated load runs insta-fail (#3638 parity: any reject is fatal). stellar-core cannot observe this state — its queue cleanup is synchronous with close on the main thread.

Fix: `TransactionQueue::drop_stale_pending(account, on_ledger_seq)` — drops the account's pending tx iff its seq ≤ the account's on-ledger seq, with the staleness condition re-checked under the store/account locks (no double fee-release against a concurrent `remove_applied`), fee bookkeeping mirrored from `remove_applied`, and no ban (if the tx applied, `remove_applied` bans it on its own schedule). `App::submit_transaction` invokes it when a `TryAgainLater` is attributable to a stale pending, then re-admits once. The healed result (Added) matches what core would return in the same situation.

## Part 1 — phantom demand records feeding the sole-advertiser strand

`run_tx_demands` marked a peer as demanded **during selection, before the send**. When `try_send_to` failed (channel full — 7 occurrences observed in one failing step), the phantom record made the demander believe it had demanded; the hashes had also been destructively popped from the peer's advert queue, so nothing ever retried (until #3718's 2 s same-peer expiry — and never if the channel stayed full). For a sole-advertiser tx (warmup, an account's first tx) this was the only pull path.

Fix: on send failure, unmark the per-peer demand records and re-queue the hashes onto that peer's retry queue, so the next demand round retries immediately.

## Tests

- `test_drop_stale_pending_unblocks_account` — reproduces the bug (`TryAgainLater` with a consumed-seq pending), asserts the heal admits the next tx
- `test_drop_stale_pending_keeps_live_pending` — a genuinely-pending tx (seq above on-ledger) is untouched
- `test_drop_stale_pending_releases_fee_state` — fee bookkeeping fully cleaned
- `test_failed_demand_send_is_unmarked_and_requeued` — capacity-1 pre-filled channel: no phantom mark, hashes re-queued, retry round sends and marks
- Full `henyey-herder` (1206) and `henyey-app` (1163) lib suites green; clippy green.

## Validation

Live MaxTPS validation on a fresh nsc instance is running; results will be posted as a follow-up comment (the wedge was stochastic at 1600 tx/s — the previously-failing level — so the comment will include repeated sustained steps there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzuKRiPrevW9qizRBw3oK7