### PR TITLE
Disable watchdog auto-abort in History Publish CI fixture

### DIFF
--- a/configs/test-history-publish.toml
+++ b/configs/test-history-publish.toml
@@ -62,6 +62,28 @@ known_peers = [
     "core-testnet3.stellar.org:11625"
 ]
 
+[diagnostics]
+# Disable the event-loop watchdog auto-abort in this CI harness.
+#
+# The default watchdog (watchdog_abort_secs = 120) exists to recover a
+# genuinely deadlocked validator on a *supervised* host (systemd /
+# monitor-loop restarts it after the abort). This harness has no supervisor,
+# and scripts/test-history-publish.sh already bounds the run (--timeout 1500
+# plus the job's timeout-minutes: 40), so the process-level self-abort is
+# redundant here.
+#
+# Worse, it produces false positives: under legitimate heavy near-tip
+# SCP-verify load the event loop can stall >120s while still making forward
+# progress, and the watchdog would SIGABRT the node before it publishes its
+# first checkpoint — the exact ~5-min cancel seen in issue #3727. Setting 0
+# (the documented disable sentinel) removes the false-positive abort while
+# preserving all watchdog *logging* (warn >=15s / error >=30s) into the
+# artifact-uploaded validator.log, so a genuine freeze stays diagnosable.
+#
+# The underlying near-tip verify-capacity issue is tracked in #3702; this
+# suppression is scoped to the CI fixture only, not shipped validator configs.
+watchdog_abort_secs = 0
+
 [http]
 enabled = false
 

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -4257,6 +4257,16 @@ name = "test"
             Some(format!("mkdir -p {test_history_dir}/{{0}}").as_str()),
             "local archive mkdir command mismatch"
         );
+
+        // The fixture disables the event-loop watchdog auto-abort so a
+        // slow-but-progressing near-tip sync under live-testnet SCP load is
+        // not converted into a hard SIGABRT before the first checkpoint is
+        // published. See issue #3727 (and underlying capacity issue #3702).
+        assert_eq!(
+            config.diagnostics.watchdog_abort_secs, 0,
+            "history-publish fixture must disable the watchdog auto-abort \
+             (watchdog_abort_secs = 0)"
+        );
     }
 
     /// Asserts that the shared sections between `configs/test-history-publish.toml`


### PR DESCRIPTION
Closes #3727

## Summary

The `History Publish (Testnet)` scheduled workflow was canceling ~5 min into the checkpoint wait on repeated attempts. Root cause: the plain testnet validator rendered from `configs/test-history-publish.toml` inherits the default event-loop watchdog (`watchdog_abort_secs = 120`), which calls `std::process::abort()` when the loop stalls >120s. Under live-testnet near-tip SCP-verify load the loop stalls that long while still making forward progress, so the watchdog SIGABRT-ed the node before it could publish its first checkpoint.

This adds a `[diagnostics]` section to the CI fixture with `watchdog_abort_secs = 0` (the documented disable sentinel). The self-abort is redundant in this harness: there is no supervisor to restart the node, and `scripts/test-history-publish.sh` already bounds runtime via `--timeout 1500` plus the job's `timeout-minutes: 40`. Watchdog logging (warn >=15s / error >=30s tiers) is preserved into the artifact-uploaded `validator.log`, so a genuine freeze stays diagnosable. Shipped validator configs are unchanged — on real mainnet/testnet validators the auto-abort + supervisor-restart is desirable and out of scope. The underlying near-tip verify-capacity issue is tracked in #3702.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3727#issuecomment-5050879919)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-app --lib config:: — 295 passed (incl. shared-sections + shipped-parse tests)

## Regression test (bug-fix)

- **Test:** `crates/app/src/config.rs::test_history_publish_fixture_renders_and_parses` (Phase 5 assertion `config.diagnostics.watchdog_abort_secs == 0`)
- **Pre-fix:** committed as `d3ff14a9` — verified FAILED (fixture had no `[diagnostics]` section → defaulted to 120, `== 0` assertion failed)
- **Post-fix:** verified PASSES after `c7386618`

## Deviations from plan

None. (The plan referenced the test at ~line 3629; it actually lives at line 4141, but is the same test function named in the plan.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)