### PR TITLE
Demote P25/P26/P27 diagnostic-event logs from warn! to debug!

### DIFF
--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -1566,7 +1566,7 @@ fn execute_host_function_p25(
             for (i, event) in diagnostic_events.iter().enumerate() {
                 use soroban_env_host25::xdr::WriteXdr as _;
                 if let Ok(encoded) = event.to_xdr(soroban_env_host25::xdr::Limits::none()) {
-                    tracing::warn!(
+                    tracing::debug!(
                         event_idx = i,
                         event_hex = hex::encode(&encoded),
                         "P25: Diagnostic event"
@@ -1966,7 +1966,7 @@ fn execute_host_function_p26(
             for (i, event) in diagnostic_events.iter().enumerate() {
                 use soroban_env_host26::xdr::WriteXdr as _;
                 if let Ok(encoded) = event.to_xdr(soroban_env_host26::xdr::Limits::none()) {
-                    tracing::warn!(
+                    tracing::debug!(
                         event_idx = i,
                         event_hex = hex::encode(&encoded),
                         "P26: Diagnostic event"
@@ -2226,7 +2226,7 @@ fn execute_host_function_p27(
             for (i, event) in diagnostic_events.iter().enumerate() {
                 use soroban_env_host27::xdr::WriteXdr as _;
                 if let Ok(encoded) = event.to_xdr(soroban_env_host27::xdr::Limits::none()) {
-                    tracing::warn!(
+                    tracing::debug!(
                         event_idx = i,
                         event_hex = hex::encode(&encoded),
                         "P27: Diagnostic event"

--- a/crates/tx/src/soroban/host.rs
+++ b/crates/tx/src/soroban/host.rs
@@ -3125,4 +3125,83 @@ mod tests {
             "With key in previously_restored_keys, hot archive must be skipped"
         );
     }
+
+    /// Regression test for #3761: the per-event diagnostic dump on a failed
+    /// Soroban invocation must log at `debug!`, matching the sibling
+    /// failure-summary/success statements at the same call site. Failed
+    /// contract invocations are routine on mainnet (ordinary contract
+    /// reverts); logging each diagnostic event at `warn!` produced 21.5k
+    /// WARN lines over 26 days (30% of WARN volume) for a non-actionable
+    /// condition. This test inspects the crate's own source rather than
+    /// invoking the (deep, private, version-gated) dispatch functions
+    /// end-to-end, since constructing full footprint/budget/ledger-info
+    /// fixtures per protocol version is disproportionate for a log-level
+    /// change.
+    #[test]
+    fn test_p25_p26_p27_diagnostic_event_logs_are_debug_not_warn() {
+        const SRC: &str = include_str!("host.rs");
+
+        // Truncate the haystack at the `#[cfg(test)] mod tests` boundary.
+        // Without this, the string literals declared a few lines below
+        // (used to state what we're searching for) would themselves appear
+        // in `SRC` once `include_str!` pulls in this very file, and could
+        // be mistaken for production call sites. Restricting the search to
+        // production code makes plain first-occurrence `str::find` (not
+        // `matches().count()`, which would double-count across production
+        // + test code) both correct and sufficient -- not incidental.
+        let boundary = SRC
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("expected a `#[cfg(test)] mod tests` boundary in host.rs");
+        let production_src = &SRC[..boundary];
+
+        let messages = [
+            "\"P25: Diagnostic event\"",
+            "\"P26: Diagnostic event\"",
+            "\"P27: Diagnostic event\"",
+        ];
+
+        let mut sites_found = 0;
+        for message in messages {
+            // First-occurrence search: each message literal names exactly
+            // one call site (one per protocol version) in production code.
+            let msg_pos = production_src
+                .find(message)
+                .unwrap_or_else(|| panic!("expected to find {message} in production code"));
+
+            // Find the line containing the literal, then scan backward up
+            // to 6 lines for the nearest `tracing::` macro invocation that
+            // opens this log statement.
+            let line_idx = production_src[..msg_pos].matches('\n').count();
+            let lines: Vec<&str> = production_src.lines().collect();
+            let start = line_idx.saturating_sub(6);
+            let macro_line = lines[start..=line_idx]
+                .iter()
+                .rev()
+                .find(|l| l.contains("tracing::"))
+                .unwrap_or_else(|| {
+                    panic!("expected a `tracing::` macro within 6 lines above {message}")
+                });
+
+            assert!(
+                macro_line.contains("tracing::debug!"),
+                "{message} must log at debug!, not warn! (found: {})",
+                macro_line.trim()
+            );
+            assert!(
+                !macro_line.contains("tracing::warn!"),
+                "{message} must not log at warn! (found: {})",
+                macro_line.trim()
+            );
+
+            sites_found += 1;
+        }
+
+        // Guards against a future rename silently making the search above
+        // find nothing (each iteration would panic before reaching here,
+        // but this makes the "exactly 3 sites" invariant explicit).
+        assert_eq!(
+            sites_found, 3,
+            "expected exactly 3 diagnostic-event log sites (P25/P26/P27)"
+        );
+    }
 }


### PR DESCRIPTION
Closes #3761

## Summary

`crates/tx/src/soroban/host.rs` logs every diagnostic event of every **failed**
Soroban invocation at `warn!`, one line per event, each carrying the full
hex-encoded XDR of the event. Failed contract invocations are entirely routine
on mainnet (ordinary contract reverts), so this produces a steady stream of
WARN-level output for a non-actionable condition — 21,529 WARN lines over 26
days on the live monitored validator, 30% of all WARN volume.

The two sibling log statements at each call site (the failure summary, and the
success path) were already `debug!`; only the per-event dump was `warn!`, an
apparent copy-paste inconsistency across the P25/P26/P27 protocol-version
forks (P24 has no per-event dump at all). This PR demotes all three sites to
`debug!` to match their siblings.

The diagnostic events are not lost by this change: each function's returned
`SorobanExecutionError` already carries `diagnostic_events` structurally
(`convert_diagnostic_events_p{25,26,27}(...)`), independent of the log line's
tracing level. This also brings henyey in line with stellar-core's own
`CLOG_DEBUG` treatment of the identical event class in
`DiagnosticEventManager::debugLogEvents()`.

Operational only — no correctness or consensus impact. Logging is an internal
surface per `docs/PARITY.md`.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3761#issuecomment-5099650299)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-tx` — 1349 passed, 0 failed

## Regression test

- **Test:** `crates/tx/src/soroban/host.rs::tests::test_p25_p26_p27_diagnostic_event_logs_are_debug_not_warn`
- **Pre-fix:** committed as `d1886bc1` — verified FAILED with: `"P25: Diagnostic event" must log at debug!, not warn! (found: tracing::warn!())`
- **Post-fix:** verified PASSES after `e0383e1f`

The test reads the crate's own source via `include_str!("host.rs")`, truncated
at the `#[cfg(test)] mod tests` boundary so the test's own message-literal
declarations don't self-match. For each of the three message literals it uses
first-occurrence `str::find` (not `matches().count()`, which would double-count),
scans backward up to 6 lines for the nearest `tracing::` macro, and asserts
`debug!` (not `warn!`). It also asserts exactly 3 sites are found, guarding
against a future rename silently making the search find nothing.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)