### PR TITLE
Widen near-tip hard-reset/emit guards to verified peer_gap==0

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -1564,24 +1564,53 @@ impl App {
             return None;
         }
 
-        // Defense-in-depth (#2664): skip hard reset when the node is at-tip
-        // (latest_ext == current_ledger, both non-zero). There is nothing to
-        // catch up to — any spawned catchup would fail with "archive not
-        // ahead of min_ledger." Clear coupled stale state so callers don't
-        // immediately retry. Excludes startup (latest_ext == 0) where
-        // Ahead-no-ext semantics require escalation.
+        // Defense-in-depth (#2664, widened #3733): skip hard reset when the
+        // node is at-tip. There is nothing to catch up to — any spawned
+        // catchup would fail with "archive not ahead of min_ledger." Clear
+        // coupled stale state so callers don't immediately retry.
+        //
+        // Two at-tip signals fire the skip (both exclude startup latest_ext==0,
+        // where Ahead-no-ext semantics require escalation):
+        //   1. Exact equality latest_ext == current_ledger (the original #2664
+        //      steady-state tip).
+        //   2. #3733: latest_ext is transiently 1–2 AHEAD of current_ledger
+        //      (within the near-tip band, <= TX_SET_REQUEST_WINDOW) yet
+        //      verified peers are NOT ahead (effective_peer_gap == 0). This is
+        //      the inbound-flap transient: EXTERNALIZE envelopes for slots
+        //      > current_ledger+1 briefly arm sync_recovery_pending; by the time
+        //      this runs the node has closed those ledgers and is glued to the
+        //      tip (max_verified_scp_slot == current_ledger), but
+        //      herder.latest_externalized_slot() lags one tick behind and reads
+        //      current+1..2. The strict-equality guard let that slip past into a
+        //      doomed ProbeAhead ("checkpoint N not ahead of min_ledger M"). The
+        //      verified peer gap is the authoritative near-tip signal (same
+        //      evidence the heartbeat reports as peer_gap=0). Genuine
+        //      behind-the-network escalation (peer_gap >= 3) is untouched — it
+        //      falls through to the #2713/#3262 suppression and the real reset.
+        //      The near-tip band bound (<= TX_SET_REQUEST_WINDOW) is what keeps
+        //      a genuine large local behind (e.g. latest_ext = current + 50 with
+        //      stale-low max_verified_scp_slot) from being mis-suppressed — such
+        //      a gap is never a near-tip blip. Mirrors is_spurious_near_tip_behind
+        //      at the consensus.rs emit site.
         //
         // Positioned before the livelock breaker: spurious resets should not
         // contribute to the fatal-shutdown timeout.
-        if latest_ext > 0 && latest_ext == current_ledger as u64 {
+        let local_gap = latest_ext.saturating_sub(current_ledger as u64);
+        let at_tip_exact = latest_ext == current_ledger as u64;
+        let near_tip_peers_not_ahead =
+            local_gap <= TX_SET_REQUEST_WINDOW && self.effective_peer_gap(current_ledger) == 0;
+        if latest_ext > 0 && (at_tip_exact || near_tip_peers_not_ahead) {
             self.clear_archive_recovery_state(ArchiveRecoveryClear::DefenseSkip)
                 .await;
             tracing::debug!(
                 current_ledger,
                 latest_externalized = latest_ext,
+                peer_gap = self.effective_peer_gap(current_ledger),
+                at_tip_exact,
+                near_tip_peers_not_ahead,
                 ?reason,
-                "Hard reset skipped: node is at-tip (latest_ext == current_ledger > 0), \
-                 cleared stale recovery state (#2664)"
+                "Hard reset skipped: node is at-tip (exact equality or near-tip with \
+                 verified peer_gap==0), cleared stale recovery state (#2664/#3733)"
             );
             return None;
         }
@@ -6864,6 +6893,150 @@ mod tests {
         assert!(
             !app.archive_checkpoint_cache.is_urgent(),
             "urgent polling must be disarmed"
+        );
+    }
+
+    /// #3733: when the node is near-tip — `latest_ext` is transiently 1
+    /// ahead of `current_ledger` (NOT equal, so the exact-equality #2664
+    /// guard does not match) but verified peers are NOT ahead
+    /// (`effective_peer_gap == 0`) — the widened guard must still skip the
+    /// hard reset and clear the same coupled stale state. On origin/main the
+    /// strict `latest_ext == current_ledger` guard does not match
+    /// `latest_ext = 5_001`, so the fn proceeds to `spawn_catchup(ProbeAhead)`
+    /// which fails with "archive not ahead of min_ledger."
+    #[tokio::test]
+    async fn test_hard_reset_skipped_near_tip_peer_gap_zero() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let mut app = App::new(config).await.unwrap();
+
+        let current_ledger: u32 = 5_000;
+
+        // latest_externalized is transiently ONE ahead of current_ledger
+        // (5_001 != 5_000) — the exact-equality #2664 guard does NOT match.
+        app.herder.scp_driver().record_externalized(
+            current_ledger as u64 + 1,
+            Default::default(),
+            None,
+        );
+        app.herder
+            .scp_driver()
+            .publish_externalized(current_ledger as u64 + 1);
+
+        // Verified peers are NOT ahead: max_verified_scp_slot <= current_ledger
+        // → effective_peer_gap == 0. This is the authoritative near-tip signal.
+        app.max_verified_scp_slot
+            .store(current_ledger as u64, Ordering::Relaxed);
+
+        // Arm stale archive-behind state.
+        {
+            let mut guard = app.archive_recovery_status.write().await;
+            *guard = ArchiveRecoveryStatus::ConfirmedBehind {
+                backoff_until: Some(std::time::Instant::now() + std::time::Duration::from_secs(60)),
+            };
+        }
+        app.archive_checkpoint_cache.set_urgent(true);
+        app.hard_reset_livelock_start.store(42, Ordering::Relaxed);
+
+        // Backdate start_instant so cooldown doesn't block.
+        app.start_instant = std::time::Instant::now() - std::time::Duration::from_secs(500);
+
+        let counter_before = app.post_catchup_hard_reset_total.load(Ordering::Relaxed);
+
+        let result = app
+            .force_post_catchup_hard_reset(
+                current_ledger,
+                HardResetReason::ArchiveBehindStallWallClock,
+            )
+            .await;
+
+        // Should return None (near-tip guard fired).
+        assert!(
+            result.is_none(),
+            "near-tip peer_gap==0 guard should return None"
+        );
+
+        // Counter should NOT have incremented.
+        assert_eq!(
+            app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
+            counter_before,
+            "counter must not increment when near-tip guard fires"
+        );
+
+        // All coupled state should be cleared identically to the at-tip path.
+        assert!(
+            matches!(
+                *app.archive_recovery_status.read().await,
+                ArchiveRecoveryStatus::Unknown
+            ),
+            "archive_recovery_status must be cleared"
+        );
+        assert_eq!(
+            app.hard_reset_livelock_start.load(Ordering::Relaxed),
+            0,
+            "livelock_start must be cleared"
+        );
+        assert!(
+            !app.archive_checkpoint_cache.is_urgent(),
+            "urgent polling must be disarmed"
+        );
+    }
+
+    /// #3733 negative: when the node is genuinely behind the network — peers
+    /// verifiably ahead (`effective_peer_gap >= 3`) even though `latest_ext`
+    /// is only 1 ahead — the widened near-tip guard must NOT fire; the hard
+    /// reset must proceed to escalation.
+    #[tokio::test]
+    async fn test_hard_reset_not_skipped_near_tip_when_peers_ahead() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let mut app = App::new(config).await.unwrap();
+
+        let current_ledger: u32 = 5_000;
+
+        app.herder.scp_driver().record_externalized(
+            current_ledger as u64 + 1,
+            Default::default(),
+            None,
+        );
+        app.herder
+            .scp_driver()
+            .publish_externalized(current_ledger as u64 + 1);
+
+        // Peers verifiably ahead: peer_gap = 50 (>= HARD_RESET_GAP_ESCALATION).
+        app.max_verified_scp_slot
+            .store(current_ledger as u64 + 50, Ordering::Relaxed);
+
+        // Seed a known-ahead archive checkpoint so the #2713/#3262 tip
+        // suppression does not swallow the reset — this test isolates the
+        // #3733 near-tip guard, which must NOT fire when peers are ahead.
+        app.archive_checkpoint_cache.seed(current_ledger + 50);
+
+        app.start_instant = std::time::Instant::now() - std::time::Duration::from_secs(500);
+
+        let counter_before = app.post_catchup_hard_reset_total.load(Ordering::Relaxed);
+
+        let result = app
+            .force_post_catchup_hard_reset(
+                current_ledger,
+                HardResetReason::ArchiveBehindStallWallClock,
+            )
+            .await;
+
+        // On the test harness `spawn_catchup` returns None even when the
+        // reset proceeds, so the authoritative signal that no guard swallowed
+        // it is the counter increment (mirrors test_hard_reset_proceeds_when_behind).
+        let _ = result;
+        assert_eq!(
+            app.post_catchup_hard_reset_total.load(Ordering::Relaxed),
+            counter_before + 1,
+            "hard reset must proceed (counter increments) when peers are verifiably ahead"
         );
     }
 

--- a/crates/app/src/app/consensus.rs
+++ b/crates/app/src/app/consensus.rs
@@ -231,6 +231,30 @@ pub(super) fn is_near_tip_gap_suppressed(
         && !should_escalate_to_catchup(attempts, relation, ahead_no_ext)
 }
 
+/// Whether an `is_behind()` relation at the emit site of `trigger_recovery_catchup`
+/// is a *spurious near-tip blip* rather than a genuine fall-behind (#3733).
+///
+/// When inbound peers authenticate-then-drop, EXTERNALIZE envelopes for slots
+/// `> current_ledger + 1` briefly arm `sync_recovery_pending`; by the time the
+/// consensus tick runs, the node has closed those ledgers and is glued to the
+/// tip with `effective_peer_gap == 0` (verified `max_verified_scp_slot ==
+/// current_ledger`). But `herder.latest_externalized_slot()` can still be
+/// transiently 1–2 ahead of `current_ledger`, so `LedgerRelation` reports
+/// `Behind { gap: 1..2 }`. That transient must NOT be counted as
+/// `forcing_catchup_behind` (the +81/+431 alarm bursts) — the authoritative
+/// near-tip signal is the verified peer gap, exactly what the heartbeat reports
+/// as `peer_gap=0`.
+///
+/// The predicate is deliberately stricter than a bare `behind_gap <= N` test:
+/// it additionally requires `peer_gap == 0`, so a node that is genuinely behind
+/// the network (peers verifiably ahead, `peer_gap >= PEER_AHEAD_ESCALATION_THRESHOLD`)
+/// is never mis-classified as near-tip. The `behind_gap <= TX_SET_REQUEST_WINDOW`
+/// bound keeps the carve-out to the near-tip band; a large local behind gap is
+/// never spurious even at `peer_gap == 0`.
+pub(super) fn is_spurious_near_tip_behind(behind_gap: u64, peer_gap: u64) -> bool {
+    behind_gap <= TX_SET_REQUEST_WINDOW && peer_gap == 0
+}
+
 impl App {
     /// Try to trigger consensus for the next ledger.
     ///
@@ -1820,6 +1844,28 @@ impl App {
                     urgent,
                     "Recovery stalled for too long — forcing catchup"
                 );
+            } else if is_spurious_near_tip_behind(
+                relation.behind_gap().unwrap_or(0),
+                self.effective_peer_gap(current_ledger),
+            ) {
+                // #3733: latest_externalized is transiently 1–2 ahead of
+                // current_ledger (LedgerRelation reports Behind) but verified
+                // peers are NOT ahead (effective_peer_gap == 0) — the
+                // inbound-peer-flap near-tip blip, not a genuine fall-behind.
+                // Count it in the benign bucket and log at debug so it does not
+                // inflate the forcing_catchup_behind alarm (the +81/+431 bursts).
+                crate::metrics::RECOVERY_STALLED_TICK_TOTAL
+                    .increment("forcing_catchup_near_tip", 1);
+                tracing::debug!(
+                    current_ledger,
+                    latest_externalized,
+                    gap = relation.behind_gap().unwrap_or(0),
+                    peer_gap = self.effective_peer_gap(current_ledger),
+                    attempts,
+                    ?cache_age_secs,
+                    urgent,
+                    "Recovery stalled near tip (verified peer_gap==0) — forcing catchup (#3733)"
+                );
             } else {
                 crate::metrics::RECOVERY_STALLED_TICK_TOTAL.increment("forcing_catchup_behind", 1);
                 tracing::info!(
@@ -2369,9 +2415,42 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_cannot_apply_reason, is_near_tip_gap_suppressed, should_escalate_to_catchup,
-        CannotApplyReason, LedgerRelation, RECOVERY_ESCALATION_NEAR_TIP_GAP_STALL_ATTEMPTS,
+        classify_cannot_apply_reason, is_near_tip_gap_suppressed, is_spurious_near_tip_behind,
+        should_escalate_to_catchup, CannotApplyReason, LedgerRelation,
+        RECOVERY_ESCALATION_NEAR_TIP_GAP_STALL_ATTEMPTS,
     };
+
+    // ── is_spurious_near_tip_behind tests (#3733) ───────────────────────
+
+    #[test]
+    fn test_near_tip_behind_not_counted_as_forcing_catchup_behind() {
+        // #3733: when herder.latest_externalized is transiently 1–2 ahead of
+        // current_ledger BUT verified peers are NOT ahead (peer_gap == 0), the
+        // `is_behind()` relation is a spurious near-tip blip caused by
+        // inbound-peer flapping — not a genuine fall-behind. It must NOT be
+        // counted as `forcing_catchup_behind`.
+        assert!(
+            is_spurious_near_tip_behind(1, 0),
+            "gap=1, peer_gap=0 is a spurious near-tip blip"
+        );
+        assert!(
+            is_spurious_near_tip_behind(2, 0),
+            "gap=2, peer_gap=0 is a spurious near-tip blip"
+        );
+        // Genuine behind-the-network: peers ARE ahead → not spurious, must
+        // still fire forcing_catchup_behind and escalate.
+        assert!(
+            !is_spurious_near_tip_behind(1, 3),
+            "gap=1 but peer_gap=3 is genuine behind — peers are ahead"
+        );
+        // Large local behind gap: even with peer_gap==0 this exceeds the
+        // near-tip window (TX_SET_REQUEST_WINDOW=12) → not treated as a
+        // near-tip blip.
+        assert!(
+            !is_spurious_near_tip_behind(15, 0),
+            "gap=15 exceeds the near-tip window — not spurious"
+        );
+    }
 
     // ── should_escalate_to_catchup tests (#3728) ────────────────────────
 


### PR DESCRIPTION
Closes #3733

## Summary

Inbound-peer flapping (authenticate-then-drop) briefly arms `sync_recovery_pending` with EXTERNALIZE envelopes for slots `> current_ledger + 1`. By the time the consensus tick runs, the node has already closed those ledgers and is glued to the tip (`max_verified_scp_slot == current_ledger`, `effective_peer_gap == 0`), but `herder.latest_externalized_slot()` can transiently read `current + 1..2` for a tick — so `LedgerRelation` reports `Behind{gap:1..2}`. That transient slipped past two strict-equality at-tip guards and drove spurious recovery churn:

1. `force_post_catchup_hard_reset`'s `#2664` at-tip defense required *exact* `latest_ext == current_ledger`, so a gap of 1–2 slipped into `spawn_catchup(ProbeAhead)` which failed with "checkpoint N not ahead of min_ledger M".
2. `trigger_recovery_catchup`'s `is_behind()` branch counted the blip as `forcing_catchup_behind` (the +81/+431 alarm bursts) at info level.

The fix treats verified `effective_peer_gap == 0` (within the near-tip band, local gap `<= TX_SET_REQUEST_WINDOW`) as the authoritative at-tip signal — the same evidence the heartbeat reports as `peer_gap=0`:

- **catchup_impl.rs**: widen the `#2664` guard to also fire when `local_gap <= TX_SET_REQUEST_WINDOW && effective_peer_gap == 0`, clearing the identical coupled state via `ArchiveRecoveryClear::DefenseSkip` (status→Unknown, livelock_start→0, urgent→false). The near-tip band bound prevents mis-suppressing a genuine large local behind with stale-low `max_verified_scp_slot`.
- **consensus.rs**: extract the pure predicate `is_spurious_near_tip_behind(behind_gap, peer_gap)` and use it at the emit site to route the transient to a benign `forcing_catchup_near_tip` metric bucket + debug log instead of `forcing_catchup_behind` + info. The escalation decision at consensus.rs:424 is untouched.

Genuine behind-the-network escalation (`peer_gap >= 3`) is preserved. Moves henyey toward stellar-core `HerderImpl::outOfSyncRecovery()`, which early-returns at the tip. The overlay-side inbound-flap trigger is split to #3736 (out of scope here).

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3733#issuecomment-5053184751)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-app --lib` — 1172 passed, 0 failed

## Regression test (kind: bug-fix)

- **Test:** `catchup_impl::test_hard_reset_skipped_near_tip_peer_gap_zero` (+ negative `test_hard_reset_not_skipped_near_tip_when_peers_ahead`; + pure predicate `consensus::test_near_tip_behind_not_counted_as_forcing_catchup_behind`)
- **Pre-fix:** verified FAILED — the strict `latest_ext == current_ledger` guard does not match `latest_ext = 5_001`, so the fn proceeds toward `spawn_catchup(ProbeAhead)` and leaves `archive_recovery_status` as `ConfirmedBehind` (panic: "archive_recovery_status must be cleared").
- **Post-fix:** verified PASSES.

## Deviations from plan

- Committed the failing test and the fix as a single commit rather than two. Reason: the extracted `is_spurious_near_tip_behind` predicate is unused until wired into the emit site, and the pre-commit hook runs `clippy -D warnings`, which rejects `dead_code`. The TDD failing-first step was still performed and verified out-of-band (near-tip skip test confirmed FAILING on unmodified code before the guard was widened).
- Added a near-tip band bound (`local_gap <= TX_SET_REQUEST_WINDOW`) to the widened catchup_impl guard (the plan named only `effective_peer_gap == 0`). Without it, two existing tests (`test_hard_reset_not_suppressed_flag_false`, `test_hard_reset_not_suppressed_fresh_cache_ahead`) with a genuine 50-ledger local behind + stale-low `max_verified_scp_slot` were mis-suppressed. The bound mirrors `is_spurious_near_tip_behind` at the consensus.rs emit site, keeping both sites consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)