### PR TITLE
Accept XDR continuation-bit-clear frames to match stellar-core

### DIFF
--- a/crates/overlay/PARITY_STATUS.md
+++ b/crates/overlay/PARITY_STATUS.md
@@ -21,7 +21,7 @@
 | SurveyManager | Partial | Owned by the app layer (`crates/app/src/survey.rs` `SurveyDataManager`/`SurveyState`/`SurveyMessageLimiter` + `crates/app/src/app/survey_impl.rs`); overlay handles transport only. Survey flow complete; JSON summary and limiter behavior simplified |
 | OverlayMetrics | Full | Counters and timers for all message types |
 | PeerBareAddress | Full | Mapped to PeerAddress in lib.rs |
-| MessageCodec (framing) | Full | Length-prefix with auth bit (bit 31) |
+| MessageCodec (framing) | Full | Length-prefix with XDR record-marking continuation bit (bit 31): always set on send, masked and ignored on receive |
 | Error Handling | Full | ERR_LOAD load shedding, 100-byte truncation, send_error_and_drop |
 
 ## File Mapping
@@ -441,7 +441,7 @@ Corresponds to: XDR framing in `TCPPeer.cpp`
 | stellar-core | Rust | Status |
 |--------------|------|--------|
 | RM framing (4-byte header) | `MessageCodec` (Decoder+Encoder) | Full |
-| Auth bit handling (bit 31) | `is_authenticated` field | Full |
+| RM continuation bit (bit 31) — `getIncomingMsgLength()` masks it (`length &= 0x7f`) and never inspects it; the writer (xdrpp `marshal.cc`) always sets it | `MessageFrame::is_last_fragment` (descriptive metadata only; masked, never rejected on) | Full |
 | `MAX_UNAUTH_MESSAGE_SIZE` | `MIN_MESSAGE_SIZE` / `MAX_MESSAGE_SIZE` | Full |
 
 ### PeerSharedKeyId (`N/A`)

--- a/crates/overlay/src/codec.rs
+++ b/crates/overlay/src/codec.rs
@@ -12,8 +12,13 @@
 //! # Length Field Format
 //!
 //! The length field uses XDR record marking semantics:
-//! - **Bit 31 (MSB)**: Final-fragment flag. Henyey emits and accepts only
-//!   single-fragment overlay messages, so this bit must be set.
+//! - **Bit 31 (MSB)**: Record-marking continuation ("last fragment") flag.
+//!   Henyey always sets it on send, since every overlay message is written as
+//!   a single XDR record fragment. On receive the bit is **masked off and
+//!   never rejected on**, matching stellar-core's
+//!   `TCPPeer::getIncomingMsgLength()` (`TCPPeer.cpp:673-686`), which does
+//!   `length &= 0x7f` and never inspects the bit. It is surfaced as
+//!   [`MessageFrame::is_last_fragment`] for diagnostics only.
 //! - **Bits 0-30**: Actual message body length in bytes.
 //!
 //! # Message Size Limits
@@ -163,17 +168,18 @@ impl Decoder for MessageCodec {
                         return Ok(None);
                     }
 
-                    // Read XDR record-marking prefix. Bit 31 is the final
-                    // fragment flag, not an authentication marker.
+                    // Read XDR record-marking prefix. Bit 31 is the
+                    // continuation ("last fragment") flag, not an
+                    // authentication marker. It is masked off and never
+                    // rejected on: stellar-core's
+                    // `TCPPeer::getIncomingMsgLength()` (TCPPeer.cpp:673-686)
+                    // does `length &= 0x7f` and never inspects the bit, so
+                    // rejecting a clear bit would drop peers stellar-core
+                    // keeps (#3776). The value is retained purely as
+                    // descriptive metadata on `MessageFrame`.
                     let raw_len = u32::from_be_bytes([src[0], src[1], src[2], src[3]]);
                     let is_last_fragment = (raw_len & 0x80000000) != 0;
                     let len = (raw_len & 0x7FFFFFFF) as usize;
-
-                    if !is_last_fragment {
-                        return Err(OverlayError::Message(
-                            "fragmented XDR records are not supported".into(),
-                        ));
-                    }
 
                     // Validate length
                     // OVERLAY_SPEC §3.3: len==0 is handled distinctly as

--- a/crates/overlay/src/codec.rs
+++ b/crates/overlay/src/codec.rs
@@ -468,6 +468,71 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_accepts_continuation_bit_clear() {
+        // Regression for #3776: a frame whose XDR record-marking bit 31 is
+        // CLEAR must decode exactly like the bit-31-set equivalent.
+        // stellar-core's `TCPPeer::getIncomingMsgLength()` masks the bit off
+        // (`length &= 0x7f`) and never inspects it, and stellar-core's own
+        // writer (xdrpp `marshal.cc`) always sets it and never implements
+        // continuation fragments — so rejecting a clear bit is strictly
+        // stricter than upstream and drops peers stellar-core would keep.
+        let msg = make_test_message();
+
+        // Reference frame: bit 31 set (what `encode_message` emits).
+        let with_bit = MessageCodec::encode_message(&msg).unwrap();
+        let body = &with_bit[4..];
+
+        // Same frame, bit 31 cleared in the length prefix.
+        let mut without_bit = Vec::with_capacity(with_bit.len());
+        without_bit.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        without_bit.extend_from_slice(body);
+
+        // Sanity: the two differ only in bit 31 of the prefix.
+        let raw_len_set = u32::from_be_bytes([with_bit[0], with_bit[1], with_bit[2], with_bit[3]]);
+        let raw_len_clear = u32::from_be_bytes([
+            without_bit[0],
+            without_bit[1],
+            without_bit[2],
+            without_bit[3],
+        ]);
+        assert_eq!(raw_len_set & 0x80000000, 0x80000000);
+        assert_eq!(raw_len_clear & 0x80000000, 0);
+        assert_eq!(raw_len_set & 0x7FFFFFFF, raw_len_clear & 0x7FFFFFFF);
+
+        // Decode the bit-31-set frame for comparison.
+        let mut codec = MessageCodec::new();
+        let mut buf = BytesMut::from(&with_bit[..]);
+        let expected = codec
+            .decode(&mut buf)
+            .expect("bit-31-set frame should decode")
+            .expect("bit-31-set frame should yield a complete frame");
+        assert!(expected.is_last_fragment);
+
+        // Decode the bit-31-clear frame: must succeed identically, only with
+        // `is_last_fragment == false` as descriptive metadata.
+        let mut codec = MessageCodec::new();
+        let mut buf = BytesMut::from(&without_bit[..]);
+        let frame = codec
+            .decode(&mut buf)
+            .expect("bit-31-clear frame must not be rejected (#3776)")
+            .expect("bit-31-clear frame should yield a complete frame");
+
+        assert!(
+            !frame.is_last_fragment,
+            "bit 31 clear should be reported as is_last_fragment == false"
+        );
+        assert_eq!(frame.raw_len, expected.raw_len);
+        match (frame.message, expected.message) {
+            (AuthenticatedMessage::V0(got), AuthenticatedMessage::V0(want)) => {
+                assert_eq!(got.sequence, want.sequence);
+                assert_eq!(got.mac.mac, want.mac.mac);
+                assert!(matches!(got.message, StellarMessage::Peers(_)));
+            }
+        }
+        assert!(buf.is_empty(), "the whole frame should have been consumed");
+    }
+
+    #[test]
     fn test_codec_streaming() {
         let msg = make_test_message();
         let mut codec = MessageCodec::new();


### PR DESCRIPTION
Closes #3776

## Summary

`crates/overlay/src/codec.rs`'s `Decoder::decode` rejected any inbound frame whose XDR record-marking bit 31 (the "continuation"/"last fragment" bit) was clear, returning `Err("fragmented XDR records are not supported")`. stellar-core's `TCPPeer::getIncomingMsgLength()` (`TCPPeer.cpp:673-686`) masks that bit off (`length &= 0x7f`) and never inspects it — there is no fragment-rejection path anywhere in its reader — and stellar-core's own writer (xdrpp `marshal.cc`) always sets the bit and never implements continuation fragments, so the bit is vestigial on the wire. Being stricter than upstream on the MUST-match overlay wire-framing surface dropped connections stellar-core keeps: both of Creit Tech's preferred peers had been continuously unreachable since 2026-07-29T04:59Z (6,521+ rejected dials at filing).

This is a deletion, not a rewrite: the masked-length computation and all existing length validations (`len == 0`, `MIN_MESSAGE_SIZE`, pre-/post-auth `max_size`) are unchanged, and `is_last_fragment` is still computed and threaded into `MessageFrame` as descriptive metadata. Two stale doc references are corrected alongside: the module-level doc comment in `codec.rs`, and the two `crates/overlay/PARITY_STATUS.md` rows that mischaracterized bit 31 as an "auth bit" backed by an `is_authenticated` field (stale even before this change), per CLAUDE.md's parity-status-update requirement.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3776#issuecomment-5134809891)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-overlay` — 487 + 8 + 3 + 1 + 4 passed, 0 failed

## Regression test

- **Test:** `crates/overlay/src/codec.rs::test_decode_accepts_continuation_bit_clear`
- **Pre-fix:** committed as `38e5826664d8837b677e2b3e9d251b201017dafe` — verified FAILED with: `bit-31-clear frame must not be rejected (#3776): Message("fragmented XDR records are not supported")`
- **Post-fix:** verified PASSES after `c665be6c57daf37eaa520ad309f8d5526bfb2128`

The test builds a frame with `encode_message` (bit 31 set), rebuilds the identical frame with bit 31 cleared, decodes both, and asserts the bit-31-clear frame yields `Ok(Some(MessageFrame))` with the same `raw_len` and decoded message, differing only in `is_last_fragment == false`.

## Deviations from plan

- The plan stated `is_last_fragment`/`MessageFrame` have "zero consumers outside `codec.rs`". Precisely: the **`is_last_fragment` field** has zero consumers outside `codec.rs` (the load-bearing claim — verified, the deletion is self-contained), but the **`MessageFrame` type** is re-exported from `lib.rs` and used as a return type in `connection.rs:317/349/443`. No behavior depends on the field, so the conclusion is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)