### PR TITLE
Threshold PhaseTimer WARN on inline time, drop stale issue cite

### DIFF
--- a/crates/app/src/app/ledger_close.rs
+++ b/crates/app/src/app/ledger_close.rs
@@ -2664,6 +2664,24 @@ impl App {
                 tracing::warn!("{}", warning);
             }
         }
+        // Test-only: simulate additional inline (event-loop-blocking) work
+        // immediately before the `overlay_bookkeeping_ms` mark below, so
+        // tests can force this phase over the `PhaseTimer` inline-sum
+        // threshold (#3755) without depending on real overlay/survey/drift
+        // timing. Mirrors `close_complete_inject_blocking_ms` (which
+        // injects into the off-loaded `spawn_blocking` phase below) but
+        // targets the INLINE phase instead — placement matters: this must
+        // land here, before `overlay_bookkeeping_ms`, not before the later
+        // `spawn_blocking_setup_ms` mark, or the delay would be
+        // misattributed.
+        #[cfg(test)]
+        {
+            let inject_inline_ms = self.close_complete_inject_inline_ms.load(Ordering::Relaxed);
+            if inject_inline_ms > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(inject_inline_ms));
+            }
+        }
+
         // Mark end of the inline overlay/survey/drift bookkeeping window.
         // This brackets lines that touch tokio RwLocks (overlay, survey_state)
         // and the std::Mutex drift tracker. Each internal operation is
@@ -3079,7 +3097,7 @@ impl App {
                 );
             }
         }
-        timer.mark("tx_queue_background_wait_ms");
+        timer.mark_cooperative("tx_queue_background_wait_ms");
         record_phase_histogram(crate::metrics::CLOSE_COMPLETE_TX_QUEUE_SECONDS, &timer);
 
         // Update current ledger tracking.

--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -988,6 +988,23 @@ pub struct App {
     #[cfg(test)]
     pub(crate) close_complete_inject_blocking_ms: AtomicU64,
 
+    /// Test-only: injects a synthetic **inline** (event-loop-blocking)
+    /// sleep (in milliseconds), immediately before the
+    /// `overlay_bookkeeping_ms` `PhaseTimer` mark inside
+    /// `handle_close_complete_inner`. Mirrors
+    /// `close_complete_inject_blocking_ms` above, but targets the
+    /// INLINE phase instead of the `spawn_blocking`-off-loaded phase.
+    ///
+    /// Needed because `PhaseTimer::finish` (#3755) thresholds its
+    /// slow-call WARN on the inline phase sum only, and
+    /// `tx_queue_background_wait_ms` (the phase
+    /// `close_complete_inject_blocking_ms` lands in) is now recorded via
+    /// `mark_cooperative`, so it no longer counts toward that threshold
+    /// on its own. When set to 0 (the default), the inline preamble
+    /// behaves exactly as in production.
+    #[cfg(test)]
+    pub(crate) close_complete_inject_inline_ms: AtomicU64,
+
     /// Regression-only hook for testing that `process_externalized_slots`
     /// does NOT hold `syncing_ledgers` write lock during the iteration phase.
     /// Set by tests that need deterministic synchronization; `None` otherwise.
@@ -1665,6 +1682,8 @@ impl App {
             close_cycle_last_start: parking_lot::Mutex::new(None),
             #[cfg(test)]
             close_complete_inject_blocking_ms: AtomicU64::new(0),
+            #[cfg(test)]
+            close_complete_inject_inline_ms: AtomicU64::new(0),
             #[cfg(test)]
             pes_iteration_gate: None,
             sync_recovery_pending: AtomicBool::new(false),
@@ -8499,11 +8518,13 @@ mod tests {
     ///    attributing inline preamble work to labels that named the
     ///    off-loaded work).
     ///
-    /// 2. **Event-loop blocking time**: the sum of the two pre-spawn marks
-    ///    (`overlay_bookkeeping_ms + spawn_blocking_setup_ms`) is < 50 ms.
-    ///    These brackets span only inline overlay/survey/drift bookkeeping
-    ///    plus the preamble that moves fields into the spawn_blocking
-    ///    closure — pure sync CPU + a handful of tokio RwLock reads.
+    /// 2. **Inline event-loop-blocking time (#3755)**: `overlay_bookkeeping_ms`
+    ///    reflects the 260 ms inline delay injected via
+    ///    `close_complete_inject_inline_ms` (one-sided `>= 260 ms` — no tight
+    ///    upper bound, matching this test's own jitter-tolerant style used
+    ///    below for `tx_queue_background_wait_ms`), while
+    ///    `spawn_blocking_setup_ms` remains `< 50 ms` (pure capture-list
+    ///    moves, unaffected by the inline injection).
     ///
     /// 3. **Spawn-blocking wait visibility (#1775)**:
     ///    `tx_queue_background_wait_ms >= 300 ms`, confirming the injected
@@ -8524,6 +8545,12 @@ mod tests {
         // is always emitted regardless of preamble timing jitter on slow CI.
         app.close_complete_inject_blocking_ms
             .store(400, Ordering::Relaxed);
+        // Also inject 260 ms of synthetic inline work (lands in
+        // `overlay_bookkeeping_ms`) so the WARN still fires post-#3755, now
+        // that `tx_queue_background_wait_ms` is `mark_cooperative` and no
+        // longer counts toward the inline-sum threshold on its own.
+        app.close_complete_inject_inline_ms
+            .store(260, Ordering::Relaxed);
         app.set_applying_ledger(true);
 
         // Capture tracing output to inspect PhaseTimer WARN emissions.
@@ -8667,16 +8694,27 @@ mod tests {
             "WARN line should contain tx_queue_background_wait_ms field (new in #1775 Phase 2)",
         );
 
-        // Assertion (2): Event-loop blocking time < 50 ms. The two pre-spawn
-        // marks bracket only inline overlay/survey/drift bookkeeping plus
-        // the preamble that moves fields into the spawn_blocking closure.
-        // Post-fix this is microseconds of real CPU cost; pre-#1778 (misnamed
-        // marks) this window used to read ~200 ms because the marks fired
-        // AFTER work that had moved off-thread in #1775 Phase 2.
+        // Assertion (2a): `overlay_bookkeeping_ms` reflects the 260 ms
+        // inline delay injected via `close_complete_inject_inline_ms`
+        // (#3755). One-sided lower bound only — no tight upper bound —
+        // matching this same test's jitter-tolerant style for
+        // `tx_queue_background_wait_ms` below.
         assert!(
-            overlay_ms + setup_ms < 50,
-            "overlay_bookkeeping_ms ({overlay_ms}) + spawn_blocking_setup_ms \
-             ({setup_ms}) must be < 50 ms post-fix; WARN line was: {phase_line}"
+            overlay_ms >= 260,
+            "overlay_bookkeeping_ms ({overlay_ms}) should reflect the 260 ms \
+             injected inline delay; WARN line was: {phase_line}"
+        );
+        // Assertion (2b): `spawn_blocking_setup_ms` < 50 ms. This bracket
+        // spans only the preamble that moves fields into the spawn_blocking
+        // closure — pure sync CPU + a handful of tokio RwLock reads, and is
+        // unaffected by the inline injection above. Post-fix this is
+        // microseconds of real CPU cost; pre-#1778 (misnamed marks) this
+        // window used to read ~200 ms because the marks fired AFTER work
+        // that had moved off-thread in #1775 Phase 2.
+        assert!(
+            setup_ms < 50,
+            "spawn_blocking_setup_ms ({setup_ms}) must be < 50 ms post-fix; \
+             WARN line was: {phase_line}"
         );
 
         // Assertion (3): The 400 ms injected work must show up under
@@ -8695,13 +8733,21 @@ mod tests {
     /// observed pre-fix on mainnet binary `3a6388b9`.
     ///
     /// Unlike `test_close_complete_event_loop_marks_correctly_attributed`,
-    /// this test injects NO synthetic blocking work. It exercises the
+    /// this test injects no work inside `spawn_blocking`. It exercises the
     /// smallest possible close (empty tx_set, no meta), so the WARN line
     /// may not fire at the 250 ms PhaseTimer threshold; the assertion
-    /// uses the DEBUG-level "start" / "finish" path by triggering the
-    /// WARN unconditionally via a tiny 260 ms injection (comfortably above
-    /// the 250 ms gate but small enough that it does not mask a
-    /// setup-window regression).
+    /// triggers the WARN unconditionally via a tiny 260 ms **inline**
+    /// injection (`close_complete_inject_inline_ms`), which lands in
+    /// `overlay_bookkeeping_ms` immediately before that mark — NOT inside
+    /// `spawn_blocking`. This is comfortably above the 250 ms gate but
+    /// small enough that it does not mask a setup-window regression.
+    ///
+    /// The injection must be inline rather than inside `spawn_blocking`:
+    /// since #3755, `PhaseTimer::finish` thresholds its slow-call WARN on
+    /// the **inline** phase sum only, and `tx_queue_background_wait_ms`
+    /// (the phase `close_complete_inject_blocking_ms` — used by the
+    /// sibling test above — lands in) is recorded via `mark_cooperative`,
+    /// so it no longer counts toward that threshold on its own.
     ///
     /// **Assertions**:
     ///
@@ -8730,14 +8776,13 @@ mod tests {
             .build();
         let app = App::new(config).await.unwrap();
 
-        // Inject 260 ms of synthetic blocking work INSIDE the spawn_blocking
-        // closure (just above the PhaseTimer's 250 ms WARN gate) so the
-        // WARN line always fires and the sub-phase numbers can be parsed.
-        // The injection sits inside `spawn_blocking`, so it shows up under
-        // `tx_queue_background_wait_ms`, NOT under
-        // `spawn_blocking_setup_ms`. Any value leaking into
-        // `spawn_blocking_setup_ms` is the real regression.
-        app.close_complete_inject_blocking_ms
+        // Inject 260 ms of synthetic inline work (just above the
+        // PhaseTimer's 250 ms WARN gate) so the WARN line always fires and
+        // the sub-phase numbers can be parsed. The injection lands in
+        // `overlay_bookkeeping_ms`, NOT under `spawn_blocking_setup_ms`.
+        // Any value leaking into `spawn_blocking_setup_ms` is the real
+        // regression.
+        app.close_complete_inject_inline_ms
             .store(260, Ordering::Relaxed);
         app.set_applying_ledger(true);
 

--- a/crates/common/src/tracking.rs
+++ b/crates/common/src/tracking.rs
@@ -212,7 +212,9 @@ mod tests {
         call: Option<String>,
         elapsed_ms: Option<u64>,
         total_ms: Option<u64>,
+        inline_ms: Option<u64>,
         phases: Option<String>,
+        message: Option<String>,
     }
 
     impl Visit for CapturedEvent {
@@ -226,6 +228,8 @@ mod tests {
                 self.elapsed_ms = Some(value);
             } else if field.name() == "total_ms" {
                 self.total_ms = Some(value);
+            } else if field.name() == "inline_ms" {
+                self.inline_ms = Some(value);
             }
         }
         fn record_i64(&mut self, field: &Field, value: i64) {
@@ -238,6 +242,13 @@ mod tests {
             // assert on the formatted phase-breakdown string.
             if field.name() == "phases" {
                 self.phases = Some(format!("{:?}", value).trim_matches('"').to_string());
+            } else if field.name() == "message" {
+                // The macro's format-string/args are recorded as the
+                // implicit "message" field, routed through
+                // `record_debug` (`std::fmt::Arguments`'s `Debug` impl
+                // delegates to `Display`). Capture it so tests can
+                // assert on the human-readable WARN text itself.
+                self.message = Some(format!("{:?}", value).trim_matches('"').to_string());
             }
         }
     }
@@ -410,5 +421,116 @@ mod tests {
         // Durations are non-negative (no wall-clock assertions)
         assert!(phases[0].1 >= Duration::ZERO);
         assert!(phases[1].1 >= Duration::ZERO);
+    }
+
+    /// Regression test for #3755: a `PhaseTimer` whose only recorded
+    /// phase is *cooperative* (an `.await` where the event loop was
+    /// free to run other tasks) must not trigger the slow-call WARN,
+    /// even though the wall-clock total comfortably exceeds
+    /// [`LOCK_SLOW_THRESHOLD`]. This mirrors mainnet
+    /// `herder.receive_tx_set`, whose entire slow-call time was the
+    /// cooperative await of a `spawn_blocking` drain.
+    #[test]
+    fn phase_timer_cooperative_only_does_not_warn() {
+        let sub = CapturingSubscriber::default();
+        let events = sub.events.clone();
+
+        with_default(sub, || {
+            let mut timer = PhaseTimer::start();
+            std::thread::sleep(TEST_SLOW_DURATION);
+            timer.mark_cooperative("cooperative_wait_ms");
+            timer.finish("common.test_cooperative_only");
+        });
+
+        let evs = events.lock().unwrap();
+        let call_events: Vec<_> = evs
+            .iter()
+            .filter(|e| e.call.as_deref() == Some("common.test_cooperative_only"))
+            .collect();
+        assert_eq!(
+            call_events.len(),
+            0,
+            "a cooperative-only phase must not trigger the slow-call WARN; saw: {:?}",
+            *evs
+        );
+    }
+
+    /// Regression test for #3755: a genuine inline (event-loop-blocking)
+    /// phase must still trigger the WARN even when a cooperative phase
+    /// also elapsed in the same call, and the reported `inline_ms` must
+    /// reflect only the inline phase — strictly less than `total_ms`.
+    #[test]
+    fn phase_timer_inline_still_warns_alongside_cooperative() {
+        let sub = CapturingSubscriber::default();
+        let events = sub.events.clone();
+
+        with_default(sub, || {
+            let mut timer = PhaseTimer::start();
+            std::thread::sleep(TEST_SLOW_DURATION);
+            timer.mark("inline_phase_ms");
+            std::thread::sleep(TEST_SLOW_DURATION);
+            timer.mark_cooperative("cooperative_phase_ms");
+            timer.finish("common.test_inline_and_cooperative");
+        });
+
+        let evs = events.lock().unwrap();
+        let call_events: Vec<_> = evs
+            .iter()
+            .filter(|e| e.call.as_deref() == Some("common.test_inline_and_cooperative"))
+            .collect();
+        assert_eq!(
+            call_events.len(),
+            1,
+            "expected exactly one slow-call WARN; saw: {:?}",
+            *evs
+        );
+        assert_eq!(call_events[0].level, "WARN");
+        let total = call_events[0].total_ms.expect("total_ms missing");
+        let inline = call_events[0].inline_ms.expect("inline_ms missing");
+        assert!(
+            inline >= TEST_SLOW_DURATION.as_millis() as u64,
+            "inline_ms ({inline}) should reflect the inline phase alone"
+        );
+        assert!(
+            inline < total,
+            "inline_ms ({inline}) must be strictly less than total_ms ({total}) \
+             since a cooperative phase also elapsed"
+        );
+    }
+
+    /// Regression test for #3755: the slow-call WARN message must not
+    /// cite the now-closed #1759/#1772 issues. The message is
+    /// label-agnostic, so a stale reference on any label is a defect —
+    /// this exercises `PhaseTimer::finish` directly.
+    #[test]
+    fn phase_timer_message_omits_stale_issue_reference() {
+        let sub = CapturingSubscriber::default();
+        let events = sub.events.clone();
+
+        with_default(sub, || {
+            let mut timer = PhaseTimer::start();
+            std::thread::sleep(TEST_SLOW_DURATION);
+            timer.mark("phase_one_ms");
+            timer.finish("common.test_message_text");
+        });
+
+        let evs = events.lock().unwrap();
+        let call_events: Vec<_> = evs
+            .iter()
+            .filter(|e| e.call.as_deref() == Some("common.test_message_text"))
+            .collect();
+        assert_eq!(call_events.len(), 1);
+        let message = call_events[0]
+            .message
+            .as_deref()
+            .expect("message field missing");
+        assert!(
+            !message.contains("#1759"),
+            "message must not cite closed #1759: {message:?}"
+        );
+        assert!(
+            !message.contains("#1772"),
+            "message must not cite closed #1772: {message:?}"
+        );
     }
 }

--- a/crates/common/src/tracking.rs
+++ b/crates/common/src/tracking.rs
@@ -19,11 +19,17 @@
 //!   point (e.g. `herder.receive_tx_set`).
 //!
 //! - [`PhaseTimer`] — record a sequence of named phase durations
-//!   between `mark` points. On `finish`, emit a single structured
-//!   `WARN` with every phase as a `<name>=<ms>` field plus a
-//!   `total_ms=<sum>` field, iff total >= [`LOCK_SLOW_THRESHOLD`].
-//!   Intended for breaking a slow `time_call`ed function into its
-//!   sub-phases so the next freeze log names the dominant phase.
+//!   between `mark` points. Each phase is classified as **inline**
+//!   (event-loop-blocking, recorded via [`PhaseTimer::mark`]) or
+//!   **cooperative** (an `.await` where the event loop is free to run
+//!   other tasks, recorded via [`PhaseTimer::mark_cooperative`]). On
+//!   `finish`, emit a single structured `WARN` with every phase as a
+//!   `<name>=<ms>` field plus `total_ms=<sum>` and `inline_ms=<inline
+//!   sum>` fields, iff the **inline** sum reaches
+//!   [`LOCK_SLOW_THRESHOLD`]. Intended for breaking a slow
+//!   `time_call`ed function into its sub-phases so the next freeze log
+//!   names the dominant *blocking* phase, without firing on off-loaded
+//!   work that the event loop was free to ignore.
 //!
 //! ## Fast-path cost
 //!
@@ -114,6 +120,14 @@ pub struct PhaseTimer {
     start: Instant,
     last_mark: Instant,
     phases: Vec<(&'static str, Duration)>,
+    /// Sum of durations recorded via [`mark`](Self::mark) (inline,
+    /// event-loop-blocking phases) only. Durations recorded via
+    /// [`mark_cooperative`](Self::mark_cooperative) are excluded.
+    /// [`finish`](Self::finish) thresholds on this sum, not on the
+    /// full wall-clock total, so cooperative `.await`s on off-loaded
+    /// work (e.g. `spawn_blocking`) don't trigger the slow-call WARN
+    /// on their own.
+    inline_total: Duration,
 }
 
 impl PhaseTimer {
@@ -125,19 +139,43 @@ impl PhaseTimer {
             start: now,
             last_mark: now,
             phases: Vec::with_capacity(8),
+            inline_total: Duration::ZERO,
         }
     }
 
     /// Record the elapsed time since the previous `mark` (or since
-    /// `start` for the first call) under `name`.
+    /// `start` for the first call) under `name`, as an **inline**
+    /// (event-loop-blocking) phase. Counts toward the
+    /// [`finish`](Self::finish) slow-call threshold.
     ///
     /// `name` is a `&'static str` by design: phase names live in the
     /// call-site source, not in per-call allocations, and the WARN
     /// line below reads them cheaply.
     pub fn mark(&mut self, name: &'static str) {
+        self.mark_impl(name, true);
+    }
+
+    /// Record the elapsed time since the previous `mark` (or since
+    /// `start` for the first call) under `name`, as a **cooperative**
+    /// phase — an `.await` (e.g. of a `spawn_blocking` `JoinHandle`)
+    /// during which the event loop is free to run other tasks.
+    /// Recorded in `phases()`/`total_ms` exactly like [`mark`](Self::mark),
+    /// but excluded from the [`finish`](Self::finish) slow-call
+    /// threshold, since this time does not represent event-loop
+    /// blockage.
+    pub fn mark_cooperative(&mut self, name: &'static str) {
+        self.mark_impl(name, false);
+    }
+
+    /// Shared implementation backing [`mark`](Self::mark) and
+    /// [`mark_cooperative`](Self::mark_cooperative).
+    fn mark_impl(&mut self, name: &'static str, inline: bool) {
         let now = Instant::now();
         let phase = now.saturating_duration_since(self.last_mark);
         self.phases.push((name, phase));
+        if inline {
+            self.inline_total += phase;
+        }
         self.last_mark = now;
     }
 
@@ -153,15 +191,22 @@ impl PhaseTimer {
         &self.phases
     }
 
-    /// Finish the timer. If the total wall time since `start` reaches
-    /// [`LOCK_SLOW_THRESHOLD`], emit a single structured `WARN` line
-    /// with every phase as a field plus `total_ms` and `call`.
+    /// Finish the timer. If the **inline** (event-loop-blocking) phase
+    /// sum reaches [`LOCK_SLOW_THRESHOLD`], emit a single structured
+    /// `WARN` line with every phase as a field plus `total_ms`,
+    /// `inline_ms`, and `call`.
+    ///
+    /// Thresholding on `inline_ms` rather than `total_ms` means a call
+    /// dominated by a cooperative `.await` (e.g. awaiting a
+    /// `spawn_blocking` `JoinHandle`) does not trigger the WARN on its
+    /// own — the event loop was free to run other tasks during that
+    /// time. `total_ms` is still reported for full-wall-clock context.
     ///
     /// The WARN is emitted exactly once per `finish` call; the timer
     /// is consumed (`self`) to prevent accidental double emission.
     pub fn finish(self, label: &'static str) {
         let total = self.start.elapsed();
-        if total < LOCK_SLOW_THRESHOLD {
+        if self.inline_total < LOCK_SLOW_THRESHOLD {
             return;
         }
 
@@ -183,9 +228,10 @@ impl PhaseTimer {
         tracing::warn!(
             call = label,
             total_ms = total.as_millis() as u64,
+            inline_ms = self.inline_total.as_millis() as u64,
             threshold_ms = LOCK_SLOW_THRESHOLD.as_millis() as u64,
             phases = %phases_field,
-            "Slow call (>= {}ms) phase breakdown — possible #1759/#1772 contributor",
+            "Slow call (>= {}ms) phase breakdown",
             LOCK_SLOW_THRESHOLD.as_millis()
         );
     }

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -4551,7 +4551,7 @@ impl Herder {
                 "envelope drain after tx-set receive"
             );
         }
-        timer.mark("process_ready_spawn_blocking_ms");
+        timer.mark_cooperative("process_ready_spawn_blocking_ms");
 
         timer.finish("herder.receive_tx_set");
         slot


### PR DESCRIPTION
Closes #3755

## Summary

`PhaseTimer::finish()` thresholded its slow-call WARN on `total_ms` — the sum of inline (event-loop-blocking) and cooperative (`.await` on off-loaded work, e.g. a `spawn_blocking` `JoinHandle`) phases together — and hardcoded a "possible #1759/#1772 contributor" reference into the message text, even though both issues are closed and the phases doing so (`process_ready_spawn_blocking_ms`, `tx_queue_background_wait_ms`) are documented in-code as expected cooperative-await time, not event-loop blockage.

This PR adds `PhaseTimer::mark_cooperative()` alongside `mark()`, both backed by a shared `mark_impl(name, inline)` that only accumulates a new `inline_total` when the phase is inline. `finish()` now thresholds on `inline_total` (reported as a new `inline_ms` field; `total_ms` is unchanged) and drops the stale issue reference from the WARN text. The two known cooperative-await call sites — `herder.receive_tx_set`'s `process_ready_spawn_blocking_ms` and `app.handle_close_complete`'s `tx_queue_background_wait_ms` — are converted to `mark_cooperative`. A new `close_complete_inject_inline_ms` test-support atomic (mirroring the existing `close_complete_inject_blocking_ms`) lets the two existing tests that relied on the old total-based threshold keep exercising the slow-call WARN under the new inline-only semantics.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3755#issuecomment-5102435636)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-common` — 222 lib tests + 38 doc-tests pass (includes the 3 new `PhaseTimer` tests)
- [x] `cargo test -p henyey-herder` — 1211 lib tests + all integration/doc tests pass
- [x] `cargo test -p henyey-app` — 1172 lib tests + all integration/doc tests pass, including both updated tests: `test_close_complete_event_loop_marks_correctly_attributed` and `test_close_complete_setup_preamble_is_minimal`

## Regression test (kind: bug-fix)

- **Test:** `crates/common/src/tracking.rs::tests::{phase_timer_cooperative_only_does_not_warn, phase_timer_inline_still_warns_alongside_cooperative, phase_timer_message_omits_stale_issue_reference}`
- **Pre-fix:** committed as `84b01d8052235d30196e66568f31aa6b4e413319` — verified the crate FAILS TO COMPILE against unmodified `origin/main` with `error[E0599]: no method named `mark_cooperative` found for struct `tracking::PhaseTimer``
- **Post-fix:** verified all 3 tests PASS after `913d29d6b4271ee6af33b2bdb601ded348e3216f`

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)