### PR TITLE
Make storestate prefix scans index-usable to bound SCP-purge write lock

### DIFF
--- a/crates/db/src/queries/scp.rs
+++ b/crates/db/src/queries/scp.rs
@@ -27,6 +27,25 @@ use super::state::StateQueries;
 
 const TX_SET_KEY_PREFIX: &str = "txset:";
 
+/// SQL for [`ScpStatePersistenceQueries::load_all_scp_slot_states`].
+///
+/// Shared with its query-plan regression test
+/// (`test_scpstate_prefix_query_uses_index_not_scan`) so the two can never
+/// drift onto different SQL.
+const LOAD_ALL_SCP_SLOT_STATES_SQL: &str =
+    "SELECT statename, state FROM storestate WHERE statename LIKE ?1 ORDER BY statename";
+
+/// SQL for [`ScpStatePersistenceQueries::load_all_tx_set_data`].
+const LOAD_ALL_TX_SET_DATA_SQL: &str =
+    "SELECT statename, state FROM storestate WHERE statename LIKE ?1";
+
+/// SQL for [`ScpStatePersistenceQueries::get_all_tx_set_hashes`].
+///
+/// Shared with its query-plan regression test
+/// (`test_txset_prefix_query_uses_index_not_scan`).
+const GET_ALL_TX_SET_HASHES_SQL: &str =
+    "SELECT statename FROM storestate WHERE statename LIKE ?1";
+
 /// Query trait for SCP consensus state operations.
 ///
 /// Provides methods for persisting and retrieving SCP envelopes and quorum sets.
@@ -379,9 +398,7 @@ impl ScpStatePersistenceQueries for Connection {
     }
 
     fn load_all_scp_slot_states(&self) -> Result<Vec<(u64, String)>, DbError> {
-        let mut stmt = self.prepare(
-            "SELECT statename, state FROM storestate WHERE statename LIKE ?1 ORDER BY statename",
-        )?;
+        let mut stmt = self.prepare(LOAD_ALL_SCP_SLOT_STATES_SQL)?;
         let pattern = format!("{}:%", state_keys::SCP_STATE);
         let rows = stmt.query_map(params![pattern], |row| {
             let key: String = row.get(0)?;
@@ -434,8 +451,7 @@ impl ScpStatePersistenceQueries for Connection {
     }
 
     fn load_all_tx_set_data(&self) -> Result<Vec<(Hash, Vec<u8>)>, DbError> {
-        let mut stmt =
-            self.prepare("SELECT statename, state FROM storestate WHERE statename LIKE ?1")?;
+        let mut stmt = self.prepare(LOAD_ALL_TX_SET_DATA_SQL)?;
         let pattern = format!("{TX_SET_KEY_PREFIX}%");
         let rows = stmt.query_map(params![pattern], |row| {
             let key: String = row.get(0)?;
@@ -474,7 +490,7 @@ impl ScpStatePersistenceQueries for Connection {
     }
 
     fn get_all_tx_set_hashes(&self) -> Result<Vec<Hash>, DbError> {
-        let mut stmt = self.prepare("SELECT statename FROM storestate WHERE statename LIKE ?1")?;
+        let mut stmt = self.prepare(GET_ALL_TX_SET_HASHES_SQL)?;
         let pattern = format!("{TX_SET_KEY_PREFIX}%");
         let rows = stmt.query_map(params![pattern], |row| {
             let key: String = row.get(0)?;
@@ -666,6 +682,52 @@ mod tests {
         )
         .unwrap();
         conn
+    }
+
+    /// Return the `detail` column of every `EXPLAIN QUERY PLAN` row for `sql`,
+    /// joined by newlines. Binds dummy TEXT values for any `?N` placeholders so
+    /// the statement prepares regardless of how many parameters it declares
+    /// (LIKE = 1, range = 2).
+    fn query_plan(conn: &Connection, sql: &str) -> String {
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+        let n = stmt.parameter_count();
+        let dummies: Vec<String> = (0..n).map(|_| String::from("txset:")).collect();
+        let params: Vec<&dyn rusqlite::types::ToSql> = dummies
+            .iter()
+            .map(|s| s as &dyn rusqlite::types::ToSql)
+            .collect();
+        let rows = stmt
+            .query_map(params.as_slice(), |row| row.get::<_, String>(3))
+            .unwrap();
+        rows.map(|r| r.unwrap()).collect::<Vec<_>>().join("\n")
+    }
+
+    /// The `txset:` prefix scan on `storestate` (run inside the
+    /// `BEGIN IMMEDIATE` write lock during near-tip back-fill) must resolve to
+    /// an index SEARCH, not a full-table SCAN. Regression for #3702: the
+    /// `LIKE 'txset:%'` form scanned the whole table under the WAL write lock,
+    /// starving SCP intake on the post-restart tracking path.
+    #[test]
+    fn test_txset_prefix_query_uses_index_not_scan() {
+        let conn = setup_db();
+        let plan = query_plan(&conn, GET_ALL_TX_SET_HASHES_SQL);
+        assert!(
+            plan.contains("SEARCH") && !plan.contains("SCAN storestate"),
+            "txset prefix query must use an index SEARCH, not a full-table SCAN; plan was:\n{plan}"
+        );
+    }
+
+    /// The `scpstate:` prefix scan on `storestate` (also run inside the
+    /// `BEGIN IMMEDIATE` write lock) must resolve to an index SEARCH, not a
+    /// full-table SCAN. Regression for #3702.
+    #[test]
+    fn test_scpstate_prefix_query_uses_index_not_scan() {
+        let conn = setup_db();
+        let plan = query_plan(&conn, LOAD_ALL_SCP_SLOT_STATES_SQL);
+        assert!(
+            plan.contains("SEARCH") && !plan.contains("SCAN storestate"),
+            "scpstate prefix query must use an index SEARCH, not a full-table SCAN; plan was:\n{plan}"
+        );
     }
 
     #[test]

--- a/crates/db/src/queries/scp.rs
+++ b/crates/db/src/queries/scp.rs
@@ -29,22 +29,25 @@ const TX_SET_KEY_PREFIX: &str = "txset:";
 
 /// SQL for [`ScpStatePersistenceQueries::load_all_scp_slot_states`].
 ///
-/// Shared with its query-plan regression test
+/// Uses a half-open BINARY range (`statename >= ?1 AND statename < ?2`, bounds
+/// from [`prefix_range`]) rather than `LIKE 'prefix%'` so the `storestate`
+/// BINARY primary-key autoindex resolves it as an index SEARCH instead of a
+/// full-table SCAN (#3702). Shared with its query-plan regression test
 /// (`test_scpstate_prefix_query_uses_index_not_scan`) so the two can never
 /// drift onto different SQL.
 const LOAD_ALL_SCP_SLOT_STATES_SQL: &str =
-    "SELECT statename, state FROM storestate WHERE statename LIKE ?1 ORDER BY statename";
+    "SELECT statename, state FROM storestate WHERE statename >= ?1 AND statename < ?2 ORDER BY statename";
 
-/// SQL for [`ScpStatePersistenceQueries::load_all_tx_set_data`].
+/// SQL for [`ScpStatePersistenceQueries::load_all_tx_set_data`]. Range-bound
+/// (see [`LOAD_ALL_SCP_SLOT_STATES_SQL`]).
 const LOAD_ALL_TX_SET_DATA_SQL: &str =
-    "SELECT statename, state FROM storestate WHERE statename LIKE ?1";
+    "SELECT statename, state FROM storestate WHERE statename >= ?1 AND statename < ?2";
 
-/// SQL for [`ScpStatePersistenceQueries::get_all_tx_set_hashes`].
-///
-/// Shared with its query-plan regression test
-/// (`test_txset_prefix_query_uses_index_not_scan`).
+/// SQL for [`ScpStatePersistenceQueries::get_all_tx_set_hashes`]. Range-bound
+/// (see [`LOAD_ALL_SCP_SLOT_STATES_SQL`]). Shared with its query-plan
+/// regression test (`test_txset_prefix_query_uses_index_not_scan`).
 const GET_ALL_TX_SET_HASHES_SQL: &str =
-    "SELECT statename FROM storestate WHERE statename LIKE ?1";
+    "SELECT statename FROM storestate WHERE statename >= ?1 AND statename < ?2";
 
 /// Query trait for SCP consensus state operations.
 ///
@@ -321,6 +324,34 @@ fn tx_set_key(hash: &Hash) -> String {
     format!("{TX_SET_KEY_PREFIX}{}", hex::encode(hash.0))
 }
 
+/// Compute the half-open BINARY range `[lower, upper)` that matches exactly the
+/// keys beginning with `prefix`, for use as `statename >= lower AND statename <
+/// upper`. `lower` is `prefix` verbatim; `upper` is `prefix` with its final byte
+/// incremented by one, giving an exclusive upper bound that excludes adjacent
+/// prefixes (`txset:` -> `[txset:, txset;)`).
+///
+/// This range is index-usable against the BINARY `storestate` primary-key
+/// autoindex (an index SEARCH), unlike a case-insensitive `LIKE 'prefix%'`,
+/// which forces a full-table SCAN and holds the WAL write lock far longer under
+/// the SCP-purge `BEGIN IMMEDIATE` during near-tip back-fill (#3702). Row
+/// membership is identical to the old `LIKE` for the call sites' prefixes: all
+/// stored keys are the literal lowercase prefix followed by lowercase hex or a
+/// decimal slot, so dropping `LIKE`'s (default-on) case-insensitivity never
+/// changes results.
+///
+/// The two call sites pass `txset:` and `scpstate:`, both ending in `:` (0x3A),
+/// so the increment is `:` -> `;` (0x3B) with no carry and stays valid ASCII.
+fn prefix_range(prefix: &str) -> (String, String) {
+    let mut upper = prefix.as_bytes().to_vec();
+    let last = upper
+        .last_mut()
+        .expect("prefix_range requires a non-empty prefix");
+    // Callers pass ':'-terminated prefixes; the increment never carries.
+    *last += 1;
+    let upper = String::from_utf8(upper).expect("incremented prefix stays valid UTF-8");
+    (prefix.to_string(), upper)
+}
+
 fn parse_slot_key(key: &str) -> Option<u64> {
     key.strip_prefix(&format!("{}:", state_keys::SCP_STATE))?
         .parse()
@@ -399,8 +430,8 @@ impl ScpStatePersistenceQueries for Connection {
 
     fn load_all_scp_slot_states(&self) -> Result<Vec<(u64, String)>, DbError> {
         let mut stmt = self.prepare(LOAD_ALL_SCP_SLOT_STATES_SQL)?;
-        let pattern = format!("{}:%", state_keys::SCP_STATE);
-        let rows = stmt.query_map(params![pattern], |row| {
+        let (lower, upper) = prefix_range(&format!("{}:", state_keys::SCP_STATE));
+        let rows = stmt.query_map(params![lower, upper], |row| {
             let key: String = row.get(0)?;
             let state: String = row.get(1)?;
             Ok((key, state))
@@ -452,8 +483,8 @@ impl ScpStatePersistenceQueries for Connection {
 
     fn load_all_tx_set_data(&self) -> Result<Vec<(Hash, Vec<u8>)>, DbError> {
         let mut stmt = self.prepare(LOAD_ALL_TX_SET_DATA_SQL)?;
-        let pattern = format!("{TX_SET_KEY_PREFIX}%");
-        let rows = stmt.query_map(params![pattern], |row| {
+        let (lower, upper) = prefix_range(TX_SET_KEY_PREFIX);
+        let rows = stmt.query_map(params![lower, upper], |row| {
             let key: String = row.get(0)?;
             let state: String = row.get(1)?;
             Ok((key, state))
@@ -491,8 +522,8 @@ impl ScpStatePersistenceQueries for Connection {
 
     fn get_all_tx_set_hashes(&self) -> Result<Vec<Hash>, DbError> {
         let mut stmt = self.prepare(GET_ALL_TX_SET_HASHES_SQL)?;
-        let pattern = format!("{TX_SET_KEY_PREFIX}%");
-        let rows = stmt.query_map(params![pattern], |row| {
+        let (lower, upper) = prefix_range(TX_SET_KEY_PREFIX);
+        let rows = stmt.query_map(params![lower, upper], |row| {
             let key: String = row.get(0)?;
             Ok(key)
         })?;
@@ -727,6 +758,49 @@ mod tests {
         assert!(
             plan.contains("SEARCH") && !plan.contains("SCAN storestate"),
             "scpstate prefix query must use an index SEARCH, not a full-table SCAN; plan was:\n{plan}"
+        );
+    }
+
+    #[test]
+    fn test_prefix_range_upper_bound() {
+        assert_eq!(
+            prefix_range("txset:"),
+            ("txset:".to_string(), "txset;".to_string())
+        );
+        assert_eq!(
+            prefix_range("scpstate:"),
+            ("scpstate:".to_string(), "scpstate;".to_string())
+        );
+    }
+
+    /// The half-open range must return exactly the keys under the prefix and
+    /// exclude adjacent-prefix keys (the exclusive upper bound `txset;` and the
+    /// next-prefix `txseu`). Guards the membership equivalence of the range
+    /// rewrite vs. the old `LIKE 'txset:%'`.
+    #[test]
+    fn test_prefix_range_membership_excludes_adjacent() {
+        let conn = setup_db();
+        for key in ["txset:00", "txset:ff", "txset;", "txseu"] {
+            conn.execute(
+                "INSERT INTO storestate (statename, state) VALUES (?1, 'x')",
+                params![key],
+            )
+            .unwrap();
+        }
+
+        let (lower, upper) = prefix_range(TX_SET_KEY_PREFIX);
+        let mut stmt = conn
+            .prepare("SELECT statename FROM storestate WHERE statename >= ?1 AND statename < ?2 ORDER BY statename")
+            .unwrap();
+        let matched: Vec<String> = stmt
+            .query_map(params![lower, upper], |row| row.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(
+            matched,
+            vec!["txset:00".to_string(), "txset:ff".to_string()]
         );
     }
 


### PR DESCRIPTION
Contributes to #3702

## Summary

The three `storestate` prefix SELECTs (`load_all_scp_slot_states`, `load_all_tx_set_data`, `get_all_tx_set_hashes`) used case-insensitive `LIKE 'prefix%'`. With `PRAGMA case_sensitive_like` OFF (default) and the `storestate` primary-key autoindex collated BINARY, SQLite cannot apply the LIKE-index optimization, so each query plans as a **full-table SCAN**. Two of these run inside `purge_unreferenced_tx_sets_atomic`'s `BEGIN IMMEDIATE`, holding the single WAL write lock for the whole scan during near-tip back-fill — the SCP-intake-starvation mechanism behind #3702.

This rewrites each to a half-open BINARY range `statename >= ?1 AND statename < ?2` (bounds from a new `prefix_range()` helper that increments the prefix's final byte, `txset:` → `[txset:, txset;)`). The range plans as an index **SEARCH** and returns a byte-for-byte identical row set (all stored keys are the literal lowercase prefix followed by lowercase hex or a decimal slot), so no observable behavior changes — only the query plan.

Each rewritten SELECT lives in a module-level `const` shared between the production query and its EQP test, so the two can't drift (Critic A).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3702#issuecomment-5051976855)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p henyey-db --all-targets -- -D warnings`
- [x] `cargo test -p henyey-db` — 116 passed

## Regression test (kind: bug-fix)

- **Tests:** `crates/db/src/queries/scp.rs::test_txset_prefix_query_uses_index_not_scan` and `::test_scpstate_prefix_query_uses_index_not_scan` (EXPLAIN QUERY PLAN asserts SEARCH, not `SCAN storestate`)
- **Pre-fix:** committed as `9b7fbd9` — verified FAILED with `SCAN storestate USING [COVERING] INDEX sqlite_autoindex_storestate_1`
- **Post-fix:** verified PASSES after `bb4d48c` (`SEARCH ... (statename>? AND statename<?)`)
- Plus `test_prefix_range_upper_bound` and `test_prefix_range_membership_excludes_adjacent` (range membership equivalence vs. old LIKE).

## Deviations from plan

None.

## Parity

n/a — internal SQLite query-plan optimization only (`docs/PARITY.md` permits internal DB/perf deviation). Row sets are byte-identical, so persisted SCP state, tx-set GC selection, and ledger/bucket/result/meta hashes are unaffected.

## Note on closure

Per the plan (Critic C), this is candidate holder (B), following (A)+instrumentation in #3704. It **contributes to** #3702; closure waits on #3704's `WriteCtxGuard` instrumentation confirming the write-lock hold is bounded on a real restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)