### PR TITLE
Key VE deploy-target greenness on each sha's most-recent verdict

### DIFF
--- a/scripts/lib/monitor-decisions.sh
+++ b/scripts/lib/monitor-decisions.sh
@@ -775,15 +775,28 @@ classify_path_binary_relevance() {
 # (exactly the `gh run list … --json headSha,status,conclusion --jq` order):
 #     <headSha>|<status>|<conclusion>
 #
+# Greenness is keyed on each sha's MOST-RECENT definitive verdict, not "any
+# success ever". `Verify Execution (Mainnet)` is deterministic per-sha, so a
+# newer `failure` on a sha whose older run `success`ed means a genuine
+# regression (or a flake) surfaced by newer mainnet data — either way "latest
+# success ever" is the wrong signal for "safe to ship now" (#3740). Because
+# records arrive newest-first, the FIRST definitive (success/failure) row per
+# sha wins; an older success can no longer resurrect a sha whose newest run
+# failed. Non-definitive conclusions (cancelled/skipped/neutral/…) are
+# cancel-per-head noise and are ignored (older rows still decide the sha).
+#
 # Prints the chosen deploy-target sha to STDOUT (empty if none), and a single
 # reason token to STDERR. Reason tokens:
 #     (sha printed)        — a valid newer green target was selected
-#     no-green-run         — no record is completed/success
+#     no-green-run         — no definitive verdict yielded a usable green target
 #     green-equals-deployed— newest valid green sha == deployed (up-to-date)
 #     green-behind-deployed— only green sha(s) are ancestors of deployed (no
 #                            backwards deploy)
 #     green-not-on-main    — only green sha(s) are not ancestors of ORIGIN_SHA
 #                            (off-main / force-pushed / unresolvable locally)
+#     green-superseded-by-failure — a sha's newest VE verdict was a failure that
+#                            superseded an older success for that same sha, and
+#                            no other usable green remained (#3740)
 #     walk-exceeded        — newest valid green sha is > MAX_DEPLOY_WALK commits
 #                            ahead of deployed (defensive staleness bound)
 #
@@ -836,14 +849,57 @@ select_latest_green_deploy_target() {
   # makes the deploy gate fail-closed to `defer-no-green`, silently deferring
   # every deploy (#3581). Use a non-reserved name.
   local line sha run_status conclusion
-  local saw_green=0           # any completed/success record at all
+  local saw_green=0           # any completed/success record that was NOT superseded
   local saw_on_main=0         # any green record that is on main (ancestor of HEAD)
+  local saw_superseded=0      # a sha's newest verdict was failure but an older run succeeded
+  # Per-sha bookkeeping via whitespace-delimited accumulator strings (NOT a
+  # bash-4 `local -A` associative array): the function is invoked under
+  # `emulate -L zsh` in the deploy gate (see the #3581/#3592 zsh cases), where
+  # associative-array semantics diverge. Hex shas contain no whitespace, so
+  # space-delimited membership (`case " $set " in *" $sha "*)`) is exact.
+  local seen_shas=''          # shas whose newest DEFINITIVE verdict is already recorded
+  local failed_shas=''        # shas whose newest definitive verdict was failure
 
   while IFS='|' read -r sha run_status conclusion; do
     # Skip blank lines.
     [[ -z "$sha" ]] && continue
-    # Only completed/success records are deploy candidates.
-    [[ "$run_status" == "completed" && "$conclusion" == "success" ]] || continue
+    # Only completed runs carry a verdict; in-progress/queued rows are not yet a
+    # conclusion for this sha — skip without recording (an older completed row
+    # for the same sha still decides it).
+    [[ "$run_status" == "completed" ]] || continue
+    # Only success/failure are DEFINITIVE verdicts. Any other conclusion
+    # (cancelled/skipped/neutral/timed_out/action_required/…) is cancel-per-head
+    # noise on a busy main — ignore the row and keep consulting older rows for
+    # this sha (preserves the HEAD|cancelled → older-green behavior of #3351).
+    [[ "$conclusion" == "success" || "$conclusion" == "failure" ]] || continue
+
+    # Records arrive newest-first, so the FIRST definitive row per sha is that
+    # sha's authoritative (most-recent) verdict. Once recorded, an older row for
+    # the same sha cannot change it — an older success can no longer resurrect a
+    # sha whose newest VE run failed. When a later (older) success row shows up
+    # for a sha we already recorded as failed, note that a green was superseded
+    # by a newer failure (the "note when skipped due to a newer failure" #3740
+    # asks for) — then skip it.
+    case " $seen_shas " in
+      *" $sha "*)
+        if [[ "$conclusion" == "success" ]]; then
+          case " $failed_shas " in *" $sha "*) saw_superseded=1 ;; esac
+        fi
+        continue
+        ;;
+    esac
+    seen_shas="$seen_shas $sha"
+
+    if [[ "$conclusion" == "failure" ]]; then
+      # Newest verdict for this sha is a failure → disqualify the sha entirely.
+      # Record it so a later (older) success row for the same sha is reported as
+      # green-superseded-by-failure rather than a bare no-green-run. saw_green is
+      # intentionally NOT set for a disqualified sha.
+      failed_shas="$failed_shas $sha"
+      continue
+    fi
+
+    # conclusion == success and this is the sha's newest definitive verdict.
     saw_green=1
 
     # Guardrail 1 — on main: the green sha must be an ancestor-or-equal of the
@@ -895,8 +951,12 @@ select_latest_green_deploy_target() {
     # Green sha(s) exist but none are ancestors of origin HEAD (off-main /
     # force-pushed / unresolvable locally).
     echo "green-not-on-main" >&2
+  elif (( saw_superseded == 1 )); then
+    # No usable green remained, and the reason is that a sha's newest VE verdict
+    # was a failure that superseded an older success for that same sha (#3740).
+    echo "green-superseded-by-failure" >&2
   else
-    # No completed/success record at all.
+    # No definitive (success/failure) verdict yielded a usable green target.
     echo "no-green-run" >&2
   fi
   return 0

--- a/scripts/test-monitor-skill-snippets.sh
+++ b/scripts/test-monitor-skill-snippets.sh
@@ -10371,6 +10371,57 @@ BOARDEOF
     tap_not_ok "select_latest_green: green > MAX_DEPLOY_WALK ahead → empty + walk-exceeded (#3351)" "out='$_out6' err='$_err6'"
   fi
 
+  # Case 7 (#3740): a sha whose NEWEST Verify-Execution run concluded `failure`
+  # must be disqualified even though an OLDER run of the SAME sha succeeded.
+  # Records newest-first: G's newest is failure (supersedes G's older success),
+  # so the selector must fall through to the next green sha G_OLD, NOT return G.
+  # FAILS on main (main skips the failure row and returns G off the older success).
+  _records_newer_failure_same_sha() {
+    printf '%s\n' \
+      "G|completed|failure" \
+      "G|completed|success" \
+      "G_OLD|completed|success"
+  }
+  _sel7="$(_records_newer_failure_same_sha | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null)"
+  if [[ "$_sel7" == "G_OLD" ]]; then
+    tap_ok "select_latest_green: sha with newer failure is disqualified (#3740)"
+  else
+    tap_not_ok "select_latest_green: sha with newer failure is disqualified (#3740)" "got '$_sel7' (expected 'G_OLD')"
+  fi
+
+  # Case 8 (#3740): newest run for the only candidate sha is a failure that
+  # supersedes an older success, and there is no other green → empty stdout +
+  # reason green-superseded-by-failure (the "note logged when a sha is skipped
+  # due to a newer failure" the issue asks for). FAILS on main (returns G).
+  _records_superseded_only() {
+    printf '%s\n' \
+      "G|completed|failure" \
+      "G|completed|success"
+  }
+  _err8="$(_records_superseded_only | select_latest_green_deploy_target "DEP" "HEAD" 2>&1 >/dev/null)"
+  _out8="$(_records_superseded_only | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null)"
+  if [[ -z "$_out8" && "$_err8" == *"green-superseded-by-failure"* ]]; then
+    tap_ok "select_latest_green: newer failure + no other green → green-superseded-by-failure (#3740)"
+  else
+    tap_not_ok "select_latest_green: newer failure + no other green → green-superseded-by-failure (#3740)" "out='$_out8' err='$_err8'"
+  fi
+
+  # Case 9 (#3740, GUARD — passes on main too): a `cancelled` newest row is
+  # cancel-per-head noise, NOT a definitive verdict, so it must NOT disqualify an
+  # older success for the same sha. Guards the fix against over-disqualifying:
+  # only success/failure are definitive; cancelled/skipped/etc. are ignored.
+  _records_cancelled_newest_same_sha() {
+    printf '%s\n' \
+      "G|completed|cancelled" \
+      "G|completed|success"
+  }
+  _sel9="$(_records_cancelled_newest_same_sha | select_latest_green_deploy_target "DEP" "HEAD" 2>/dev/null)"
+  if [[ "$_sel9" == "G" ]]; then
+    tap_ok "select_latest_green: cancelled newest does not mask older green same sha (#3740)"
+  else
+    tap_not_ok "select_latest_green: cancelled newest does not mask older green same sha (#3740)" "got '$_sel9' (expected 'G')"
+  fi
+
   # ── #3581: select_latest_green_deploy_target runs under zsh ────────────────
   # The monitor-tick deploy gate invokes this selector INLINE in the tick shell,
   # which is zsh. Under zsh, `status` is a read-only special parameter (alias for


### PR DESCRIPTION
Closes #3740

## Summary

`select_latest_green_deploy_target` (`scripts/lib/monitor-decisions.sh`) selected a deploy target off **any historical** `Verify Execution (Mainnet)` success for a sha, *skipping* (rather than disqualifying) a **more-recent `failure`** of that same sha — a fail-open in a correctness-critical deploy gate (#3740). VE is deterministic per-sha, so a newer failure on a previously-green sha is either a genuine regression surfaced by newer mainnet data (e.g. #3730) or a flake; either way "latest success ever" is the wrong signal for "safe to ship now."

The fix keys greenness on each sha's **most-recent definitive verdict**. Because `gh run list` feeds records newest-first, the first definitive (`success`/`failure`) row per sha is authoritative; an older `success` can no longer resurrect a sha whose newest VE run `failure`d. Non-definitive conclusions (`cancelled`/`skipped`/…) remain cancel-per-head noise and let older rows decide the sha (preserves the #3351 `HEAD|cancelled` → older-green behavior). Per-sha bookkeeping uses whitespace-delimited accumulator strings rather than a bash-4 associative array, because the deploy gate invokes this under `emulate -L zsh` (#3581/#3592). A new terminal reason token `green-superseded-by-failure` is emitted when a newer failure superseded an older success and no other usable green remained; it flows through the caller's existing `defer-no-green` branch, so there is **no caller change** and the fail-closed contract is preserved.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3740#issuecomment-5133312132)

## Test plan

- [x] `bash -n` on both changed files; `zsh -n` on the lib (zsh-invoked path)
- [x] `shellcheck -S warning` — no new warnings in the selector region
- [x] `scripts/test-monitor-skill-snippets.sh` passes (0 failures; #3351/#3581/#3592 cases preserved)

## Regression test (kind: bug-fix)

- **Tests:** `scripts/test-monitor-skill-snippets.sh` — Case 7 (`sha with newer failure is disqualified`) and Case 8 (`newer failure + no other green → green-superseded-by-failure`); plus a guard Case 9 (`cancelled newest does not mask older green same sha`, passes on main too).
- **Pre-fix:** committed as `a5417de` — verified Cases 7 & 8 FAILED (selector returned `G` off the older success: `got 'G' (expected 'G_OLD')`, `out='G' err=''`).
- **Post-fix:** verified PASS after `c69baec` (Case 7 → `G_OLD`; Case 8 → empty + `green-superseded-by-failure`).

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)