### PR TITLE
Add in-loop stall detector and live diagnostic tail to History Publish CI fixture

### DIFF
--- a/scripts/test-history-publish-harness.sh
+++ b/scripts/test-history-publish-harness.sh
@@ -40,6 +40,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCRIPT="$REPO_ROOT/scripts/test-history-publish.sh"
 WORKFLOW="$REPO_ROOT/.github/workflows/history-publish.yml"
 RUN_CMD="$REPO_ROOT/crates/app/src/run_cmd.rs"
+APP_MOD="$REPO_ROOT/crates/app/src/app/mod.rs"
+LIFECYCLE="$REPO_ROOT/crates/app/src/app/lifecycle.rs"
 
 # The exact sync marker the run loop emits when the node reaches sync. This is
 # the single source of truth shared between the classifier and the assertion
@@ -303,8 +305,160 @@ test_workflow_wires_soft_flag() {
     fi
 }
 
+# ============================================================
+# Tests 7-8: in-loop stall detector (#3741)
+#
+# Background (#3741): #3732 disabled the fixture's internal watchdog auto-abort
+# because it was killing a still-progressing node under legitimate slow-verify
+# load. That removed the only code path that turned "event loop badly stalled"
+# into a clean, script-detected process death — so now the node just keeps
+# grinding until GitHub Actions' own external job/run-level cancellation kills
+# the whole runner, which skips even if: always()-gated steps (Upload
+# logs/Summary never run), leaving zero validator.log evidence for any of the
+# four recurrences (#3280, #3707, #3727, #3741).
+#
+# is_log_stalled() (driven via the --classify-stall-only <log_file>
+# <threshold_secs> CLI seam) is a pure mtime-staleness check: if validator.log
+# has produced zero new bytes for threshold_secs while the harness's own
+# process liveness check still says the node is alive, this is a genuine stall
+# distinct from "testnet never became reachable" (SYNC-TIMEOUT) — always a hard
+# red (DISPOSITION: STALL, exit 1, never covered by --soft-on-sync-timeout), so
+# the workflow's existing `if: failure()` Upload-logs step fires and the full
+# validator.log artifact is captured.
+# ============================================================
+
+# Build a synthetic validator.log fixture with a controllable mtime.
+# Args: <name> <mtime_offset_secs>  (0 = now/fresh; >0 = that many seconds ago)
+make_stall_fixture() {
+    local name="$1"
+    local mtime_offset_secs="$2"
+    local data_dir="$TMPDIR_BASE/stall-fixture-$name"
+    local log="$data_dir/validator.log"
+
+    mkdir -p "$data_dir"
+    echo "closing ledger 1" > "$log"
+
+    if [[ "$mtime_offset_secs" -gt 0 ]]; then
+        touch -d "@$(( $(date +%s) - mtime_offset_secs ))" "$log"
+    fi
+
+    echo "$log"
+}
+
+# ------------------------------------------------------------
+# Test 7: a validator.log with a stale mtime (no forward progress for longer
+# than the threshold) is flagged as a stall — hard red, DISPOSITION: STALL.
+# FAILS on origin/main: --classify-stall-only does not exist (the script hits
+# the `*) echo "Unknown arg: $1"; exit 1 ;;` branch, exit code happens to be 1
+# for the wrong reason, and NO "DISPOSITION: STALL" marker is ever printed).
+# ------------------------------------------------------------
+test_stall_detector_flags_stale_log() {
+    local log
+    log=$(make_stall_fixture "stale" 600)  # mtime 10 minutes in the past
+
+    local out="$TMPDIR_BASE/out-stall-stale.txt"
+    local exit_code=0
+    "$SCRIPT" --classify-stall-only "$log" 180 >"$out" 2>&1 || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        tap_ok "stale_log_stall_detector_exits_nonzero"
+    else
+        tap_not_ok "stale_log_stall_detector_exits_nonzero" "exit=$exit_code (expected 1, stalled)"
+    fi
+
+    if grep -q 'DISPOSITION: STALL' "$out"; then
+        tap_ok "stale_log_stall_detector_emits_disposition_stall"
+    else
+        tap_not_ok "stale_log_stall_detector_emits_disposition_stall" \
+            "no DISPOSITION: STALL marker in output: $(cat "$out")"
+    fi
+}
+
+# ------------------------------------------------------------
+# Test 8: a validator.log with a fresh mtime (progress within the threshold)
+# is NOT flagged — exit 0, no STALL marker. Same origin/main failure mode as
+# test 7 (flag doesn't exist yet).
+# ------------------------------------------------------------
+test_stall_detector_ignores_fresh_log() {
+    local log
+    log=$(make_stall_fixture "fresh" 0)
+
+    local out="$TMPDIR_BASE/out-stall-fresh.txt"
+    local exit_code=0
+    "$SCRIPT" --classify-stall-only "$log" 180 >"$out" 2>&1 || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        tap_ok "fresh_log_stall_detector_exits_zero"
+    else
+        tap_not_ok "fresh_log_stall_detector_exits_zero" "exit=$exit_code (expected 0, not stalled)"
+    fi
+
+    if ! grep -q 'DISPOSITION: STALL' "$out"; then
+        tap_ok "fresh_log_stall_detector_no_stall_marker"
+    else
+        tap_not_ok "fresh_log_stall_detector_no_stall_marker" \
+            "unexpected DISPOSITION: STALL marker for a fresh log"
+    fi
+}
+
+# ============================================================
+# Test 9: the live-tail diagnostic grep filter is pinned to real signal names
+#
+# The script's incremental live-tail (new validator.log lines echoed into the
+# step's own GitHub-captured stdout every poll iteration) is filtered through a
+# grep for known diagnostic families, so it doesn't flood CI log volume. This
+# pins those family tokens to (a) their presence in the script's filter, and
+# (b) the actual strings still emitted by the Rust source that produced them
+# (crates/app/src/app/mod.rs's "WATCHDOG: ..." events, #3727/#3732; and
+# crates/app/src/app/lifecycle.rs's db_write_ctx = "peer-record-update",
+# #3702/#3704) — mirroring test_sync_marker_matches_run_loop_log's "pin the
+# string so wording drift breaks loudly" pattern.
+# ============================================================
+test_diagnostic_grep_pins_known_signal_names() {
+    if [[ ! -f "$APP_MOD" ]] || [[ ! -f "$LIFECYCLE" ]]; then
+        tap_not_ok "diagnostic_filter_pins_all_known_families" "source files not found"
+        tap_not_ok "watchdog_marker_present_in_app_mod" "source files not found"
+        tap_not_ok "db_write_ctx_marker_present_in_lifecycle" "source files not found"
+        return
+    fi
+
+    # (a) The script's live-tail filter must reference each known diagnostic
+    # family token established by #3727's root-cause capture and the #3702
+    # db_write_ctx instrumentation.
+    local families=("WATCHDOG" "maxtps_scp" "database is locked" "straggler timeout" "db_write_ctx")
+    local missing=""
+    for f in "${families[@]}"; do
+        if ! grep -qF "$f" "$SCRIPT"; then
+            missing="$missing [$f]"
+        fi
+    done
+    if [[ -z "$missing" ]]; then
+        tap_ok "diagnostic_filter_pins_all_known_families"
+    else
+        tap_not_ok "diagnostic_filter_pins_all_known_families" \
+            "test-history-publish.sh live-tail filter missing:$missing"
+    fi
+
+    # (b) Cross-check those tokens are still emitted by the real source, so a
+    # future wording change breaks this harness loudly instead of silently
+    # rotting the live-tail filter into a no-op for that family.
+    if grep -qF "WATCHDOG:" "$APP_MOD"; then
+        tap_ok "watchdog_marker_present_in_app_mod"
+    else
+        tap_not_ok "watchdog_marker_present_in_app_mod" \
+            "crates/app/src/app/mod.rs no longer emits a WATCHDOG: marker"
+    fi
+
+    if grep -qF 'db_write_ctx = "peer-record-update"' "$LIFECYCLE"; then
+        tap_ok "db_write_ctx_marker_present_in_lifecycle"
+    else
+        tap_not_ok "db_write_ctx_marker_present_in_lifecycle" \
+            "crates/app/src/app/lifecycle.rs no longer emits db_write_ctx = \"peer-record-update\""
+    fi
+}
+
 # --- Run all tests ---
-tap_plan 14
+tap_plan 21
 
 test_never_synced_soft_skip
 test_synced_no_publish_hard_red
@@ -312,6 +466,9 @@ test_never_synced_default_red
 test_published_proceeds
 test_sync_marker_matches_run_loop_log
 test_workflow_wires_soft_flag
+test_stall_detector_flags_stale_log
+test_stall_detector_ignores_fresh_log
+test_diagnostic_grep_pins_known_signal_names
 
 echo ""
 echo "# Results: $PASS_COUNT/$TEST_COUNT passed, $FAIL_COUNT failed"

--- a/scripts/test-history-publish.sh
+++ b/scripts/test-history-publish.sh
@@ -11,12 +11,48 @@
 #   ./scripts/test-history-publish.sh --data-dir /tmp/x # use specific data directory
 #   ./scripts/test-history-publish.sh --soft-on-sync-timeout  # neutral skip if testnet never synced
 #   ./scripts/test-history-publish.sh --classify-only /path/to/data-dir  # offline classifier (tests)
+#   ./scripts/test-history-publish.sh --stall-threshold 180   # in-loop stall detector threshold
+#   ./scripts/test-history-publish.sh --classify-stall-only /path/to/validator.log 180  # offline stall classifier (tests)
 #
 # Exit codes:
 #   0 = checkpoint matches SDF archive (or an environmental sync-timeout was
 #       soft-skipped under --soft-on-sync-timeout)
 #   1 = mismatch, real error, or a genuine publish regression (synced but no
 #       checkpoint published; see the disposition taxonomy below)
+#
+# --- In-loop stall detector + live diagnostic tail (#3741) ---
+# #3732 disabled this fixture's internal watchdog auto-abort, which correctly
+# stopped a still-progressing node from self-SIGABRTing under legitimate
+# slow-verify load — but it also removed the only code path that turned "event
+# loop badly stalled" into a clean, script-detected process death. Without it,
+# a genuinely stalled-but-alive node just keeps grinding until GitHub Actions'
+# own external job/run-level cancellation kills the whole runner — which skips
+# even if: always()-gated steps, so Upload logs/Summary never run and NO
+# validator.log evidence survives (confirmed on all 4 recurrences of this
+# fixture's "waiting for first published checkpoint" symptom: #3280, #3707,
+# #3727, #3741).
+#
+# Two independent, complementary mitigations (neither fixes the underlying
+# SCP-verify/WAL-contention capacity problem — that stays #3702/#3266's scope):
+#   1. Live diagnostic tail: every ~5s poll iteration, new validator.log lines
+#      are grep-filtered (WATCHDOG|maxtps_scp|database is locked|straggler
+#      timeout|db_write_ctx) and echoed into the step's own stdout, which
+#      GitHub Actions captures even under an external job-level cancellation
+#      (unlike the artifact upload, which does not survive it).
+#   2. Stall-based clean exit: is_log_stalled() checks validator.log's mtime
+#      against --stall-threshold (default 180s). If the node is still alive
+#      (kill -0 succeeds) but the log has produced zero new bytes for that
+#      long, this is treated as a genuine stall — DISPOSITION: STALL, always a
+#      hard red (exit 1, never covered by --soft-on-sync-timeout), so the
+#      workflow's own `if: failure()` Upload-logs step fires and the full
+#      validator.log artifact is captured too.
+#
+# 180s was chosen against two observed external-cancellation timings for this
+# fixture (~287s and ~1437s) and against the periodic progress-logging cadence
+# already present during healthy-but-slow catchup (bucket-download progress,
+# ledger-prefetch progress, and the watchdog's own 15s/30s warn/error tiers) —
+# none of which leave a genuine 180s silent gap. Configurable via
+# --stall-threshold without a code change if real-world tuning is needed.
 #
 # --- Phase-1 deadline disposition taxonomy (#3280) ---
 # The test has two phases: phase 1 waits up to --timeout for the node to sync
@@ -72,6 +108,18 @@ SOFT_ON_SYNC_TIMEOUT=false
 # classified disposition — no validator/build/testnet required. Used by
 # scripts/test-history-publish-harness.sh.
 CLASSIFY_ONLY_DIR=""
+# In-loop stall detector (#3741): if validator.log produces zero new bytes for
+# this many seconds while the node process is still alive, the poll loop treats
+# it as a genuine stall — DISPOSITION: STALL, always a hard red (never covered
+# by --soft-on-sync-timeout; see the header comment above). Overridable via
+# --stall-threshold.
+STALL_THRESHOLD_SECS=180
+# Offline test seam: when set (via --classify-stall-only <log_file>
+# <threshold_secs>), run only is_log_stalled() against an existing log file and
+# exit with the classified disposition — no validator/build/testnet required.
+# Used by scripts/test-history-publish-harness.sh.
+CLASSIFY_STALL_LOG=""
+CLASSIFY_STALL_THRESHOLD=""
 
 # The exact run-loop sync marker (crates/app/src/run_cmd.rs::wait_for_sync logs
 # tracing::info!(..., "Node is synced") once on reaching Synced/Validating). This
@@ -92,6 +140,8 @@ while [[ $# -gt 0 ]]; do
     --data-dir)             DATA_DIR_OVERRIDE="$2"; KEEP_DATA=true; shift 2 ;;
     --soft-on-sync-timeout) SOFT_ON_SYNC_TIMEOUT=true; shift ;;
     --classify-only)        CLASSIFY_ONLY_DIR="$2"; shift 2 ;;
+    --stall-threshold)      STALL_THRESHOLD_SECS="$2"; shift 2 ;;
+    --classify-stall-only)  CLASSIFY_STALL_LOG="$2"; CLASSIFY_STALL_THRESHOLD="$3"; shift 3 ;;
     -h|--help)
       sed -n '3,14p' "$0" | sed 's/^# \?//'
       exit 0 ;;
@@ -153,6 +203,56 @@ if [[ -n "$CLASSIFY_ONLY_DIR" ]]; then
   CLASSIFY_EXIT=0
   classify_deadline "$CLASSIFY_ONLY_DIR" || CLASSIFY_EXIT=$?
   exit $CLASSIFY_EXIT
+fi
+
+# --- In-loop stall detector (#3741) ---
+# Pure mtime-staleness check: has <log_file> produced zero new bytes for at
+# least <threshold_secs>? No side effects beyond the return code, so the
+# harness can drive it offline via --classify-stall-only against a synthetic
+# fixture with a manipulated mtime (`touch -d`).
+#
+# Return convention (bash truthiness: 0 = success = "true"):
+#   0 -> stalled     (log_file missing its mtime freshness bar)
+#   1 -> not stalled (log_file updated within threshold_secs, or unreadable)
+# The CLI seam below and the poll-loop call site both treat a 0 return as "the
+# node is stalled" and act accordingly (DISPOSITION: STALL, hard exit 1).
+is_log_stalled() {
+  local log_file="$1"
+  local now_epoch="$2"
+  local threshold_secs="$3"
+
+  if [[ ! -f "$log_file" ]]; then
+    # No log yet at all — not a "stall" in the sense this detector cares
+    # about; the pre-existing process-liveness and HAS-file checks in the
+    # poll loop handle "nothing has happened yet" separately.
+    return 1
+  fi
+
+  local mtime
+  mtime=$(stat -c %Y "$log_file" 2>/dev/null) || return 1
+
+  local age=$(( now_epoch - mtime ))
+  if [[ $age -ge $threshold_secs ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Offline test seam: classify a single validator.log for staleness and exit.
+# --classify-stall-only <log_file> <threshold_secs>
+#   exit 0 -> not stalled
+#   exit 1 -> stalled (DISPOSITION: STALL, tail printed)
+# No build/validator required.
+if [[ -n "$CLASSIFY_STALL_LOG" ]]; then
+  if is_log_stalled "$CLASSIFY_STALL_LOG" "$(date +%s)" "$CLASSIFY_STALL_THRESHOLD"; then
+    echo "Last 200 lines of $CLASSIFY_STALL_LOG:"
+    tail -200 "$CLASSIFY_STALL_LOG" 2>/dev/null || true
+    echo
+    echo "DISPOSITION: STALL — validator.log produced no new output for >= ${CLASSIFY_STALL_THRESHOLD}s (hard red, #3741)"
+    exit 1
+  fi
+  echo "DISPOSITION: not stalled — validator.log updated within ${CLASSIFY_STALL_THRESHOLD}s"
+  exit 0
 fi
 
 # --- Data dirs ---
@@ -277,7 +377,18 @@ echo
 
 # --- Poll for published checkpoint ---
 HAS_FILE="$HISTORY_DIR/.well-known/stellar-history.json"
-echo "Waiting for first published checkpoint (timeout: ${TIMEOUT}s)..."
+echo "Waiting for first published checkpoint (timeout: ${TIMEOUT}s, stall threshold: ${STALL_THRESHOLD_SECS}s)..."
+
+# Live diagnostic tail (#3741): grep filter for the known diagnostic families
+# already root-caused for this exact fixture (#3727: SCP-verify falling behind
+# under load) and the #3702 db_write_ctx/WAL-contention instrumentation.
+# Grep-filtered (not a full firehose) so it doesn't meaningfully add to CI log
+# volume or runner I/O load. Pinned by
+# scripts/test-history-publish-harness.sh::test_diagnostic_grep_pins_known_signal_names
+# so a future wording change in the Rust source breaks that test loudly instead
+# of silently rotting this filter into a no-op.
+DIAG_GREP_PATTERN='WATCHDOG|maxtps_scp|database is locked|straggler timeout|db_write_ctx'
+LAST_LOG_LINE=0
 
 START_TIME=$(date +%s)
 while true; do
@@ -303,6 +414,34 @@ while true; do
     echo "Last 50 lines of validator log:"
     tail -50 "$LOG_FILE"
     exit 1
+  fi
+
+  # In-loop stall detector (#3741): the node process is alive (checked above)
+  # but validator.log has produced zero new bytes for >= $STALL_THRESHOLD_SECS.
+  # This is a genuine, previously-invisible stall (the class of failure that
+  # used to end in an artifact-less external GitHub Actions cancellation) —
+  # always a hard red, never covered by --soft-on-sync-timeout (a stalled-but-
+  # alive process is meaningfully different from "testnet never became
+  # reachable"). Exiting here (rather than letting the job run to an external
+  # cancellation) makes the workflow's own `if: failure()` Upload-logs step
+  # fire, so the full validator.log artifact is captured too.
+  if is_log_stalled "$LOG_FILE" "$(date +%s)" "$STALL_THRESHOLD_SECS"; then
+    echo "Last 200 lines of validator log:"
+    tail -200 "$LOG_FILE"
+    echo
+    echo "DISPOSITION: STALL — validator.log produced no new output for >= ${STALL_THRESHOLD_SECS}s while the validator process was still alive (hard red, #3741)"
+    exit 1
+  fi
+
+  # Incremental live-tail (#3741): echo any new validator.log lines matching
+  # the diagnostic filter into this step's own stdout, which GitHub Actions
+  # captures even under an external job-level cancellation (unlike the
+  # artifact upload). No background process/PID cleanup needed — this stays
+  # inside the existing single-threaded 5s poll loop.
+  CURRENT_LOG_LINES=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+  if [[ "$CURRENT_LOG_LINES" -gt "$LAST_LOG_LINE" ]]; then
+    tail -n "+$(( LAST_LOG_LINE + 1 ))" "$LOG_FILE" | grep -E "$DIAG_GREP_PATTERN" || true
+    LAST_LOG_LINE="$CURRENT_LOG_LINES"
   fi
 
   # Check for published HAS


### PR DESCRIPTION
Refs #3741

## Summary

The `History Publish (Testnet)` CI fixture has failed 4 times (#3280, #3707,
#3727, #3741) with the same "waiting for first published checkpoint" symptom.
Raw CI log investigation (`gh run view --log`, both attempts of #3741's own
failing run) showed both attempts were killed by an **external GitHub Actions
job-level cancellation** — never reaching the script's own internal 1500s
deadline or printing a `DISPOSITION:` line. That external cancellation skips
even `if: always()`-gated steps, so `Upload logs`/`Summary` never ran and
**no validator.log evidence has survived any of the 4 recurrences**.

#3732's prior fix (disabling the fixture's internal watchdog auto-abort)
correctly stopped a still-progressing node from self-SIGABRTing under
legitimate slow-verify load, but it also removed the only code path that
turned "event loop badly stalled" into a clean, script-detected process
death — trading a fast/diagnosable failure for a slow/opaque one.

This PR adds, to `scripts/test-history-publish.sh`:

1. **`is_log_stalled(log_file, now_epoch, threshold_secs)`** — a pure
   mtime-based staleness check on `validator.log`, wired into the poll loop
   (after the existing `kill -0` liveness check) as a hard-red
   `DISPOSITION: STALL` exit (default threshold 180s, overridable via
   `--stall-threshold`). This is **always** a hard red — never covered by
   `--soft-on-sync-timeout` (a stalled-but-alive process is a different
   failure mode than "testnet never became reachable"). Exiting here (rather
   than waiting for the external cancellation) makes the workflow's own
   `if: failure()` Upload-logs step fire, so the full `validator.log`
   artifact is captured.
2. An **incremental, grep-filtered live tail** of new `validator.log` lines
   into the step's own stdout every ~5s poll iteration (filter:
   `WATCHDOG|maxtps_scp|database is locked|straggler timeout|db_write_ctx`,
   the diagnostic families already root-caused for this fixture in #3727 and
   the #3702 `db_write_ctx` instrumentation). GitHub Actions captures step
   stdout even under an external job-level cancellation, unlike the artifact
   upload.
3. A `--classify-stall-only <log_file> <threshold_secs>` offline CLI seam
   mirroring the existing `--classify-only` pattern, so `is_log_stalled()` is
   testable without a live validator/build.

The 180s threshold was chosen against two observed external-cancellation
timings for this fixture (~287s and ~1437s) and against the periodic
progress-logging cadence already present during healthy-but-slow catchup
(bucket-download progress, ledger-prefetch progress, the watchdog's own
15s/30s warn/error tiers) — none of which leave a genuine 180s silent gap.

**This is NOT a fix for the underlying stall.** The root cause is the
SCP-verify/WAL-contention capacity family tracked by #3702/#3266 (confirmed
distinct from #3702's specific "restore from disk" mechanism, since this
fixture always does a fresh cold catchup — see the converged plan for the
full investigation). This PR is diagnostic instrumentation only, so the next
recurrence produces real evidence instead of another artifact-less external
cancellation. #3741 stays open pending that evidence.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3741#issuecomment-5057784903)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `bash scripts/test-history-publish-harness.sh` — 21/21 TAP assertions pass (14 pre-existing + 7 new)
- [x] `cargo test -p henyey-app --lib config::tests` — 295 passed (unaffected; no config changes)
- [x] `shellcheck scripts/test-history-publish.sh` — same warning count as origin/main (14), no new warnings introduced
- [x] Manual smoke test of `--classify-stall-only` against synthetic stale/fresh fixtures (matches harness assertions)

## Regression test

- **Tests:** `scripts/test-history-publish-harness.sh::test_stall_detector_flags_stale_log`,
  `::test_stall_detector_ignores_fresh_log`, `::test_diagnostic_grep_pins_known_signal_names`
- **Pre-fix:** committed as `e45b49f7` — verified 3 of 7 new assertions FAILED
  (`--classify-stall-only` unrecognized → script hit the `Unknown arg` branch,
  no `DISPOSITION: STALL` marker ever printed, live-tail filter tokens absent
  from the script) — 18/21 total.
- **Post-fix:** verified all 21/21 PASS after `49bd1cc7`.

## Deviations from plan

None — implementation follows the converged plan's file list, approach, and
explicit disposition rule (STALL always hard red) as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)