### PR TITLE
Emit wipe signal on fatal startup catchup failure

### DIFF
--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -7941,4 +7941,202 @@ mod tests {
              herder has externalized target+1 — the run_mode gate is broken"
         );
     }
+
+    // -- #3797: startup (boot-time) catchup must emit the wipe signal ---------
+    //
+    // The online catchup handler (`handle_catchup_result`) already emits
+    // `fatal_wipe_required=true` (via `trigger_fatal_shutdown`) on the fatal
+    // catchup/integrity class, which the monitor greps to drive its (3a)
+    // auto-wipe self-heal. The STARTUP catchup path in `run_cmd` historically
+    // `?`-propagated the same fatal class WITHOUT emitting that signal, so the
+    // monitor never auto-recovered and the operator had to wipe by hand — the
+    // ~9 h outage in #3797. These tests lock the fix: the startup path now
+    // classifies the failure via `startup_catchup_failure_requires_wipe` and
+    // emits the signal via `signal_startup_catchup_failure`.
+
+    /// Helper: build an `App` whose LCL is past genesis (a node with committed
+    /// state worth protecting), matching the #3797 incident node.
+    #[cfg(test)]
+    async fn app_past_genesis() -> App {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+        let mut header = app.ledger_manager.current_header();
+        header.ledger_seq = 63_733_600;
+        app.ledger_manager
+            .set_header_for_test(header, henyey_common::Hash256::ZERO);
+        assert!(
+            app.current_ledger_seq() > GENESIS_LEDGER_SEQ,
+            "precondition: node must be past genesis"
+        );
+        // Keep the tempdir alive for the app's lifetime by leaking it — the app
+        // holds an open DB handle into it and the process exits at test end.
+        std::mem::forget(dir);
+        app
+    }
+
+    /// PRIMARY REGRESSION (#3797). Drives the exact production seam that
+    /// `run_cmd`'s startup-catchup Err arm calls — `signal_startup_catchup_failure`
+    /// — under a capturing subscriber, feeding a realistically `.context()`-wrapped
+    /// knit-to-LCL `HistoryError` at `LCL > genesis` (the incident shape). Asserts
+    /// the rendered event carries `fatal_wipe_required=true`.
+    ///
+    /// FAILS on `origin/main`: the startup path there `?`-propagates the error
+    /// with no wipe field (grep over the incident crash log returned 0 matches),
+    /// so the monitor's (3a) auto-wipe never fired. PASSES after the fix.
+    #[tokio::test]
+    async fn test_startup_catchup_fatal_emits_wipe_field() {
+        use std::sync::atomic::Ordering;
+        use std::sync::{Arc, Mutex};
+        use tracing::{
+            field::{Field, Visit},
+            subscriber::with_default,
+            Event, Metadata, Subscriber,
+        };
+
+        const FATAL_WIPE_FIELD: &str = "fatal_wipe_required";
+
+        #[derive(Default)]
+        struct CapturedBool {
+            value: Option<bool>,
+        }
+        impl Visit for CapturedBool {
+            fn record_bool(&mut self, field: &Field, value: bool) {
+                if field.name() == FATAL_WIPE_FIELD {
+                    self.value = Some(value);
+                }
+            }
+            fn record_debug(&mut self, _: &Field, _: &dyn std::fmt::Debug) {}
+        }
+
+        #[derive(Default, Clone)]
+        struct WipeFieldSubscriber {
+            captured: Arc<Mutex<Option<bool>>>,
+        }
+        impl Subscriber for WipeFieldSubscriber {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
+                true
+            }
+            fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+                tracing::span::Id::from_u64(1)
+            }
+            fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+            fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+            fn event(&self, event: &Event<'_>) {
+                let mut cap = CapturedBool::default();
+                event.record(&mut cap);
+                if let Some(v) = cap.value {
+                    *self.captured.lock().unwrap() = Some(v);
+                }
+            }
+            fn enter(&self, _: &tracing::span::Id) {}
+            fn exit(&self, _: &tracing::span::Id) {}
+        }
+
+        let app = app_past_genesis().await;
+
+        // Realistic incident shape: a typed knit-to-LCL HistoryError wrapped in
+        // an anyhow `.context()` layer, as `?` would add on the way out.
+        let err: anyhow::Error = anyhow::Error::from(henyey_history::HistoryError::KnitLclHashMismatch {
+            expected: "4426b58c".into(),
+            actual: "6f828db4".into(),
+        })
+        .context("close_ledger failed at ledger 63733632");
+
+        // Guard the downcast-through-context path used by the classifier.
+        assert!(
+            app.startup_catchup_failure_requires_wipe(&err),
+            "classifier must fire on a .context()-wrapped knit-to-LCL error at LCL > genesis"
+        );
+
+        let sub = WipeFieldSubscriber::default();
+        let captured = sub.captured.clone();
+
+        // Drive the exact production seam run_cmd's Err arm calls.
+        with_default(sub, || {
+            app.signal_startup_catchup_failure(&err);
+        });
+
+        assert_eq!(
+            *captured.lock().unwrap(),
+            Some(true),
+            "startup catchup fatal failure must emit {FATAL_WIPE_FIELD}=true so the \
+             monitor's (3a) auto-wipe self-heal fires (#3797)"
+        );
+        assert!(
+            app.fatal_state_failure.load(Ordering::SeqCst),
+            "fatal_state_failure must be set on a fatal startup catchup failure"
+        );
+    }
+
+    /// #3797 predicate: a knit-to-LCL fatal at `LCL > genesis` requires a wipe.
+    #[tokio::test]
+    async fn test_startup_catchup_knit_fatal_beyond_genesis_requires_wipe() {
+        let app = app_past_genesis().await;
+        let err: anyhow::Error = henyey_history::HistoryError::KnitLclHashMismatch {
+            expected: "aa".into(),
+            actual: "bb".into(),
+        }
+        .into();
+        assert!(
+            app.startup_catchup_failure_requires_wipe(&err),
+            "knit-to-LCL at LCL > genesis is unrecoverable in-process — must wipe"
+        );
+    }
+
+    /// #3797 preserves #3410: a knit-to-LCL fatal at genesis (stateless fresh
+    /// node) must NOT wipe — there is no committed local state to protect.
+    #[tokio::test]
+    async fn test_startup_catchup_knit_fatal_at_genesis_no_wipe() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("rs-stellar-test.db");
+        let config = crate::config::ConfigBuilder::new()
+            .database_path(db_path)
+            .build();
+        let app = App::new(config).await.unwrap();
+        assert_eq!(
+            app.current_ledger_seq(),
+            GENESIS_LEDGER_SEQ,
+            "precondition: fresh app must be at genesis"
+        );
+        let err: anyhow::Error = henyey_history::HistoryError::KnitLclHashMismatch {
+            expected: "aa".into(),
+            actual: "bb".into(),
+        }
+        .into();
+        assert!(
+            !app.startup_catchup_failure_requires_wipe(&err),
+            "knit-to-LCL at genesis must NOT wipe (preserves #3410)"
+        );
+    }
+
+    /// #3797: a transient (download/archive/ENOSPC-class) error must NOT be
+    /// classified wipe-required — no false wipe on disk-full.
+    #[tokio::test]
+    async fn test_startup_catchup_transient_error_no_wipe() {
+        let app = app_past_genesis().await;
+        let err: anyhow::Error =
+            henyey_history::HistoryError::ArchiveUnreachable("timeout".into()).into();
+        assert!(
+            !app.startup_catchup_failure_requires_wipe(&err),
+            "transient errors must not trigger a wipe"
+        );
+    }
+
+    /// #3797: a non-knit verification/integrity fatal at `LCL > genesis`
+    /// (genuine local corruption) requires a wipe.
+    #[tokio::test]
+    async fn test_startup_catchup_verification_fatal_requires_wipe() {
+        let app = app_past_genesis().await;
+        let err: anyhow::Error =
+            henyey_history::HistoryError::VerificationFailed("bucket list hash mismatch".into())
+                .into();
+        assert!(
+            app.startup_catchup_failure_requires_wipe(&err),
+            "a verification/integrity fatal at LCL > genesis must wipe"
+        );
+    }
 }

--- a/crates/app/src/app/catchup_impl.rs
+++ b/crates/app/src/app/catchup_impl.rs
@@ -3004,6 +3004,68 @@ impl App {
         false
     }
 
+    /// #3797: classify a **startup (boot-time) catchup** failure as
+    /// wipe-required.
+    ///
+    /// Returns `true` iff `err` downcasts to a fatal catchup/integrity
+    /// [`HistoryError`](henyey_history::HistoryError)
+    /// (`is_fatal_catchup_failure()`) **and** it is not the narrow
+    /// stateless-fresh-genesis knit carve-out (`current_ledger_seq() ==
+    /// GENESIS_LEDGER_SEQ && is_knit_to_lcl_failure()`). This mirrors, for the
+    /// startup path, the exact classification the online catchup handler
+    /// [`handle_catchup_result`](Self::handle_catchup_result) already applies —
+    /// the #3410 genesis-knit exception (a stateless fresh node has no committed
+    /// state to protect) is preserved, and for `LCL > genesis` the #3282/#3288
+    /// terminal semantics are unchanged.
+    ///
+    /// The downcast searches the anyhow source chain, so a typed `HistoryError`
+    /// wrapped by `?`'s `.context(...)` on the way out of the startup catchup
+    /// call is still classified correctly.
+    ///
+    /// Transient/download and ENOSPC-class errors are **not**
+    /// `is_fatal_catchup_failure()`, so they return `false` — a disk-full during
+    /// startup catchup must not be mis-signalled as requiring a wipe (matching
+    /// the #3478 "free space, no wipe" recoverable-shutdown semantics).
+    pub(crate) fn startup_catchup_failure_requires_wipe(&self, err: &anyhow::Error) -> bool {
+        let is_fatal = err
+            .downcast_ref::<henyey_history::HistoryError>()
+            .is_some_and(|e| e.is_fatal_catchup_failure());
+        if !is_fatal {
+            return false;
+        }
+        let at_genesis = self.current_ledger_seq() == GENESIS_LEDGER_SEQ;
+        let is_knit_to_lcl = err
+            .downcast_ref::<henyey_history::HistoryError>()
+            .is_some_and(|e| e.is_knit_to_lcl_failure());
+        !(at_genesis && is_knit_to_lcl)
+    }
+
+    /// #3797: emit the monitor's auto-wipe signal on a fatal **startup
+    /// (boot-time) catchup** failure, then let the caller propagate the error.
+    ///
+    /// The online catchup handler already emits `fatal_wipe_required=true` (via
+    /// [`trigger_fatal_shutdown`](Self::trigger_fatal_shutdown)) on the fatal
+    /// class, which the monitor greps to drive its `(3a)` auto-wipe self-heal.
+    /// The startup catchup path in `run_cmd` historically `?`-propagated the
+    /// same fatal class WITHOUT emitting that signal, so the monitor never
+    /// auto-recovered and the operator had to wipe by hand — the ~9 h outage in
+    /// #3797. Call this from the startup-catchup `Err` arm BEFORE returning the
+    /// error: on the wipe-required class it emits the signal; otherwise it is a
+    /// no-op and the caller propagates the (transient/recoverable) error
+    /// unchanged.
+    ///
+    /// At startup the main run loop is not yet spawned, so
+    /// `trigger_fatal_shutdown`'s `shutdown()` broadcast is a harmless send; the
+    /// caller still returns `Err`, so `run_node` exits non-zero for the
+    /// supervisor.
+    pub(crate) fn signal_startup_catchup_failure(&self, err: &anyhow::Error) {
+        if self.startup_catchup_failure_requires_wipe(err) {
+            self.trigger_fatal_shutdown(&format!(
+                "startup catchup verification/integrity failure: {err}"
+            ));
+        }
+    }
+
     pub(super) async fn maybe_start_externalized_catchup(
         &self,
         latest_externalized: u64,
@@ -8040,11 +8102,12 @@ mod tests {
 
         // Realistic incident shape: a typed knit-to-LCL HistoryError wrapped in
         // an anyhow `.context()` layer, as `?` would add on the way out.
-        let err: anyhow::Error = anyhow::Error::from(henyey_history::HistoryError::KnitLclHashMismatch {
-            expected: "4426b58c".into(),
-            actual: "6f828db4".into(),
-        })
-        .context("close_ledger failed at ledger 63733632");
+        let err: anyhow::Error =
+            anyhow::Error::from(henyey_history::HistoryError::KnitLclHashMismatch {
+                expected: "4426b58c".into(),
+                actual: "6f828db4".into(),
+            })
+            .context("close_ledger failed at ledger 63733632");
 
         // Guard the downcast-through-context path used by the classifier.
         assert!(

--- a/crates/app/src/run_cmd.rs
+++ b/crates/app/src/run_cmd.rs
@@ -483,14 +483,29 @@ async fn run_main_loop(app: Arc<App>, options: RunOptions) -> anyhow::Result<()>
                 app.database().clone(),
                 app.ledger_manager().clone(),
             );
-            let _result = app
+            // #3797: on a fatal startup-catchup failure (knit-to-LCL with
+            // LCL > genesis, verification/hash-integrity corruption), emit the
+            // `fatal_wipe_required=true` signal BEFORE propagating the error, so
+            // the monitor's (3a) auto-wipe self-heal fires automatically. The
+            // online catchup handler already does this; the startup path used to
+            // `?`-propagate the same fatal class silently, forcing a manual wipe
+            // (the ~9 h outage in #3797). Transient/ENOSPC-class errors are not
+            // classified wipe-required, so they propagate unchanged.
+            match app
                 .catchup_with_run_mode(
                     CatchupTarget::Current,
                     catchup_mode,
                     CatchupRunMode::Online,
                     finalize,
                 )
-                .await?;
+                .await
+            {
+                Ok(_result) => {}
+                Err(e) => {
+                    app.signal_startup_catchup_failure(&e);
+                    return Err(e);
+                }
+            }
 
             // Wait for SCP state request to complete
             let _ = scp_request_handle.await;


### PR DESCRIPTION
Closes #3797

## Summary

On a fatal boot-time (startup) catchup failure — a knit-to-LCL mismatch with `LCL > genesis`, or a verification/hash-integrity corruption — the node now emits the `fatal_wipe_required=true` signal (via `trigger_fatal_shutdown`) before propagating the error, so the monitor's existing `(3a)` auto-wipe self-heal fires automatically. Previously the startup catchup path `?`-propagated the same fatal class silently (the online `handle_catchup_result` already emitted the signal), so the monitor never auto-recovered and an operator had to wipe by hand — the ~9 h manual-intervention gap that kept the mainnet validator OFFLINE in #3797.

The change adds a shared classifier `App::startup_catchup_failure_requires_wipe` that mirrors `handle_catchup_result`'s exact #3410 stateless-fresh-genesis knit carve-out (a genesis node has no committed state to protect, so it is not wiped), plus a thin `App::signal_startup_catchup_failure` seam the `run_cmd` startup Err arm calls. Transient/download and ENOSPC-class errors are not `is_fatal_catchup_failure()`, so they are never classified wipe-required — a disk-full during startup catchup is not mis-signalled as corruption (#3478 semantics preserved).

This fixes only the recovery-signal leg of the umbrella incident; the residual root causes (ENOSPC row-loss #3811, monitor-side signal gap #3799) are tracked separately and #3797 should not be silently resolved by this PR alone.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3797#issuecomment-5233422838)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all -- -D warnings
- [x] cargo test -p henyey-app (1180 + integration tests pass)

## Regression test

- **Test:** `crates/app/src/app/catchup_impl.rs::test_startup_catchup_fatal_emits_wipe_field` (primary) + 4 predicate unit tests
- **Pre-fix:** committed as `9dcd55b` — verified FAILED (seam methods absent; startup path emits no wipe field)
- **Post-fix:** verified PASSES after `5140ad3`

## Deviations from plan

- The primary regression test drives the production seam `signal_startup_catchup_failure` (the exact method `run_cmd`'s Err arm calls) rather than reimplementing the match-arm logic inline, so it locks the real wired behavior. Because that method is new, the failing artifact on `origin/main` is a compile failure (cannot find method) rather than a behavioral assertion failure; the behavioral gap it guards (no `fatal_wipe_required` on the startup path) is real and matches the incident log.
- Did not refactor `handle_catchup_result`'s fatal branch onto the shared predicate (the plan marked this optional / defer-if-risky); the online path's branch has additional interleaved genesis-knit and self-heal handling, so deduplication was left out to avoid disturbing those branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)