### PR TITLE
Drop DNS-dead v3/v4.stellar.lobstr.co from mainnet known_peers (Part 1 of 2 for #3760)

### DIFF
--- a/configs/mainnet.toml
+++ b/configs/mainnet.toml
@@ -123,11 +123,9 @@ known_peers = [
     "core-live-a.stellar.org:11625",
     "core-live-b.stellar.org:11625",
     "core-live-c.stellar.org:11625",
-    # LOBSTR
+    # LOBSTR (v3/v4 dropped: A/AAAA records removed upstream 2026-07-27)
     "v1.stellar.lobstr.co:11625",
     "v2.stellar.lobstr.co:11625",
-    "v3.stellar.lobstr.co:11625",
-    "v4.stellar.lobstr.co:11625",
     "v5.stellar.lobstr.co:11625",
     # Blockdaemon
     "stellar-full-validator1.bdnodes.net:11625",

--- a/configs/validator-mainnet-rpc.toml
+++ b/configs/validator-mainnet-rpc.toml
@@ -131,11 +131,9 @@ known_peers = [
     "core-live-a.stellar.org:11625",
     "core-live-b.stellar.org:11625",
     "core-live-c.stellar.org:11625",
-    # LOBSTR
+    # LOBSTR (v3/v4 dropped: A/AAAA records removed upstream 2026-07-27)
     "v1.stellar.lobstr.co:11625",
     "v2.stellar.lobstr.co:11625",
-    "v3.stellar.lobstr.co:11625",
-    "v4.stellar.lobstr.co:11625",
     "v5.stellar.lobstr.co:11625",
     # Blockdaemon
     "stellar-full-validator1.bdnodes.net:11625",

--- a/configs/validator-mainnet.toml
+++ b/configs/validator-mainnet.toml
@@ -128,11 +128,9 @@ known_peers = [
     "core-live-a.stellar.org:11625",
     "core-live-b.stellar.org:11625",
     "core-live-c.stellar.org:11625",
-    # LOBSTR
+    # LOBSTR (v3/v4 dropped: A/AAAA records removed upstream 2026-07-27)
     "v1.stellar.lobstr.co:11625",
     "v2.stellar.lobstr.co:11625",
-    "v3.stellar.lobstr.co:11625",
-    "v4.stellar.lobstr.co:11625",
     "v5.stellar.lobstr.co:11625",
     # Blockdaemon
     "stellar-full-validator1.bdnodes.net:11625",


### PR DESCRIPTION
Refs #3760

> ⚠️ **This is Part 1 of 2 — issue #3760 must stay OPEN after this merges.**
> The converged plan deliberately splits #3760 into two separately-shipped PRs.
> **Part 2 (still outstanding):** per-host DNS-resolution backoff
> (`dns_resolve_state` / `next_allowed_attempt`) plus transition-only logging in
> `crates/app/src/app/peers.rs` and the 5 call sites (`store_config_peers` ×2,
> `refresh_known_peers` ×2, `lifecycle.rs::start_overlay` ×1). That is the
> general-case fix; this PR only removes the two specific dead hostnames.
> This PR intentionally says `Refs`, **not** `Closes`, so the issue survives merge.

## Summary

`v3.stellar.lobstr.co` and `v4.stellar.lobstr.co` had their DNS A/AAAA records
removed upstream on 2026-07-27 (the zone entries still exist, but resolve to
nothing — confirmed against the local resolver, 8.8.8.8, and 1.1.1.1). They are
still listed in `known_peers` in the three shipped mainnet configs, so
`resolve_peers_for_storage` re-resolves them every 60s forever and emits an
unconditional `warn!` per host per cycle — ~2,880 WARN lines/day for a condition
that cannot self-resolve.

This drops those two hostnames from `known_peers` in `configs/mainnet.toml`,
`configs/validator-mainnet.toml`, and `configs/validator-mainnet-rpc.toml`
(6 entries total, 2 per file), and annotates the `# LOBSTR` comment with why
they are gone so they don't get re-added from an upstream tier-1 list.

LOBSTR retains 3 resolvable known peers (`v1`, `v2`, `v5`) in every config.
`preferred_peers` in `configs/validator-mainnet-rpc.toml` only ever listed
`v1`/`v2`, so its "LOBSTR (2 of 3)" annotation is still accurate and is
unchanged.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3760#issuecomment-5134335084)
— see the "**Part 1 (dispatch first, minimal, code-free)**" file list. The plan
explicitly instructs: "`/do` should dispatch Part 1 and Part 2 as separate PRs
(Part 1 first) ... do not bundle them into one PR even though they originate
from the same issue."

## Test plan

Part 1 is a **configuration-data-only** change — it removes two dead hostnames
from three TOML files. There is no new or changed code path, so there is no
behavior to regression-test, and a test that asserted the file contents back to
itself would be circular. The plan's regression tests
(`test_next_allowed_attempt_backs_off_and_caps`,
`test_resolve_peers_for_storage_skips_lookup_within_backoff_window`,
`test_resolve_peers_for_storage_logs_only_on_transition`) all target the
`peers.rs` helper introduced in **Part 2** and are deferred to that PR along
with the code they cover.

Existing coverage that does exercise this change: `henyey-app`'s
`config::tests::test_shipped_config_files_parse` parses every `configs/*.toml`
against `AppConfig` with `deny_unknown_fields`, so it validates that all three
edited files still parse.

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-app`

## Regression test

N/A for Part 1 — config-data-only, no code path (see Test plan above). The
plan's `kind: bug-fix` regression tests belong to Part 2.

## Deviations from plan

- The plan describes Part 1 as "2 lines each, 6 total" pure deletions. In
  addition to the 6 deletions, each file's `# LOBSTR` comment is amended to
  `# LOBSTR (v3/v4 dropped: A/AAAA records removed upstream 2026-07-27)` — 1
  comment line per file — so the removal is self-documenting and the entries
  don't silently come back. No other content changed.
- **Not changed (deliberately out of scope):** `OverlayConfig::mainnet()` in
  `crates/overlay/src/lib.rs:352-353` also hardcodes `v3`/`v4.stellar.lobstr.co`
  in its `known_peers` default. It has **no non-doc callers** anywhere in the
  workspace, so it does not contribute to the observed log noise, and touching
  it would make this "code-free" PR a code change. Flagged here for Part 2 (or a
  follow-up) to sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
