### PR TITLE
Expose SCP persist-worker backlog as Prometheus gauges

### DIFF
--- a/crates/app/src/app/mod.rs
+++ b/crates/app/src/app/mod.rs
@@ -3404,6 +3404,7 @@ impl App {
             scp: self.herder.scp_metrics_snapshot(),
             scp_phase: self.herder.tracking_slot_ballot_phase(),
             scp_cumulative_statements: self.herder.scp_cumulative_statement_count() as u64,
+            scp_persist: self.herder.scp_persist_stats(),
             consensus_trigger_timer_fires: self
                 .consensus_trigger_timer_fires
                 .load(Ordering::Relaxed),

--- a/crates/app/src/app/types.rs
+++ b/crates/app/src/app/types.rs
@@ -382,6 +382,8 @@ pub struct AppMetricsSnapshot {
     pub scp: henyey_herder::ScpMetricsSnapshot,
     pub scp_phase: u8,
     pub scp_cumulative_statements: u64,
+    /// SCP persist-worker backlog counters (#3796).
+    pub scp_persist: henyey_herder::ScpPersistStats,
     /// Event-driven consensus-trigger timer firings (#2702).
     pub consensus_trigger_timer_fires: u64,
     pub nomination_timeout_fires: u64,

--- a/crates/app/src/metrics.rs
+++ b/crates/app/src/metrics.rs
@@ -303,6 +303,14 @@ metric_catalog! {
             => "Current depth of the SCP signature-verify input channel (event-loop sampled)";
         SCP_VERIFY_INPUT_BACKLOG_PEAK = "henyey_scp_verify_input_backlog_peak"
             => "Monotonic high-water mark of verifier input backlog (worker sampled)";
+
+        // SCP persist-worker backlog gauges (#3796). The emit hot path spawns
+        // one detached persist worker per envelope; these expose the in-flight
+        // count that #3796 §2 had to measure with a bespoke /proc sampler.
+        SCP_PENDING_PERSISTS = "henyey_scp_pending_persists"
+            => "SCP persist worker threads currently in flight (deferred SQLite writes)";
+        SCP_PENDING_PERSISTS_PEAK = "henyey_scp_pending_persists_peak"
+            => "Process-lifetime high-water mark of in-flight SCP persist workers";
         SCP_VERIFY_OUTPUT_BACKLOG = "henyey_scp_verify_output_backlog"
             => "Current depth of the verified-envelope output channel (envelopes awaiting the event loop)";
         SCP_VERIFIER_THREAD_STATE = "henyey_scp_verifier_thread_state"
@@ -815,6 +823,12 @@ metric_catalog! {
             => "Total SCP envelopes with invalid signature";
         SCP_ENVELOPE_SIGN_TOTAL = "stellar_scp_envelope_sign_total"
             => "Total SCP envelopes signed locally";
+        // SCP persist-worker spawn counters (#3796). `attempted - spawn_failed`
+        // is the number of persist worker threads actually spawned.
+        SCP_PERSIST_ATTEMPTED_TOTAL = "henyey_scp_persist_attempted_total"
+            => "Total SCP persist worker spawns attempted (counted before the spawn)";
+        SCP_PERSIST_SPAWN_FAILED_TOTAL = "henyey_scp_persist_spawn_failed_total"
+            => "Total SCP persist worker spawns that failed to launch (e.g. EAGAIN)";
         SCP_VALUE_VALID_TOTAL = "stellar_scp_value_valid_total"
             => "Total SCP value validations returning valid (includes MaybeValid and MaybeValidDeferred)";
         SCP_VALUE_INVALID_TOTAL = "stellar_scp_value_invalid_total"
@@ -1509,6 +1523,14 @@ pub(crate) async fn refresh_gauges(state: &ServerState) {
     SCP_VALUE_INVALID_TOTAL.absolute(snap.scp.value_invalid_total);
     SCP_NOMINATION_COMBINECANDIDATES_TOTAL.absolute(snap.scp.combine_candidates_total);
 
+    // SCP persist-worker backlog (#3796). Live + peak gauges plus monotonic
+    // attempt/failure counters (pushed with `.absolute` = fetch_max, matching
+    // the other cumulative SCP counters — both values are monotonic).
+    SCP_PENDING_PERSISTS.set(snap.scp_persist.pending as f64);
+    SCP_PENDING_PERSISTS_PEAK.set(snap.scp_persist.pending_peak as f64);
+    SCP_PERSIST_ATTEMPTED_TOTAL.absolute(snap.scp_persist.attempted_total);
+    SCP_PERSIST_SPAWN_FAILED_TOTAL.absolute(snap.scp_persist.spawn_failed_total);
+
     // Feed the medida-compat scp meters (`scp.value.valid`/`scp.value.invalid`)
     // for the stellar-core-compatible /metrics endpoint by delta-marking the
     // cumulative totals on this periodic refresh, so marks are spread over time
@@ -1847,6 +1869,70 @@ mod tests {
             assert!(
                 output.contains(&format!("{} 0", name)),
                 "counter {} should be pre-registered at 0",
+                name
+            );
+        }
+    }
+
+    /// The SCP persist-worker series (#3796) are present in the catalog: two
+    /// gauges and two counters, all unlabeled and pre-registered at 0, with
+    /// HELP/TYPE emitted after `describe_metrics()` + `register_label_series()`.
+    #[test]
+    fn test_scp_persist_metrics_in_catalog() {
+        for name in [
+            "henyey_scp_pending_persists",
+            "henyey_scp_pending_persists_peak",
+        ] {
+            assert!(
+                ALL_GAUGE_NAMES.contains(&name),
+                "gauge {} missing from ALL_GAUGE_NAMES",
+                name
+            );
+            assert!(
+                ALL_PREREGISTERED_GAUGE_NAMES.contains(&name),
+                "gauge {} should be pre-registered",
+                name
+            );
+        }
+        for name in [
+            "henyey_scp_persist_attempted_total",
+            "henyey_scp_persist_spawn_failed_total",
+        ] {
+            assert!(
+                ALL_COUNTER_NAMES.contains(&name),
+                "counter {} missing from ALL_COUNTER_NAMES",
+                name
+            );
+            assert!(
+                ALL_PREREGISTERED_COUNTER_NAMES.contains(&name),
+                "counter {} should be pre-registered",
+                name
+            );
+        }
+
+        let (recorder, handle) = fresh_local_recorder();
+        metrics::with_local_recorder(&recorder, || {
+            describe_metrics();
+            register_label_series();
+        });
+        let output = handle.render();
+        assert!(
+            output.contains("# TYPE henyey_scp_pending_persists gauge"),
+            "pending gauge TYPE missing"
+        );
+        assert!(
+            output.contains("# TYPE henyey_scp_persist_attempted_total counter"),
+            "attempted counter TYPE missing"
+        );
+        for name in [
+            "henyey_scp_pending_persists",
+            "henyey_scp_pending_persists_peak",
+            "henyey_scp_persist_attempted_total",
+            "henyey_scp_persist_spawn_failed_total",
+        ] {
+            assert!(
+                output.contains(&format!("{} 0", name)),
+                "{} should be pre-registered at 0",
                 name
             );
         }

--- a/crates/herder/src/herder.rs
+++ b/crates/herder/src/herder.rs
@@ -884,6 +884,11 @@ impl Herder {
                 })
                 .map_err(|e| {
                     // If spawn fails we still need to drop the pending count.
+                    // `record_spawn_failure` is ADDITIVE — it does not replace
+                    // the `pending_persist_end` decrement (#3796): dropping the
+                    // decrement would leak `pending_persists` upward forever and
+                    // hang `wait_for_pending_persists`.
+                    manager_for_cb.record_spawn_failure();
                     manager_for_cb.pending_persist_end();
                     warn!(error = %e, slot, "failed to spawn scp-persist worker");
                 })
@@ -1513,6 +1518,16 @@ impl Herder {
     /// Get a snapshot of the SCP event counters for the metrics scrape path.
     pub fn scp_metrics_snapshot(&self) -> crate::metrics::ScpMetricsSnapshot {
         self.scp_metrics.snapshot()
+    }
+
+    /// Get a snapshot of the SCP persist-worker backlog counters for the
+    /// metrics scrape path (#3796). Returns all-zero defaults when no
+    /// persistence manager is installed (non-validator / pre-bootstrap).
+    pub fn scp_persist_stats(&self) -> crate::persistence::ScpPersistStats {
+        let Some(manager) = self.scp_persistence.get() else {
+            return crate::persistence::ScpPersistStats::default();
+        };
+        manager.persist_stats()
     }
 
     /// Get the cumulative SCP statement count (retained-memory gauge).
@@ -10099,6 +10114,54 @@ mod tests {
         assert!(
             herder.scp_driver.get_externalized(1).is_some(),
             "solo validator must externalize even without persistence"
+        );
+    }
+
+    /// End-to-end proof that the emit hot path feeds the SCP persist-worker
+    /// stats series (#3796): after a real emit + drain, `attempted_total >= 1`,
+    /// `pending == 0`, and `peak >= 1`.
+    #[tokio::test]
+    async fn test_scp_persist_stats_reports_after_emit() {
+        let (herder, _secret) = make_validator_herder();
+        let manager = Arc::new(crate::persistence::ScpPersistenceManager::in_memory());
+        assert!(
+            herder.set_scp_persistence(Arc::clone(&manager)).is_ok(),
+            "install scp persistence"
+        );
+
+        herder.bootstrap(0);
+        herder
+            .trigger_next_ledger(1)
+            .expect("trigger_next_ledger should succeed");
+
+        assert!(
+            manager.wait_for_pending_persists(std::time::Duration::from_secs(5)),
+            "persist worker threads must drain within 5s"
+        );
+
+        let stats = herder.scp_persist_stats();
+        assert!(
+            stats.attempted_total >= 1,
+            "emit hot path must record at least one persist attempt; got {}",
+            stats.attempted_total
+        );
+        assert_eq!(stats.pending, 0, "backlog must have drained");
+        assert!(
+            stats.pending_peak >= 1,
+            "peak must reflect the in-flight worker; got {}",
+            stats.pending_peak
+        );
+    }
+
+    /// `scp_persist_stats` returns all-zero defaults (no panic) when no
+    /// persistence manager is installed.
+    #[test]
+    fn test_scp_persist_stats_default_without_manager() {
+        let (herder, _secret) = make_validator_herder();
+        // Intentionally DO NOT install a persistence manager.
+        assert_eq!(
+            herder.scp_persist_stats(),
+            crate::persistence::ScpPersistStats::default()
         );
     }
 

--- a/crates/herder/src/lib.rs
+++ b/crates/herder/src/lib.rs
@@ -167,8 +167,8 @@ pub use tx_queue::{
 
 // Persistence
 pub use persistence::{
-    get_tx_set_hashes, Database, PersistedSlotState, RestoredScpState, ScpPersistenceManager,
-    ScpStatePersistence, SqliteScpPersistence,
+    get_tx_set_hashes, Database, PersistedSlotState, RestoredScpState, ScpPersistStats,
+    ScpPersistenceManager, ScpStatePersistence, SqliteScpPersistence,
 };
 
 // HerderUtils

--- a/crates/herder/src/persistence.rs
+++ b/crates/herder/src/persistence.rs
@@ -415,6 +415,46 @@ pub struct ScpPersistenceManager {
     pending_persists: std::sync::Mutex<usize>,
     /// Condvar signaled when `pending_persists` reaches zero.
     pending_persists_cv: std::sync::Condvar,
+    /// Lock-free mirror of `pending_persists`, published under the same mutex
+    /// (see `pending_persist_begin`/`_end`). The `/metrics` scrape path reads
+    /// this with `Ordering::Relaxed` and never touches the mutex, so it can
+    /// never contend with a persist worker. `pending_persists` remains the
+    /// single source of truth (it is paired with `pending_persists_cv`).
+    persist_pending: std::sync::atomic::AtomicU64,
+    /// Monotonic high-water mark of `persist_pending`. Process-lifetime; resets
+    /// on restart. Mirrors the accepted `SCP_VERIFY_INPUT_BACKLOG_PEAK`
+    /// precedent — a live gauge alone would read `0` on the large majority of
+    /// scrapes (see #3796 §2: concurrency was `0` for 82.9% of wall-clock).
+    persist_pending_peak: std::sync::atomic::AtomicU64,
+    /// Total persist worker spawns attempted (incremented in
+    /// `pending_persist_begin`, which runs BEFORE the thread is spawned).
+    /// `attempted - spawn_failed = threads actually spawned`.
+    persist_attempted_total: std::sync::atomic::AtomicU64,
+    /// Total persist worker spawns that failed (e.g. `EAGAIN` / thread-table
+    /// exhaustion). Bumped only by `record_spawn_failure`.
+    persist_spawn_failed_total: std::sync::atomic::AtomicU64,
+}
+
+/// Snapshot of the SCP persist-worker backlog counters for the `/metrics`
+/// scrape path (issue #3796).
+///
+/// - `pending`: persist workers currently in flight (live gauge).
+/// - `pending_peak`: process-lifetime high-water mark of `pending`.
+/// - `attempted_total`: cumulative persist spawns attempted.
+/// - `spawn_failed_total`: cumulative persist spawns that failed to launch.
+///
+/// `attempted_total - spawn_failed_total` is the number of persist worker
+/// threads actually spawned.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScpPersistStats {
+    /// Persist workers currently in flight.
+    pub pending: u64,
+    /// Process-lifetime high-water mark of `pending`.
+    pub pending_peak: u64,
+    /// Cumulative persist spawns attempted (before the spawn).
+    pub attempted_total: u64,
+    /// Cumulative persist spawns that failed to launch.
+    pub spawn_failed_total: u64,
 }
 
 impl ScpPersistenceManager {
@@ -425,6 +465,10 @@ impl ScpPersistenceManager {
             last_slot_saved: parking_lot::RwLock::new(0),
             pending_persists: std::sync::Mutex::new(0),
             pending_persists_cv: std::sync::Condvar::new(),
+            persist_pending: std::sync::atomic::AtomicU64::new(0),
+            persist_pending_peak: std::sync::atomic::AtomicU64::new(0),
+            persist_attempted_total: std::sync::atomic::AtomicU64::new(0),
+            persist_spawn_failed_total: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -447,23 +491,62 @@ impl ScpPersistenceManager {
     /// Increment the pending-persist counter. Called by the emit callback's
     /// worker thread spawner BEFORE the thread is detached.
     pub(crate) fn pending_persist_begin(&self) {
+        use std::sync::atomic::Ordering;
         let mut pending = self
             .pending_persists
             .lock()
             .expect("pending mutex poisoned");
         *pending += 1;
+        // Publish the atomic mirrors WHILE the guard is still live, so the
+        // scrape path and any `wait_for_pending_persists` waiter observe a
+        // consistent view. `attempted_total` counts attempts (this runs before
+        // the spawn), and the peak is exact because it is taken under the lock.
+        let now = *pending as u64;
+        self.persist_pending.store(now, Ordering::Relaxed);
+        self.persist_pending_peak.fetch_max(now, Ordering::Relaxed);
+        self.persist_attempted_total.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Decrement the pending-persist counter and notify waiters. Called by
     /// the worker thread on completion (success or error).
     pub(crate) fn pending_persist_end(&self) {
+        use std::sync::atomic::Ordering;
         let mut pending = self
             .pending_persists
             .lock()
             .expect("pending mutex poisoned");
         *pending = pending.saturating_sub(1);
+        // Store the mirror BEFORE `notify_all` and BEFORE dropping the guard —
+        // otherwise a waiter released by `notify_all` could observe
+        // `wait_for_pending_persists() == true` while `persist_stats().pending`
+        // is still nonzero (#3796 plan, Critic A).
+        self.persist_pending
+            .store(*pending as u64, Ordering::Relaxed);
         if *pending == 0 {
             self.pending_persists_cv.notify_all();
+        }
+    }
+
+    /// Record a persist worker spawn failure (e.g. `EAGAIN` / thread-table
+    /// exhaustion). Additive to — never a replacement for —
+    /// `pending_persist_end`, which the failure path must still call to release
+    /// the pending count.
+    pub(crate) fn record_spawn_failure(&self) {
+        use std::sync::atomic::Ordering;
+        self.persist_spawn_failed_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Snapshot the SCP persist-worker backlog counters for the metrics scrape
+    /// path. Lock-free: reads the atomic mirrors with `Ordering::Relaxed` and
+    /// never touches the `pending_persists` mutex.
+    pub fn persist_stats(&self) -> ScpPersistStats {
+        use std::sync::atomic::Ordering;
+        ScpPersistStats {
+            pending: self.persist_pending.load(Ordering::Relaxed),
+            pending_peak: self.persist_pending_peak.load(Ordering::Relaxed),
+            attempted_total: self.persist_attempted_total.load(Ordering::Relaxed),
+            spawn_failed_total: self.persist_spawn_failed_total.load(Ordering::Relaxed),
         }
     }
 
@@ -688,6 +771,113 @@ mod tests {
                 .unwrap(),
             inner_sets: vec![].try_into().unwrap(),
         }
+    }
+
+    // --- SCP persist-worker stats (#3796) ---
+
+    #[test]
+    fn test_persist_stats_mirror_matches_pending_counter() {
+        let manager = ScpPersistenceManager::in_memory();
+        manager.pending_persist_begin();
+        manager.pending_persist_begin();
+        manager.pending_persist_begin();
+        manager.pending_persist_end();
+        manager.pending_persist_end();
+
+        let stats = manager.persist_stats();
+        assert_eq!(stats.pending, 1);
+        assert_eq!(stats.pending_peak, 3);
+        assert_eq!(stats.attempted_total, 3);
+        assert_eq!(stats.spawn_failed_total, 0);
+        // The atomic mirror must agree with the mutex source of truth.
+        assert_eq!(
+            stats.pending as usize,
+            *manager.pending_persists.lock().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_persist_stats_peak_is_monotonic() {
+        let manager = ScpPersistenceManager::in_memory();
+        for _ in 0..3 {
+            manager.pending_persist_begin();
+        }
+        for _ in 0..3 {
+            manager.pending_persist_end();
+        }
+        assert_eq!(manager.persist_stats().pending, 0);
+        assert_eq!(manager.persist_stats().pending_peak, 3);
+
+        // Draining to zero must not reset the peak.
+        manager.pending_persist_begin();
+        let stats = manager.persist_stats();
+        assert_eq!(stats.pending, 1);
+        assert_eq!(stats.pending_peak, 3);
+    }
+
+    #[test]
+    fn test_persist_stats_end_saturates_at_zero() {
+        let manager = ScpPersistenceManager::in_memory();
+        // End with nothing pending must not underflow (a wrapped u64 would
+        // render as ~1.8e19 in the gauge).
+        manager.pending_persist_end();
+        assert_eq!(manager.persist_stats().pending, 0);
+    }
+
+    #[test]
+    fn test_persist_attempted_minus_spawn_failed_is_actual_spawns() {
+        let manager = ScpPersistenceManager::in_memory();
+        manager.pending_persist_begin();
+        manager.pending_persist_begin();
+        manager.pending_persist_begin();
+        manager.record_spawn_failure();
+
+        let stats = manager.persist_stats();
+        assert_eq!(stats.attempted_total, 3);
+        assert_eq!(stats.spawn_failed_total, 1);
+        // Documented arithmetic: attempted - spawn_failed == threads spawned.
+        assert_eq!(stats.attempted_total - stats.spawn_failed_total, 2);
+    }
+
+    #[test]
+    fn test_spawn_failure_path_does_not_leak_pending() {
+        let manager = ScpPersistenceManager::in_memory();
+        // Mirror the herder's `.map_err` arm: begin, then on spawn failure
+        // record the failure AND still end the pending count.
+        manager.pending_persist_begin();
+        manager.record_spawn_failure();
+        manager.pending_persist_end();
+
+        let stats = manager.persist_stats();
+        assert_eq!(stats.pending, 0);
+        assert_eq!(stats.spawn_failed_total, 1);
+    }
+
+    #[test]
+    fn test_persist_stats_concurrent_begin_end_settles_to_zero() {
+        use std::sync::Arc;
+        let manager = Arc::new(ScpPersistenceManager::in_memory());
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let m = Arc::clone(&manager);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..50 {
+                    m.pending_persist_begin();
+                    m.pending_persist_end();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let stats = manager.persist_stats();
+        assert_eq!(stats.pending, 0);
+        assert_eq!(stats.attempted_total, 400);
+        assert!(
+            stats.pending_peak >= 1 && stats.pending_peak <= 8,
+            "peak {} out of expected 1..=8 range",
+            stats.pending_peak
+        );
     }
 
     #[test]

--- a/metrics/metrics-mapping.md
+++ b/metrics/metrics-mapping.md
@@ -250,6 +250,15 @@ Fine-grained breakdown of ledger close phases, all in seconds.
 | `SCP_VERIFY_LATENCY_US_SUM` | `henyey_scp_verify_latency_us_sum` | Cumulative verification latency (μs) |
 | `SCP_VERIFY_LATENCY_US_COUNT` | `henyey_scp_verify_latency_us_count` | Verification count |
 
+### SCP State Persistence (#3796)
+
+| Constant | Prometheus name | Description |
+|---|---|---|
+| `SCP_PENDING_PERSISTS` | `henyey_scp_pending_persists` | Persist worker threads currently in flight (deferred SQLite writes) |
+| `SCP_PENDING_PERSISTS_PEAK` | `henyey_scp_pending_persists_peak` | Process-lifetime high-water mark of in-flight persist workers |
+| `SCP_PERSIST_ATTEMPTED_TOTAL` | `henyey_scp_persist_attempted_total` | Persist worker spawns attempted (counted before spawn) |
+| `SCP_PERSIST_SPAWN_FAILED_TOTAL` | `henyey_scp_persist_spawn_failed_total` | Persist worker spawns that failed to launch; `attempted - spawn_failed` = threads spawned |
+
 ### Clock Drift
 
 | Constant | Prometheus name | Description |


### PR DESCRIPTION
Closes #3796

## Summary

Bridges the already-maintained SCP persist-worker backlog (`ScpPersistenceManager::pending_persists`) to Prometheus as four additive `henyey_scp_*` series, so the fan-out that #3796 §2 had to measure with a bespoke 21 ms `/proc` sampler becomes a `/metrics` read:

| Prometheus | type | meaning |
|---|---|---|
| `henyey_scp_pending_persists` | gauge | persist workers currently in flight |
| `henyey_scp_pending_persists_peak` | gauge | process-lifetime high-water mark |
| `henyey_scp_persist_attempted_total` | counter | persist spawns attempted (before spawn) |
| `henyey_scp_persist_spawn_failed_total` | counter | persist spawns that failed to launch |

`attempted_total - spawn_failed_total` = threads actually spawned.

The atomics are lock-free mirrors **published inside the existing `pending_persists` mutex critical section** (store-before-`notify_all`, per the plan/Critic A), so a waiter released by `wait_for_pending_persists` can never observe a stale `pending`. The scrape path reads them `Relaxed` and never touches the mutex.

Deliberately unchanged: the thread-per-emit spawn and the `pending_persists` mutex/condvar. The thread hop avoids a **confirmed** SCP `slots` RwLock deadlock (a synchronous callback would re-take the read lock while the write guard is live). Bounding the fan-out is deferred to #3813; a `henyey_process_threads` gauge to #3814.

## Plan reference

[Converged Plan comment](https://github.com/stellar-experimental/henyey/issues/3796#issuecomment-5230358591)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p henyey-herder` — 1219 lib + integration pass (7 new)
- [x] `cargo test -p henyey-app` — 1181 lib pass (1 new catalog test)

New coverage: persist-stats mirror/peak/saturation/arithmetic/spawn-failure/concurrency in `persistence.rs`; emit-hot-path + no-manager-default in `herder.rs`; catalog + preregistered-at-0 in `metrics.rs`.

## Regression test (kind: bug-fix only)

n/a — `kind: refactor` (observability). No behavioural defect is fixed; no persist is added, removed, delayed, or reordered.

## Deviations from plan

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)